### PR TITLE
docs: add agent infrastructure problem document

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is not a product spec. It's an evolving exploration of a hard problem space
   - [Intent Representation](docs/problems/intent-representation.md) — How do we capture, verify, and enforce what changes are wanted?
   - [Security Threat Model](docs/problems/security-threat-model.md) — Prompt injection, insider threats, agent drift, supply chain attacks
   - [Agent Architecture](docs/problems/agent-architecture.md) — What agents exist, what authority do they have, how do they interact?
+  - [Agent Infrastructure](docs/problems/agent-infrastructure.md) — Where agents run, what resources they get, 3rd party vs internal vs build our own
   - [Autonomy Spectrum](docs/problems/autonomy-spectrum.md) — When to auto-merge vs. escalate to humans
   - [Governance](docs/problems/governance.md) — Who controls the agents and their configuration?
   - [Repo Readiness](docs/problems/repo-readiness.md) — Test coverage, CI/CD maturity, what's needed before agents can be trusted

--- a/docs/problems/agent-architecture.md
+++ b/docs/problems/agent-architecture.md
@@ -146,9 +146,9 @@ Without a coordinator, what happens when agents disagree? (e.g., correctness age
 ## Open questions
 
 - Should agents be stateless (fresh context per task) or stateful (accumulated knowledge of the codebase)? Stateless is safer (no poisoned state persists) but less efficient.
-- Should there be one instance of each agent type per repo, per org, or shared? Per-repo is simpler but more expensive. Shared agents need careful isolation.
+- Should there be one instance of each agent type per repo, per org, or shared? Per-repo is simpler but more expensive. Shared agents need careful isolation. (Infrastructure constrains this — see [agent-infrastructure.md](agent-infrastructure.md).)
 - What's the right model for agent identity? Agents need GitHub accounts to post comments and status checks. Separate bot accounts per agent role? A single bot account with role indicated in the comment? GitHub App installations?
 - How do we test the interaction model? Can we simulate adversarial scenarios (injection attempts, unauthorized changes, agent disagreements) in a sandbox repo?
-- How does the two-phase review model work in practice? Does the implementation agent run all six sub-agents locally, or a subset? Is the pre-PR review a lighter version?
+- How does the two-phase review model work in practice? Does the implementation agent run all six sub-agents locally, or a subset? Is the pre-PR review a lighter version? (Depends on [agent-infrastructure.md](agent-infrastructure.md) — what compute is available where.)
 - What's the iteration limit before human escalation? Too low and humans get pulled in constantly. Too high and the system wastes resources on unresolvable conflicts.
 - How do we handle agent-generated PR content that is itself an injection vector? An implementation agent's code, commit messages, and PR description are all consumed by review agents. The injection defense agent needs to evaluate this content, but how do we prevent the injection defense agent itself from being influenced by it?

--- a/docs/problems/agent-infrastructure.md
+++ b/docs/problems/agent-infrastructure.md
@@ -1,0 +1,81 @@
+# Agent Infrastructure
+
+Where do agents run, what resources do they get, and do we adopt a 3rd party solution, use existing internal systems, or build our own?
+
+This document explores the infrastructure layer that executes agents and provides them with the compute, tooling, and isolation they need to do their work. It is distinct from [agent-architecture.md](agent-architecture.md) (which defines *what* agents do and how they coordinate via the repo) and [governance.md](governance.md) (which defines *who* controls policy). Here we focus on *where* and *how* agents execute.
+
+## Why this matters
+
+Agents need:
+
+- **Compute** — to run models, run tools (clones, linters, tests), and process context
+- **Isolation** — so one compromised or buggy agent doesn't affect others; see [security-threat-model.md](security-threat-model.md) (agent-to-agent injection, lateral movement)
+- **Resources** — access to repos, CI artifacts, intent sources, and possibly internal APIs in a controlled way
+- **Observability** — logs, traces, and auditability so we can attribute actions and debug failures
+
+The choice of platform affects cost, lock-in, compliance, integration with existing konflux-ci systems, and how we scale (per-repo vs shared agents — see agent-architecture open questions).
+
+## The three directions
+
+### Adopt a 3rd party solution
+
+Use a commercial or open-source platform that provides agent runtime, orchestration, and often model access (e.g. Cursor-like workflows, CodeRabbit-style review infrastructure, or generic agent platforms).
+
+**Pros:** Faster to value, maintained by vendors, often includes model orchestration and tooling out of the box.
+
+**Cons:** Vendor lock-in, data residency and compliance constraints, may not align with our zero-trust and repo-as-coordinator model, cost at scale, and we may still need to integrate with internal systems (GitHub, policy repos, internal APIs).
+
+**Open questions:**
+
+- Which vendors support our constraints (no coordinator agent, status-check–driven coordination, CODEOWNERS as authority)?
+- What data leaves our boundary, and is that acceptable for konflux-ci?
+- Can we run their stack in our environment (e.g. self-hosted) or is it only SaaS?
+
+### Use existing internal solutions
+
+Leverage infrastructure konflux-ci or the broader org already runs — e.g. CI runners, internal Kubernetes, shared platforms — and run agents as workloads on that infrastructure.
+
+**Pros:** No new vendor, data stays internal, consistent with existing operational and security practices, possible reuse of identity and secrets management.
+
+**Cons:** Internal platforms may not be designed for long-running or bursty agent workloads; we may need to add isolation, scaling, and tooling; ownership and SLOs may be unclear.
+
+**Open questions:**
+
+- What internal platforms exist that could host agent workloads (e.g. OpenShift, internal CI, shared Kube)?
+- What would we need to add (sandboxing, resource limits, agent-specific tooling)?
+- Who operates and pays for the capacity?
+
+### Build our own
+
+Design and operate dedicated agent infrastructure: runner pool, sandboxing, tool access, and integration with GitHub and policy repos.
+
+**Pros:** Full control over security model, isolation, and integration; no vendor lock-in; can align exactly with repo-as-coordinator and zero-trust principles.
+
+**Cons:** High build and operational cost; we own reliability, scaling, and upgrades; may duplicate what vendors or internal platforms already provide.
+
+**Open questions:**
+
+- What is the minimum viable agent runtime (e.g. “run one review agent in a container with repo access and status-check API”)?
+- How does it integrate with existing konflux-ci CI/CD (e.g. Tekton, task runner, build-definitions)?
+- Can we iterate with a thin custom layer on top of internal or 3rd party compute and only “build our own” where we must?
+
+## Hybrid and incremental options
+
+- **Thin orchestration layer** — We build a small layer that triggers agents, gathers results, and posts status checks; the actual compute is 3rd party or internal. This keeps coordination logic in our control while deferring platform choice.
+- **Phase by phase** — Start with a 3rd party or internal option for early experiments (e.g. review agents only); decide later whether to replace or extend with custom infrastructure as autonomy expands.
+- **By agent type** — Triage and review agents might run on one platform (e.g. event-driven, short-lived); implementation agents that need more tooling and longer runs might need a different environment.
+
+## Relationship to other problem areas
+
+- **Agent architecture** — Instance topology (per-repo vs shared) and “local vs remote” for pre-PR review depend on what infrastructure we have. Infrastructure enables or constrains those choices.
+- **Security threat model** — Isolation and “separate execution environments” are implemented by this layer. Supply chain (what base images and dependencies the runtime uses) also lives here.
+- **Governance** — Policy may be applied at runtime by agents reading from a policy repo; infrastructure determines where that runtime runs and how it accesses policy.
+- **Repo readiness** — Repos need reliable CI and signals; agent infrastructure may consume or depend on the same CI (e.g. for “run tests” or “run linters”) and should not conflict with it.
+
+## Open questions
+
+- What is the right level of isolation per agent (process, container, microVM, separate cluster)?
+- How do we provide agents with “resources to do their work” (clone, tools, APIs) without over-privileging them or creating a single high-value target?
+- Do we need a dedicated “agent runner” image or environment (similar in spirit to the existing [task runner](https://github.com/konflux-ci/architecture/blob/main/ADR/0046-common-task-runner-image.md) for Tekton) with a known, auditable tool set?
+- How do we compare 3rd party vs internal vs build-our-own on concrete criteria: cost, time to first agent, compliance, and alignment with our security and coordination model?
+- Who in the org would own and operate agent infrastructure, and how does that align with existing platform or CI ownership?

--- a/docs/problems/security-threat-model.md
+++ b/docs/problems/security-threat-model.md
@@ -159,7 +159,7 @@ In a multi-agent system, agents consume each other's output. If any agent trusts
 - How do we implement zero trust without making the system too slow or expensive? Every agent re-evaluating everything is costly.
 - Can we use cryptographic signing or attestation to verify agent output integrity without trusting content?
 - How do we detect a compromised agent? What are the signals?
-- Should agents be isolated (separate execution environments) to limit lateral movement?
+- Should agents be isolated (separate execution environments) to limit lateral movement? (See [agent-infrastructure.md](agent-infrastructure.md) for the infrastructure dimension.)
 
 ## Cross-cutting security principles
 


### PR DESCRIPTION
Adds a new problem document for discussing where agents run and what resources they get: 3rd party vs internal vs build our own.

- **New:** `docs/problems/agent-infrastructure.md` — platform choice, isolation, hybrid options, open questions; cross-links to agent-architecture, security-threat-model, governance, repo-readiness.
- **Updated:** README problem list, agent-architecture and security-threat-model cross-references.

Made with [Cursor](https://cursor.com)