### PR TITLE
Add dual-interpretation escalation pattern for agent-to-human handoffs

### DIFF
--- a/docs/problems/agent-architecture.md
+++ b/docs/problems/agent-architecture.md
@@ -140,7 +140,7 @@ Without a coordinator, what happens when agents disagree? (e.g., correctness age
 
 - **Security and intent sub-agents have veto power** via required status checks. If they block, the PR doesn't merge. This is configured in branch protection, not in agent logic.
 - **The implementation agent can iterate** — push new commits to address blocking concerns, which re-triggers the review sub-agents
-- **Persistent disagreement escalates to humans** — if an implementation agent can't satisfy a blocking reviewer after N iterations, the PR is flagged for human intervention. This is a safeguard against infinite loops, not a normal path. The escalation can use [dual-interpretation escalation](code-review.md#dual-interpretation-escalation) to present the human with both the approving and blocking agents' readings, so the human resolves the disagreement quickly rather than re-reviewing the entire PR.
+- **Persistent disagreement escalates to humans** — if an implementation agent can't satisfy a blocking reviewer after N iterations, the PR is flagged for human intervention. This is a safeguard against infinite loops, not a normal path. The escalation can use [dual-interpretation escalation](code-review.md#dual-interpretation-escalation) to present the human with the approving and blocking agents' readings — while making clear the human can reject both framings or the PR itself — so the human resolves the disagreement quickly rather than re-reviewing the entire PR.
 - **Humans can always override** — a human with approval rights can approve despite agent objections. The system assists; humans retain ultimate authority.
 
 ## Open questions

--- a/docs/problems/agent-architecture.md
+++ b/docs/problems/agent-architecture.md
@@ -140,7 +140,7 @@ Without a coordinator, what happens when agents disagree? (e.g., correctness age
 
 - **Security and intent sub-agents have veto power** via required status checks. If they block, the PR doesn't merge. This is configured in branch protection, not in agent logic.
 - **The implementation agent can iterate** — push new commits to address blocking concerns, which re-triggers the review sub-agents
-- **Persistent disagreement escalates to humans** — if an implementation agent can't satisfy a blocking reviewer after N iterations, the PR is flagged for human intervention. This is a safeguard against infinite loops, not a normal path.
+- **Persistent disagreement escalates to humans** — if an implementation agent can't satisfy a blocking reviewer after N iterations, the PR is flagged for human intervention. This is a safeguard against infinite loops, not a normal path. The escalation can use [dual-interpretation escalation](code-review.md#dual-interpretation-escalation) to present the human with both the approving and blocking agents' readings, so the human resolves the disagreement quickly rather than re-reviewing the entire PR.
 - **Humans can always override** — a human with approval rights can approve despite agent objections. The system assists; humans retain ultimate authority.
 
 ## Open questions

--- a/docs/problems/code-review.md
+++ b/docs/problems/code-review.md
@@ -160,14 +160,16 @@ A human reviewer can say "I'm not sure about this, let me think" or "I need some
 
 ### Dual-interpretation escalation
 
-When an agent escalates to a human, the quality of that escalation matters. A vague "I'm not confident" wastes the human's time. A more useful pattern: when the agent's uncertainty stems from a change being legitimately interpretable in two ways, it presents both interpretations as structured alternatives.
+When an agent escalates to a human, the quality of that escalation matters. A vague "I'm not confident" wastes the human's time. A more useful pattern: when the agent's uncertainty stems from a change being legitimately interpretable in multiple ways, it presents its best interpretations as structured alternatives — while explicitly inviting the human to reject all of them.
 
 For example, a review agent uncertain about tier classification could escalate with:
 
 - **Reading A:** "This is a bug fix (Tier 1) — the existing behavior doesn't match the documented intent, and the change is scoped to correcting that gap. Requires: linked issue."
 - **Reading B:** "This is a new feature (Tier 2) — the system never intended to do this, and the change adds new capability. Requires: authorized feature file in `approved/`."
 
-The human sees two coherent framings and picks the one that matches their understanding, rather than starting from scratch. This is faster and more structured than an open-ended "please review."
+Critically, the escalation must always include an explicit "none of the above" option — the human may see a framing the agent missed entirely, or may decide the change should be rejected outright. The agent's interpretations are a starting point for the human's decision, not an exhaustive menu. This avoids presenting a false dichotomy that pressures the human into picking whichever option seems least wrong.
+
+The human sees coherent framings and can pick the one that matches their understanding, offer their own, or reject the change — rather than starting from scratch. This is faster and more structured than an open-ended "please review."
 
 This pattern is most valuable at escalation boundaries — where the system has already decided it can't resolve something autonomously. It doesn't replace confidence scores or explicit uncertainty signals; it complements them by making the *nature* of the uncertainty actionable. It applies wherever agents interact with humans: tier classification (see [intent-representation.md](intent-representation.md#the-tier-escalation-problem)), the exploration phase for proposed features (see [intent-representation.md](intent-representation.md#the-try-it-phase)), and deadlock resolution between review sub-agents (see [agent-architecture.md](agent-architecture.md#how-deadlocks-are-resolved)).
 

--- a/docs/problems/code-review.md
+++ b/docs/problems/code-review.md
@@ -158,6 +158,19 @@ A human reviewer can say "I'm not sure about this, let me think" or "I need some
 - How does an agent express uncertainty? Confidence scores? Explicit "I don't know" signals?
 - Should there be a minimum number of agent reviewers that agree before auto-merge?
 
+### Dual-interpretation escalation
+
+When an agent escalates to a human, the quality of that escalation matters. A vague "I'm not confident" wastes the human's time. A more useful pattern: when the agent's uncertainty stems from a change being legitimately interpretable in two ways, it presents both interpretations as structured alternatives.
+
+For example, a review agent uncertain about tier classification could escalate with:
+
+- **Reading A:** "This is a bug fix (Tier 1) — the existing behavior doesn't match the documented intent, and the change is scoped to correcting that gap. Requires: linked issue."
+- **Reading B:** "This is a new feature (Tier 2) — the system never intended to do this, and the change adds new capability. Requires: authorized feature file in `approved/`."
+
+The human sees two coherent framings and picks the one that matches their understanding, rather than starting from scratch. This is faster and more structured than an open-ended "please review."
+
+This pattern is most valuable at escalation boundaries — where the system has already decided it can't resolve something autonomously. It doesn't replace confidence scores or explicit uncertainty signals; it complements them by making the *nature* of the uncertainty actionable. It applies wherever agents interact with humans: tier classification (see [intent-representation.md](intent-representation.md#the-tier-escalation-problem)), the exploration phase for proposed features (see [intent-representation.md](intent-representation.md#the-try-it-phase)), and deadlock resolution between review sub-agents (see [agent-architecture.md](agent-architecture.md#how-deadlocks-are-resolved)).
+
 ## Open questions
 
 - Can we quantify review quality? How do we know if an agent's review is as good as a human's?

--- a/docs/problems/intent-representation.md
+++ b/docs/problems/intent-representation.md
@@ -68,6 +68,8 @@ For some types of change this phase *could* leverage a **vibe-to-spec** workflow
 
 Any draft PR created at this stage cannot merge — it's gated on the generated feature file being in approved/. Low cost, high information value. This decouples understanding a change from authorizing a change.
 
+The exploration phase can also benefit from [dual-interpretation escalation](code-review.md#dual-interpretation-escalation): when a proposed feature has two plausible implementation approaches, the agent can build both as draft PRs so stakeholders compare concrete alternatives rather than debating in the abstract.
+
 
 ### The "ship it" phase
 
@@ -240,6 +242,8 @@ Review agents must independently assess what tier a change *actually* represents
 - **Impact analysis** — does this change affect security, UX, or API surface? If so, it's at least Tier 2 regardless of the issue label.
 - **Intent verification** — does the linked issue actually describe what this PR does? And does the code do exactly what the intent file says, and nothing more? The vibe-to-spec workflow gives the agent a strict checklist. If someone tries to sneak a major new feature into a low-tier bug fix, the agent will automatically block it because the extra code won't match the generated spec.
 - **Pattern detection** — multiple "small" changes from the same source that collectively add up to a feature should trigger escalation.
+
+When tier classification is genuinely ambiguous, rather than making a weak call or defaulting to escalation without context, the review agent can use [dual-interpretation escalation](code-review.md#dual-interpretation-escalation) — presenting the human with both tier readings and the evidence for each, so the human makes a fast, informed decision rather than re-analyzing from scratch.
 
 This applies equally to review agents looking at code PRs *and* to agents evaluating intent changes in the intent repo itself. A low-tier intent statement that describes something high-impact should be flagged and escalated.
 

--- a/docs/problems/intent-representation.md
+++ b/docs/problems/intent-representation.md
@@ -68,7 +68,7 @@ For some types of change this phase *could* leverage a **vibe-to-spec** workflow
 
 Any draft PR created at this stage cannot merge — it's gated on the generated feature file being in approved/. Low cost, high information value. This decouples understanding a change from authorizing a change.
 
-The exploration phase can also benefit from [dual-interpretation escalation](code-review.md#dual-interpretation-escalation): when a proposed feature has two plausible implementation approaches, the agent can build both as draft PRs so stakeholders compare concrete alternatives rather than debating in the abstract.
+The exploration phase can also benefit from [dual-interpretation escalation](code-review.md#dual-interpretation-escalation): when a proposed feature has multiple plausible implementation approaches, the agent can build them as draft PRs so stakeholders compare concrete alternatives rather than debating in the abstract. Stakeholders may also reject all approaches or propose a direction the agent didn't consider.
 
 
 ### The "ship it" phase
@@ -243,7 +243,7 @@ Review agents must independently assess what tier a change *actually* represents
 - **Intent verification** — does the linked issue actually describe what this PR does? And does the code do exactly what the intent file says, and nothing more? The vibe-to-spec workflow gives the agent a strict checklist. If someone tries to sneak a major new feature into a low-tier bug fix, the agent will automatically block it because the extra code won't match the generated spec.
 - **Pattern detection** — multiple "small" changes from the same source that collectively add up to a feature should trigger escalation.
 
-When tier classification is genuinely ambiguous, rather than making a weak call or defaulting to escalation without context, the review agent can use [dual-interpretation escalation](code-review.md#dual-interpretation-escalation) — presenting the human with both tier readings and the evidence for each, so the human makes a fast, informed decision rather than re-analyzing from scratch.
+When tier classification is genuinely ambiguous, rather than making a weak call or defaulting to escalation without context, the review agent can use [dual-interpretation escalation](code-review.md#dual-interpretation-escalation) — presenting the human with its tier readings and the evidence for each, while always leaving room for the human to see a different framing or reject the change entirely.
 
 This applies equally to review agents looking at code PRs *and* to agents evaluating intent changes in the intent repo itself. A low-tier intent statement that describes something high-impact should be flagged and escalated.
 


### PR DESCRIPTION
When agents escalate to humans due to genuine ambiguity (e.g. bug fix vs. feature, tier classification, sub-agent disagreement), presenting two structured interpretations lets the human make a faster, more informed decision than an open-ended "please review."

Defines the pattern in code-review.md and references it from intent-representation.md (tier escalation, exploration phase) and agent-architecture.md (deadlock resolution).