### PR TITLE
Human factors: add research evidence and propose fire drill experiment

### DIFF
--- a/docs/problems/autonomy-spectrum.md
+++ b/docs/problems/autonomy-spectrum.md
@@ -49,6 +49,8 @@ Possible criteria (all TBD — this needs experimentation):
 - History of successful agent-reviewed PRs (agents review but don't merge, humans validate the agent's judgment)
 - No recent security incidents attributable to missed review
 
+These criteria are all properties of the repo and the agents. But graduation also changes the role of the humans responsible for guarded paths — from active participants to approvers of agent output. Whether those humans can remain effective in that reduced role is an open question explored in [human-factors.md](human-factors.md).
+
 ## The probationary period
 
 Before flipping a repo to full autonomy, run agents in "shadow mode":
@@ -97,3 +99,6 @@ This addresses the gap where the binary model can miss risky changes that don't 
 - Is per-repo binary too coarse? Should there be sub-repo zones of autonomy beyond what CODEOWNERS provides?
 - What about cross-repo changes? If a change spans an autonomous repo and a non-autonomous one, which rules apply?
 - How do we handle the CODEOWNERS bootstrap — who decides the initial set of guarded paths?
+- Should graduation criteria include human factors — not just "can agents be trusted here?" but "can the humans responsible for guarded paths remain effective once they stop implementing?" (See [human-factors.md](human-factors.md))
+- Automation research suggests that [intermediate levels of automation preserve better human oversight than full automation](human-factors.md#the-out-of-the-loop-performance-problem). Does this argue for a third autonomy level between "human-approved" and "fully autonomous" — one where agents do most of the work but humans retain some implementation role?
+- If autonomy can be revoked, should human engagement metrics (approval times, review depth, domain expert confidence) be among the triggers, alongside code quality metrics?

--- a/docs/problems/human-factors.md
+++ b/docs/problems/human-factors.md
@@ -35,7 +35,7 @@ This is still fatiguing, in different ways:
 
 - **Volume.** Agents can generate and process changes faster than humans can evaluate whether the results match what they wanted. The bottleneck moves from "review this diff" to "verify this outcome aligns with what I meant."
 - **Abstraction gap.** Reviewing intent alignment is harder than reviewing code. With code, you can trace logic. With intent, you're asking "did the agent understand what I meant?" — a fuzzier question that requires holding both the intent document and the implementation in mind.
-- **Vigilance problem.** If agents correctly interpret intent 95% of the time, the remaining 5% becomes harder to catch. This is well-studied in automation research — humans are poor monitors of mostly-correct automated systems. The shift from code review to intent review doesn't fix this; it may make it worse, since intent misalignment is subtler than a logic bug.
+- **Vigilance problem.** If agents correctly interpret intent 95% of the time, the remaining 5% becomes harder to catch. This is well-studied in automation research (see [evidence section below](#evidence-from-automation-and-ai-research)) — humans are poor monitors of mostly-correct automated systems, and this complacency cannot be trained away. The shift from code review to intent review doesn't fix this; it may make it worse, since intent misalignment is subtler than a logic bug.
 
 ## Contributor motivation in open source
 
@@ -56,6 +56,48 @@ Most konflux-ci contributors are paid engineers. For them, the concerns above ha
 - "Humans set direction" is reassuring until you realize that direction-setting is a smaller team than implementation.
 
 This doesn't mean autonomous agents are wrong. But pretending this concern doesn't exist will generate resistance that looks like technical objections but is actually about something deeper.
+
+## Evidence from automation and AI research
+
+The concerns above are not speculative. There is a substantial body of research — from decades of automation studies and from recent AI-specific work — that supports them.
+
+### The ironies of automation
+
+Bainbridge's foundational ["Ironies of Automation" (1983)](https://doi.org/10.1016/0005-1098(83)90046-8) identified the central paradox: automating a task removes the practice that keeps operators skilled enough to intervene when automation fails. The more reliable the automation, the worse the problem — because operators have fewer opportunities to exercise their skills, and failures are rarer but harder to catch. This remains one of the most-cited papers in human factors research and its core argument is directly applicable: if agents handle all routine development, the domain experts who approve guarded-path changes lose the practice that makes their approval meaningful.
+
+### The out-of-the-loop performance problem
+
+Endsley & Kiris ["The Out-of-the-Loop Performance Problem and Level of Control in Automation" (1995)](https://doi.org/10.1518/001872095779064555) demonstrated that when operators are removed from active control, their situation awareness degrades — they may still perceive low-level data, but lose comprehension of what it means. Critically, **this effect was significantly greater under full automation than under intermediate levels of automation**. When operators retained some active role in the decision-making loop, their situation awareness was preserved and they performed better when they needed to intervene. This finding directly challenges a model where humans are fully removed from implementation: partial involvement isn't just a compromise, it produces measurably better oversight than full removal.
+
+### Automation complacency and bias
+
+Parasuraman & Manzey ["Complacency and Bias in Human Use of Automation" (2010)](https://doi.org/10.1177/0018720810376055) found that automation complacency occurs in both novice and expert users, **cannot be overcome with training or instructions**, and worsens under high automation reliability. Operators of highly reliable systems were 50% less likely to detect failures than operators of less reliable systems. In our context: if agents produce correct results 95% of the time, the remaining 5% becomes harder for human reviewers to catch, not easier.
+
+### AI coding tools and skill formation
+
+Recent research on AI coding tools specifically reinforces these patterns:
+
+- An [Anthropic study (2025)](https://www.anthropic.com/research/AI-assistance-coding-skills) found that developers using AI coding assistance scored **17% lower on comprehension tests** when learning new libraries. Developers who delegated code generation to AI scored below 40% on comprehension, while those who used AI for conceptual inquiry scored 65% or higher. The mode of interaction — whether you do the work or delegate it — directly affects whether you build understanding.
+- A [METR randomized controlled trial (2025)](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/) found that experienced open-source developers working on their own repositories were **19% slower with AI tools** — but perceived themselves as 20% faster. The gap between perceived and actual performance is relevant to the rubber-stamping risk: people may believe they are reviewing effectively when they are not.
+- Research on [overreliance in human-AI interaction (2025)](https://arxiv.org/html/2509.08010v1) identifies cognitive offloading, automation bias, and the erosion of critical thinking as risks of LLM-assisted work, and notes that long-term deskilling is a serious concern in environments where AI tools dominate routine tasks.
+
+### Newcomer pathways and communities of practice
+
+Lave & Wenger's *Situated Learning: Legitimate Peripheral Participation* (1991) established that learning in communities of practice happens through a gradient — newcomers enter through small, peripheral tasks and gradually take on more central roles. If automation removes the peripheral tasks (small bug fixes, documentation, simple features), the pathway that produces future experts and maintainers is disrupted. This is not just an open-source concern; it applies to any organization that needs to develop new domain experts over time.
+
+## Is the two-point model enough?
+
+The [vision](../vision.md) defines two points of human participation: strategic intent and guarded paths. Everything else is autonomous. The problems described above — expertise atrophy, loss of creative work, review fatigue, disappearing contributor pathways — are all consequences of that model. But rather than treating them as side-effects to mitigate, it's worth asking whether they indicate a problem with the model itself.
+
+The two-point model assumes that humans can remain effective at their two roles (setting direction and approving guarded-path changes) without doing the work in between. The research summarized above suggests they can't:
+
+- **Guarded-path approval requires understanding.** If domain experts stop implementing changes, their ability to evaluate agent-produced changes degrades. The security model depends on informed human approval, but the autonomy model removes the activity that keeps humans informed. Over time, guarded-path approvals risk becoming rubber stamps — not because people are careless, but because they've lost the context that made their judgment valuable.
+- **Strategic direction requires ground-level knowledge.** Architectural decisions that aren't grounded in recent hands-on experience with the codebase tend to drift from reality. If humans only interact with code through intent documents and approval queues, the quality of their strategic input declines.
+- **The contributor pipeline depends on a gradient.** Open-source contributors enter through small contributions and grow into larger roles. If agent autonomy eliminates the small-contribution layer, the pipeline that produces future domain experts and maintainers dries up. The two-point model assumes a supply of capable humans at both points, but doesn't account for where those humans come from.
+
+This doesn't mean the vision is wrong — it means it may be incomplete. There may need to be a third category of human participation: not strategic intent, not guarded-path approval, but **ongoing hands-on involvement** in parts of the codebase, specifically to maintain the understanding and skills that make the other two roles work.
+
+What this third category looks like, how it interacts with the [autonomy spectrum](autonomy-spectrum.md), and whether it can be designed without simply slowing everything down, are open questions. But the problems documented in the sections above suggest that a model with only two human touchpoints may undermine its own foundations.
 
 ## What might help
 
@@ -82,3 +124,5 @@ These aren't solutions — they're directions worth exploring:
 - What skills should contributors be building to stay effective in a heavily agentic workflow?
 - How do we handle the fact that different people will feel differently about this? Some engineers will welcome agent autonomy; others will experience it as loss. One-size-fits-all approaches won't work.
 - Can agents themselves help with the human factors — for example, by surfacing "this area hasn't had human-authored changes in 6 months" as a signal worth attention?
+- Should human engagement be an input to autonomy decisions? If full autonomy in a repo is degrading the understanding of the people responsible for its guarded paths, is that a reason to pull back autonomy — even if the code quality metrics look fine?
+- What would a "third category" of human participation look like in practice? Is it reserved areas of the codebase, periodic implementation rotations, collaborative agent-human work, or something else?

--- a/experiments/003-agent-outage-fire-drill.md
+++ b/experiments/003-agent-outage-fire-drill.md
@@ -1,0 +1,95 @@
+# Experiment 003: Agent Outage Fire Drill
+
+**Date:** 2026-03-16
+**Status:** Proposed
+
+## Hypothesis
+
+After several months of agent autonomy, engineering teams will have difficulty operating without agents — not because agents are better, but because humans have lost familiarity with their own codebases and workflows. Specifically:
+
+1. Tasks that took a predictable amount of time pre-autonomy will take significantly longer post-autonomy, even though the humans involved are the same people who built the systems.
+2. Domain experts will need a reorientation period before they can implement effectively in subsystems they nominally own.
+3. The team may not recognise the extent of their dependency until the agents are removed.
+
+This tests the core claim from [Bainbridge (1983)](../problems/human-factors.md#the-ironies-of-automation): automation removes the practice that keeps operators skilled enough to intervene when automation fails. If the claim holds for software development, an agent outage — even a planned one — should produce measurable degradation in human performance.
+
+## Why this matters beyond the experiment
+
+This is chaos engineering for human capability. Netflix's Chaos Monkey kills production servers to prove the infrastructure can survive failures. This experiment kills the agent to prove the *people* can survive without it. The same logic applies: if you haven't tested the failure mode, you don't know whether you can handle it.
+
+Agent outages are not hypothetical. Infrastructure fails, API keys expire, providers have incidents, budgets get cut. If the team cannot function during a two-week outage, the organisation has an undisclosed single point of failure in its engineering capability. This experiment surfaces that risk while there's still time to address it.
+
+## Design
+
+### Prerequisites
+
+- A repo that has been operating with agent autonomy for at least three months (long enough for habits to shift)
+- Pre-autonomy baseline data: typical task completion times, PR throughput, defect rates from before agents were introduced
+- Team buy-in — this needs to be framed as a resilience exercise, not a punishment
+
+### Setup
+
+1. **Select a two-week window.** Avoid periods with major deadlines or releases. The point is to measure normal work under normal conditions, minus the agents.
+
+2. **Disable agent access.** No agent-produced PRs, no agent reviews, no agent triage. Humans handle the full development lifecycle as they did before autonomy.
+
+3. **Keep the backlog realistic.** Don't cherry-pick easy tasks or defer hard ones. The team should work from the same backlog they'd have worked from with agents. If agents would normally have picked up certain issues automatically, those issues still need to be addressed — by humans.
+
+4. **Instrument everything.** Capture the same metrics you tracked pre-autonomy so the comparison is like-for-like.
+
+### What to measure
+
+**Quantitative:**
+
+- **Task completion time** compared to pre-autonomy baselines. Not compared to agent-assisted speed (agents will obviously be faster) — compared to how fast the *same team* was before agents existed. If human performance has degraded relative to the team's own historical baseline, that's skill atrophy.
+- **PR throughput** — number of PRs opened, reviewed, and merged per week.
+- **Defect rates** — bugs introduced during the outage period vs. the pre-autonomy baseline. Are humans making more mistakes than they used to?
+- **Time to first commit** — when someone picks up a task, how long before their first meaningful commit? A long orientation period suggests lost familiarity.
+- **Questions asked** — how often do people ask for help understanding code they're nominally responsible for? Track Slack questions, PR comments, or pairing sessions that wouldn't have happened pre-autonomy.
+
+**Qualitative:**
+
+- **Daily journal entries** from participants: what was hard, what was surprising, what felt different. Capture reactions while they're fresh.
+- **Retrospective** at the end of the two weeks: how did it feel? What was easier or harder than expected? Would you be comfortable if this were permanent?
+- **Confidence self-assessment** at the start and end: "how confident are you that you can work effectively without agents?" Compare the start-of-drill prediction against the end-of-drill reality.
+
+### Controls and caveats
+
+- **The pre-autonomy baseline is the key comparison**, not agent-assisted performance. The question is "have humans degraded?" not "are agents faster?" We already know agents are faster.
+- **Learning effects during the drill.** Performance may improve over the two weeks as people re-familiarise themselves. The trajectory matters — a steep initial drop that recovers suggests temporary rust, while a sustained deficit suggests deeper atrophy.
+- **Hawthorne effect.** People may work harder during the drill because they know they're being observed. This makes the experiment conservative — if performance degrades even with heightened effort, the real-world situation is likely worse.
+
+## Expected outcomes
+
+**If the hypothesis holds:**
+
+- Task completion times are significantly worse than pre-autonomy baselines, at least in the first week
+- Domain experts need meaningful reorientation time in subsystems they own
+- The confidence self-assessment reveals a gap — people predicted they'd be fine but weren't
+- This is strong evidence for the [third category of participation](../problems/human-factors.md#is-the-two-point-model-enough): humans need ongoing hands-on involvement to maintain capability, and the current autonomy model doesn't provide it
+- It also reframes agent autonomy as an organisational risk: a capability that degrades the team's ability to function without it
+
+**If the hypothesis doesn't hold:**
+
+- The team performs at or near pre-autonomy baselines after a brief adjustment
+- Domain experts retain sufficient understanding of their subsystems
+- This weakens the skill atrophy argument and suggests the two-point model may be sufficient for this context
+- The drill still has value as a resilience exercise — confirming the team *can* operate without agents is worth knowing
+
+**Mixed outcome (likely):**
+
+- Some subsystems show degradation, others don't. The difference may correlate with how much hands-on work humans retained during the autonomy period — providing natural-experiment evidence for the third category argument.
+- Some individuals adapt quickly, others struggle. The difference may correlate with experience level, domain depth, or how they interacted with agents (supervisory vs. collaborative).
+
+## Timing
+
+This experiment requires an agent autonomy period to have elapsed first. It can't run until at least one repo has been autonomous for several months. But it should be planned now so that:
+
+- Pre-autonomy baseline data is captured before agents are introduced (you can't measure degradation without a baseline)
+- The team knows the drill is coming (builds it into expectations rather than springing it as a surprise)
+- The cadence is established early — this should be a recurring exercise (quarterly or biannually), not a one-off
+
+## Relationship to other experiments
+
+- **[Experiment 002](adr46-claude-scanner/README.md)** tests automated enforcement of architectural invariants. This experiment tests whether the humans responsible for architectural judgment can still exercise it without agent support.
+- A complementary experiment could measure review quality specifically (can humans still evaluate agent-produced code?) — this experiment is broader, testing whether humans can still write, review, debug, and ship.


### PR DESCRIPTION
- Add research evidence from established automation and AI-specific studies to human-factors.md 
- Add a new section questioning whether the vision's two-point model (strategic intent + guarded paths) is sufficient, given that the oversight quality it depends on degrades without ongoing hands-on involvement
- Connect human factors back into the autonomy spectrum as open questions, so autonomy decisions can account for human effectiveness
- Propose experiment 002: an agent outage fire drill (chaos engineering for human capability) to test whether skill atrophy is real in this context
