### PR TITLE
Reconcile inconsistent language across markdown files

### DIFF
--- a/docs/problems/contributor-guidance.md
+++ b/docs/problems/contributor-guidance.md
@@ -4,7 +4,7 @@ How do we make Konflux contribution rules clear to both human contributors and A
 
 ## Why this matters
 
-Konflux aspires to be an "upstream" open source project capable of accepting contributions from the general public. Contributors range from individual hobbyists to engineers at large corporations, with varying levels of familiarity with Konflux's architecture and conventions.
+Konflux aspires to be an "upstream" open-source project capable of accepting contributions from the general public. Contributors range from individual hobbyists to engineers at large corporations, with varying levels of familiarity with Konflux's architecture and conventions.
 
 If agents are actively developing Konflux, the contribution process must work for:
 
@@ -98,7 +98,7 @@ Human and agents will need to understand how to contribute automated tests along
 
 - What tests need to pass before a PR is ready for review?
 - What are the conventions for contributing new tests?
-- What distinguishes unit, integration, and end to end testing? Which types of testing are
+- What distinguishes unit, integration, and end-to-end testing? Which types of testing are
   emphasized?
 - Which tests can be run locally vs. those that require a dedicated environment?
 - Do code coverage metrics matter, and how are they computed?
@@ -115,9 +115,9 @@ For exploratory contributions ("I think this might fix the issue but I'm not sur
 - Do we expect agents to generate exploratory/draft changes?
 - Draft status is about the state of the work, not about who submitted it — the same exploratory/iterative workflow applies whether the PR comes from a human experimenting or an agent exploring alternatives
 
-## Key Principles
+## Key principles
 
-### No Agent Assistance Required
+### No agent assistance required
 
 A critical constraint: **using AI must not be required to contribute to Konflux.**
 
@@ -137,7 +137,7 @@ This is both a practical accessibility concern and a philosophical one. Open sou
 
 Beyond accessibility, there's a deeper question about whether contribution remains meaningful when agents handle routine work. See [human-factors.md](human-factors.md) for exploration of contributor motivation, domain ownership, and the shift from hands-on development to supervising agent output.
 
-### Human and Agent Equality
+### Human and agent equality
 
 The "no agent required" principle also has security implications, aligned with the [zero trust model](security-threat-model.md):
 
@@ -179,7 +179,7 @@ The goal: make implicit knowledge explicit (which helps AI agents) **without** m
 - Should we explicitly signal which documentation is "need to know" for humans vs. "supplementary context" primarily for AI assistants?
 - How do we capture and document the "why" behind decisions when that context is currently tribal knowledge?
 
-## Potential Solutions
+## Potential solutions
 
 Below is a suggested set of solutions that could be candidates for experiments.
 

--- a/docs/problems/performance-verification.md
+++ b/docs/problems/performance-verification.md
@@ -144,7 +144,7 @@ Based on observed behavior across agentic coding tools, agents commonly produce 
 
 These patterns are detectable by static analysis if codified into rules. The challenge is maintaining the rule set as new anti-patterns emerge.
 
-## Interaction with other problem areas
+## Relationship to other problem areas
 
 - **[Code Review](code-review.md):** A performance-focused review sub-agent could be added to the review decomposition. It would evaluate diffs for performance implications using codebase context (is this a controller reconcile loop? does this code path make API server calls?). This is complementary to automated detection — the review agent catches what the linters miss, and the linters catch what the review agent misses.
 - **[Repo Readiness](repo-readiness.md):** Benchmark coverage and performance test infrastructure could be added to the readiness criteria. A repo without performance baselines is harder to protect from agent-introduced regressions. For controller repos, this might mean envtest-based benchmarks of reconciliation paths.

--- a/docs/problems/production-feedback.md
+++ b/docs/problems/production-feedback.md
@@ -1,5 +1,7 @@
 # Production Feedback
 
+How should production signals feed back into the agents developing and maintaining the system?
+
 ## Problem
 
 Any project adopting an agentic software factory model faces a general question:
@@ -123,7 +125,7 @@ Detection requires two complementary stopping conditions. First, iteration count
 
 Prevention: the triage agent should not generate an implementation-ready issue without sufficient corroborating evidence — a correlated deploy event, minimum cross-tenant breadth, signal-to-noise ratio above threshold, and failure log content consistent with a platform origin. Below that threshold, the output is a flagged observation for human triage, not an actionable issue.
 
-## Relationship to other problems
+## Relationship to other problem areas
 
 This problem does not exist in isolation. The closed-loop model described above intersects with several other open problems in the repo.
 

--- a/docs/problems/testing-agents.md
+++ b/docs/problems/testing-agents.md
@@ -1,6 +1,6 @@
 # Testing the Agents
 
-We have CI for code, but no CI for prompts. If someone tweaks the Intent Alignment Agent's instructions, how do we prove it didn't forget how to detect Tier Escalation?
+We have CI for code, but no CI for prompts. If someone tweaks the intent alignment agent's instructions, how do we prove it didn't forget how to detect tier escalation?
 
 ## Why this is a distinct problem
 
@@ -20,11 +20,11 @@ An agent's behavior is the product of its instructions, the model it runs on, th
 
 ### Absence detection
 
-The hardest bugs to catch are capabilities that silently disappear. If someone simplifies the Intent Alignment Agent's instructions and removes the paragraph about tier escalation detection, the agent won't error — it will simply stop checking for tier escalation. There's no compile error, no stack trace, no failing import. The capability quietly vanishes, and you only discover it when a tier-gaming attack succeeds.
+The hardest bugs to catch are capabilities that silently disappear. If someone simplifies the intent alignment agent's instructions and removes the paragraph about tier escalation detection, the agent won't error — it will simply stop checking for tier escalation. There's no compile error, no stack trace, no failing import. The capability quietly vanishes, and you only discover it when a tier-gaming attack succeeds.
 
 ### Interaction effects
 
-Agents don't operate alone. The review sub-agents described in [code-review.md](code-review.md) compose their decisions. A change to one agent's instructions might not cause that agent to fail in isolation, but might break the overall review process — for example, if the Intent Alignment Agent starts flagging things that the Correctness Agent used to handle, creating a gap where neither catches certain issues.
+Agents don't operate alone. The review sub-agents described in [code-review.md](code-review.md) compose their decisions. A change to one agent's instructions might not cause that agent to fail in isolation, but might break the overall review process — for example, if the intent alignment agent starts flagging things that the correctness agent used to handle, creating a gap where neither catches certain issues.
 
 ### Model updates
 
@@ -43,7 +43,7 @@ When someone modifies an agent's system prompt, CLAUDE.md, or configuration:
 
 ### Capability coverage
 
-For each agent role described in [agent-architecture.md](agent-architecture.md) and [code-review.md](code-review.md), there's an implicit set of capabilities. The Intent Alignment Agent should detect tier escalation. The Injection Defense Agent should catch known injection patterns. The Platform Security Agent should flag RBAC changes. These capabilities need explicit test coverage.
+For each agent role described in [agent-architecture.md](agent-architecture.md) and [code-review.md](code-review.md), there's an implicit set of capabilities. The intent alignment agent should detect tier escalation. The injection defense agent should catch known injection patterns. The platform security agent should flag RBAC changes. These capabilities need explicit test coverage.
 
 ### Cross-agent composition
 
@@ -99,7 +99,7 @@ How do you know the golden set is sufficient? For application code, coverage too
 
 Define contracts for each agent — formal statements about what the agent must and must not do — and test against those contracts. This is more abstract than golden-set testing but potentially more robust.
 
-### Example contracts for the Intent Alignment Agent
+### Example contracts for the intent alignment agent
 
 - MUST flag any PR where the linked issue describes a bug fix but the diff adds new API surface
 - MUST flag any PR that modifies files in more than 3 directories when the linked issue is labeled "bug"
@@ -179,7 +179,7 @@ The approaches above aren't purely theoretical — an emerging class of LLM eval
 - Has a red-teaming mode that generates adversarial inputs, relevant to the adversarial evaluation step in the CI pipeline
 - Designed for CI integration, producing machine-readable output
 
-The main gap: promptfoo evaluates single prompts against single outputs. It doesn't natively model multi-agent composition or cross-agent interaction effects. Testing whether the Intent Alignment Agent and Correctness Agent together produce correct outcomes would require custom harness code on top.
+The main gap: promptfoo evaluates single prompts against single outputs. It doesn't natively model multi-agent composition or cross-agent interaction effects. Testing whether the intent alignment agent and correctness agent together produce correct outcomes would require custom harness code on top.
 
 ### deepeval
 

--- a/experiments/003-agent-outage-fire-drill.md
+++ b/experiments/003-agent-outage-fire-drill.md
@@ -9,7 +9,7 @@ After several months of agent autonomy, engineering teams will have difficulty o
 
 1. Tasks that took a predictable amount of time pre-autonomy will take significantly longer post-autonomy, even though the humans involved are the same people who built the systems.
 2. Domain experts will need a reorientation period before they can implement effectively in subsystems they nominally own.
-3. The team may not recognise the extent of their dependency until the agents are removed.
+3. The team may not recognize the extent of their dependency until the agents are removed.
 
 This tests the core claim from [Bainbridge (1983)](../problems/human-factors.md#the-ironies-of-automation): automation removes the practice that keeps operators skilled enough to intervene when automation fails. If the claim holds for software development, an agent outage — even a planned one — should produce measurable degradation in human performance.
 
@@ -17,7 +17,7 @@ This tests the core claim from [Bainbridge (1983)](../problems/human-factors.md#
 
 This is chaos engineering for human capability. Netflix's Chaos Monkey kills production servers to prove the infrastructure can survive failures. This experiment kills the agent to prove the *people* can survive without it. The same logic applies: if you haven't tested the failure mode, you don't know whether you can handle it.
 
-Agent outages are not hypothetical. Infrastructure fails, API keys expire, providers have incidents, budgets get cut. If the team cannot function during a two-week outage, the organisation has an undisclosed single point of failure in its engineering capability. This experiment surfaces that risk while there's still time to address it.
+Agent outages are not hypothetical. Infrastructure fails, API keys expire, providers have incidents, budgets get cut. If the team cannot function during a two-week outage, the organization has an undisclosed single point of failure in its engineering capability. This experiment surfaces that risk while there's still time to address it.
 
 ## Design
 
@@ -56,7 +56,7 @@ Agent outages are not hypothetical. Infrastructure fails, API keys expire, provi
 ### Controls and caveats
 
 - **The pre-autonomy baseline is the key comparison**, not agent-assisted performance. The question is "have humans degraded?" not "are agents faster?" We already know agents are faster.
-- **Learning effects during the drill.** Performance may improve over the two weeks as people re-familiarise themselves. The trajectory matters — a steep initial drop that recovers suggests temporary rust, while a sustained deficit suggests deeper atrophy.
+- **Learning effects during the drill.** Performance may improve over the two weeks as people re-familiarize themselves. The trajectory matters — a steep initial drop that recovers suggests temporary rust, while a sustained deficit suggests deeper atrophy.
 - **Hawthorne effect.** People may work harder during the drill because they know they're being observed. This makes the experiment conservative — if performance degrades even with heightened effort, the real-world situation is likely worse.
 
 ## Expected outcomes
@@ -67,7 +67,7 @@ Agent outages are not hypothetical. Infrastructure fails, API keys expire, provi
 - Domain experts need meaningful reorientation time in subsystems they own
 - The confidence self-assessment reveals a gap — people predicted they'd be fine but weren't
 - This is strong evidence for the [third category of participation](../problems/human-factors.md#is-the-two-point-model-enough): humans need ongoing hands-on involvement to maintain capability, and the current autonomy model doesn't provide it
-- It also reframes agent autonomy as an organisational risk: a capability that degrades the team's ability to function without it
+- It also reframes agent autonomy as an organizational risk: a capability that degrades the team's ability to function without it
 
 **If the hypothesis doesn't hold:**
 


### PR DESCRIPTION
Really, I was just playing with [cgwalters/devaipod](https://github.com/cgwalters/devaipod) here. It produced this change. I wanted to see the contents here in a PR (and, grok the workflow).

---

Standardize terminology and formatting across all design documents:

- Fix UK spellings to US English (recognise/organisation/re-familiarise in fire drill experiment) to match the rest of the repo
- Hyphenate compound adjectives: 'end-to-end testing', 'open-source project'
- Standardize cross-reference section heading to 'Relationship to other problem areas' (was 'Relationship to other problems' in production-feedback and 'Interaction with other problem areas' in performance-verification)
- Use sentence case for headings in contributor-guidance (was title case for Key Principles, No Agent Assistance Required, Human and Agent Equality, Potential Solutions)
- Lowercase agent role names in running text in testing-agents (intent alignment agent, correctness agent, etc.) to match usage in agent-architecture and code-review docs
- Add missing one-line description after heading in production-feedback to match the pattern used by all other problem documents