### PR TITLE
Add contribution guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you're applying fullsend to your own organization, consider adding your speci
 | A question, bug, or small suggestion | **File an issue** — lowest friction, can graduate later. |
 | A new problem area no existing doc covers | **Create a problem doc** in `docs/problems/` and link it here. |
 | More to say about an existing problem area | **Expand the existing problem doc.** |
-| A specific decision that needs a yes-or-no answer | **Propose an ADR** in `docs/ADRs/` ([see ADR 0001](docs/ADRs/0001-use-adrs-for-decision-making.md)). |
+| A specific decision that needs a yes-or-no answer | **Propose an ADR** in `docs/ADRs/` — even with only one option, file it as `Undecided` ([see ADR 0001](docs/ADRs/0001-use-adrs-for-decision-making.md)). |
 | Something you want to try in practice | **Log an experiment** in `experiments/`. |
 
 When in doubt, start with an issue.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,15 @@ Pick a problem area that interests you. Read the existing document. Add your per
 If you want to run an experiment — try an agent workflow in a repo, test a security guardrail, prototype an intent system — document what you did and what you learned in `experiments/`.
 
 If you're applying fullsend to your own organization, consider adding your specific considerations to `docs/problems/applied/` — your experience and feedback will strengthen the general problem documents.
+
+### Where does my contribution go?
+
+| If you have... | Then... |
+|---|---|
+| A question, bug, or small suggestion | **File an issue** — lowest friction, can graduate later. |
+| A new problem area no existing doc covers | **Create a problem doc** in `docs/problems/` and link it here. |
+| More to say about an existing problem area | **Expand the existing problem doc.** |
+| A specific decision that needs a yes-or-no answer | **Propose an ADR** in `docs/ADRs/` ([see ADR 0001](docs/ADRs/0001-use-adrs-for-decision-making.md)). |
+| Something you want to try in practice | **Log an experiment** in `experiments/`. |
+
+When in doubt, start with an issue.


### PR DESCRIPTION
## Summary

- Adds a "Where does my contribution go?" quick-reference table to the README
- Covers the five contribution types: issues, new problem docs, expanding existing docs, ADRs, and experiments
- Prompted by a teammate's feedback about not knowing where to put new ideas

## Test plan

- [ ] Verify table renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)