### PR TITLE
Update CODEOWNERS team reference for org move to fullsend-ai

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # These users have approval access to all resources (wildcard)
-* @konflux-ci/fullsend-sig
+* @fullsend-ai/fullsend-sig

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # These users have approval access to all resources (wildcard)
-* @fullsend-ai/fullsend-sig
+* @fullsend-ai/core 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # These users have approval access to all resources (wildcard)
-* @fullsend-ai/core 
+* @fullsend-ai/core


### PR DESCRIPTION
The repo moved from konflux-ci/fullsend to fullsend-ai/fullsend. Update the CODEOWNERS team reference accordingly.

Assisted-by: OpenCode claude-opus-4-6@default