### PR TITLE
Incorporate software factory insights: backpressure, production orchestration, product discovery

### DIFF
--- a/docs/landscape.md
+++ b/docs/landscape.md
@@ -101,6 +101,36 @@ Launched November 2025. The closest thing in the industry to autonomous merging.
 - **OpenAI Codex** — Triggered by `@codex review` in GitHub PRs. Behaves as an additional reviewer focused on high-severity issues.
 - **Bito** — Uses Claude Sonnet for human-like review. GitHub, GitLab, Bitbucket integration.
 
+## Production agent orchestration systems
+
+While the tools above focus on code review, a separate category of systems addresses end-to-end agent orchestration — from task intake through implementation and merge. These are closer to the fullsend vision than review-only tools.
+
+### Stripe Minions
+
+[Architecture blog post](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents) | [Part 2](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents-part-2)
+
+One-shot coding agents that merge over 1,300 pull requests per week at Stripe. A task starts in a Slack message and ends in a CI-passing pull request ready for human review, with no interaction in between.
+
+**Architecture:** Before the LLM runs, a deterministic orchestrator prefetches context — scanning threads for links, pulling tickets, and searching code via MCP. Each Minion gets its own isolated devbox (same machines human engineers use, spins up in 10 seconds). An internal MCP server called Toolshed provides ~500 tools, curated per task so the agent starts focused rather than overwhelmed.
+
+**Blueprints:** Stripe's term for hybrid pipelines that combine deterministic code nodes (run linters, push changes) with agentic subtasks (implement feature, fix CI failures). This is not full autonomy — it's a structured pipeline with guardrails at each stage.
+
+**Bounded retry:** If CI fails, the Minion gets one attempt to fix it. Two CI rounds maximum, then the task is handed off to humans. This explicit stopping condition prevents unbounded agent loops — a concrete answer to the iteration-count stopping condition discussed in [production-feedback.md](problems/production-feedback.md).
+
+**Key insight:** "If a tool is good for human engineers, it's good for LLMs." Every investment in developer tooling, documentation, devboxes, and CI directly improved agent performance. The factory runs on the same infrastructure humans use. This aligns with the backpressure framing in [repo-readiness.md](problems/repo-readiness.md) — developer experience investment compounds for agents.
+
+**Relevance to fullsend:** Stripe's deterministic-then-agentic pipeline pattern ("blueprints") is a concrete implementation of the hybrid approach we've been exploring. Their context prefetching (deterministic orchestrator before LLM invocation) and tool curation (subset of 500 tools per task) are practical solutions to the context management problem discussed in [codebase-context.md](problems/codebase-context.md). The bounded retry model provides a production-validated answer to our open question about stopping conditions. However, Minions are built for Stripe's proprietary codebase (hundreds of millions of lines of Ruby with internal libraries) — the approach requires significant internal tooling investment.
+
+### Gas Town
+
+[GitHub](https://github.com/steveyegge/gastown) | [Architecture overview](https://cloudnativenow.com/features/gas-town-what-kubernetes-for-ai-coding-agents-actually-looks-like/)
+
+Steve Yegge's open-source multi-agent orchestration system, described as "Kubernetes for AI coding agents." Coordinates 20-30 parallel coding agents working on feature branches simultaneously.
+
+**Architecture:** A "Mayor" agent acts as the coordinator, dispatching work to parallel coding agents called "Polecats." A "Refinery" manages the merge queue so parallel work doesn't collide. Git is the persistence layer — if the system crashes, it reads the git history and resumes. This is a concrete implementation of the repo-as-coordination-layer pattern, though with a coordinator agent (which fullsend's model avoids).
+
+**Relevance to fullsend:** Gas Town's use of git as crash-recovery persistence validates the "repo is the coordinator" principle — all state is in git, not in ephemeral coordinator memory. However, it uses a coordinator agent (the Mayor), which conflicts with fullsend's position that coordination should happen through branch protection, CODEOWNERS, and status checks rather than through a coordinator agent. The Refinery merge queue concept is relevant to how we'd sequence autonomous merges.
+
 ## Architectural patterns in the field
 
 Three distinct approaches:
@@ -117,7 +147,11 @@ Build a full code graph, trace dependencies across the entire repo. Deepest unde
 
 Make the problem easier by making PRs smaller. Stacked PRs with clear scope are more tractable for AI review. Doesn't improve the agent's capability, but improves the input quality.
 
-These are complementary, not competing. A system could use stacked PRs (Graphite's insight) reviewed by specialized sub-agents (CodeRabbit's insight) with deep codebase context where needed (Greptile's insight).
+### 4. Deterministic-then-agentic pipelines (Stripe Minions)
+
+Structure the workflow as a pipeline where deterministic steps (context prefetching, linting, pushing) alternate with agentic steps (implementation, CI fix attempts). The agent operates within a bounded, instrumented pipeline rather than with open-ended autonomy. Bounded retry limits prevent runaway loops.
+
+These are complementary, not competing. A system could use stacked PRs (Graphite's insight) reviewed by specialized sub-agents (CodeRabbit's insight) with deep codebase context where needed (Greptile's insight), all orchestrated through a deterministic pipeline with agentic steps (Stripe's insight).
 
 ## What nobody is doing
 

--- a/docs/problems/production-feedback.md
+++ b/docs/problems/production-feedback.md
@@ -107,6 +107,21 @@ Detection requires two complementary stopping conditions. First, iteration count
 
 Prevention: the triage agent should not generate an implementation-ready issue without sufficient corroborating evidence — a correlated deploy event, minimum cross-tenant breadth, signal-to-noise ratio above threshold, and failure log content consistent with a platform origin. Below that threshold, the output is a flagged observation for human triage, not an actionable issue.
 
+## Product discovery signals
+
+The three signal categories above focus on system health — detecting and fixing failures. But production systems also generate **product discovery signals**: data about how users interact with the product that suggests what to build or improve next. This extends the feedback loop from reactive (fix what's broken) to proactive (build what's needed).
+
+Examples of product discovery signals:
+
+- **User feedback clustering**: Support tickets, GitHub issues, and forum posts contain recurring themes. Agents can cluster these by topic, identify the most frequently reported pain points, and create backlog items with supporting evidence from the original reports.
+- **Usage pattern analysis**: Feature adoption rates, drop-off points in workflows, and frequently abandoned actions reveal where users struggle. An agent monitoring these patterns can flag UX improvements with quantitative backing.
+- **A/B test interpretation**: When experiments conclude, agents can identify winning variants, summarize the results, and propose follow-up experiments — reducing the latency between experiment completion and action.
+- **Error-adjacent behavior**: Users who encounter errors and then change their approach (retrying with different parameters, switching to a different feature) reveal workarounds that indicate missing functionality or poor error recovery.
+
+The distinction from health signals is important: health signals have clear correct/incorrect states (error rate should be low, latency should be within SLO). Product discovery signals are **ambiguous** — a feature with low adoption might be poorly designed, poorly documented, or simply not needed. This ambiguity means product discovery agents should produce observations and recommendations for human triage, not actionable issues. The governance question is sharper here than for health signals: should agents that interpret user behavior be able to populate the backlog autonomously, or should they always produce proposals that humans approve?
+
+This creates a potential closed loop: observe user behavior → propose improvements → implement changes → observe behavior again. The risk is that this loop optimizes for measurable metrics (conversion rate, click-through) at the expense of harder-to-measure qualities (simplicity, coherence, long-term usability). Stopping conditions and human judgment gates are critical to prevent metric-chasing drift.
+
 ## Relationship to other problems
 
 This problem does not exist in isolation. The closed-loop model described above intersects with several other open problems in the repo.
@@ -129,3 +144,5 @@ There is also a governance question: if production feedback can autonomously cre
 - What attribution confidence threshold separates an implementation-ready issue from a human-triage observation, and how is that confidence measured in practice?
 - Should signal-driven issue creation be gated behind human approval initially (shadow mode) before graduating to fully autonomous triage?
 - How do we ensure failure signals don't leak user-sensitive content from raw execution logs into agent context?
+- Should product discovery signals (user feedback clustering, usage patterns, A/B test results) feed into the same backlog as health signals, or should they be a separate, human-curated channel?
+- What prevents a product discovery feedback loop from optimizing for easily measurable metrics at the expense of harder-to-measure qualities like simplicity and long-term usability?

--- a/docs/problems/repo-readiness.md
+++ b/docs/problems/repo-readiness.md
@@ -15,6 +15,16 @@ Test coverage is necessary but not sufficient. For agents to merge autonomously,
 - **CODEOWNERS** — defines the human-required approval paths
 - **Language properties** — type safety, tooling ecosystem, and deployment simplicity affect how effectively agents can operate (see [agent-compatible-code.md](agent-compatible-code.md))
 
+## Backpressure as throughput investment
+
+The readiness criteria above are typically framed as prerequisites — things that must be true before agents can operate. But there's a more productive framing: these same mechanisms (type checkers, linters, test suites, build systems) function as **backpressure** that keeps agents self-correcting during operation.
+
+When a linter catches a style violation, the agent fixes it without human intervention. When a type checker rejects an invalid assignment, the agent corrects course immediately. When a test fails, the agent knows the implementation is wrong. Without backpressure, humans spend review time pointing out trivial mistakes. With it, agents self-correct and humans focus on architecture and judgment.
+
+This reframes readiness investment: improving CI infrastructure is not just a prerequisite for agent autonomy — it's a continuous investment in agent throughput. Every new lint rule, every type annotation, every test case increases the rate at which agents can produce correct output without human correction. Organizations that treat readiness as a one-time gate miss the compounding returns of ongoing backpressure investment.
+
+The implication for repo graduation: repos with stronger backpressure mechanisms can support higher autonomy tiers not just because they're "more ready," but because their agents produce fewer errors that require human attention per unit of work.
+
 ## Diagnostic tooling
 
 [agentready](https://github.com/ambient-code/agentready) can assess repos against research-backed criteria for AI-assisted development readiness. Recommended as a diagnostic step to generate a baseline readiness assessment across an org, but not a dependency for the agentic system itself.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -33,6 +33,14 @@ This project exists to explore these problems in a way that's applicable to any 
 
 OpenAI's [Harness engineering](https://openai.com/index/harness-engineering/) work demonstrates agents handling engineering tasks end-to-end with sandboxed execution and automated testing as primary guardrails. Our technology stack and constraints are different, but the ambition is similar.
 
+## The development system as a compounding asset
+
+In an agentic development model, the organization maintains two products simultaneously: the software it ships, and the development system that produces it. Skills, CI pipelines, context files, architectural constraints, testing infrastructure, lint rules — these are the tooling of the factory, and they compound.
+
+A team that spends a week improving test infrastructure ships future features faster — not because the tests themselves are the product, but because agents operating against stronger test suites produce correct output at higher rates with less human correction (see [repo-readiness: backpressure](problems/repo-readiness.md#backpressure-as-throughput-investment)). A team that writes a debugging skill lets agents resolve future incidents autonomously. Every investment in the development system multiplies the throughput of all future work done through it.
+
+This has a practical implication for how organizations allocate effort: time spent improving agent infrastructure, writing skills, strengthening CI, and refining codebase context is not overhead — it's product development for the development system itself. Organizations that recognize this and invest accordingly will see compounding returns in agent effectiveness.
+
 ## What this is not
 
 - Not a product spec. This is an exploration.


### PR DESCRIPTION
Add insights from analysis of production agent orchestration patterns and software factory concepts:

- repo-readiness: Add backpressure framing — CI/linting/type checking as continuous throughput investment, not just a prerequisite gate
- landscape: Add Stripe Minions and Gas Town as production agent orchestration systems, plus deterministic-then-agentic pipeline pattern
- production-feedback: Add product discovery signals section (user feedback clustering, usage patterns, A/B test interpretation) extending the feedback loop from reactive to proactive
- vision: Add 'development system as compounding asset' — the tooling that produces software is itself a product that compounds

Sources: alexop.dev/posts/the-software-factory/, stripe.dev/blog/minions, banay.me/dont-waste-your-backpressure/

Assisted-by: OpenCode claude-opus-4-6@default