### PR TITLE
Add make bootstrap target to install development tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,47 @@
 .DEFAULT_GOAL := help
-.PHONY: help lint check fmt lint-adr-status lint-adr-numbers lint-adr-frontmatter
+.PHONY: help bootstrap lint check fmt lint-adr-status lint-adr-numbers lint-adr-frontmatter
 
 help:
 	@echo "Available targets:"
 	@echo "  help                 - Show this help message"
+	@echo "  bootstrap            - Install all development tools"
 	@echo "  lint                 - Run all linting and validation"
 	@echo "  check                - Run ruff and ty checks on Python"
 	@echo "  fmt                  - Format Python code with ruff"
 	@echo "  lint-adr-status      - Validate ADR statuses in all ADR files"
 	@echo "  lint-adr-numbers     - Check for duplicate ADR numeric identifiers"
 	@echo "  lint-adr-frontmatter - Validate ADR frontmatter and cross-references"
+
+# Install all development tools needed for linting, formatting, and pre-commit hooks.
+# Prerequisites: uv (https://docs.astral.sh/uv/) and go (https://go.dev/)
+#
+# Installs tools to ~/.local/ so no root access is required.  Ensure
+# ~/.local/bin is on your PATH (most distros include this by default).
+BOOTSTRAP_TOOL_DIR := $(HOME)/.local/share/uv-tools
+BOOTSTRAP_BIN_DIR  := $(HOME)/.local/bin
+
+bootstrap:
+	@mkdir -p "$(BOOTSTRAP_BIN_DIR)"
+	@echo "==> Installing Python 3.12 (via uv)..."
+	uv python install 3.12
+	@echo "==> Installing ruff (linter/formatter)..."
+	UV_TOOL_DIR="$(BOOTSTRAP_TOOL_DIR)" UV_TOOL_BIN_DIR="$(BOOTSTRAP_BIN_DIR)" uv tool install ruff || \
+	UV_TOOL_DIR="$(BOOTSTRAP_TOOL_DIR)" UV_TOOL_BIN_DIR="$(BOOTSTRAP_BIN_DIR)" uv tool upgrade ruff
+	@echo "==> Installing ty (type checker)..."
+	UV_TOOL_DIR="$(BOOTSTRAP_TOOL_DIR)" UV_TOOL_BIN_DIR="$(BOOTSTRAP_BIN_DIR)" uv tool install ty || \
+	UV_TOOL_DIR="$(BOOTSTRAP_TOOL_DIR)" UV_TOOL_BIN_DIR="$(BOOTSTRAP_BIN_DIR)" uv tool upgrade ty
+	@echo "==> Installing pre-commit..."
+	UV_TOOL_DIR="$(BOOTSTRAP_TOOL_DIR)" UV_TOOL_BIN_DIR="$(BOOTSTRAP_BIN_DIR)" uv tool install pre-commit || \
+	UV_TOOL_DIR="$(BOOTSTRAP_TOOL_DIR)" UV_TOOL_BIN_DIR="$(BOOTSTRAP_BIN_DIR)" uv tool upgrade pre-commit
+	@echo "==> Installing actionlint (GitHub Actions linter)..."
+	GOBIN="$(BOOTSTRAP_BIN_DIR)" go install github.com/rhysd/actionlint/cmd/actionlint@latest
+	@echo "==> Installing gitleaks (secret scanner)..."
+	GOBIN="$(BOOTSTRAP_BIN_DIR)" go install github.com/zricethezav/gitleaks/v8@latest
+	@echo "==> Installing pre-commit hooks..."
+	PATH="$(BOOTSTRAP_BIN_DIR):$(PATH)" pre-commit install
+	@echo ""
+	@echo "==> Bootstrap complete!"
+	@echo "    Make sure $(BOOTSTRAP_BIN_DIR) is on your PATH."
 
 lint: check lint-adr-status lint-adr-numbers lint-adr-frontmatter
 


### PR DESCRIPTION
Identified tools needed for linting and pre-commit hooks that are not present in a fresh environment:

- ruff (Python linter/formatter, used by make lint and pre-commit)
- ty (Python type checker, used by make lint and pre-commit)
- pre-commit (git hook manager, used by .pre-commit-config.yaml)
- actionlint (GitHub Actions linter, used by pre-commit hook)
- gitleaks (secret scanner, used by pre-commit hook)
- Python 3.12 (required by .python-version)

The new bootstrap target installs all of these via uv (for Python tools) and go install (for Go binaries) into ~/.local/bin, requiring no root access. The target is idempotent and handles the case where tools are already installed.

Assisted-by: OpenCode claude-opus-4-6@default