### PR TITLE
ADR 0006: Forge abstraction layer

### DIFF
--- a/docs/ADRs/0006-forge-abstraction-layer.md
+++ b/docs/ADRs/0006-forge-abstraction-layer.md
@@ -1,0 +1,163 @@
+---
+title: "6. Forge abstraction layer"
+status: Proposed
+relates_to:
+  - agent-architecture
+  - agent-infrastructure
+topics:
+  - portability
+  - architecture
+  - tooling
+---
+
+# 6. Forge abstraction layer
+
+Date: 2026-03-27
+
+## Status
+
+Proposed
+
+## Context
+
+Fullsend currently targets GitHub-hosted organizations but intends to support
+GitLab and eventually Forgejo. Many components interact with forge-specific
+APIs: creating issues, opening pull/merge requests, applying labels, posting
+status checks, and reading CODEOWNERS. Branch protection configuration varies
+significantly across forges and is out of scope for the initial abstraction —
+it remains an unsolved portability problem.
+
+These interactions happen in two distinct contexts:
+
+1. **Agent runtime (LLM-driven).** The agent decides to open a PR, comment on
+   an issue, or check labels. LLM-based agents are naturally good at detecting
+   which forge they're on and using its native CLI (`gh`, `glab`, etc.).
+   Forcing them through an abstraction adds friction without clear benefit —
+   the agent adapts.
+
+2. **Deterministic code paths (scripted).** Two specific places run
+   deterministic, non-LLM code that must work across forges:
+   - The **agent runtime wrapper** — the script that runs inside the sandbox,
+     configures the harness, and launches the agent runtime. It reads issue
+     metadata, posts status updates, and fetches configuration. This code
+     must work identically regardless of forge.
+   - **Skill scripts** — scripts embedded in `scripts/` directories within
+     skills that agents invoke as tools. These are shipped by fullsend and
+     must be portable.
+
+The forge abstraction belongs in the deterministic code, not in the agent's
+mouth.
+
+## Options
+
+### Option 1: Abstraction everywhere
+
+A CLI tool that all forge interactions go through, including agent-initiated
+ones. Agent prompts say `fullsend pr create` instead of `gh pr create`.
+
+**Pros:**
+- Uniform interface everywhere. Easy to audit forge interactions.
+
+**Cons:**
+- Fights the LLM's natural behavior. Agents are good at using native CLIs.
+- Requires teaching every agent a non-standard CLI instead of leveraging
+  existing training data for `gh`, `glab`, etc.
+- The abstraction is only valuable in deterministic code paths where we control
+  the source. In agent-generated commands, the LLM adapts naturally.
+
+### Option 2: Abstraction in deterministic code only
+
+A shared library/module used by the agent runtime wrapper and skill scripts.
+Agents themselves use whatever forge CLI is available.
+
+**Pros:**
+- Forge portability where it matters (our code), natural behavior where it
+  doesn't (agent-generated commands).
+- Fewer moving parts — no CLI binary to distribute, just a library used by
+  code we already ship.
+- Agents benefit from their training data on `gh`, `glab`, etc.
+
+**Cons:**
+- Agents may use forge-specific features that don't exist on other forges. This
+  is acceptable — agent prompts can be tuned per-forge if needed, and the
+  harness can provide forge-appropriate context.
+
+### Option 3: No abstraction — accept GitHub coupling
+
+Use `gh` and GitHub APIs everywhere, including deterministic code.
+
+**Pros:**
+- Simplest now.
+
+**Cons:**
+- Porting the runtime wrapper and skill scripts to GitLab requires rewriting
+  every forge interaction in those code paths.
+
+## Decision
+
+Forge-specific interactions are abstracted in the two deterministic code paths
+that fullsend controls: the **agent runtime wrapper** and **skill scripts**.
+Agents themselves are free to use native forge CLIs.
+
+### Where the abstraction lives
+
+A shared library (working name: `forgekit`) provides functions for the forge
+operations that deterministic code needs:
+
+- Issue operations: read metadata, apply labels, post comments
+- PR/MR operations: create, update status, post review comments
+- Status checks: post pass/fail results
+- Code ownership: query CODEOWNERS / equivalent
+- Repository metadata: default branch, permissions, clone URLs
+
+The agent runtime wrapper and skill scripts import this library. The library
+detects the forge type from the repo's remote URL or from configuration in the
+`.fullsend` repo, and dispatches to the appropriate backend.
+
+### What agents do
+
+Agents use whatever forge CLI is available in the sandbox (`gh`, `glab`, etc.).
+The harness provides forge-appropriate context so agents know which system
+they're on, but agents are not forced through an abstraction layer. LLMs are
+naturally effective at using native CLIs based on their training data.
+
+### Key design points
+
+- **Labels are fullsend vocabulary.** Labels used as control signals (e.g.,
+  "agent-ready", "not-reproducible") are part of the fullsend vocabulary.
+  The library maps them to the appropriate forge mechanism. Agents may also
+  apply these labels using native CLIs — the label names are the contract,
+  not the mechanism.
+- **CODEOWNERS parsing is wrapped.** Different forges have different syntax
+  for code ownership. The library abstracts this behind a uniform query
+  interface for use by the runtime wrapper and review logic.
+- **Skill scripts use the library, not forge CLIs.** Any `scripts/` shipped
+  with fullsend skills call `forgekit` functions, making skills portable
+  without rewriting.
+
+## Consequences
+
+- **Deterministic code is forge-portable.** The runtime wrapper and skill
+  scripts work across GitHub, GitLab, and Forgejo without modification.
+- **Agent prompts are forge-aware, not forge-abstracted.** Agent definitions
+  may include forge-specific context (e.g., "you are working on a GitHub
+  repo, use `gh` for forge operations"), but this is a harness concern, not
+  an architectural constraint.
+- **New forge backends require implementing the library adapter.** Adding
+  GitLab or Forgejo support means implementing `forgekit` backends and
+  ensuring the right forge CLI is available in the sandbox.
+- **The library is a fullsend deliverable** that must be versioned and tested,
+  but it is simpler than a standalone CLI since it only needs to support the
+  operations used by deterministic code paths.
+- **The agent dispatch and coordination layer uses this library.** It runs
+  deterministic code that interacts with forge APIs for event processing and
+  work assignment — it goes through `forgekit`, not forge APIs directly.
+- **The Agent Identity Provider uses this library for credential issuance.**
+  `forgekit` is responsible for making agent identity credentials available to
+  the agent runtime (e.g., generating scoped tokens from a GitHub App or
+  equivalent). The sandbox is responsible for making those scoped tokens
+  available to the layers it controls (harness and runtime).
+- **Branch protection remains an unsolved portability problem.** Branch
+  protection rules vary significantly across forges in both semantics and
+  configuration mechanisms. The initial `forgekit` abstraction does not attempt
+  to unify branch protection management.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ This is the thing that actually reasons and acts. Everything else in this docume
 
 ## Agent Identity Provider
 
-The system that gives agents credentials to act on external services. Responsible for issuing, scoping, rotating, and revoking the identities agents use to interact with GitHub, container registries, and other APIs.
+The system that gives agents credentials to act on external services. Responsible for issuing, scoping, rotating, and revoking the identities agents use to interact with the hosting forge, container registries, and other APIs. Credential issuance is deterministic code; `forgekit` handles forge-portable token generation (e.g., GitHub App installation tokens vs. GitLab project access tokens). The sandbox makes scoped tokens available to the layers it controls (harness and runtime). (See [ADR 0006](ADRs/0006-forge-abstraction-layer.md).)
 
 Identity is not the same as trust. An agent's identity lets it authenticate to external services; the trust model is defined by repository permissions and CODEOWNERS, not by which credentials the agent holds. (See [agent-architecture.md](problems/agent-architecture.md) — "trust derives from repository permissions, not agent identity.")
 
@@ -89,15 +89,27 @@ Identity is not the same as trust. An agent's identity lets it authenticate to e
 - How are credentials rotated and revoked, and who has authority to do that?
 - Does the identity provider integrate with existing secrets management, or is it a new system?
 
-## Agent Dispatch and Coordination Layer
+## Forge Abstraction Layer
 
-The mechanism that assigns work to agents and prevents conflicts. Responsible for translating triggers (GitHub events, schedules, manual requests) into agent tasks and ensuring two agents don't work the same problem simultaneously.
+The boundary between fullsend's deterministic code and the hosting forge (GitHub, GitLab, Forgejo). A shared library (`forgekit`) provides a uniform interface to forge operations — issues, pull/merge requests, labels, status checks, and code ownership queries.
 
-The existing design principle is that [the repo is the coordinator](problems/agent-architecture.md#interaction-model-the-repo-as-coordinator) — branch protection, CODEOWNERS, status checks, and GitHub events provide coordination without a central orchestrator. The agent dispatch and coordination layer may be nothing more than the glue that connects GitHub webhooks to agent infrastructure. Or it may need to be more.
+The abstraction applies to two specific code paths: the **agent runtime wrapper** (the script inside the sandbox that configures the harness and launches the agent) and **skill scripts** (deterministic scripts embedded in fullsend-shipped skills). These are the code paths fullsend controls and must be forge-portable. Agents themselves use native forge CLIs (`gh`, `glab`, etc.) — LLMs are naturally effective at adapting to the forge they're working with. (See [ADR 0006](ADRs/0006-forge-abstraction-layer.md).)
 
 **Open questions:**
 
-- Is GitHub's event system sufficient, or do we need additional coordination logic (e.g. to prevent two implementation agents from picking up the same issue)?
+- What is the right implementation language for the library?
+- How does the library authenticate — does it receive credentials from the Agent Identity Provider, or discover them from the environment?
+- How are forge-specific features that have no cross-forge equivalent handled — silently ignored, explicitly errored, or degraded gracefully?
+
+## Agent Dispatch and Coordination Layer
+
+The mechanism that assigns work to agents and prevents conflicts. Responsible for translating triggers (forge events, schedules, manual requests) into agent tasks and ensuring two agents don't work the same problem simultaneously.
+
+The existing design principle is that [the repo is the coordinator](problems/agent-architecture.md#interaction-model-the-repo-as-coordinator) — branch protection, CODEOWNERS, status checks, and forge events provide coordination without a central orchestrator. The agent dispatch and coordination layer may be nothing more than the glue that connects forge webhooks to agent infrastructure. Or it may need to be more.
+
+**Open questions:**
+
+- Is the forge's event system sufficient, or do we need additional coordination logic (e.g. to prevent two implementation agents from picking up the same issue)?
 - How does work assignment interact with the backlog/priority agent described in [agent-architecture.md](problems/agent-architecture.md)?
 - What happens when work needs to be cancelled, retried, or reassigned?
 - Does the coordinator need state (a queue, a lock, a claim system), or can it be stateless and event-driven?


### PR DESCRIPTION
## Summary

- Deterministic code paths (agent runtime wrapper and skill scripts) use a shared library (forgekit) for forge-portable operations
- Agents themselves use native forge CLIs (gh, glab, etc.) — LLMs adapt naturally
- Updates Identity Provider to clarify forgekit handles credential issuance
- Branch protection called out as unsolved portability problem
- Adds Forge Abstraction Layer section to architecture.md

## Dependencies

- Depends on #104 (ADR 0005: Unidirectional control flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)