### PR TITLE
Make ADR options section optional instead of required

### DIFF
--- a/docs/ADRs/0000-adr-template.md
+++ b/docs/ADRs/0000-adr-template.md
@@ -21,13 +21,11 @@ What is the issue that we're seeing that motivates this decision or change?
 
 ## Options
 
-_Required for Undecided ADRs. Describe the options under consideration without
-choosing one yet. Each option should have a brief description and known
-trade-offs._
-
-### Option 1: ...
-
-### Option 2: ...
+_Optional. Include only when there are genuine alternatives worth documenting.
+For Undecided ADRs, describe the options under consideration without choosing
+one yet. For Proposed or Accepted ADRs, include only if the rejected
+alternatives add useful context. If the decision is obvious, skip this
+section._
 
 ## Decision
 

--- a/skills/writing-adrs/SKILL.md
+++ b/skills/writing-adrs/SKILL.md
@@ -17,7 +17,7 @@ are point-in-time records (immutable once accepted).
 ## When to Use
 
 - A specific decision has emerged from discussion in a problem doc
-- You need to frame an upcoming decision with options (Undecided status)
+- You need to frame an upcoming decision (Undecided status)
 - An ADR has been accepted and living documents need updating
 
 Do NOT use for open-ended exploration -- that belongs in problem docs.
@@ -42,7 +42,7 @@ decide..." or "We also require...", stop. That is a second ADR.
 | Section | Target | Anti-pattern |
 |---------|--------|-------------|
 | Context | 1-3 paragraphs | Restating entire problem docs |
-| Options | 1 paragraph each | Multi-page analysis per option |
+| Options (if any) | 1 paragraph each | Multi-page analysis per option |
 | Decision | Direct statement + brief rationale | Burying the decision in prose |
 | Consequences | 3-5 one-sentence bullets | Essay-length explanations |
 
@@ -75,9 +75,10 @@ Follow these steps in order:
    apply to all problem areas. The `status` in frontmatter must match the
    `## Status` heading in the body (the linter enforces this).
 4. **Choose the right status.** Use **Proposed** for a draft awaiting
-   discussion. Use **Undecided** when the problem is identified and options are
-   described but no choice has been made -- Undecided ADRs must include an
-   Options section. Use **Accepted** when the decision is made.
+   discussion. Use **Undecided** when the problem is identified but no choice
+   has been made. Use **Accepted** when the decision is made. Include an
+   Options section only when there are genuine alternatives worth documenting;
+   if the decision is obvious, just decide it.
 5. **Write the ADR.** Follow the conciseness rules above.
 6. **Run linters.** Execute `make lint` and fix any errors before committing.
 7. **If status is Accepted, update living documents** (see below).


### PR DESCRIPTION
Drop the requirement for multiple options from the ADR template and writing-adrs skill. The Options section is now optional -- include it only when there are genuine alternatives worth documenting. If the decision is obvious, just decide it.

This avoids needlessly wordy ADRs that enumerate options for the sake of the template rather than because the alternatives add real value.

Assisted-by: OpenCode claude-opus-4-6@default