### PR TITLE
feat: add release workflow with GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,36 @@
+version: 2
+
+builds:
+  - main: ./cmd/fullsend/
+    binary: fullsend
+    ldflags:
+      - -s -w -X github.com/fullsend-ai/fullsend/internal/cli.version={{.Version}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+release:
+  github:
+    owner: fullsend-ai
+    name: fullsend

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ lint-adr-frontmatter:
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 
 go-build:
-	go build -ldflags "-X main.version=$(VERSION)" -o bin/fullsend ./cmd/fullsend/
+	go build -ldflags "-X github.com/fullsend-ai/fullsend/internal/cli.version=$(VERSION)" -o bin/fullsend ./cmd/fullsend/
 
 go-test:
 	go test -race -cover ./...


### PR DESCRIPTION
## Summary

Adds automated release infrastructure so that pushing a semver tag (e.g. `git tag v0.1.0 && git push origin v0.1.0`) cross-compiles the `fullsend` binary and publishes a GitHub Release with downloadable assets.

- **`.goreleaser.yml`** — GoReleaser v2 config targeting linux and darwin on amd64/arm64, with checksums and a filtered changelog
- **`.github/workflows/release.yml`** — triggers on `v*` tags, runs GoReleaser to build and publish
- **`Makefile` fix** — corrects the `-ldflags` path from `main.version` to `github.com/fullsend-ai/fullsend/internal/cli.version` so `fullsend --version` reports correctly in local builds too

## How to use

```bash
# Tag a release on main
git tag v0.1.0
git push origin v0.1.0

# The workflow builds and publishes automatically.
# Users download with:
gh release download v0.1.0 --repo fullsend-ai/fullsend --pattern '*linux_amd64*'
```

## Test plan

- [x] `make go-build && ./bin/fullsend --version` reports the git-described version
- [ ] After merge, push a `v0.0.1-rc.1` tag to verify the workflow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)