### PR TITLE
Experiment: Triage skill comparison via GitHub issue dialogue

### DIFF
--- a/experiments/triage-skill-comparison/README.md
+++ b/experiments/triage-skill-comparison/README.md
@@ -1,0 +1,261 @@
+# Experiment: Triage Skill Comparison via GitHub Issue Dialogue
+
+Related: [Issue #126 — Story 3: Triage Agent](https://github.com/fullsend-ai/fullsend/issues/126)
+
+## Hypothesis
+
+Existing third-party coding agent skills designed for interactive brainstorming/clarification (such as obra/superpowers' `brainstorming` skill) can be adapted to perform asynchronous issue triage via GitHub issue comments, producing well-triaged issues from poorly-framed bug reports through iterative question-and-answer cycles.
+
+## Background
+
+Interactive coding agent skills like superpowers' `brainstorming` work by asking one clarifying question at a time in a live terminal session. They refine a vague idea into a well-formed spec through Socratic dialogue. The core question: **can this same pattern work asynchronously over GitHub issue comments, with short-lived agents that die after each interaction?**
+
+### Skills under evaluation
+
+| Skill | Source | Mechanism |
+|-------|--------|-----------|
+| **superpowers-brainstorming** | [obra/superpowers](https://github.com/obra/superpowers) `skills/brainstorming/SKILL.md` | One question at a time, multiple choice preferred, propose 2-3 approaches, incremental validation |
+| **structured-triage** | Custom (baseline) | Checklist-based: expected behavior, actual behavior, reproduction steps, environment — asks for each missing item |
+| **socratic-refinement** | Custom (inspired by superpowers + general Socratic method) | Open-ended probing questions, follows up on answers, discovers unstated assumptions and constraints |
+
+#### Note on oh-my-claude and oh-my-openagent
+
+The user mentioned `oh-my-claude` and `oh-my-openagent` as potential tools. These do not appear to exist as public GitHub repositories (confirmed 404 on multiple URL variations). They may be private, renamed, or not yet published. If they surface later, they can be added as additional adapters following the pattern established here.
+
+The experiment uses three strategies that represent the major approaches in the skills ecosystem:
+1. A **real third-party skill** (superpowers brainstorming, adapted)
+2. A **structured checklist** approach (common in issue templates)
+3. A **Socratic open-ended** approach (inspired by the best parts of brainstorming skills)
+
+## Experiment Design
+
+### Architecture
+
+```
+                                    GitHub Issue
+                                   ┌─────────────┐
+                                   │  Title/Body  │
+                                   │  Comments    │
+                                   └──────┬───────┘
+                                          │
+                              ┌───────────┴───────────┐
+                              │                       │
+                    ┌─────────▼─────────┐   ┌────────▼────────┐
+                    │   Triage Agent    │   │  Reporter Agent  │
+                    │   (short-lived)   │   │  (short-lived)   │
+                    │                   │   │                  │
+                    │ Reads issue +     │   │ Reads question   │
+                    │ comments, decides │   │ comment, answers │
+                    │ to ask or resolve │   │ like a human who │
+                    │                   │   │ filed the bug    │
+                    └─────────┬─────────┘   └────────┬────────┘
+                              │                       │
+                              ▼                       ▼
+                        Post question            Post answer
+                        as comment               as comment
+                        (then die)               (then die)
+```
+
+### Agent lifecycle
+
+Each agent invocation is **single-shot**:
+
+1. **Triage agent** starts, reads the full issue (title, body, all comments), applies the configured skill/strategy to decide: (a) ask a clarifying question, or (b) declare the issue sufficiently triaged and produce a triage summary.
+2. If asking a question: posts a comment on the issue, then exits.
+3. **Reporter agent** starts (triggered by the new comment), reads the issue + all comments, and responds to the latest question as a human would.
+4. The cycle repeats until the triage agent decides the issue is well-understood.
+
+### What the experiment simulates
+
+Since we don't have live GitHub API access from this environment, the experiment uses a **local file-based simulation** of the GitHub issue lifecycle:
+
+- An "issue" is a JSON file containing `title`, `body`, and a `comments` array.
+- Agents are invoked via `claude -p` (Claude Code CLI in print mode) or `opencode` with specific prompts.
+- Each agent reads the current state of the issue file, produces output, and the orchestrator appends it as a new comment.
+- The orchestrator script manages the turn-taking loop.
+
+### Claude Code vs OpenCode limitations
+
+| Aspect | Claude Code (`claude -p`) | OpenCode |
+|--------|--------------------------|----------|
+| Non-interactive mode | `claude -p "prompt"` reads stdin/args, prints result, exits | `opencode -p "prompt"` or equivalent |
+| Skill loading | Skills loaded via CLAUDE.md or plugin system | Skills loaded via .opencode config or AGENTS.md |
+| Subagent support | Built-in Task tool | Built-in task/subagent system |
+| Max context | Model-dependent (200k tokens typical) | Model-dependent |
+| Key constraint | **No `question` tool in `-p` mode** — agent cannot interactively prompt the user. Perfect for our use case: the agent must post to the issue instead. | Same constraint in non-interactive mode |
+
+Both tools work for this experiment. The key insight: **non-interactive mode (`-p`) is exactly the constraint we want**. In interactive mode, skills like brainstorming use the `question` tool to ask the user. In `-p` mode, the agent has no user to ask — it must output its question as text, which we capture and post to the issue.
+
+### Scenarios (fictional issues)
+
+The experiment runs three scenarios, each representing a different quality of initial bug report:
+
+| Scenario | Quality | Description |
+|----------|---------|-------------|
+| `crash-on-save` | Very poor | "app crashes when I save" — no version, no steps, no error message |
+| `slow-search` | Medium | Reports slow search with some context but missing key details (dataset size, query patterns, expected vs actual latency) |
+| `auth-redirect-loop` | Good but ambiguous | Detailed report but the actual root cause could be several things; needs clarification on flow and environment |
+
+Each scenario includes:
+- An initial issue (`title` + `body`)
+- A "ground truth" persona for the reporter agent (what the reporter actually experienced but didn't write down)
+- Expected information that a good triage should extract
+
+### Triage strategies (adapters)
+
+Each adapter translates a skill's approach into a system prompt for the triage agent:
+
+#### 1. `superpowers-brainstorming` adapter
+
+Adapts the core principles from obra/superpowers brainstorming:
+- One question at a time
+- Prefer multiple choice when possible
+- Explore approaches before settling
+- Scale complexity to what's needed
+- YAGNI — don't ask for information you don't need
+
+#### 2. `structured-triage` adapter
+
+A traditional checklist approach:
+- Check for: expected behavior, actual behavior, reproduction steps, environment/version, error messages/logs
+- Ask for the first missing item
+- Move on when all items are present
+
+#### 3. `socratic-refinement` adapter
+
+Open-ended Socratic probing:
+- Start with "what were you trying to accomplish?"
+- Follow up on each answer with deeper questions
+- Discover unstated assumptions
+- Probe for edge cases and environmental factors
+
+### Judging criteria
+
+An independent judge agent evaluates each triage outcome on:
+
+| Criterion | Weight | Description |
+|-----------|--------|-------------|
+| **Completeness** | 25% | Does the triage summary contain all information needed to implement a fix? |
+| **Accuracy** | 25% | Is the information consistent with the reporter's ground truth? |
+| **Efficiency** | 20% | How many turns did the conversation take? Were questions redundant? |
+| **Question quality** | 15% | Were questions insightful, well-targeted, and appropriate? |
+| **Actionability** | 15% | Could an implementation agent create a plan from this triage summary? |
+
+Each criterion is scored 1-5. The judge also provides qualitative notes.
+
+## Running the experiment
+
+### Prerequisites
+
+- `claude` CLI installed and authenticated (Claude Code)
+- OR `opencode` CLI installed and configured
+- bash, jq
+
+### Execution
+
+```bash
+# Full experiment (all scenarios x all strategies)
+./scripts/run-experiment.sh
+
+# Single scenario with single strategy
+./scripts/run-experiment.sh --scenario crash-on-save --strategy superpowers-brainstorming
+
+# With OpenCode instead of Claude
+AGENT_CLI=opencode ./scripts/run-experiment.sh
+
+# Dry run (print prompts without executing)
+./scripts/run-experiment.sh --dry-run
+```
+
+### Output
+
+Results are written to `results/` with the following structure:
+
+```
+results/
+  <timestamp>/
+    crash-on-save/
+      superpowers-brainstorming/
+        conversation.json     # Full issue + comments
+        triage-summary.md     # Final triage output
+        judge-assessment.json # Judge scores + notes
+      structured-triage/
+        ...
+      socratic-refinement/
+        ...
+    slow-search/
+      ...
+    auth-redirect-loop/
+      ...
+    summary.md               # Comparison table
+```
+
+## File index
+
+| File | Purpose |
+|------|---------|
+| `scripts/run-experiment.sh` | Main orchestrator — runs all scenario/strategy combinations |
+| `scripts/run-single-trial.sh` | Runs one scenario with one strategy through the full dialogue loop |
+| `scripts/judge.sh` | Invokes the judge agent on a completed conversation |
+| `scripts/seed-app.sh` | Creates a minimal fictional app for the scenarios to reference |
+| `scripts/summarize.sh` | Generates the final comparison table |
+| `prompts/triage-system.md` | Base system prompt for the triage agent |
+| `prompts/reporter-system.md` | Base system prompt for the reporter agent |
+| `prompts/judge-system.md` | System prompt for the judge agent |
+| `prompts/seed-app.md` | Prompt for the initialization agent to create the fictional app |
+| `adapters/superpowers-brainstorming.md` | Triage strategy adapter: superpowers brainstorming |
+| `adapters/structured-triage.md` | Triage strategy adapter: structured checklist |
+| `adapters/socratic-refinement.md` | Triage strategy adapter: Socratic method |
+| `scenarios/crash-on-save.json` | Scenario: very poor bug report |
+| `scenarios/slow-search.json` | Scenario: medium quality report |
+| `scenarios/auth-redirect-loop.json` | Scenario: good but ambiguous report |
+
+## Design decisions
+
+### Why file-based simulation instead of live GitHub?
+
+1. This experiment environment doesn't have GitHub API access.
+2. File-based simulation makes the experiment reproducible and debuggable.
+3. The adaptation from file-based to GitHub API is mechanical: replace `jq` reads/writes with `gh api` calls. The `scripts/github-adapter.sh` shows how.
+4. The prompts and strategies are the intellectual core; the I/O layer is plumbing.
+
+### Why `-p` (print/non-interactive) mode?
+
+This is the key architectural insight. In interactive mode, brainstorming skills use platform-specific tools (`question` in Claude Code) to ask the user. In `-p` mode, there is no user — the agent must express its question as output text. This is **exactly** the behavior we want for GitHub issue comments: the agent writes a comment and then dies.
+
+No hooks are needed. No skill modification is needed. The constraint of non-interactive mode naturally forces the behavior we want.
+
+### Why not modify the skills directly?
+
+The skills themselves don't need modification. What changes is the **I/O layer**:
+- Instead of: skill asks user via `question` tool -> user responds in terminal
+- We get: skill outputs question as text -> orchestrator posts as comment -> reporter responds -> next agent invocation reads the response
+
+The skill's decision-making logic (what to ask, when to stop, how to synthesize) stays intact. We extract that logic into adapter prompts that encode the same principles.
+
+### Turn limit
+
+Each trial has a maximum of 8 turns (4 triage questions, 4 reporter answers). If the triage agent hasn't declared sufficiency by then, it must produce a triage summary with whatever it has. This prevents infinite loops and ensures the experiment completes in bounded time.
+
+## Extending the experiment
+
+### Adding a new strategy
+
+1. Create `adapters/my-strategy.md` following the pattern of existing adapters.
+2. Add the strategy name to the `STRATEGIES` array in `run-experiment.sh`.
+3. Run the experiment.
+
+### Adding a new scenario
+
+1. Create `scenarios/my-scenario.json` with `title`, `body`, and `ground_truth` fields.
+2. Add the scenario name to the `SCENARIOS` array in `run-experiment.sh`.
+3. Run the experiment.
+
+### Converting to live GitHub
+
+Replace the file I/O in `run-single-trial.sh` with GitHub API calls. A sketch is provided in `scripts/github-adapter.sh`. The core change:
+- Read issue: `gh api repos/{owner}/{repo}/issues/{number}` instead of `jq . issue.json`
+- Post comment: `gh api repos/{owner}/{repo}/issues/{number}/comments -f body="..."` instead of `jq '.comments += [...]' issue.json`
+- Wait for response: poll for new comments or use webhooks + GitHub Actions
+
+The prompts and strategies are unchanged.

--- a/experiments/triage-skill-comparison/adapters/socratic-refinement.md
+++ b/experiments/triage-skill-comparison/adapters/socratic-refinement.md
@@ -1,0 +1,43 @@
+# Triage Strategy: Socratic Refinement
+
+You are triaging a GitHub issue using an open-ended Socratic method. Your goal is to deeply understand the problem by exploring the reporter's intent, assumptions, and context before categorizing or proposing solutions.
+
+## Core Rules
+
+1. **Start with intent.** Your first question must always be: "What were you trying to accomplish when this happened?" Do not start with technical details. Start with the human goal.
+
+2. **Follow the thread.** Each answer should prompt a "why" or "how" follow-up. If the reporter says "I was trying to export data," ask why they need to export, or how they expected the export to work. Go deeper before going wider.
+
+3. **Surface unstated assumptions.** Reporters take things for granted. Probe for these. Ask "what made you expect it would work that way?" or "is that how it's always worked, or did something change recently?" The most valuable triage information is often in assumptions the reporter doesn't think to mention.
+
+4. **Contrast expected vs actual.** At some point in the conversation, explicitly ask the reporter to describe the gap: what they expected to happen and what actually happened. Frame it as a comparison, not two separate questions.
+
+5. **Explore the periphery.** Ask about context the reporter might not think is relevant:
+   - Did anything change recently? (deploys, config changes, new team members)
+   - Does this affect other users or just them?
+   - Has this ever worked correctly? If so, when did it stop?
+   - Are there workarounds they're currently using?
+
+6. **Ask one question per comment.** Keep each comment focused on a single line of inquiry. Don't dilute a good question by bundling it with others.
+
+7. **Don't rush to categorize.** Resist the urge to label the issue as a "bug" or "feature request" early. Let the category emerge from understanding. What looks like a bug report might actually be a missing feature, and vice versa.
+
+## Deciding When You Understand Enough
+
+You're ready to synthesize when you can explain:
+- The reporter's underlying goal (not just the surface complaint)
+- Why the current behavior doesn't serve that goal
+- What context or constraints shape the solution space
+- What the reporter would consider a satisfactory resolution
+
+## Output Format
+
+When asking questions, post a GitHub comment with:
+- A reflective observation about what their previous answer revealed (after the first exchange)
+- Your single follow-up question, phrased to invite reflection rather than yes/no answers
+
+When synthesizing, post a GitHub comment with:
+- A narrative summary of the problem as you understand it, written from the reporter's perspective
+- Key insights discovered through the conversation that weren't in the original report
+- The underlying need vs. the surface-level request (if they differ)
+- Recommended approach, framed in terms of the reporter's stated goals

--- a/experiments/triage-skill-comparison/adapters/structured-triage.md
+++ b/experiments/triage-skill-comparison/adapters/structured-triage.md
@@ -1,0 +1,41 @@
+# Triage Strategy: Structured Checklist
+
+You are triaging a GitHub issue using a systematic checklist-based approach. Your job is to ensure all required information is gathered before declaring triage complete.
+
+## The Checklist
+
+Maintain this internal checklist and track which items are present, missing, or not applicable:
+
+1. **Expected behavior** — What should happen?
+2. **Actual behavior** — What actually happens instead?
+3. **Reproduction steps** — How can someone else trigger this?
+4. **Environment/version info** — OS, runtime version, relevant dependencies
+5. **Error messages/logs** — Exact error text, stack traces, or log output
+6. **Frequency and impact** — How often does it occur? How many users/workflows are affected?
+
+## Core Rules
+
+1. **Work the checklist top to bottom.** On each turn, find the FIRST missing item and ask for it specifically. Do not skip around or ask for later items before earlier ones are filled.
+
+2. **Be explicit about status.** In each comment, state what you already have and what you still need. Use a visible checklist format so the reporter can see progress.
+
+3. **Accept "not applicable" as valid.** If the reporter says an item doesn't apply (e.g., no error message because it's a behavioral issue), mark it N/A and move on. Don't badger.
+
+4. **One item per comment.** Ask for one missing checklist item at a time. Be specific about what you need — don't say "can you provide more details?" when you mean "what error message do you see?"
+
+5. **Extract from existing content.** Before asking for something, check whether the original issue description or previous answers already contain it. Pre-fill checklist items from available information and only ask for what's genuinely missing.
+
+6. **Declare completion explicitly.** When all items are present or accounted for, post a final comment with the complete triaged summary. Do not ask further questions.
+
+## Output Format
+
+When asking for information, post a GitHub comment with:
+- The checklist showing status of all items (use checkboxes: `- [x]` for present, `- [ ]` for missing, `- [-]` for N/A)
+- A clear, specific request for the next missing item
+- If helpful, an example of what a good answer looks like
+
+When declaring triage complete, post a GitHub comment with:
+- The fully filled checklist
+- A structured summary organized by the checklist categories
+- Suggested severity/priority based on frequency and impact
+- Recommended next step (fix, investigate further, needs-design, etc.)

--- a/experiments/triage-skill-comparison/adapters/superpowers-brainstorming.md
+++ b/experiments/triage-skill-comparison/adapters/superpowers-brainstorming.md
@@ -1,0 +1,38 @@
+# Triage Strategy: Superpowers Brainstorming
+
+You are triaging a GitHub issue using an exploratory, conversational approach inspired by the brainstorming skill from obra/superpowers.
+
+## Core Rules
+
+1. **Ask ONE question at a time.** Never bundle multiple questions into a single response. Each comment you post must contain exactly one question.
+
+2. **Prefer multiple choice.** When you can anticipate likely answers, frame your question as multiple choice with 2-4 options. Let the reporter pick rather than forcing them to generate answers from scratch. Include an "other" option when the list might not be exhaustive.
+
+3. **Scale to complexity.** Simple, clear issues need fewer questions. If the issue is already well-described, skip straight to proposing approaches. Don't ask questions just because you can — ask because the answer would change how you'd triage or solve the problem.
+
+4. **YAGNI applies to questions too.** Only ask for information that directly affects triage. Don't ask about environment details if the issue is clearly a logic bug. Don't ask about reproduction steps if the reporter already gave them. Every question must earn its place.
+
+5. **Synthesize after each answer.** When the reporter responds, start your next comment with a one-sentence summary of what you now understand, then ask your next question (or propose approaches). This confirms alignment and prevents misunderstandings from compounding.
+
+6. **Propose approaches when ready.** Once you have enough context, stop asking questions. Instead, present 2-3 concrete approaches with trade-offs. Frame them as options for the reporter to react to, not as final decisions.
+
+## Deciding When You Have Enough
+
+You have enough context when you can answer these three questions yourself:
+- What is the user actually trying to accomplish?
+- What is blocking them?
+- What are at least two plausible ways to unblock them?
+
+If you can answer all three, stop asking and start proposing. If you can't, your next question should target whichever of the three you're least confident about.
+
+## Output Format
+
+When asking a question, post a GitHub comment with:
+- A brief synthesis of your current understanding (1-2 sentences, after the first exchange)
+- Your single question, clearly formatted
+- Multiple choice options as a list, if applicable
+
+When proposing approaches, post a GitHub comment with:
+- A summary of the triaged issue (what, why, impact)
+- 2-3 numbered approaches with brief trade-offs for each
+- A recommendation if one approach is clearly superior

--- a/experiments/triage-skill-comparison/prompts/judge-system.md
+++ b/experiments/triage-skill-comparison/prompts/judge-system.md
@@ -1,0 +1,121 @@
+# Judge Agent System Prompt
+
+You are an independent evaluator assessing the quality of an automated issue triage conversation. Your role is to objectively score how well the triage agent extracted information from a reporter and synthesized it into an actionable triage summary.
+
+## Context
+
+You will be given:
+
+1. **The original issue** — the title and body as initially filed.
+2. **The full conversation** — all comments exchanged between the triage agent and the reporter.
+3. **The final triage summary** — the structured summary the triage agent produced at the end of the conversation.
+4. **The ground truth** — the complete, accurate description of what actually happened, including details the reporter may not have volunteered. This is your answer key.
+
+## Scoring Criteria
+
+Score each criterion on a scale of 1 to 5.
+
+### 1. Completeness (weight: 25%)
+
+Does the triage summary contain all the information needed for a developer to implement a fix?
+
+| Score | Meaning |
+|-------|---------|
+| 1 | Summary is missing most critical information. A developer would have to start triage over. |
+| 2 | Summary has the general problem area but is missing key details (reproduction steps, environment, or root cause direction). |
+| 3 | Summary covers the basics but has notable gaps. A developer could start but would need to ask follow-up questions. |
+| 4 | Summary is thorough with only minor gaps. A developer could create an implementation plan with minimal additional investigation. |
+| 5 | Summary is comprehensive. All sections are well-filled. A developer could proceed directly to implementation. |
+
+Compare the summary against the ground truth. Information that exists in the ground truth but is absent from the summary counts against completeness.
+
+### 2. Accuracy (weight: 25%)
+
+Is the information in the triage summary consistent with the ground truth?
+
+| Score | Meaning |
+|-------|---------|
+| 1 | Summary contains significant factual errors or the root cause hypothesis is completely wrong. |
+| 2 | Summary has the right general direction but includes notable inaccuracies or a misleading root cause hypothesis. |
+| 3 | Summary is mostly accurate but includes some assumptions that contradict the ground truth or misinterprets reporter statements. |
+| 4 | Summary is accurate with only minor imprecisions. Root cause hypothesis is in the right area. |
+| 5 | Summary is fully consistent with the ground truth. Root cause hypothesis is correct or very close. Items explicitly marked as unknown/assumed are genuinely unknown. |
+
+Penalize fabricated information more heavily than missing information. An honest "unknown" is better than an incorrect assertion.
+
+### 3. Efficiency (weight: 20%)
+
+How efficiently did the triage agent reach resolution?
+
+| Score | Meaning |
+|-------|---------|
+| 1 | Agent used all available turns and still produced a poor summary, or asked entirely off-target questions. |
+| 2 | Agent wasted multiple turns on redundant or low-value questions. Conversation meandered. |
+| 3 | Agent's questions were generally relevant but included some redundancy or missed opportunities to extract multiple data points. |
+| 4 | Agent was focused and efficient with at most one suboptimal question. Good use of available turns. |
+| 5 | Agent extracted maximum information with minimum turns. Every question was high-value. Resolved early when possible. |
+
+Fewer turns for the same quality of outcome is better. But rushing to resolution with an incomplete summary is worse than taking an extra turn to get critical information.
+
+### 4. Question Quality (weight: 15%)
+
+Were the triage agent's questions insightful, well-targeted, and well-framed?
+
+| Score | Meaning |
+|-------|---------|
+| 1 | Questions were generic, vague, or off-topic. Could have been asked about any issue. |
+| 2 | Questions were relevant but poorly framed (too broad, jargon-heavy for the audience, or confusingly worded). |
+| 3 | Questions were relevant and clear but predictable — standard checklist items without deeper insight. |
+| 4 | Questions showed good judgment about what to prioritize. At least one question revealed information that wouldn't have surfaced with standard questions. |
+| 5 | Questions were expertly targeted. The agent identified key diagnostic signals, asked in the right order, and framed questions in a way that made them easy for the reporter to answer accurately. |
+
+Consider: Did any question uncover a crucial piece of information? Did the questions build on each other logically? Were they appropriate for the reporter's apparent technical level?
+
+### 5. Actionability (weight: 15%)
+
+Could an implementation agent create a concrete plan from the triage summary?
+
+| Score | Meaning |
+|-------|---------|
+| 1 | Summary is too vague or disorganized to act on. An implementation agent would need to re-triage. |
+| 2 | Summary identifies the problem area but lacks specifics. An implementation agent would know where to look but not what to do. |
+| 3 | Summary provides a reasonable starting point. An implementation agent could begin with some investigation. |
+| 4 | Summary is well-structured with a clear root cause hypothesis and suggested test case. An implementation agent could write a plan. |
+| 5 | Summary is immediately actionable. Root cause is well-identified, test case is concrete, and the path to a fix is clear. An implementation agent could start coding. |
+
+## Output Format
+
+Output a single JSON object:
+
+```json
+{
+  "scores": {
+    "completeness": <1-5>,
+    "accuracy": <1-5>,
+    "efficiency": <1-5>,
+    "question_quality": <1-5>,
+    "actionability": <1-5>
+  },
+  "weighted_total": <calculated weighted score, to 2 decimal places>,
+  "qualitative_notes": "<2-4 sentences summarizing the overall triage quality, notable strengths, and key weaknesses>",
+  "best_question": "<quote the single best question the triage agent asked, or 'N/A' if the agent resolved without asking questions>",
+  "missed_information": "<list the most important pieces of information from the ground truth that the triage summary failed to capture, or 'None' if completeness is 5>"
+}
+```
+
+### Calculating `weighted_total`
+
+```
+weighted_total = (completeness * 0.25) + (accuracy * 0.25) + (efficiency * 0.20) + (question_quality * 0.15) + (actionability * 0.15)
+```
+
+Round to 2 decimal places. Maximum possible score: 5.00.
+
+## Rules
+
+- **Output ONLY valid JSON.** No preamble, no explanation, no surrounding text.
+- **Be objective.** Score based on evidence, not impression. If you're unsure between two scores, choose the lower one.
+- **Ground truth is authoritative.** If the summary contradicts the ground truth, that's an accuracy problem. If the summary omits something in the ground truth, that's a completeness problem.
+- **Don't penalize honest uncertainty.** If the triage agent correctly marked something as "unknown" or "needs confirmation," that's better than asserting an incorrect answer.
+- **Score each criterion independently.** A high score on one criterion doesn't influence another. An efficient conversation can still produce an inaccurate summary.
+- **Consider the starting point.** A very poor initial report that results in a decent triage summary means the agent did well. A good initial report that results in a barely-better summary means the agent added little value.

--- a/experiments/triage-skill-comparison/prompts/reporter-system.md
+++ b/experiments/triage-skill-comparison/prompts/reporter-system.md
@@ -1,0 +1,55 @@
+# Reporter Agent System Prompt
+
+You are role-playing as the person who filed a bug report on a GitHub issue. You are a real user of the software — not a developer, not a QA engineer, not an AI assistant. You filed the bug because it's blocking your work and you want it fixed.
+
+## Context
+
+You will be given:
+
+1. The issue you originally filed (title and body) — this is what you wrote.
+2. The full conversation so far (all comments, including your previous responses).
+3. A **ground truth** document describing what actually happened to you — the full details of the bug as you experienced it, including information you didn't include in your original report.
+4. The latest question from the triage agent, which you need to respond to.
+
+## How to Respond
+
+Respond as a real, helpful-but-human user would:
+
+### Be responsive, not exhaustive
+- Answer the specific question that was asked.
+- Don't volunteer your entire ground truth in one response. Real users answer what's asked and move on.
+- It's okay to add a small piece of extra context if the question naturally triggers a memory (e.g., "Oh, now that you mention it, I did notice that shorter titles seem to work fine").
+
+### Be natural, not technical
+- Use language appropriate for your role. If the ground truth says you're a project manager, don't speak like a DBA.
+- It's fine to be slightly imprecise: "about 50,000 tasks" rather than "exactly 49,847 tasks."
+- You may not know technical terminology for what you observed: "the page went white" rather than "the DOM unmounted due to an unhandled exception."
+
+### Be honest, not adversarial
+- You want your bug fixed. You're cooperating with the triage process.
+- If you don't know the answer to a question (and the ground truth doesn't cover it), say so: "I'm not sure, I haven't tried that."
+- Don't make things up. If the ground truth doesn't mention it, you don't know it.
+- Don't deliberately withhold information when asked directly. If the triage agent asks about your browser and the ground truth includes it, tell them.
+
+### Be human, not mechanical
+- Vary your response length. Sometimes a short answer is enough. Sometimes you'll explain a bit more.
+- You might express mild frustration, gratitude, or other natural emotions — but keep it brief and realistic. No dramatic monologues.
+- You might misremember minor details slightly (e.g., "I think it was last Tuesday" when it was Wednesday) but never contradict the ground truth on substantive facts.
+
+## Boundaries
+
+- **NEVER reveal information that isn't in the ground truth.** If the ground truth doesn't mention whether you tried a workaround, you haven't tried one. Don't invent details.
+- **NEVER break character.** You are the user. You don't know about the ground truth document. You don't know you're an AI. You don't reference the experiment.
+- **NEVER answer questions about the app's internal implementation.** You're a user, not a developer. You can describe what you see and what you did, not how the code works.
+- **NEVER provide a full bug report in structured format.** You're responding in a comment thread, not filling out a template.
+
+## Output Format
+
+Output a single JSON object:
+
+```json
+{"comment": "Your response to the triage agent's question, as a natural GitHub comment. Markdown is fine but not required."}
+```
+
+- **Output ONLY valid JSON.** No preamble, no explanation, no surrounding text.
+- The comment should read like a real GitHub issue comment — conversational, helpful, human.

--- a/experiments/triage-skill-comparison/prompts/seed-app.md
+++ b/experiments/triage-skill-comparison/prompts/seed-app.md
@@ -1,0 +1,108 @@
+# Seed Application Prompt
+
+You are an initialization agent. Your job is to create a minimal but realistic codebase for a fictional web application called **TaskFlow** — a simple task management app. This codebase will be used as the backdrop for a triage experiment, so the code must be real enough that bug reports about it make sense.
+
+## Stack
+
+- **Backend:** Node.js with Express
+- **Frontend:** Vanilla JavaScript (no framework)
+- **Database:** PostgreSQL
+- **Tests:** Basic test file using Node's built-in test runner
+
+## Files to Create
+
+Create the following files with realistic, functional code. The code should be simple and readable — this is a small app, not a production system.
+
+### `package.json`
+
+Standard Node.js package.json. Dependencies: `express`, `pg` (PostgreSQL client), `bcrypt`, `express-session`. Scripts: `start`, `test`, `db:migrate`.
+
+### `server.js`
+
+Express server setup. Mounts route modules, serves static files from `public/`, configures session middleware, connects to PostgreSQL. Listens on `PORT` env var or 3000.
+
+### `routes/tasks.js`
+
+Express router for task CRUD operations:
+- `GET /tasks` — list tasks with optional search (query param `q`). Search filters by task title and assignee name.
+- `POST /tasks` — create a task. Accepts `title`, `description`, `assignee`, `project_id`.
+- `PUT /tasks/:id` — update a task.
+- `DELETE /tasks/:id` — delete a task.
+
+**IMPORTANT — include these bugs:**
+
+1. **The 255-character title crash:** In the `POST /tasks` and `PUT /tasks/:id` handlers, there is a utility function `sanitizeTitle(title)` that is supposed to truncate titles to 255 characters. However, the function has a bug: if the input string is longer than 255 characters, a validation step returns `undefined` instead of the string, and then a subsequent `.slice(0, 255)` call on `undefined` throws a `TypeError`. The function should look approximately like this:
+
+```javascript
+function sanitizeTitle(title) {
+  // Validate title length
+  const validated = title.length <= 255 ? title : undefined; // BUG: should return title, not undefined
+  // Truncate to max length
+  return validated.slice(0, 255); // TypeError when validated is undefined
+}
+```
+
+2. **The missing search index:** The `GET /tasks` search route performs a query like:
+```sql
+SELECT * FROM tasks WHERE title ILIKE $1 OR assignee_name ILIKE $1
+```
+There is no bug in the code itself, but the `db/schema.sql` file does NOT include indexes on `title` or `assignee_name`. Additionally, add a comment in the search handler noting that the v2.4.0 migration was supposed to add these indexes. The code works correctly but will be extremely slow on large datasets.
+
+### `routes/auth.js`
+
+Express router for authentication:
+- `POST /auth/login` — email/password login using bcrypt.
+- `POST /auth/register` — create account.
+- `GET /auth/callback` — OAuth callback handler.
+
+**IMPORTANT — include this bug:**
+
+3. **The OAuth callback proxy bug:** The `GET /auth/callback` handler constructs a redirect URL after successful OAuth authentication. It reads `req.headers.host` to build the redirect URL but does NOT check for `X-Forwarded-Host` or `X-Forwarded-Proto` headers. When the app is behind a reverse proxy (nginx, AWS ALB, etc.), `req.headers.host` returns the internal hostname (e.g., `localhost:3000`) instead of the public hostname, causing an infinite redirect loop. The code should look approximately like:
+
+```javascript
+router.get('/auth/callback', async (req, res) => {
+  // ... OAuth token exchange ...
+  const redirectUrl = `${req.protocol}://${req.headers.host}/dashboard`;
+  // BUG: Behind a proxy, req.protocol is 'http' and req.headers.host is 'localhost:3000'
+  // instead of 'https' and 'app.example.com'
+  res.redirect(redirectUrl);
+});
+```
+
+### `public/app.js`
+
+Minimal frontend JavaScript:
+- Fetches and renders tasks from the API.
+- Has a form to create new tasks (title, description, assignee fields).
+- Has a search input that calls the search API.
+- **No error handling on the fetch calls for task creation** — if the API returns a 500 (from the title crash bug), the UI has no catch block and the page state corrupts silently.
+
+### `db/schema.sql`
+
+PostgreSQL schema:
+- `users` table: `id`, `email`, `password_hash`, `name`, `created_at`.
+- `projects` table: `id`, `name`, `owner_id`, `created_at`.
+- `tasks` table: `id`, `project_id`, `title` (VARCHAR(500) — note: larger than the 255-char validation limit in code), `description`, `assignee_name`, `assignee_id`, `status`, `created_at`, `updated_at`.
+- **NO indexes on `tasks.title`, `tasks.assignee_name`, or `tasks.assignee_id`.** This is deliberate — it's the missing index bug.
+- Include a comment: `-- TODO: v2.4.0 migration should add indexes on tasks(title), tasks(assignee_name), tasks(project_id, assignee_id, status)`
+
+### `test/tasks.test.js`
+
+Basic tests using Node's built-in `node:test` and `node:assert`:
+- Test that creating a task with a valid title succeeds.
+- Test that creating a task with a short title (under 255 chars) succeeds.
+- **Do NOT include a test for titles over 255 characters** — this is a gap that the triage process should identify.
+- Test that search returns matching results.
+- Test format only — these can mock the database layer or test the sanitizeTitle function directly.
+
+## Code Style
+
+- Use `const`/`let`, not `var`.
+- Use async/await, not callbacks.
+- Include brief comments explaining what each section does.
+- Keep each file under 100 lines. This is a minimal app.
+- Use CommonJS (`require`) not ESM (`import`).
+
+## Output
+
+Create all files listed above with complete, working (modulo the intentional bugs) code. Write each file to the `taskflow/` directory within the experiment workspace.

--- a/experiments/triage-skill-comparison/prompts/triage-system.md
+++ b/experiments/triage-skill-comparison/prompts/triage-system.md
@@ -1,0 +1,65 @@
+# Triage Agent System Prompt
+
+You are a triage agent processing a GitHub issue. Your job is to read the issue and determine whether you have enough information to produce a complete triage summary, or whether you need to ask the reporter a clarifying question.
+
+## Context
+
+You will be given:
+
+1. The issue title and body (the original report).
+2. All comments on the issue so far (the conversation history).
+3. A questioning strategy (provided separately as an adapter) that tells you HOW to decide what to ask.
+4. Your current turn number and the maximum number of triage turns allowed.
+
+Read everything carefully. The conversation history IS your memory — you have no other state.
+
+## Turn Awareness
+
+You will be told: "This is triage turn N of M."
+
+- You have at most M turns total. After turn M, you MUST resolve regardless of information gaps.
+- Plan accordingly: if you are on turn M-1 and still missing critical details, make your question count. If you are on turn M, you must resolve with whatever you have.
+- Front-load important questions. Don't save critical questions for later turns.
+- If the issue is clear enough to resolve early, do so. Don't ask questions just because you have turns remaining.
+
+## Actions
+
+You have exactly two possible actions:
+
+### Action 1: Ask a Clarifying Question
+
+Choose this when you do not yet have enough information to produce a useful triage summary AND you have remaining turns. Your questioning strategy (from the adapter) will guide what kind of question to ask and how to frame it.
+
+Output:
+```json
+{"action": "ask", "comment": "Your question to the reporter, as a GitHub comment. Markdown formatting is fine."}
+```
+
+### Action 2: Resolve with a Triage Summary
+
+Choose this when EITHER:
+- You have enough information to produce a complete triage summary, OR
+- You have reached your maximum turn count and must resolve with available information.
+
+The triage summary must be a structured document covering these sections:
+
+1. **Problem Description** — A clear, precise statement of what is going wrong. Not the reporter's words — your synthesis after understanding the issue.
+2. **Reproduction Steps** — Numbered steps to trigger the bug. If not fully known, state what is known and flag what's assumed.
+3. **Environment** — Relevant version/platform/configuration details. Mark unknown items explicitly.
+4. **Root Cause Hypothesis** — Your best guess at what's causing this, based on all available evidence. If multiple hypotheses are plausible, list them in order of likelihood.
+5. **Severity Assessment** — Rate as Critical / High / Medium / Low with a brief justification considering frequency, impact, and workaround availability.
+6. **Suggested Test Case** — A concrete test (or set of test assertions) that would verify the fix. Should be specific enough that a developer could implement it.
+
+Output:
+```json
+{"action": "resolve", "summary": "Your full triage summary as a markdown document."}
+```
+
+## Rules
+
+- **Output ONLY valid JSON.** No preamble, no explanation, no markdown fencing around the JSON. Your entire output must be a single JSON object parseable by `JSON.parse()` or `jq`.
+- **Never fabricate information.** If the reporter hasn't told you something, don't invent it. In your triage summary, explicitly mark gaps as "Unknown — not provided" or "Assumed — needs confirmation."
+- **Use the adapter strategy.** Your questioning approach is determined by the adapter prompt you receive alongside this prompt. Follow its guidance on question framing, pacing, and resolution criteria.
+- **Don't repeat yourself.** If the reporter already answered a question (even indirectly), don't ask it again. Synthesize what you know from ALL comments, not just the latest one.
+- **Be concise in questions, thorough in summaries.** Questions should be focused and easy to answer. Triage summaries should be comprehensive and precise.
+- **One action per invocation.** You either ask or resolve. Never both. You will not get another chance to act after this response.

--- a/experiments/triage-skill-comparison/scenarios/auth-redirect-loop.json
+++ b/experiments/triage-skill-comparison/scenarios/auth-redirect-loop.json
@@ -1,0 +1,42 @@
+{
+  "scenario_id": "auth-redirect-loop",
+  "quality": "good-but-ambiguous",
+  "title": "OAuth login enters infinite redirect loop",
+  "body": "When attempting to log in via Google OAuth on our TaskFlow instance, the browser enters an infinite redirect loop between our app and the Google OAuth consent screen.\n\nSteps to reproduce:\n1. Go to https://taskflow.internal.acmecorp.com/login\n2. Click 'Sign in with Google'\n3. Google consent screen appears, I approve access\n4. Browser redirects back to TaskFlow, but then immediately redirects to Google again\n5. This loops indefinitely until the browser shows 'too many redirects' error\n\nBrowser: Chrome 122 on Windows 11\nTaskFlow version: 2.4.0 (self-hosted)\n\nI've tried:\n- Different Google accounts (same result)\n- Clearing all cookies and site data for both domains\n- Incognito mode (same result)\n- Different browser (Firefox — same result)\n\nOther users in my office have the same issue. Users working remotely from home do NOT have this issue, which is strange.\n\nThe redirect URL in the address bar during the loop looks correct to me:\nhttps://taskflow.internal.acmecorp.com/auth/google/callback?code=4/0A...\n\nOur Google Cloud Console OAuth config has the correct redirect URI listed.\n\nServer logs show the callback endpoint is being hit, receiving the auth code, but then issuing a 302 back to /login instead of completing the session.\n\nThis started after our IT department made some network changes last week, but they say nothing should affect web app traffic.",
+  "ground_truth": {
+    "actual_experience": "The reporter is behind a corporate proxy (Zscaler) that performs SSL inspection and URL rewriting on outbound traffic. The proxy rewrites the 'state' parameter in the OAuth callback URL by re-encoding special characters, which causes TaskFlow's CSRF validation to fail (the state token no longer matches what was stored in the session). When CSRF validation fails, the auth middleware silently redirects back to /login, which initiates a new OAuth flow, creating the loop. The reporter does not realize the proxy is modifying the traffic because the proxy is transparent to them.",
+    "environment": {
+      "app": "TaskFlow",
+      "app_version": "2.4.0",
+      "platform": "web",
+      "browser": "Chrome 122",
+      "os": "Windows 11 Enterprise",
+      "deployment": "self-hosted",
+      "network": "Corporate network with Zscaler transparent proxy performing SSL inspection",
+      "oauth_provider": "Google",
+      "internal_domain": "taskflow.internal.acmecorp.com"
+    },
+    "red_herrings": {
+      "cookies": "Cookies are not the issue — the reporter already tested in incognito mode and cleared all cookies",
+      "cors": "CORS is not the issue — the redirects are full-page navigation, not XHR/fetch requests, so CORS does not apply",
+      "session_storage": "Session storage is functioning correctly — the server is writing and reading session data fine, the problem is the state parameter mismatch",
+      "oauth_callback_url": "The OAuth callback URL configuration is correct in both Google Cloud Console and TaskFlow config"
+    },
+    "actual_root_cause": {
+      "summary": "Corporate Zscaler proxy re-encodes the OAuth state parameter during SSL inspection, breaking CSRF validation",
+      "mechanism": "The OAuth 'state' parameter contains a base64-encoded CSRF token. The Zscaler proxy's URL normalization re-encodes certain characters ('+' becomes '%2B', '/' becomes '%2F') in the query string during its inspection pass. When TaskFlow's auth callback handler compares the received state parameter against the stored session token, they no longer match. The CSRF validation fails, and the auth middleware issues a 302 redirect to /login.",
+      "evidence_available": "Comparing the state parameter value in the initial OAuth request vs. the callback URL would reveal the character encoding difference. The server logs show 'CSRF state mismatch' at DEBUG level, but the default log level is INFO so this message is not visible in normal operation.",
+      "key_clue_in_report": "The reporter mentions 'users working remotely from home do NOT have this issue' and 'IT department made some network changes last week' — both point to a network-level cause. Remote users bypass the corporate proxy via split-tunnel VPN."
+    },
+    "reproduction_steps": [
+      "Access TaskFlow through a network with a transparent SSL-inspecting proxy that normalizes URL query parameters",
+      "Initiate Google OAuth login flow",
+      "Complete the Google consent screen",
+      "Observe: the callback URL's state parameter has been re-encoded by the proxy",
+      "Observe: TaskFlow's CSRF validation fails due to state parameter mismatch",
+      "Observe: auth middleware redirects to /login, restarting the OAuth flow"
+    ],
+    "frequency": "100% reproducible for any user behind the corporate proxy. 0% for users accessing directly or via VPN.",
+    "workaround": "Connect via VPN (which bypasses the proxy), or have IT add taskflow.internal.acmecorp.com and accounts.google.com to the proxy's SSL inspection bypass list."
+  }
+}

--- a/experiments/triage-skill-comparison/scenarios/crash-on-save.json
+++ b/experiments/triage-skill-comparison/scenarios/crash-on-save.json
@@ -1,0 +1,29 @@
+{
+  "scenario_id": "crash-on-save",
+  "quality": "very-poor",
+  "title": "app crashes when I save",
+  "body": "The app keeps crashing whenever I try to save. This is really frustrating, I've lost work multiple times now. Please fix ASAP.",
+  "ground_truth": {
+    "actual_experience": "When saving a task whose title exceeds 255 characters, the TaskFlow web app crashes with an unhandled exception. The UI freezes momentarily, then the entire page goes blank white. The task data being edited is lost and must be re-entered. The reporter discovered through trial and error that shorter titles save fine, but did not mention this in the report.",
+    "environment": {
+      "app": "TaskFlow",
+      "app_version": "2.3.1",
+      "platform": "web",
+      "browser": "Chrome 122",
+      "os": "macOS Sonoma 14.3",
+      "screen_resolution": "2560x1440"
+    },
+    "reproduction_steps": [
+      "Open TaskFlow web app and log in",
+      "Navigate to any project board",
+      "Click 'New Task' to create a task",
+      "Enter a title that is longer than 255 characters (e.g., paste a long paragraph into the title field)",
+      "Fill in any other fields as desired",
+      "Click the 'Save' button",
+      "Observe: the page freezes briefly, then goes blank white"
+    ],
+    "error_details": "TypeError: Cannot read properties of undefined (reading 'slice') — visible in the browser developer console at the moment of the crash. The stack trace points to a truncation utility function that assumes the input string is non-null after a validation step that silently returns undefined for strings exceeding 255 characters.",
+    "frequency": "100% reproducible when title exceeds 255 characters. Saving with titles of 255 characters or fewer works normally.",
+    "workaround": "Keep task titles under 255 characters. The reporter has been shortening titles to avoid the crash but finds this inconvenient and did not mention it in the report."
+  }
+}

--- a/experiments/triage-skill-comparison/scenarios/slow-search.json
+++ b/experiments/triage-skill-comparison/scenarios/slow-search.json
@@ -1,0 +1,35 @@
+{
+  "scenario_id": "slow-search",
+  "quality": "medium",
+  "title": "Search is extremely slow since last update",
+  "body": "Since the v2.4.0 update last week, search has become painfully slow. It used to return results almost instantly, but now it takes 10+ seconds every time I search. I use search heavily throughout the day and this is a major productivity killer.\n\nI've tried clearing my browser cache and restarting, no change. Other parts of the app seem fine, it's just search.\n\nThis is blocking my workflow — any timeline on a fix?",
+  "ground_truth": {
+    "actual_experience": "The reporter manages a large organization on TaskFlow with approximately 50,000 tasks across 12 projects. They primarily search by assignee name (typing a colleague's name to find tasks assigned to them). The slowness only manifests when the search scope is set to 'All Projects' — searching within a single project returns results in under a second, but the reporter always uses 'All Projects' scope and hasn't tried narrowing it. The v2.4.0 update introduced a new full-text search engine migration that dropped several database indexes during the migration and failed to recreate them due to a silent error in the migration script.",
+    "environment": {
+      "app": "TaskFlow",
+      "app_version": "2.4.0",
+      "platform": "web",
+      "browser": "Firefox 123",
+      "os": "Ubuntu 22.04",
+      "deployment": "self-hosted",
+      "database": "PostgreSQL 15.2"
+    },
+    "missing_details": {
+      "dataset_size": "~50,000 tasks across 12 projects",
+      "query_pattern": "Searching by assignee name (partial match, e.g., typing 'Sarah' to find tasks assigned to Sarah Chen)",
+      "scope_dependency": "Slowness only occurs with 'All Projects' search scope; single-project scoped searches return in under 1 second",
+      "root_cause": "The v2.4.0 migration script dropped indexes on the tasks table (including the assignee_name index and a composite index on project_id + assignee_id) and silently failed to recreate them. The migration log shows 'CREATE INDEX' statements but they errored due to a locking conflict during the hot migration.",
+      "database_state": "PostgreSQL is missing indexes on tasks.assignee_name, tasks.assignee_id, and the composite index on (project_id, assignee_id, status). A sequential scan on 50k rows is occurring instead of an index scan."
+    },
+    "reproduction_steps": [
+      "Log in to TaskFlow with an account that has access to multiple projects",
+      "Ensure the instance has a substantial number of tasks (10,000+)",
+      "Set search scope to 'All Projects' using the dropdown in the search bar",
+      "Type an assignee name in the search box",
+      "Observe: results take 10-15 seconds to return",
+      "Compare: switch scope to a single project and repeat the same search — results return in under 1 second"
+    ],
+    "frequency": "100% reproducible on instances with large task counts when using All Projects scope. Small instances (under 1,000 tasks) are not noticeably affected.",
+    "workaround": "Search within individual projects instead of using the 'All Projects' scope. Alternatively, manually recreate the missing database indexes."
+  }
+}

--- a/experiments/triage-skill-comparison/scripts/github-adapter.sh
+++ b/experiments/triage-skill-comparison/scripts/github-adapter.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# =============================================================================
+# github-adapter.sh — Reference: converting file-based simulation to live GitHub
+# =============================================================================
+#
+# THIS SCRIPT IS NOT MEANT TO BE RUN. It is a documented sketch showing how
+# to adapt the experiment from local JSON files to live GitHub API calls.
+#
+# The experiment's core logic (prompts, strategies, judging) is identical.
+# Only the I/O layer changes: instead of reading/writing a local JSON file,
+# we read/write GitHub issues and comments via the `gh` CLI.
+#
+# =============================================================================
+
+# Prevent accidental execution
+echo "This script is a reference document, not meant to be executed."
+echo "Read the source for the GitHub API adaptation patterns."
+exit 0
+
+# ============================================================================
+# PATTERN 1: Creating an issue
+# ============================================================================
+
+create_issue() {
+  local owner="$1" repo="$2" title="$3" body="$4"
+
+  # Create the issue and capture the issue number from the response
+  local issue_number
+  issue_number=$(gh api "repos/$owner/$repo/issues" \
+    --method POST \
+    --field title="$title" \
+    --field body="$body" \
+    --jq '.number')
+
+  echo "$issue_number"
+}
+
+# Usage:
+# ISSUE_NUM=$(create_issue "myorg" "taskflow" "app crashes when I save" "The app keeps crashing...")
+
+# ============================================================================
+# PATTERN 2: Reading an issue with all comments
+# ============================================================================
+
+read_issue_state() {
+  local owner="$1" repo="$2" issue_number="$3"
+
+  # Fetch the issue metadata
+  local issue_json
+  issue_json=$(gh api "repos/$owner/$repo/issues/$issue_number")
+
+  local title body
+  title=$(echo "$issue_json" | jq -r '.title')
+  body=$(echo "$issue_json" | jq -r '.body')
+
+  # Fetch all comments (paginated — gh handles pagination with --paginate)
+  local comments_json
+  comments_json=$(gh api "repos/$owner/$repo/issues/$issue_number/comments" \
+    --paginate \
+    --jq '[.[] | {author: .user.login, body: .body, created_at: .created_at}]')
+
+  # Combine into the same format used by the file-based simulation
+  jq -n \
+    --arg title "$title" \
+    --arg body "$body" \
+    --argjson comments "$comments_json" \
+    '{title: $title, body: $body, comments: $comments}'
+}
+
+# Usage:
+# ISSUE_STATE=$(read_issue_state "myorg" "taskflow" 42)
+# This produces the same JSON structure as the local simulation's issue.json
+
+# ============================================================================
+# PATTERN 3: Posting a comment
+# ============================================================================
+
+post_comment() {
+  local owner="$1" repo="$2" issue_number="$3" body="$4"
+
+  gh api "repos/$owner/$repo/issues/$issue_number/comments" \
+    --method POST \
+    --field body="$body" \
+    --jq '.id'
+}
+
+# Usage:
+# COMMENT_ID=$(post_comment "myorg" "taskflow" 42 "Can you tell me what browser you're using?")
+
+# ============================================================================
+# PATTERN 4: Reading the latest comment
+# ============================================================================
+
+get_latest_comment() {
+  local owner="$1" repo="$2" issue_number="$3"
+
+  gh api "repos/$owner/$repo/issues/$issue_number/comments" \
+    --jq '.[-1] | {author: .user.login, body: .body, created_at: .created_at}'
+}
+
+# ============================================================================
+# PATTERN 5: Polling for new comments
+# ============================================================================
+#
+# After the triage agent posts a question, the orchestrator needs to wait for
+# the reporter to respond. In the simulation, this is instant (we invoke the
+# reporter agent immediately). In a live GitHub setup, there are two options:
+#
+# Option A: Polling (simple, works anywhere)
+# Option B: Webhooks + GitHub Actions (event-driven, preferred for production)
+
+# --- Option A: Polling ---
+
+poll_for_response() {
+  local owner="$1" repo="$2" issue_number="$3"
+  local last_known_count="$4"
+  local poll_interval=30  # seconds
+  local max_wait=3600     # 1 hour
+
+  local elapsed=0
+  while [[ $elapsed -lt $max_wait ]]; do
+    local current_count
+    current_count=$(gh api "repos/$owner/$repo/issues/$issue_number/comments" \
+      --jq '. | length')
+
+    if [[ "$current_count" -gt "$last_known_count" ]]; then
+      # New comment(s) arrived
+      get_latest_comment "$owner" "$repo" "$issue_number"
+      return 0
+    fi
+
+    sleep "$poll_interval"
+    elapsed=$((elapsed + poll_interval))
+  done
+
+  echo "Timeout waiting for response" >&2
+  return 1
+}
+
+# --- Option B: GitHub Actions (preferred) ---
+#
+# Instead of polling, use a GitHub Actions workflow that triggers on issue
+# comments. This is more efficient and more aligned with the "short-lived
+# agent" model described in the experiment design.
+#
+# .github/workflows/triage-respond.yml:
+#
+# name: Triage Agent Response
+# on:
+#   issue_comment:
+#     types: [created]
+#
+# jobs:
+#   triage:
+#     # Only run when:
+#     #   1. The issue has the "triage-experiment" label
+#     #   2. The comment was NOT from the triage bot (avoid infinite loops)
+#     if: |
+#       contains(github.event.issue.labels.*.name, 'triage-experiment') &&
+#       github.event.comment.user.login != 'triage-bot[bot]'
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#
+#       - name: Install agent CLI
+#         run: npm install -g @anthropic-ai/claude-code
+#
+#       - name: Read issue state
+#         id: read-issue
+#         run: |
+#           ISSUE_STATE=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }} \
+#             --jq '{title: .title, body: .body}')
+#           COMMENTS=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
+#             --paginate --jq '[.[] | {author: .user.login, body: .body}]')
+#           FULL_STATE=$(echo "$ISSUE_STATE" | jq --argjson c "$COMMENTS" '. + {comments: $c}')
+#           echo "issue_state<<EOF" >> $GITHUB_OUTPUT
+#           echo "$FULL_STATE" >> $GITHUB_OUTPUT
+#           echo "EOF" >> $GITHUB_OUTPUT
+#         env:
+#           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#
+#       - name: Determine triage strategy
+#         id: strategy
+#         run: |
+#           # Could be set per-issue via a label, or globally in repo config
+#           STRATEGY=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }} \
+#             --jq '.labels[] | select(.name | startswith("strategy:")) | .name | sub("strategy:"; "")')
+#           echo "strategy=${STRATEGY:-structured-triage}" >> $GITHUB_OUTPUT
+#         env:
+#           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#
+#       - name: Run triage agent
+#         id: triage
+#         run: |
+#           ADAPTER=$(cat adapters/${{ steps.strategy.outputs.strategy }}.md)
+#           PROMPT="<triage system prompt here>
+#
+#           --- STRATEGY ---
+#           $ADAPTER
+#
+#           --- ISSUE STATE ---
+#           ${{ steps.read-issue.outputs.issue_state }}
+#
+#           Respond with JSON: {action: ask|resolve, ...}"
+#
+#           RESULT=$(claude -p "$PROMPT" --output-format text)
+#           echo "result<<EOF" >> $GITHUB_OUTPUT
+#           echo "$RESULT" >> $GITHUB_OUTPUT
+#           echo "EOF" >> $GITHUB_OUTPUT
+#         env:
+#           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+#
+#       - name: Post response
+#         run: |
+#           ACTION=$(echo '${{ steps.triage.outputs.result }}' | jq -r '.action')
+#           if [ "$ACTION" = "ask" ]; then
+#             QUESTION=$(echo '${{ steps.triage.outputs.result }}' | jq -r '.question')
+#             gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
+#               --method POST --field body="$QUESTION"
+#           elif [ "$ACTION" = "resolve" ]; then
+#             SUMMARY=$(echo '${{ steps.triage.outputs.result }}' | jq -r '.triage_summary | tojson')
+#             gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
+#               --method POST --field body="## Triage Complete\n\n\`\`\`json\n$SUMMARY\n\`\`\`"
+#             # Optionally add a label
+#             gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels \
+#               --method POST --input - <<< '["triaged"]'
+#           fi
+#         env:
+#           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# ============================================================================
+# PATTERN 6: Full live orchestration (replacing run-single-trial.sh)
+# ============================================================================
+#
+# In a live GitHub setup, the orchestration is EVENT-DRIVEN, not loop-driven:
+#
+# 1. A new issue is created (or labeled "needs-triage")
+#    -> GitHub Actions triggers the triage agent
+#    -> Agent reads issue, posts a question comment, and EXITS
+#
+# 2. The reporter responds with a comment
+#    -> GitHub Actions triggers the triage agent again
+#    -> Agent reads the FULL issue (including all comments), decides:
+#       - Ask another question -> post comment, exit
+#       - Resolve -> post triage summary, add "triaged" label, exit
+#
+# 3. This repeats until resolved or max turns reached.
+#
+# The key differences from the file-based simulation:
+#
+# | Aspect          | File-based simulation         | Live GitHub                    |
+# |-----------------|-------------------------------|--------------------------------|
+# | Issue state     | Local JSON file               | GitHub API                     |
+# | Agent lifecycle | Invoked by bash loop          | Invoked by GitHub Actions      |
+# | Turn tracking   | Loop counter in bash          | Count comments by bot user     |
+# | Reporter        | AI agent invoked immediately  | Real human (or separate bot)   |
+# | Waiting         | No waiting (synchronous)      | Event-driven (webhook)         |
+# | Max turns       | Enforced by loop              | Count bot comments, enforce    |
+#
+# The PROMPTS and STRATEGIES are identical. Only the I/O plumbing changes.
+
+# ============================================================================
+# PATTERN 7: Turn counting in live mode
+# ============================================================================
+
+count_bot_turns() {
+  local owner="$1" repo="$2" issue_number="$3" bot_login="$4"
+
+  gh api "repos/$owner/$repo/issues/$issue_number/comments" \
+    --paginate \
+    --jq "[.[] | select(.user.login == \"$bot_login\")] | length"
+}
+
+# Usage in the Actions workflow:
+# BOT_TURNS=$(count_bot_turns "myorg" "taskflow" 42 "triage-bot[bot]")
+# if [ "$BOT_TURNS" -ge "$MAX_TURNS" ]; then
+#   # Force resolution
+# fi

--- a/experiments/triage-skill-comparison/scripts/judge.sh
+++ b/experiments/triage-skill-comparison/scripts/judge.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# =============================================================================
+# judge.sh — Invokes an independent judge agent on a completed trial
+# =============================================================================
+#
+# Reads the conversation and triage summary from a trial directory, compares
+# against the scenario's ground truth, and produces a scored assessment.
+#
+# Arguments:
+#   $1  trial_dir   — Path to the trial directory (contains conversation.json,
+#                     triage-summary.md)
+#   $2  agent_cli   — CLI to invoke ("claude" or "opencode")
+#
+# Output:
+#   Writes judge-assessment.json to the trial directory.
+# =============================================================================
+
+set -euo pipefail
+
+TRIAL_DIR="${1:?Usage: $0 trial_dir agent_cli}"
+AGENT_CLI="${2:?Usage: $0 trial_dir agent_cli}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPERIMENT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Validate inputs
+# ---------------------------------------------------------------------------
+
+if [[ ! -f "$TRIAL_DIR/conversation.json" ]]; then
+  echo "Error: $TRIAL_DIR/conversation.json not found" >&2
+  exit 1
+fi
+if [[ ! -f "$TRIAL_DIR/triage-summary.md" ]]; then
+  echo "Error: $TRIAL_DIR/triage-summary.md not found" >&2
+  exit 1
+fi
+
+# Determine which scenario this trial belongs to by inspecting the path.
+# Expected path structure: results/<timestamp>/<scenario>/<strategy>/
+SCENARIO_NAME="$(basename "$(dirname "$TRIAL_DIR")")"
+STRATEGY_NAME="$(basename "$TRIAL_DIR")"
+SCENARIO_FILE="$EXPERIMENT_DIR/scenarios/${SCENARIO_NAME}.json"
+
+if [[ ! -f "$SCENARIO_FILE" ]]; then
+  echo "Error: scenario file not found: $SCENARIO_FILE" >&2
+  echo "  (Inferred scenario='$SCENARIO_NAME' from trial dir path)" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Load data
+# ---------------------------------------------------------------------------
+
+CONVERSATION="$(cat "$TRIAL_DIR/conversation.json")"
+TRIAGE_SUMMARY="$(cat "$TRIAL_DIR/triage-summary.md")"
+GROUND_TRUTH="$(jq '.ground_truth' "$SCENARIO_FILE")"
+ORIGINAL_TITLE="$(jq -r '.title' "$SCENARIO_FILE")"
+ORIGINAL_BODY="$(jq -r '.body' "$SCENARIO_FILE")"
+
+# Count conversation metrics
+NUM_COMMENTS="$(echo "$CONVERSATION" | jq '.comments | length')"
+NUM_TRIAGE_QUESTIONS="$(echo "$CONVERSATION" | jq '[.comments[] | select(.author == "triage-agent") | select(.body | startswith("[TRIAGE RESOLVED]") | not)] | length')"
+
+# ---------------------------------------------------------------------------
+# Build judge prompt
+# ---------------------------------------------------------------------------
+
+read -r -d '' JUDGE_PROMPT << 'JUDGE_EOF' || true
+You are an independent judge evaluating the quality of an automated issue
+triage process. You will compare a triage agent's output against the ground
+truth about what actually happened.
+
+SCORING CRITERIA (each scored 1-5):
+
+1. COMPLETENESS (weight: 25%)
+   How much of the ground truth information was extracted during triage?
+   5 = All critical details captured
+   3 = Most important details captured, some gaps
+   1 = Major critical information missing
+
+2. ACCURACY (weight: 25%)
+   Is the triaged information consistent with the ground truth?
+   5 = Everything stated is accurate
+   3 = Mostly accurate, minor inaccuracies
+   1 = Contains significant inaccuracies or wrong conclusions
+
+3. EFFICIENCY (weight: 20%)
+   Were the conversation turns used well? Were questions redundant?
+   5 = Minimal turns, no redundancy, every question added value
+   3 = Some unnecessary questions but generally focused
+   1 = Many wasted turns, redundant or irrelevant questions
+
+4. QUESTION_QUALITY (weight: 15%)
+   Were questions insightful, well-targeted, and appropriate?
+   5 = Questions were incisive — they directly uncovered key information
+   3 = Questions were reasonable but not particularly insightful
+   1 = Questions were generic, vague, or poorly targeted
+
+5. ACTIONABILITY (weight: 15%)
+   Could an implementation agent create a fix plan from this triage summary?
+   5 = A developer could start coding a fix immediately
+   3 = A developer would have a general direction but need more info
+   1 = The summary doesn't provide enough to begin work
+
+IMPORTANT: Respond with ONLY valid JSON. Your entire response must be:
+{
+  "scenario": "<scenario name>",
+  "strategy": "<strategy name>",
+  "scores": {
+    "completeness": <1-5>,
+    "accuracy": <1-5>,
+    "efficiency": <1-5>,
+    "question_quality": <1-5>,
+    "actionability": <1-5>
+  },
+  "weighted_score": <computed weighted average, 2 decimal places>,
+  "num_turns": <number of question-answer exchanges>,
+  "notable_questions": ["list of the most insightful questions asked"],
+  "missed_information": ["list of ground truth details NOT captured"],
+  "inaccuracies": ["list of incorrect conclusions or statements"],
+  "qualitative_notes": "2-3 sentence overall assessment"
+}
+JUDGE_EOF
+
+FULL_JUDGE_PROMPT="$JUDGE_PROMPT
+
+--- ORIGINAL ISSUE ---
+Title: $ORIGINAL_TITLE
+Body: $ORIGINAL_BODY
+
+--- FULL CONVERSATION ---
+$CONVERSATION
+
+--- TRIAGE SUMMARY PRODUCED ---
+$TRIAGE_SUMMARY
+
+--- GROUND TRUTH (what actually happened) ---
+$GROUND_TRUTH
+
+--- METADATA ---
+Scenario: $SCENARIO_NAME
+Strategy: $STRATEGY_NAME
+Total comments: $NUM_COMMENTS
+Triage questions asked: $NUM_TRIAGE_QUESTIONS
+
+--- INSTRUCTIONS ---
+Evaluate the triage output against the ground truth using the criteria above.
+Compute the weighted score as:
+  (completeness * 0.25) + (accuracy * 0.25) + (efficiency * 0.20) +
+  (question_quality * 0.15) + (actionability * 0.15)
+Round to 2 decimal places.
+Respond with ONLY valid JSON."
+
+# ---------------------------------------------------------------------------
+# Invoke judge agent
+# ---------------------------------------------------------------------------
+
+echo "  Invoking judge agent..."
+
+if [[ "$AGENT_CLI" == "claude" ]]; then
+  JUDGE_RAW="$(claude -p "$FULL_JUDGE_PROMPT" --output-format text 2>/dev/null)" || true
+else
+  JUDGE_RAW="$(opencode -p "$FULL_JUDGE_PROMPT" 2>/dev/null)" || true
+fi
+
+# ---------------------------------------------------------------------------
+# Parse and save
+# ---------------------------------------------------------------------------
+
+# Try to extract JSON from the response
+extract_json() {
+  local raw="$1"
+  if echo "$raw" | jq . &>/dev/null 2>&1; then
+    echo "$raw"; return 0
+  fi
+  local fenced
+  fenced="$(echo "$raw" | sed -n '/^```json$/,/^```$/p' | sed '1d;$d')"
+  if [[ -n "$fenced" ]] && echo "$fenced" | jq . &>/dev/null 2>&1; then
+    echo "$fenced"; return 0
+  fi
+  local braced
+  braced="$(echo "$raw" | awk '/{/{found=1} found{print} /}/{if(found) exit}')"
+  if [[ -n "$braced" ]] && echo "$braced" | jq . &>/dev/null 2>&1; then
+    echo "$braced"; return 0
+  fi
+  echo "$raw"; return 1
+}
+
+JUDGE_JSON="$(extract_json "$JUDGE_RAW")" || {
+  echo "  Warning: Could not parse judge response as JSON" >&2
+  echo "$JUDGE_RAW" > "$TRIAL_DIR/error-judge-raw.txt"
+  # Create a minimal fallback assessment
+  JUDGE_JSON="$(jq -n \
+    --arg scenario "$SCENARIO_NAME" \
+    --arg strategy "$STRATEGY_NAME" \
+    '{
+      scenario: $scenario,
+      strategy: $strategy,
+      scores: {completeness:0, accuracy:0, efficiency:0, question_quality:0, actionability:0},
+      weighted_score: 0,
+      num_turns: 0,
+      notable_questions: [],
+      missed_information: ["Judge could not parse response"],
+      inaccuracies: [],
+      qualitative_notes: "Judge agent response could not be parsed. See error-judge-raw.txt."
+    }'
+  )"
+}
+
+echo "$JUDGE_JSON" | jq . > "$TRIAL_DIR/judge-assessment.json"
+
+SCORE="$(echo "$JUDGE_JSON" | jq -r '.weighted_score // "N/A"')"
+echo "  Weighted score: $SCORE"

--- a/experiments/triage-skill-comparison/scripts/run-experiment.sh
+++ b/experiments/triage-skill-comparison/scripts/run-experiment.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# =============================================================================
+# run-experiment.sh — Main orchestrator for the triage skill comparison
+# =============================================================================
+#
+# Runs all (or selected) scenario x strategy combinations, then judges
+# each result and generates a summary comparison table.
+#
+# Usage:
+#   ./scripts/run-experiment.sh                               # all combos
+#   ./scripts/run-experiment.sh --scenario crash-on-save      # one scenario
+#   ./scripts/run-experiment.sh --strategy socratic-refinement # one strategy
+#   ./scripts/run-experiment.sh --dry-run                     # prompts only
+#   ./scripts/run-experiment.sh --max-turns 4                 # limit turns
+#   AGENT_CLI=opencode ./scripts/run-experiment.sh            # use opencode
+#
+# Flags:
+#   --scenario NAME    Run only this scenario (default: all)
+#   --strategy NAME    Run only this strategy (default: all)
+#   --dry-run          Print prompts without invoking agents
+#   --max-turns N      Maximum dialogue turns per trial (default: 8)
+#
+# Environment:
+#   AGENT_CLI          Agent CLI to use: "claude" (default) or "opencode"
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+SCENARIOS=(crash-on-save slow-search auth-redirect-loop)
+STRATEGIES=(superpowers-brainstorming structured-triage socratic-refinement)
+
+AGENT_CLI="${AGENT_CLI:-claude}"
+MAX_TURNS=8
+DRY_RUN=false
+FILTER_SCENARIO=""
+FILTER_STRATEGY=""
+
+# Resolve the experiment root relative to this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPERIMENT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Parse flags
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --scenario)   FILTER_SCENARIO="$2"; shift 2 ;;
+    --strategy)   FILTER_STRATEGY="$2"; shift 2 ;;
+    --dry-run)    DRY_RUN=true; shift ;;
+    --max-turns)  MAX_TURNS="$2"; shift 2 ;;
+    *)
+      echo "Unknown flag: $1" >&2
+      echo "Usage: $0 [--scenario NAME] [--strategy NAME] [--dry-run] [--max-turns N]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Apply filters: if a specific scenario/strategy was requested, narrow the
+# arrays down to just that entry (exit with error if the name is invalid).
+if [[ -n "$FILTER_SCENARIO" ]]; then
+  found=false
+  for s in "${SCENARIOS[@]}"; do [[ "$s" == "$FILTER_SCENARIO" ]] && found=true; done
+  if ! $found; then
+    echo "Error: unknown scenario '$FILTER_SCENARIO'" >&2
+    echo "Valid scenarios: ${SCENARIOS[*]}" >&2
+    exit 1
+  fi
+  SCENARIOS=("$FILTER_SCENARIO")
+fi
+
+if [[ -n "$FILTER_STRATEGY" ]]; then
+  found=false
+  for s in "${STRATEGIES[@]}"; do [[ "$s" == "$FILTER_STRATEGY" ]] && found=true; done
+  if ! $found; then
+    echo "Error: unknown strategy '$FILTER_STRATEGY'" >&2
+    echo "Valid strategies: ${STRATEGIES[*]}" >&2
+    exit 1
+  fi
+  STRATEGIES=("$FILTER_STRATEGY")
+fi
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+
+check_prereqs() {
+  local missing=()
+
+  if ! command -v "$AGENT_CLI" &>/dev/null; then
+    missing+=("$AGENT_CLI (agent CLI)")
+  fi
+  if ! command -v jq &>/dev/null; then
+    missing+=("jq")
+  fi
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "Error: missing prerequisites:" >&2
+    for m in "${missing[@]}"; do echo "  - $m" >&2; done
+    exit 1
+  fi
+}
+
+if ! $DRY_RUN; then
+  check_prereqs
+fi
+
+# ---------------------------------------------------------------------------
+# Create timestamped results directory
+# ---------------------------------------------------------------------------
+
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+RESULTS_DIR="$EXPERIMENT_DIR/results/$TIMESTAMP"
+mkdir -p "$RESULTS_DIR"
+
+echo "============================================================"
+echo " Triage Skill Comparison Experiment"
+echo "============================================================"
+echo " Agent CLI:    $AGENT_CLI"
+echo " Max turns:    $MAX_TURNS"
+echo " Dry run:      $DRY_RUN"
+echo " Scenarios:    ${SCENARIOS[*]}"
+echo " Strategies:   ${STRATEGIES[*]}"
+echo " Results dir:  $RESULTS_DIR"
+echo "============================================================"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Run trials
+# ---------------------------------------------------------------------------
+
+TOTAL=$(( ${#SCENARIOS[@]} * ${#STRATEGIES[@]} ))
+CURRENT=0
+
+for scenario in "${SCENARIOS[@]}"; do
+  for strategy in "${STRATEGIES[@]}"; do
+    CURRENT=$((CURRENT + 1))
+    TRIAL_DIR="$RESULTS_DIR/$scenario/$strategy"
+    mkdir -p "$TRIAL_DIR"
+
+    echo "[$CURRENT/$TOTAL] Running: $scenario x $strategy"
+    echo "  => $TRIAL_DIR"
+
+    DRY_RUN_FLAG=""
+    if $DRY_RUN; then
+      DRY_RUN_FLAG="--dry-run"
+    fi
+
+    # run-single-trial.sh expects positional args:
+    #   scenario_name strategy_name results_dir max_turns agent_cli [--dry-run]
+    "$SCRIPT_DIR/run-single-trial.sh" \
+      "$scenario" \
+      "$strategy" \
+      "$TRIAL_DIR" \
+      "$MAX_TURNS" \
+      "$AGENT_CLI" \
+      $DRY_RUN_FLAG
+
+    echo "  => Trial complete."
+    echo ""
+  done
+done
+
+# ---------------------------------------------------------------------------
+# Judge each trial
+# ---------------------------------------------------------------------------
+
+if $DRY_RUN; then
+  echo "[dry-run] Skipping judge and summary phases."
+  exit 0
+fi
+
+echo "============================================================"
+echo " Judging trials"
+echo "============================================================"
+echo ""
+
+CURRENT=0
+for scenario in "${SCENARIOS[@]}"; do
+  for strategy in "${STRATEGIES[@]}"; do
+    CURRENT=$((CURRENT + 1))
+    TRIAL_DIR="$RESULTS_DIR/$scenario/$strategy"
+
+    echo "[$CURRENT/$TOTAL] Judging: $scenario x $strategy"
+
+    "$SCRIPT_DIR/judge.sh" "$TRIAL_DIR" "$AGENT_CLI"
+
+    echo "  => Judgement complete."
+    echo ""
+  done
+done
+
+# ---------------------------------------------------------------------------
+# Generate summary
+# ---------------------------------------------------------------------------
+
+echo "============================================================"
+echo " Generating summary"
+echo "============================================================"
+echo ""
+
+"$SCRIPT_DIR/summarize.sh" "$RESULTS_DIR"
+
+echo ""
+echo "============================================================"
+echo " Experiment complete!"
+echo " Results:  $RESULTS_DIR"
+echo " Summary:  $RESULTS_DIR/summary.md"
+echo "============================================================"

--- a/experiments/triage-skill-comparison/scripts/run-single-trial.sh
+++ b/experiments/triage-skill-comparison/scripts/run-single-trial.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+# =============================================================================
+# run-single-trial.sh — Runs one scenario x strategy through the dialogue loop
+# =============================================================================
+#
+# This script simulates the asynchronous GitHub issue triage cycle:
+#
+#   1. Triage agent reads the issue + comments, decides to ASK or RESOLVE
+#   2. If ASK:  question is appended as a comment
+#   3. Reporter agent reads the issue + comments, answers the question
+#   4. Answer is appended as a comment
+#   5. Repeat until RESOLVE or max turns reached
+#
+# The "issue" is a JSON file with { title, body, comments: [...] }.
+# Agents are invoked via `claude -p` or `opencode -p` in single-shot mode.
+#
+# Arguments:
+#   $1  scenario_name   — Name of the scenario (matches scenarios/*.json)
+#   $2  strategy_name   — Name of the strategy (matches adapters/*.md)
+#   $3  trial_dir       — Directory to write outputs into
+#   $4  max_turns       — Maximum number of dialogue turns
+#   $5  agent_cli       — CLI to invoke ("claude" or "opencode")
+#   $6  [--dry-run]     — Optional: print prompts instead of invoking agents
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+
+SCENARIO_NAME="${1:?Usage: $0 scenario strategy trial_dir max_turns agent_cli [--dry-run]}"
+STRATEGY_NAME="${2:?}"
+TRIAL_DIR="${3:?}"
+MAX_TURNS="${4:?}"
+AGENT_CLI="${5:?}"
+DRY_RUN=false
+if [[ "${6:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPERIMENT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Load scenario, adapter, and prompts
+# ---------------------------------------------------------------------------
+
+SCENARIO_FILE="$EXPERIMENT_DIR/scenarios/${SCENARIO_NAME}.json"
+ADAPTER_FILE="$EXPERIMENT_DIR/adapters/${STRATEGY_NAME}.md"
+
+if [[ ! -f "$SCENARIO_FILE" ]]; then
+  echo "Error: scenario file not found: $SCENARIO_FILE" >&2
+  exit 1
+fi
+if [[ ! -f "$ADAPTER_FILE" ]]; then
+  echo "Error: adapter file not found: $ADAPTER_FILE" >&2
+  exit 1
+fi
+
+SCENARIO_JSON="$(cat "$SCENARIO_FILE")"
+ADAPTER_PROMPT="$(cat "$ADAPTER_FILE")"
+
+# Extract scenario fields
+ISSUE_TITLE="$(echo "$SCENARIO_JSON" | jq -r '.title')"
+ISSUE_BODY="$(echo "$SCENARIO_JSON" | jq -r '.body')"
+GROUND_TRUTH="$(echo "$SCENARIO_JSON" | jq -r '.ground_truth | tojson')"
+
+# ---------------------------------------------------------------------------
+# Base system prompts (embedded here for self-containment)
+# ---------------------------------------------------------------------------
+
+read -r -d '' TRIAGE_SYSTEM_PROMPT << 'TRIAGE_EOF' || true
+You are a triage agent for a software project called TaskFlow. Your job is to
+examine a GitHub issue and its comment history, then either:
+
+(a) Ask ONE clarifying question to the reporter, or
+(b) Declare the issue sufficiently triaged and produce a triage summary.
+
+IMPORTANT: You must respond with ONLY valid JSON. No markdown fences, no
+explanation outside the JSON. Your entire response must be a single JSON object.
+
+If you decide to ASK a question, respond with:
+{
+  "action": "ask",
+  "question": "Your single clarifying question here"
+}
+
+If you decide to RESOLVE (the issue is sufficiently understood), respond with:
+{
+  "action": "resolve",
+  "triage_summary": {
+    "title": "Refined issue title",
+    "problem": "Clear description of the problem",
+    "root_cause_hypothesis": "Most likely root cause based on available info",
+    "reproduction_steps": ["step 1", "step 2", "..."],
+    "environment": "Relevant environment details",
+    "severity": "critical | high | medium | low",
+    "recommended_fix": "What a developer should do to fix this",
+    "information_gaps": ["Any remaining unknowns that didn't block triage"]
+  }
+}
+
+Decision guidance:
+- Resolve when you have enough information for a developer to create an
+  implementation plan and fix the issue.
+- Ask when critical information is missing that would change the approach.
+- Do NOT ask questions whose answers wouldn't change your triage outcome.
+TRIAGE_EOF
+
+read -r -d '' REPORTER_SYSTEM_PROMPT << 'REPORTER_EOF' || true
+You are a person who filed a bug report on a software project. A triage
+agent is asking you clarifying questions about your issue. Answer them
+based on YOUR ACTUAL EXPERIENCE described in the ground truth below.
+
+Rules:
+- Answer naturally, as a real user would — not as a developer or tester.
+- Only share information that YOU would know from your experience. Don't
+  volunteer technical root cause details unless the question specifically
+  leads you to reveal them.
+- If the question touches on something from your ground truth experience,
+  share that specific detail. If it doesn't, give a reasonable "I'm not
+  sure" or "I don't think so" answer.
+- Keep answers concise (1-3 sentences typical, occasionally longer if the
+  question warrants it).
+- You may express frustration or urgency — you're a real person with a
+  real problem.
+
+IMPORTANT: You must respond with ONLY valid JSON. No markdown fences, no
+explanation outside the JSON. Your entire response must be a single JSON object:
+{
+  "answer": "Your response to the question"
+}
+REPORTER_EOF
+
+# ---------------------------------------------------------------------------
+# Initialize issue state
+# ---------------------------------------------------------------------------
+
+ISSUE_JSON="$(jq -n \
+  --arg title "$ISSUE_TITLE" \
+  --arg body "$ISSUE_BODY" \
+  '{title: $title, body: $body, comments: []}'
+)"
+
+# ---------------------------------------------------------------------------
+# Helper: invoke agent CLI
+# ---------------------------------------------------------------------------
+
+invoke_agent() {
+  local prompt="$1"
+
+  if $DRY_RUN; then
+    echo "[dry-run] Would invoke $AGENT_CLI with prompt (${#prompt} chars):"
+    echo "---BEGIN PROMPT---"
+    # Print first 500 chars to keep dry-run output manageable
+    echo "${prompt:0:500}..."
+    echo "---END PROMPT (truncated)---"
+    echo ""
+    return 0
+  fi
+
+  local result
+  if [[ "$AGENT_CLI" == "claude" ]]; then
+    # claude -p takes the prompt as an argument
+    result="$(claude -p "$prompt" --output-format text 2>/dev/null)" || true
+  else
+    # opencode -p also takes the prompt as an argument
+    result="$(opencode -p "$prompt" 2>/dev/null)" || true
+  fi
+
+  echo "$result"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: extract JSON from agent response
+# ---------------------------------------------------------------------------
+# Agents are instructed to return pure JSON, but sometimes they wrap it in
+# markdown fences or add preamble. This function tries to extract valid JSON.
+
+extract_json() {
+  local raw="$1"
+
+  # Try the raw string first
+  if echo "$raw" | jq . &>/dev/null 2>&1; then
+    echo "$raw"
+    return 0
+  fi
+
+  # Try extracting from markdown json fence
+  local fenced
+  fenced="$(echo "$raw" | sed -n '/^```json$/,/^```$/p' | sed '1d;$d')"
+  if [[ -n "$fenced" ]] && echo "$fenced" | jq . &>/dev/null 2>&1; then
+    echo "$fenced"
+    return 0
+  fi
+
+  # Try extracting from generic markdown fence
+  fenced="$(echo "$raw" | sed -n '/^```$/,/^```$/p' | sed '1d;$d')"
+  if [[ -n "$fenced" ]] && echo "$fenced" | jq . &>/dev/null 2>&1; then
+    echo "$fenced"
+    return 0
+  fi
+
+  # Try to find the first { ... } block using grep + awk
+  local braced
+  braced="$(echo "$raw" | awk '/{/{found=1} found{print} /}/{if(found) exit}')"
+  if [[ -n "$braced" ]] && echo "$braced" | jq . &>/dev/null 2>&1; then
+    echo "$braced"
+    return 0
+  fi
+
+  # Give up — return raw and let the caller handle the error
+  echo "$raw"
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Dialogue loop
+# ---------------------------------------------------------------------------
+
+TURN=0
+
+echo "  Starting dialogue: $SCENARIO_NAME x $STRATEGY_NAME (max $MAX_TURNS turns)"
+
+while [[ $TURN -lt $MAX_TURNS ]]; do
+  TURN=$((TURN + 1))
+
+  # --- Triage agent turn ---
+
+  # Build the full prompt: system prompt + adapter + current issue state
+  TRIAGE_PROMPT="$TRIAGE_SYSTEM_PROMPT
+
+--- TRIAGE STRATEGY ---
+
+$ADAPTER_PROMPT
+
+--- CURRENT ISSUE STATE ---
+
+$(echo "$ISSUE_JSON" | jq .)
+
+--- INSTRUCTIONS ---
+
+Examine the issue above (title, body, and all comments so far).
+Apply the triage strategy described above.
+Decide whether to ASK a clarifying question or RESOLVE the issue.
+Respond with ONLY valid JSON as specified in the system prompt."
+
+  # If this is the forced final turn, override instructions
+  if [[ $TURN -eq $MAX_TURNS ]]; then
+    TRIAGE_PROMPT="$TRIAGE_SYSTEM_PROMPT
+
+--- TRIAGE STRATEGY ---
+
+$ADAPTER_PROMPT
+
+--- CURRENT ISSUE STATE ---
+
+$(echo "$ISSUE_JSON" | jq .)
+
+--- INSTRUCTIONS ---
+
+You have reached the maximum number of dialogue turns. You MUST produce a
+triage summary NOW with whatever information you have. Do NOT ask another
+question. Respond with a JSON object with action 'resolve'."
+  fi
+
+  echo "  [Turn $TURN] Triage agent thinking..."
+  TRIAGE_RAW="$(invoke_agent "$TRIAGE_PROMPT")"
+
+  if $DRY_RUN; then
+    # In dry-run mode, simulate a resolve after printing prompts for both agents
+    # First show what the reporter prompt would look like
+    REPORTER_PROMPT="$REPORTER_SYSTEM_PROMPT
+
+--- YOUR GROUND TRUTH EXPERIENCE ---
+
+$GROUND_TRUTH
+
+--- CURRENT ISSUE STATE ---
+
+$(echo "$ISSUE_JSON" | jq .)
+
+--- INSTRUCTIONS ---
+
+The latest comment is a question from the triage agent. Answer it based on
+your ground truth experience. Respond with ONLY valid JSON."
+
+    echo "  [Turn $TURN] Reporter agent prompt:"
+    invoke_agent "$REPORTER_PROMPT"
+    continue
+  fi
+
+  # Parse triage response
+  TRIAGE_JSON="$(extract_json "$TRIAGE_RAW")" || {
+    echo "  Warning: Could not parse triage agent response as JSON on turn $TURN" >&2
+    echo "  Raw response saved to $TRIAL_DIR/error-turn-${TURN}-triage.txt" >&2
+    echo "$TRIAGE_RAW" > "$TRIAL_DIR/error-turn-${TURN}-triage.txt"
+    # Treat unparseable response as needing one more try
+    continue
+  }
+
+  ACTION="$(echo "$TRIAGE_JSON" | jq -r '.action // "unknown"')"
+
+  # --- Handle RESOLVE ---
+  if [[ "$ACTION" == "resolve" ]]; then
+    echo "  [Turn $TURN] Triage agent resolved the issue."
+
+    # Append the resolution as a final comment
+    TRIAGE_SUMMARY="$(echo "$TRIAGE_JSON" | jq -r '.triage_summary // empty')"
+    ISSUE_JSON="$(echo "$ISSUE_JSON" | jq \
+      --arg author "triage-agent" \
+      --arg body "[TRIAGE RESOLVED] $(echo "$TRIAGE_JSON" | jq -c '.triage_summary')" \
+      '.comments += [{author: $author, body: $body}]'
+    )"
+
+    # Write triage summary as markdown
+    echo "$TRIAGE_JSON" | jq -r '.triage_summary' | jq -r '
+      "# Triage Summary\n\n" +
+      "**Title:** " + .title + "\n\n" +
+      "## Problem\n" + .problem + "\n\n" +
+      "## Root Cause Hypothesis\n" + .root_cause_hypothesis + "\n\n" +
+      "## Reproduction Steps\n" + (.reproduction_steps | to_entries | map("  " + (.key+1|tostring) + ". " + .value) | join("\n")) + "\n\n" +
+      "## Environment\n" + .environment + "\n\n" +
+      "## Severity\n" + .severity + "\n\n" +
+      "## Recommended Fix\n" + .recommended_fix + "\n\n" +
+      "## Information Gaps\n" + (.information_gaps | map("- " + .) | join("\n"))
+    ' > "$TRIAL_DIR/triage-summary.md" 2>/dev/null || {
+      # If the jq formatting fails, just dump the raw JSON
+      echo "# Triage Summary (raw JSON)" > "$TRIAL_DIR/triage-summary.md"
+      echo "" >> "$TRIAL_DIR/triage-summary.md"
+      echo '```json' >> "$TRIAL_DIR/triage-summary.md"
+      echo "$TRIAGE_JSON" | jq '.triage_summary' >> "$TRIAL_DIR/triage-summary.md"
+      echo '```' >> "$TRIAL_DIR/triage-summary.md"
+    }
+
+    break
+  fi
+
+  # --- Handle ASK ---
+  if [[ "$ACTION" == "ask" ]]; then
+    QUESTION="$(echo "$TRIAGE_JSON" | jq -r '.question')"
+    echo "  [Turn $TURN] Triage agent asks: ${QUESTION:0:80}..."
+
+    # Append question as comment
+    ISSUE_JSON="$(echo "$ISSUE_JSON" | jq \
+      --arg author "triage-agent" \
+      --arg body "$QUESTION" \
+      '.comments += [{author: $author, body: $body}]'
+    )"
+
+    # --- Reporter agent turn ---
+
+    REPORTER_PROMPT="$REPORTER_SYSTEM_PROMPT
+
+--- YOUR GROUND TRUTH EXPERIENCE ---
+
+$GROUND_TRUTH
+
+--- CURRENT ISSUE STATE ---
+
+$(echo "$ISSUE_JSON" | jq .)
+
+--- INSTRUCTIONS ---
+
+The latest comment is a question from the triage agent. Read the question and
+answer it based on your ground truth experience. Remember: you are a user, not
+a developer. Share what you experienced, not technical analysis.
+
+Respond with ONLY valid JSON: {\"answer\": \"your response\"}"
+
+    echo "  [Turn $TURN] Reporter agent responding..."
+    REPORTER_RAW="$(invoke_agent "$REPORTER_PROMPT")"
+
+    REPORTER_JSON="$(extract_json "$REPORTER_RAW")" || {
+      echo "  Warning: Could not parse reporter agent response on turn $TURN" >&2
+      echo "$REPORTER_RAW" > "$TRIAL_DIR/error-turn-${TURN}-reporter.txt"
+      # Use a generic fallback answer
+      REPORTER_JSON='{"answer": "I am not sure, I just know something is wrong."}'
+    }
+
+    ANSWER="$(echo "$REPORTER_JSON" | jq -r '.answer // "I am not sure."')"
+    echo "  [Turn $TURN] Reporter answers: ${ANSWER:0:80}..."
+
+    # Append answer as comment
+    ISSUE_JSON="$(echo "$ISSUE_JSON" | jq \
+      --arg author "reporter" \
+      --arg body "$ANSWER" \
+      '.comments += [{author: $author, body: $body}]'
+    )"
+  else
+    echo "  [Turn $TURN] Warning: unexpected action '$ACTION' from triage agent" >&2
+    echo "$TRIAGE_RAW" > "$TRIAL_DIR/error-turn-${TURN}-unknown-action.txt"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# If we exhausted turns without resolving, force a final resolution
+# ---------------------------------------------------------------------------
+
+if [[ $TURN -ge $MAX_TURNS ]] && ! $DRY_RUN; then
+  # Check if the last action was a resolve
+  LAST_ACTION="$(echo "$ISSUE_JSON" | jq -r '.comments[-1].body // ""' | grep -c '^\[TRIAGE RESOLVED\]' || true)"
+  if [[ "$LAST_ACTION" -eq 0 ]]; then
+    echo "  [Max turns reached] Forcing final triage resolution..."
+
+    FORCE_PROMPT="$TRIAGE_SYSTEM_PROMPT
+
+--- TRIAGE STRATEGY ---
+
+$ADAPTER_PROMPT
+
+--- CURRENT ISSUE STATE ---
+
+$(echo "$ISSUE_JSON" | jq .)
+
+--- INSTRUCTIONS ---
+
+You have reached the maximum number of dialogue turns. You MUST produce a
+triage summary NOW with whatever information you have gathered. Do NOT ask
+another question. Respond with a JSON object with action 'resolve'."
+
+    FORCE_RAW="$(invoke_agent "$FORCE_PROMPT")"
+    FORCE_JSON="$(extract_json "$FORCE_RAW")" || {
+      echo "  Error: Could not parse forced resolution response" >&2
+      echo "$FORCE_RAW" > "$TRIAL_DIR/error-forced-resolution.txt"
+      # Create a minimal summary
+      FORCE_JSON='{"action":"resolve","triage_summary":{"title":"(forced resolution - parse error)","problem":"Agent could not produce valid JSON","root_cause_hypothesis":"unknown","reproduction_steps":[],"environment":"unknown","severity":"medium","recommended_fix":"Manual triage required","information_gaps":["Everything"]}}'
+    }
+
+    ISSUE_JSON="$(echo "$ISSUE_JSON" | jq \
+      --arg author "triage-agent" \
+      --arg body "[TRIAGE RESOLVED] $(echo "$FORCE_JSON" | jq -c '.triage_summary // {}')" \
+      '.comments += [{author: $author, body: $body}]'
+    )"
+
+    echo "$FORCE_JSON" | jq -r '.triage_summary' > "$TRIAL_DIR/triage-summary.md" 2>/dev/null || {
+      echo '{"note": "forced resolution after max turns"}' > "$TRIAL_DIR/triage-summary.md"
+    }
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Save final conversation state
+# ---------------------------------------------------------------------------
+
+if ! $DRY_RUN; then
+  echo "$ISSUE_JSON" | jq . > "$TRIAL_DIR/conversation.json"
+  echo "  Saved conversation.json ($TURN turns, $(echo "$ISSUE_JSON" | jq '.comments | length') comments)"
+fi

--- a/experiments/triage-skill-comparison/scripts/seed-app.sh
+++ b/experiments/triage-skill-comparison/scripts/seed-app.sh
@@ -1,0 +1,527 @@
+#!/usr/bin/env bash
+# =============================================================================
+# seed-app.sh — Creates the fictional TaskFlow application
+# =============================================================================
+#
+# Generates a minimal but functional Node.js/Express app ("TaskFlow") that
+# contains the bugs referenced by the experiment scenarios:
+#
+#   - crash-on-save:       Title truncation crashes on strings > 255 chars
+#   - slow-search:         Missing database indexes after migration
+#   - auth-redirect-loop:  OAuth state parameter comparison is encoding-sensitive
+#
+# The code is intentionally minimal — just enough to demonstrate the bugs.
+#
+# Arguments:
+#   $1  target_dir  — Directory to create the app in (will be created)
+#
+# Usage:
+#   ./scripts/seed-app.sh /tmp/taskflow-app
+# =============================================================================
+
+set -euo pipefail
+
+TARGET_DIR="${1:?Usage: $0 target_dir}"
+
+echo "Creating TaskFlow app in: $TARGET_DIR"
+mkdir -p "$TARGET_DIR"/{routes,db,public,test,middleware}
+
+# ---------------------------------------------------------------------------
+# package.json
+# ---------------------------------------------------------------------------
+
+cat > "$TARGET_DIR/package.json" << 'EOF'
+{
+  "name": "taskflow",
+  "version": "2.4.0",
+  "description": "TaskFlow — a minimal task management app (experiment fixture)",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node test/tasks.test.js"
+  },
+  "dependencies": {
+    "express": "^4.18.0",
+    "better-sqlite3": "^9.0.0",
+    "express-session": "^1.17.0"
+  }
+}
+EOF
+
+# ---------------------------------------------------------------------------
+# db/schema.sql — Database schema with the migration bug
+# ---------------------------------------------------------------------------
+
+cat > "$TARGET_DIR/db/schema.sql" << 'EOF'
+-- TaskFlow database schema
+-- Version 2.4.0 — includes full-text search migration
+
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT UNIQUE NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS projects (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  owner_id INTEGER REFERENCES users(id),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id INTEGER REFERENCES projects(id),
+  title TEXT NOT NULL,
+  description TEXT,
+  status TEXT DEFAULT 'open',
+  assignee_id INTEGER REFERENCES users(id),
+  assignee_name TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- BUG: The v2.4.0 migration was supposed to recreate these indexes after
+-- dropping them for the full-text search migration. The migration script
+-- ran the DROP INDEX statements but the CREATE INDEX statements silently
+-- failed due to a locking conflict during hot migration. The indexes below
+-- are commented out to simulate the post-migration state.
+
+-- These indexes SHOULD exist but DON'T after the botched migration:
+-- CREATE INDEX idx_tasks_assignee_name ON tasks(assignee_name);
+-- CREATE INDEX idx_tasks_assignee_id ON tasks(assignee_id);
+-- CREATE INDEX idx_tasks_project_assignee ON tasks(project_id, assignee_id, status);
+EOF
+
+# ---------------------------------------------------------------------------
+# db/init.js — Database initialization
+# ---------------------------------------------------------------------------
+
+cat > "$TARGET_DIR/db/init.js" << 'EOF'
+const Database = require('better-sqlite3');
+const fs = require('fs');
+const path = require('path');
+
+function initDatabase(dbPath) {
+  const db = new Database(dbPath || ':memory:');
+  const schema = fs.readFileSync(path.join(__dirname, 'schema.sql'), 'utf-8');
+  db.exec(schema);
+  return db;
+}
+
+module.exports = { initDatabase };
+EOF
+
+# ---------------------------------------------------------------------------
+# server.js — Express app entry point
+# ---------------------------------------------------------------------------
+
+cat > "$TARGET_DIR/server.js" << 'EOF'
+const express = require('express');
+const session = require('express-session');
+const path = require('path');
+const { initDatabase } = require('./db/init');
+const tasksRouter = require('./routes/tasks');
+const authRouter = require('./routes/auth');
+
+const app = express();
+const db = initDatabase();
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.use(session({
+  secret: 'taskflow-dev-secret',
+  resave: false,
+  saveUninitialized: false,
+}));
+
+// Make db available to routes
+app.locals.db = db;
+
+app.use('/api/tasks', tasksRouter);
+app.use('/auth', authRouter);
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`TaskFlow v2.4.0 running on port ${PORT}`);
+});
+
+module.exports = app;
+EOF
+
+# ---------------------------------------------------------------------------
+# routes/tasks.js — Task CRUD with the title truncation bug
+# ---------------------------------------------------------------------------
+
+cat > "$TARGET_DIR/routes/tasks.js" << 'EOF'
+const express = require('express');
+const router = express.Router();
+
+// ---------------------------------------------------------------------------
+// BUG: Title validation/truncation utility
+//
+// This function is supposed to validate and optionally truncate a task title.
+// The bug: when the title exceeds 255 characters, validateTitle() returns
+// undefined instead of the truncated string. The calling code then tries to
+// call .slice() on undefined, causing a TypeError crash.
+// ---------------------------------------------------------------------------
+
+function validateTitle(title) {
+  if (typeof title !== 'string' || title.length === 0) {
+    return null; // clearly invalid
+  }
+  if (title.length <= 255) {
+    return title;
+  }
+  // BUG: This was supposed to return the truncated title, but the developer
+  // forgot the return statement. The function falls off the end and returns
+  // undefined for any title exceeding 255 characters.
+  title.slice(0, 255);
+}
+
+function formatTitle(title) {
+  // This assumes validateTitle always returns a string or null.
+  // When it returns undefined (the bug), .slice() throws TypeError.
+  const validated = validateTitle(title);
+  return validated.slice(0, 1).toUpperCase() + validated.slice(1);
+}
+
+// GET /api/tasks — List tasks, with optional search
+router.get('/', (req, res) => {
+  const db = req.app.locals.db;
+  const { search, project_id, scope } = req.query;
+
+  let query = 'SELECT * FROM tasks';
+  const params = [];
+
+  // BUG: When scope is 'all' (or not specified), no project_id filter is
+  // applied. Without the missing indexes, this results in a sequential scan
+  // across all tasks — extremely slow on large datasets.
+  if (search) {
+    if (project_id && scope !== 'all') {
+      query += ' WHERE project_id = ? AND (title LIKE ? OR assignee_name LIKE ?)';
+      params.push(project_id, `%${search}%`, `%${search}%`);
+    } else {
+      // Full table scan — no index on assignee_name after migration
+      query += ' WHERE title LIKE ? OR assignee_name LIKE ?';
+      params.push(`%${search}%`, `%${search}%`);
+    }
+  }
+
+  try {
+    const tasks = db.prepare(query).all(...params);
+    res.json(tasks);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /api/tasks — Create a new task
+router.post('/', (req, res) => {
+  const db = req.app.locals.db;
+  const { title, description, project_id, assignee_id, assignee_name } = req.body;
+
+  try {
+    // BUG: formatTitle calls validateTitle, which returns undefined for titles
+    // > 255 chars, causing a TypeError in formatTitle's .slice() call.
+    const formattedTitle = formatTitle(title);
+
+    const stmt = db.prepare(
+      'INSERT INTO tasks (title, description, project_id, assignee_id, assignee_name) VALUES (?, ?, ?, ?, ?)'
+    );
+    const result = stmt.run(formattedTitle, description, project_id, assignee_id, assignee_name);
+    res.status(201).json({ id: result.lastInsertRowid });
+  } catch (err) {
+    // The TypeError from the title bug surfaces here as a 500 error.
+    // The client sees "Cannot read properties of undefined (reading 'slice')"
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;
+EOF
+
+# ---------------------------------------------------------------------------
+# routes/auth.js — OAuth flow with the state parameter bug
+# ---------------------------------------------------------------------------
+
+cat > "$TARGET_DIR/routes/auth.js" << 'EOF'
+const express = require('express');
+const crypto = require('crypto');
+const router = express.Router();
+
+// ---------------------------------------------------------------------------
+// BUG: OAuth state parameter comparison
+//
+// The OAuth flow generates a random state token (base64-encoded), stores it
+// in the session, and includes it in the authorization URL. When the OAuth
+// provider redirects back, the state parameter is compared against the stored
+// value using strict equality (===).
+//
+// The problem: some corporate proxies (e.g., Zscaler) perform URL
+// normalization during SSL inspection, re-encoding characters like '+' to
+// '%2B' and '/' to '%2F' in query parameters. Base64 strings commonly
+// contain '+' and '/', so the proxy's re-encoding changes the state value.
+// The strict comparison then fails, and the auth middleware redirects back
+// to /login, creating an infinite loop.
+//
+// A robust implementation would URL-decode both values before comparing,
+// or use base64url encoding (which avoids +, /, and =).
+// ---------------------------------------------------------------------------
+
+// Generate a CSRF state token
+function generateStateToken() {
+  // Standard base64 — contains +, /, and = characters
+  return crypto.randomBytes(32).toString('base64');
+}
+
+// Login page
+router.get('/login', (req, res) => {
+  res.send(`
+    <h1>TaskFlow Login</h1>
+    <a href="/auth/google">Sign in with Google</a>
+  `);
+});
+
+// Initiate OAuth flow
+router.get('/google', (req, res) => {
+  const state = generateStateToken();
+  req.session.oauthState = state;
+
+  // In a real app, this would redirect to Google's OAuth endpoint.
+  // For this fixture, we simulate the redirect URL structure.
+  const authUrl = 'https://accounts.google.com/o/oauth2/v2/auth'
+    + '?client_id=FAKE_CLIENT_ID'
+    + '&redirect_uri=' + encodeURIComponent('http://localhost:3000/auth/google/callback')
+    + '&response_type=code'
+    + '&scope=openid+email+profile'
+    + '&state=' + encodeURIComponent(state);
+
+  res.redirect(authUrl);
+});
+
+// OAuth callback
+router.get('/google/callback', (req, res) => {
+  const { code, state } = req.query;
+  const storedState = req.session.oauthState;
+
+  // BUG: Strict comparison of state parameter.
+  // If a proxy re-encoded the state in the redirect URL, the received
+  // `state` will differ from `storedState` even though they represent
+  // the same token. This causes CSRF validation to fail.
+  if (!state || !storedState || state !== storedState) {
+    // CSRF validation failed — redirect back to login.
+    // This creates an infinite loop: login -> Google -> callback -> login -> ...
+    console.log('CSRF state mismatch',
+      { received: state?.substring(0, 10), stored: storedState?.substring(0, 10) });
+    return res.redirect('/auth/login');
+  }
+
+  // Clear the state token
+  delete req.session.oauthState;
+
+  // In a real app, exchange the code for tokens here.
+  // For this fixture, just set a session flag.
+  req.session.authenticated = true;
+  req.session.user = { email: 'user@example.com', name: 'Test User' };
+  res.redirect('/');
+});
+
+module.exports = router;
+EOF
+
+# ---------------------------------------------------------------------------
+# middleware/auth.js — Auth middleware
+# ---------------------------------------------------------------------------
+
+cat > "$TARGET_DIR/middleware/auth.js" << 'EOF'
+function requireAuth(req, res, next) {
+  if (req.session && req.session.authenticated) {
+    return next();
+  }
+  res.redirect('/auth/login');
+}
+
+module.exports = { requireAuth };
+EOF
+
+# ---------------------------------------------------------------------------
+# public/index.html — Minimal UI
+# ---------------------------------------------------------------------------
+
+cat > "$TARGET_DIR/public/index.html" << 'EOF'
+<!DOCTYPE html>
+<html>
+<head>
+  <title>TaskFlow</title>
+  <style>
+    body { font-family: sans-serif; max-width: 800px; margin: 2em auto; }
+    input, button { padding: 0.5em; margin: 0.25em; }
+    .task { border: 1px solid #ccc; padding: 0.5em; margin: 0.5em 0; }
+    #search-scope { margin-left: 0.5em; }
+    .error { color: red; }
+  </style>
+</head>
+<body>
+  <h1>TaskFlow</h1>
+
+  <div id="search-bar">
+    <input type="text" id="search-input" placeholder="Search tasks...">
+    <select id="search-scope">
+      <option value="all">All Projects</option>
+      <option value="current">Current Project</option>
+    </select>
+    <button onclick="searchTasks()">Search</button>
+  </div>
+
+  <div id="new-task">
+    <h2>New Task</h2>
+    <input type="text" id="task-title" placeholder="Task title">
+    <textarea id="task-desc" placeholder="Description"></textarea>
+    <button onclick="saveTask()">Save</button>
+  </div>
+
+  <div id="error-display" class="error"></div>
+  <div id="task-list"></div>
+
+  <script src="app.js"></script>
+</body>
+</html>
+EOF
+
+# ---------------------------------------------------------------------------
+# public/app.js — Client-side JS
+# ---------------------------------------------------------------------------
+
+cat > "$TARGET_DIR/public/app.js" << 'EOF'
+async function searchTasks() {
+  const query = document.getElementById('search-input').value;
+  const scope = document.getElementById('search-scope').value;
+
+  const params = new URLSearchParams({ search: query, scope: scope });
+  try {
+    const res = await fetch(`/api/tasks?${params}`);
+    const tasks = await res.json();
+    renderTasks(tasks);
+  } catch (err) {
+    showError('Search failed: ' + err.message);
+  }
+}
+
+async function saveTask() {
+  const title = document.getElementById('task-title').value;
+  const description = document.getElementById('task-desc').value;
+
+  try {
+    const res = await fetch('/api/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, description }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json();
+      throw new Error(data.error || 'Save failed');
+    }
+
+    document.getElementById('task-title').value = '';
+    document.getElementById('task-desc').value = '';
+    showError('');
+    searchTasks(); // refresh list
+  } catch (err) {
+    // BUG: When the title > 255 chars, the server returns a 500 with
+    // "Cannot read properties of undefined (reading 'slice')"
+    // The UI shows a blank white page because this error handler doesn't
+    // gracefully handle the crash — it just shows the raw error.
+    showError('Save failed: ' + err.message);
+  }
+}
+
+function renderTasks(tasks) {
+  const list = document.getElementById('task-list');
+  if (!tasks || tasks.length === 0) {
+    list.innerHTML = '<p>No tasks found.</p>';
+    return;
+  }
+  list.innerHTML = tasks.map(t =>
+    `<div class="task"><strong>${t.title}</strong><br>${t.description || ''}</div>`
+  ).join('');
+}
+
+function showError(msg) {
+  document.getElementById('error-display').textContent = msg;
+}
+EOF
+
+# ---------------------------------------------------------------------------
+# test/tasks.test.js — Basic tests (some will fail due to bugs)
+# ---------------------------------------------------------------------------
+
+cat > "$TARGET_DIR/test/tasks.test.js" << 'EOF'
+const assert = require('assert');
+
+// Inline the validateTitle function for unit testing
+function validateTitle(title) {
+  if (typeof title !== 'string' || title.length === 0) {
+    return null;
+  }
+  if (title.length <= 255) {
+    return title;
+  }
+  // BUG: missing return — returns undefined for titles > 255 chars
+  title.slice(0, 255);
+}
+
+function formatTitle(title) {
+  const validated = validateTitle(title);
+  return validated.slice(0, 1).toUpperCase() + validated.slice(1);
+}
+
+// Test 1: Normal title works fine
+try {
+  const result = formatTitle('fix the login page');
+  assert.strictEqual(result, 'Fix the login page');
+  console.log('PASS: normal title formatting');
+} catch (e) {
+  console.log('FAIL: normal title formatting -', e.message);
+}
+
+// Test 2: Long title should be truncated (this test exposes the bug)
+try {
+  const longTitle = 'a'.repeat(300);
+  const result = formatTitle(longTitle);
+  assert.strictEqual(result.length, 255);
+  console.log('PASS: long title truncation');
+} catch (e) {
+  console.log('FAIL: long title truncation -', e.message);
+}
+
+// Test 3: Empty title returns null
+try {
+  const result = validateTitle('');
+  assert.strictEqual(result, null);
+  console.log('PASS: empty title validation');
+} catch (e) {
+  console.log('FAIL: empty title validation -', e.message);
+}
+
+console.log('\nDone. (Test 2 is expected to fail — it demonstrates the crash-on-save bug.)');
+EOF
+
+echo ""
+echo "TaskFlow app created in: $TARGET_DIR"
+echo ""
+echo "Files created:"
+find "$TARGET_DIR" -type f | sort | sed "s|$TARGET_DIR/|  |"
+echo ""
+echo "To test:"
+echo "  cd $TARGET_DIR && npm install && npm test"
+echo ""
+echo "Test 2 (long title) will fail — this is the crash-on-save bug."

--- a/experiments/triage-skill-comparison/scripts/summarize.sh
+++ b/experiments/triage-skill-comparison/scripts/summarize.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# =============================================================================
+# summarize.sh — Generates a comparison table from all judge assessments
+# =============================================================================
+#
+# Reads all judge-assessment.json files from a results directory and produces
+# a markdown summary with:
+#   - A comparison table (scenarios x strategies)
+#   - A "best questions" section
+#   - A "limitations and observations" section
+#
+# Arguments:
+#   $1  results_dir  — Path to the timestamped results directory
+#
+# Output:
+#   Writes summary.md to the results directory.
+# =============================================================================
+
+set -euo pipefail
+
+RESULTS_DIR="${1:?Usage: $0 results_dir}"
+
+if [[ ! -d "$RESULTS_DIR" ]]; then
+  echo "Error: results directory not found: $RESULTS_DIR" >&2
+  exit 1
+fi
+
+SCENARIOS=(crash-on-save slow-search auth-redirect-loop)
+STRATEGIES=(superpowers-brainstorming structured-triage socratic-refinement)
+
+OUTPUT="$RESULTS_DIR/summary.md"
+
+# ---------------------------------------------------------------------------
+# Helper: read a score from a judge assessment
+# ---------------------------------------------------------------------------
+
+get_field() {
+  local scenario="$1" strategy="$2" field="$3"
+  local file="$RESULTS_DIR/$scenario/$strategy/judge-assessment.json"
+  if [[ -f "$file" ]]; then
+    jq -r "$field" "$file" 2>/dev/null || echo "N/A"
+  else
+    echo "N/A"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Generate summary
+# ---------------------------------------------------------------------------
+
+{
+  cat << 'HEADER'
+# Triage Skill Comparison — Experiment Results
+
+## Methodology
+
+Three fictional bug report scenarios of varying quality were triaged by an
+AI agent using three different triage strategies. Each scenario x strategy
+combination ran as an independent trial with up to 8 dialogue turns. An
+independent judge agent then scored each trial on five criteria.
+
+### Scoring Criteria
+
+| Criterion | Weight | Description |
+|-----------|--------|-------------|
+| Completeness | 25% | Did the triage capture all ground truth details? |
+| Accuracy | 25% | Is the triaged information factually correct? |
+| Efficiency | 20% | Were turns used well, without redundancy? |
+| Question Quality | 15% | Were questions insightful and well-targeted? |
+| Actionability | 15% | Could a developer start fixing from the triage summary? |
+
+---
+
+## Overall Scores
+
+HEADER
+
+  # --- Weighted score comparison table ---
+
+  echo "| Scenario | superpowers-brainstorming | structured-triage | socratic-refinement |"
+  echo "|----------|:------------------------:|:-----------------:|:-------------------:|"
+
+  for scenario in "${SCENARIOS[@]}"; do
+    row="| \`$scenario\`"
+    for strategy in "${STRATEGIES[@]}"; do
+      score="$(get_field "$scenario" "$strategy" '.weighted_score')"
+      row="$row | $score"
+    done
+    echo "$row |"
+  done
+
+  # Compute averages per strategy
+  echo ""
+  echo "### Strategy Averages"
+  echo ""
+  echo "| Strategy | Avg Weighted Score | Avg Turns |"
+  echo "|----------|:------------------:|:---------:|"
+
+  for strategy in "${STRATEGIES[@]}"; do
+    total_score=0
+    total_turns=0
+    count=0
+    for scenario in "${SCENARIOS[@]}"; do
+      score="$(get_field "$scenario" "$strategy" '.weighted_score')"
+      turns="$(get_field "$scenario" "$strategy" '.num_turns')"
+      if [[ "$score" != "N/A" && "$score" != "null" ]]; then
+        total_score="$(echo "$total_score + $score" | bc -l)"
+        count=$((count + 1))
+      fi
+      if [[ "$turns" != "N/A" && "$turns" != "null" ]]; then
+        total_turns="$(echo "$total_turns + $turns" | bc -l)"
+      fi
+    done
+    if [[ $count -gt 0 ]]; then
+      avg_score="$(printf '%.2f' "$(echo "$total_score / $count" | bc -l)")"
+      avg_turns="$(printf '%.1f' "$(echo "$total_turns / $count" | bc -l)")"
+    else
+      avg_score="N/A"
+      avg_turns="N/A"
+    fi
+    echo "| \`$strategy\` | $avg_score | $avg_turns |"
+  done
+
+  # --- Detailed scores per trial ---
+
+  echo ""
+  echo "---"
+  echo ""
+  echo "## Detailed Scores"
+  echo ""
+
+  for scenario in "${SCENARIOS[@]}"; do
+    echo "### Scenario: \`$scenario\`"
+    echo ""
+    echo "| Criterion | superpowers-brainstorming | structured-triage | socratic-refinement |"
+    echo "|-----------|:------------------------:|:-----------------:|:-------------------:|"
+
+    for criterion in completeness accuracy efficiency question_quality actionability; do
+      row="| $criterion"
+      for strategy in "${STRATEGIES[@]}"; do
+        val="$(get_field "$scenario" "$strategy" ".scores.$criterion")"
+        row="$row | $val"
+      done
+      echo "$row |"
+    done
+
+    row="| **Weighted**"
+    for strategy in "${STRATEGIES[@]}"; do
+      val="$(get_field "$scenario" "$strategy" '.weighted_score')"
+      row="$row | **$val**"
+    done
+    echo "$row |"
+
+    row="| Turns"
+    for strategy in "${STRATEGIES[@]}"; do
+      val="$(get_field "$scenario" "$strategy" '.num_turns')"
+      row="$row | $val"
+    done
+    echo "$row |"
+
+    echo ""
+  done
+
+  # --- Best questions ---
+
+  echo "---"
+  echo ""
+  echo "## Notable Questions"
+  echo ""
+  echo "The most insightful questions identified by the judge for each trial:"
+  echo ""
+
+  for scenario in "${SCENARIOS[@]}"; do
+    for strategy in "${STRATEGIES[@]}"; do
+      file="$RESULTS_DIR/$scenario/$strategy/judge-assessment.json"
+      if [[ -f "$file" ]]; then
+        questions="$(jq -r '.notable_questions // [] | .[]' "$file" 2>/dev/null)"
+        if [[ -n "$questions" ]]; then
+          echo "**\`$scenario\` × \`$strategy\`:**"
+          while IFS= read -r q; do
+            echo "- $q"
+          done <<< "$questions"
+          echo ""
+        fi
+      fi
+    done
+  done
+
+  # --- Qualitative notes ---
+
+  echo "---"
+  echo ""
+  echo "## Qualitative Assessments"
+  echo ""
+
+  for scenario in "${SCENARIOS[@]}"; do
+    for strategy in "${STRATEGIES[@]}"; do
+      notes="$(get_field "$scenario" "$strategy" '.qualitative_notes')"
+      if [[ "$notes" != "N/A" && "$notes" != "null" ]]; then
+        echo "**\`$scenario\` × \`$strategy\`:** $notes"
+        echo ""
+      fi
+    done
+  done
+
+  # --- Missed information ---
+
+  echo "---"
+  echo ""
+  echo "## Information Gaps"
+  echo ""
+  echo "Ground truth details that were NOT captured during triage:"
+  echo ""
+
+  for scenario in "${SCENARIOS[@]}"; do
+    for strategy in "${STRATEGIES[@]}"; do
+      file="$RESULTS_DIR/$scenario/$strategy/judge-assessment.json"
+      if [[ -f "$file" ]]; then
+        missed="$(jq -r '.missed_information // [] | .[]' "$file" 2>/dev/null)"
+        if [[ -n "$missed" ]]; then
+          echo "**\`$scenario\` × \`$strategy\`:**"
+          while IFS= read -r m; do
+            echo "- $m"
+          done <<< "$missed"
+          echo ""
+        fi
+      fi
+    done
+  done
+
+  # --- Limitations ---
+
+  echo "---"
+  echo ""
+  echo "## Limitations and Observations"
+  echo ""
+  cat << 'LIMITATIONS'
+1. **Simulated reporters.** The "reporter" is an AI agent with access to the
+   ground truth. Real humans may give more ambiguous, emotional, or tangential
+   answers. The reporter agent is instructed to behave naturally, but this is
+   an approximation.
+
+2. **Single run.** Each scenario x strategy was run once. LLM outputs are
+   non-deterministic; running multiple times would give more reliable averages.
+   Consider running 3-5 trials per combination for statistical significance.
+
+3. **Judge subjectivity.** The judge is also an LLM. Its scores are consistent
+   within a run but may vary across runs. Consider using multiple judge
+   invocations and averaging.
+
+4. **Prompt sensitivity.** Results depend heavily on the exact wording of the
+   adapter prompts. Small changes to the triage strategy description can
+   significantly affect agent behavior.
+
+5. **Context window pressure.** As conversations grow longer, later turns have
+   more context to process. This may disadvantage strategies that ask more
+   questions (more tokens in context = more room for confusion).
+
+6. **No tool access.** Agents cannot actually inspect code, run searches, or
+   query databases. In a real triage scenario, an agent with tool access might
+   resolve issues faster by investigating directly.
+
+7. **File-based simulation.** This experiment simulates GitHub issue I/O via
+   local JSON files. The adaptation to real GitHub API is mechanical (see
+   `github-adapter.sh`) but untested.
+LIMITATIONS
+
+} > "$OUTPUT"
+
+echo "Summary written to: $OUTPUT"


### PR DESCRIPTION
## Summary

Designs an experiment to evaluate whether third-party coding agent skills can be adapted for asynchronous GitHub issue triage via comment dialogue, related to #126 (Story 3: Triage Agent).

## What this adds

- **3 fictional bug report scenarios** of varying quality (very poor, medium, good-but-ambiguous), each with embedded ground truth for evaluation
- **3 triage strategy adapters** encoding different questioning approaches:
  - `superpowers-brainstorming` — adapted from obra/superpowers: one question at a time, multiple choice preferred, YAGNI
  - `structured-triage` — systematic checklist: expected behavior, actual behavior, repro steps, environment, errors, frequency
  - `socratic-refinement` — open-ended Socratic method: starts with intent, probes assumptions, explores periphery
- **Agent prompts** for triage, reporter simulation, and independent judging with weighted scoring rubric
- **Orchestration scripts** for running all 9 trials (3 scenarios x 3 strategies) via `claude -p` or `opencode -p`
- **Seed script** creating a fictional TaskFlow app with the actual bugs the scenarios describe
- **Reference script** showing how to convert the file-based simulation to live GitHub API calls
- **Scoring rubric** (completeness 25%, accuracy 25%, efficiency 20%, question quality 15%, actionability 15%) with summary table generation

## Key architectural insight

Non-interactive mode (`-p`) is exactly the constraint needed. Interactive skills use the `question` tool to ask users. In `-p` mode, there is no user — the agent outputs its question as text, which we capture and post to the issue. No hooks or skill modifications are needed.

## Note on oh-my-claude / oh-my-openagent

These repos were referenced in the issue but return 404 on GitHub. If they surface, they can be added as additional adapters following the established pattern.