### PR TITLE
docs: ADR 0011 — canonical org config.yaml v1 (SPEC + schema)

### DIFF
--- a/docs/ADRs/0011-admin-install-org-config-yaml-v1.md
+++ b/docs/ADRs/0011-admin-install-org-config-yaml-v1.md
@@ -1,0 +1,40 @@
+---
+title: "11. Canonical schema for admin-managed org config.yaml (v1)"
+status: Accepted
+relates_to:
+  - governance
+  - codebase-context
+  - agent-infrastructure
+topics:
+  - configuration
+  - admin-install
+  - yaml
+---
+
+# 11. Canonical schema for admin-managed org config.yaml (v1)
+
+Date: 2026-04-05
+
+## Status
+
+Accepted
+
+## Context
+
+[ADR 0003](0003-org-config-repo-convention.md) places org-level fullsend configuration in `<org>/.fullsend`, including a top-level `config.yaml`. That ADR intentionally deferred exact schema details. The admin CLI and config-repo layer now read and write a concrete v1 document; adopters and tooling need a single normative definition that stays aligned with the implementation.
+
+## Decision
+
+The **canonical** definition of admin-managed `config.yaml` **v1** is:
+
+- [SPEC.md](../normative/admin-install/v1/adr-0011-org-config-yaml/SPEC.md) (normative prose), and
+- [config.schema.json](../normative/admin-install/v1/adr-0011-org-config-yaml/config.schema.json) (Draft 7 JSON Schema for structure; semantic constraints in the SPEC prevail if they differ).
+
+Implementations that claim `config.yaml` v1 compatibility MUST conform to that SPEC for fields and validation rules it defines. Future versions SHOULD introduce a new `version` value and companion normative artifacts.
+
+## Consequences
+
+- Org configuration in `.fullsend` can be validated, reviewed, and generated against a stable, published contract.
+- The admin CLI and other tools can share one reference for field names, types, and allowed enumeration values.
+- Broader `.fullsend` layout (other files, inheritance, guardrails) remains governed by ADR 0003 and is not specified here.
+- Changes to v1 require updating the normative SPEC/schema and, when behavior changes, follow-up design or ADR work.

--- a/docs/normative/admin-install/v1/adr-0011-org-config-yaml/SPEC.md
+++ b/docs/normative/admin-install/v1/adr-0011-org-config-yaml/SPEC.md
@@ -1,0 +1,92 @@
+# Org `config.yaml` v1 (admin install)
+
+This specification defines the **v1** YAML document stored as `config.yaml` in the organization’s `.fullsend` configuration repository. Repository location and purpose follow [ADR 0003: Org-level configuration lives in a conventional repo](../../../../ADRs/0003-org-config-repo-convention.md).
+
+This document describes **data shape and validation rules** only. It does not define install workflows, enrollment, or secret handling.
+
+## Normative references
+
+- **JSON Schema:** [config.schema.json](config.schema.json) (Draft 7). Where this prose and the schema disagree, this SPEC is authoritative; the schema is a machine-readable projection.
+
+## File
+
+| Item | Value |
+|------|--------|
+| Repository | `<org>/.fullsend` (conventional name; see ADR 0003) |
+| Path in repo | `config.yaml` |
+| Format | YAML 1.x (UTF-8) |
+
+## Document model
+
+The root mapping MUST contain the keys below. Omitted keys are interpreted as type-appropriate zero values (empty sequences, `false`, empty mappings) when parsed by a conforming implementation.
+
+### `version` (string, required)
+
+Schema version of this document. For this SPEC, the value MUST be exactly `1`.
+
+### `dispatch` (mapping, required)
+
+#### `dispatch.platform` (string, required)
+
+Dispatch backend for agent work. The only defined value in v1 is `github-actions`.
+
+### `defaults` (mapping, required)
+
+Organization-wide defaults applied to repositories unless overridden elsewhere in this file.
+
+#### `defaults.roles` (sequence of strings, required)
+
+Ordered list of agent **roles** enabled by default for the org. Each element MUST be one of:
+
+`fullsend`, `triage`, `coder`, `review`
+
+#### `defaults.max_implementation_retries` (integer, required)
+
+Non-negative integer cap on implementation retries for agent workflows.
+
+#### `defaults.auto_merge` (boolean, required)
+
+Whether automatic merge is enabled by default for applicable automation (v1 uses a single boolean; semantics of merge are defined by the dispatch implementation, not by this file).
+
+### `agents` (sequence of mappings, required)
+
+Each element describes one GitHub App (or equivalent) identity for a **role**:
+
+| Field | Type | Required | Notes |
+|-------|------|----------|--------|
+| `role` | string | yes | One of the same role literals as in `defaults.roles` |
+| `name` | string | yes | Human-oriented label |
+| `slug` | string | yes | Forge application slug (e.g. GitHub App slug) |
+
+The v1 reference implementation does not require unique `role` or `slug` values; duplicates MAY be rejected by future specs or by tooling.
+
+### `repos` (mapping, required)
+
+Keys are **repository names** (short name within the org, not `owner/name`). Values are **repo entries**.
+
+#### Repo entry (mapping)
+
+| Field | Type | Required | Notes |
+|-------|------|----------|--------|
+| `enabled` | boolean | yes | When `true`, the repo participates in fullsend for this org |
+| `roles` | sequence of strings | no | Per-repo role override; elements use the same role literals as `defaults.roles`. Omitted means “use defaults” in the reference implementation |
+
+## Serialization (informative)
+
+The reference `fullsend` CLI may prepend a fixed comment header before the YAML body (project URL and “managed by fullsend” notice). That header is **not** part of the data model; parsers MUST accept documents with or without it.
+
+## Validation summary (normative)
+
+A document is **valid v1** if and only if:
+
+1. It parses as YAML into the structure above.
+2. `version` is `1`.
+3. `dispatch.platform` is `github-actions`.
+4. `defaults.max_implementation_retries` ≥ 0.
+5. Every entry in `defaults.roles` is one of the four defined role literals.
+
+Per-repo `roles`, when present, are not checked by the v1 reference validator; tooling SHOULD still restrict values to the same role literals for consistency.
+
+## Extensibility
+
+Keys not listed in this SPEC MAY appear in a file; a strictly conforming v1 parser MAY ignore them or reject them. Forward evolution SHOULD bump `version`.

--- a/docs/normative/admin-install/v1/adr-0011-org-config-yaml/config.schema.json
+++ b/docs/normative/admin-install/v1/adr-0011-org-config-yaml/config.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/fullsend-ai/fullsend/raw/main/docs/normative/admin-install/v1/adr-0011-org-config-yaml/config.schema.json",
+  "title": "fullsend org config.yaml v1",
+  "description": "JSON Schema (structural) for the YAML org config described in SPEC.md. Semantic rules in SPEC.md take precedence.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["version", "dispatch", "defaults", "agents", "repos"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1"
+    },
+    "dispatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["platform"],
+      "properties": {
+        "platform": {
+          "type": "string",
+          "const": "github-actions"
+        }
+      }
+    },
+    "defaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["roles", "max_implementation_retries", "auto_merge"],
+      "properties": {
+        "roles": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/agentRole" }
+        },
+        "max_implementation_retries": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "auto_merge": {
+          "type": "boolean"
+        }
+      }
+    },
+    "agents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["role", "name", "slug"],
+        "properties": {
+          "role": { "$ref": "#/definitions/agentRole" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" }
+        }
+      }
+    },
+    "repos": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["enabled"],
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "roles": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/agentRole" }
+          }
+        }
+      },
+      "propertyNames": {
+        "pattern": "^[A-Za-z0-9._-]+$"
+      }
+    }
+  },
+  "definitions": {
+    "agentRole": {
+      "type": "string",
+      "enum": ["fullsend", "triage", "coder", "review"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Records **[ADR 0011](docs/ADRs/0011-admin-install-org-config-yaml-v1.md)**: adopt `docs/normative/admin-install/v1/adr-0011-org-config-yaml/SPEC.md` and `config.schema.json` as the canonical definition of admin-managed `config.yaml` **v1** in `<org>/.fullsend`.

## Context

- Builds on [ADR 0003](docs/ADRs/0003-org-config-repo-convention.md) (where `config.yaml` lives).
- Aligns fields and validation with `internal/config` (`OrgConfig`, `Validate`) and `internal/layers/configrepo.go` (`config.yaml` path).

## Out of scope (per ADR)

Workflows, enrollment, and secrets are not specified here.

## Checklist

- [x] ADR frontmatter / status lint (local: `hack/lint-adr-*`, `lint-adr-frontmatter`)
- Note: `make lint` was not runnable in this environment (`uvx` / `go` unavailable on PATH); CI should run the full target.

Made with [Cursor](https://cursor.com)