### PR TITLE
docs: ADR 0012 — normative v1 files under .fullsend

### DIFF
--- a/docs/ADRs/0012-admin-install-fullsend-repo-files-v1.md
+++ b/docs/ADRs/0012-admin-install-fullsend-repo-files-v1.md
@@ -1,0 +1,56 @@
+---
+title: "12. Normative v1 Git-tracked files under `.fullsend` for admin install"
+status: Proposed
+relates_to:
+  - governance
+  - codebase-context
+  - agent-infrastructure
+topics:
+  - configuration
+  - admin-install
+  - github-actions
+---
+
+# 12. Normative v1 Git-tracked files under `.fullsend` for admin install
+
+Date: 2026-04-05
+
+## Status
+
+Proposed
+
+## Context
+
+[ADR 0003](0003-org-config-repo-convention.md) places org-level fullsend
+configuration in `<org>/.fullsend`, but it sketches a broader future layout
+than what the current admin installer writes today. The CLI and layers already
+create a concrete set of committed paths and workflow bodies; without a
+normative v1 spec, tooling and docs can drift from each other.
+
+Separately, **ADR 0011** owns the YAML document body of `config.yaml`. This
+decision covers only which paths are Git-tracked in `.fullsend` and the required
+v1 contents for each path except that body.
+
+## Decision
+
+Adopt **`docs/normative/admin-install/v1/adr-0012-fullsend-repo-files/SPEC.md`**
+as the single normative description of the **v1** set of files committed in
+`<org>/.fullsend` by admin install, including exact required contents for:
+
+- `.github/workflows/agent.yaml`
+- `.github/workflows/repo-onboard.yaml`
+- `CODEOWNERS` (pattern with the installing user’s GitHub login)
+
+The `config.yaml` path is included in that tracked set; its **document body**
+(schema and fields) remain specified in **ADR 0011** only.
+
+## Consequences
+
+- Installers, reviewers, and CI can validate `.fullsend` against one SPEC for
+  file paths and workflow/CODEOWNERS bodies.
+- Changes to tracked paths or workflow bodies require a SPEC revision and a
+  new or superseding ADR, not silent drift in Go constants alone.
+- Secret and variable storage in `.fullsend` stays outside Git, as described in
+  the SPEC’s out-of-scope section.
+- Enrollment shims in application repositories remain outside this tracked set.
+- Until accepted, downstream docs should treat this as a proposed baseline.

--- a/docs/normative/admin-install/v1/adr-0012-fullsend-repo-files/SPEC.md
+++ b/docs/normative/admin-install/v1/adr-0012-fullsend-repo-files/SPEC.md
@@ -1,0 +1,90 @@
+# SPEC: Git-tracked files in `<org>/.fullsend` (admin install v1)
+
+## 1. Scope
+
+This specification defines the **v1 set of paths committed in git** inside the
+organization configuration repository named `.fullsend`, as created and
+updated by the `fullsend admin install` flow (`ConfigRepoLayer` and
+`WorkflowsLayer`). It is limited to **files**; repository secrets, variables,
+and files written to other repositories are out of scope (see section 5).
+
+The repository name and role of `.fullsend` follow
+[ADR 0003](../../../../ADRs/0003-org-config-repo-convention.md).
+
+## 2. Normative tracked paths (v1)
+
+The following paths SHALL exist on the default branch after a complete admin
+install of these layers:
+
+| Path | Layer responsible |
+|------|-------------------|
+| `config.yaml` | `ConfigRepoLayer` |
+| `.github/workflows/agent.yaml` | `WorkflowsLayer` |
+| `.github/workflows/repo-onboard.yaml` | `WorkflowsLayer` |
+| `CODEOWNERS` | `WorkflowsLayer` |
+
+Write order for workflow-related paths: `agent.yaml`, then `repo-onboard.yaml`,
+then `CODEOWNERS` (CODEOWNERS failure is non-fatal in the implementation).
+
+## 3. Per-path requirements
+
+### 3.1 `config.yaml`
+
+- **Location:** repository root, filename exactly `config.yaml`.
+- **Document body (fields, schema, validation):** specified in **ADR 0011**
+  (this SPEC only requires that the file exists as the tracked carrier for
+  org configuration).
+
+### 3.2 `.github/workflows/agent.yaml`
+
+- **Contents:** exactly the document in
+  [`files/agent-dispatch-v1.yaml`](files/agent-dispatch-v1.yaml) (byte-for-byte
+  normative snapshot for v1).
+
+### 3.3 `.github/workflows/repo-onboard.yaml`
+
+- **Contents:** exactly the document in
+  [`files/repo-onboard-v1.yaml`](files/repo-onboard-v1.yaml) (byte-for-byte
+  normative snapshot for v1).
+
+### 3.4 `CODEOWNERS`
+
+- **Purpose:** grant the installing human ownership of all paths in the
+  configuration repo.
+- **Normative pattern (v1):** exactly two lines — a comment line, then a
+  wildcard rule for the authenticated GitHub user who ran install:
+
+```text
+# fullsend configuration is governed by org admins.
+* @<AUTHENTICATED_GITHUB_USER_LOGIN>
+```
+
+Replace `<AUTHENTICATED_GITHUB_USER_LOGIN>` with the installing user’s GitHub
+login (no `@` prefix inside the angle-bracket placeholder; the second line
+includes `@` before the login as shown).
+
+## 4. Relationship to implementation
+
+The reference implementation lives in `internal/layers/configrepo.go` and
+`internal/layers/workflows.go`. If implementation and this SPEC diverge, this
+SPEC is normative for **v1** tracked layout and file bodies (except
+`config.yaml` body per ADR 0011).
+
+## 5. Out of scope (not Git-tracked in `.fullsend`)
+
+The following are managed via the forge API, not as committed files in
+`.fullsend`:
+
+- **Repository secrets** — one per configured agent role, name pattern
+  `FULLSEND_<ROLE>_APP_PRIVATE_KEY` (PEM material), where `<ROLE>` is the
+  uppercased role string (`SecretsLayer`).
+- **Repository variables** — one per role, name pattern
+  `FULLSEND_<ROLE>_APP_ID` (string app id).
+
+**Per-repository enrollment** (for example `.github/workflows/fullsend.yaml` in
+application repos) is performed by `EnrollmentLayer` and is intentionally not
+part of the `.fullsend` repository file set.
+
+The `fullsend admin` CLI (`internal/cli/admin.go`) orchestrates these layers; it
+does not introduce additional committed paths under `.fullsend` beyond those
+listed in section 2.

--- a/docs/normative/admin-install/v1/adr-0012-fullsend-repo-files/files/agent-dispatch-v1.yaml
+++ b/docs/normative/admin-install/v1/adr-0012-fullsend-repo-files/files/agent-dispatch-v1.yaml
@@ -1,0 +1,27 @@
+# Reusable agent dispatch workflow
+# Called by per-repo shim workflows to run fullsend agents.
+name: Agent Dispatch
+
+on:
+  workflow_call:
+    inputs:
+      event_type:
+        required: true
+        type: string
+      event_payload:
+        required: true
+        type: string
+    secrets:
+      APP_PRIVATE_KEY:
+        required: true
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run fullsend entrypoint
+        run: echo "fullsend entrypoint - event=${{ inputs.event_type }}"
+        env:
+          EVENT_TYPE: ${{ inputs.event_type }}
+          EVENT_PAYLOAD: ${{ inputs.event_payload }}

--- a/docs/normative/admin-install/v1/adr-0012-fullsend-repo-files/files/repo-onboard-v1.yaml
+++ b/docs/normative/admin-install/v1/adr-0012-fullsend-repo-files/files/repo-onboard-v1.yaml
@@ -1,0 +1,27 @@
+# Repo onboarding workflow
+# Creates enrollment PRs for repos listed in config.yaml.
+name: Repo Onboard
+
+on:
+  push:
+    branches: [main]
+    paths: [config.yaml]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  onboard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read enabled repos
+        id: repos
+        run: |
+          repos=$(yq '.repos | to_entries | map(select(.value.enabled == true)) | .[].key' config.yaml)
+          echo "repos<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$repos" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+      - name: Create enrollment PRs
+        run: echo "Would create enrollment PRs for enabled repos"


### PR DESCRIPTION
## Summary

Adds **ADR 0012** (Proposed) adopting a normative SPEC for the v1 set of **Git-tracked** files under `<org>/.fullsend` created by `fullsend admin install` (workflows + CODEOWNERS + `config.yaml` path). Exact workflow bodies are snapshotted under `docs/normative/...`/files/. The **`config.yaml` document body** is intentionally out of band — specified in **ADR 0011** only (by number).

## Notes

- `internal/cli/admin.go` orchestrates layers; no extra committed paths under `.fullsend` beyond `ConfigRepoLayer` / `WorkflowsLayer`.
- `SecretsLayer` uses repo secrets/variables (not committed files). `EnrollmentLayer` writes shims in application repos, not in `.fullsend`.
- `dispatch.go` / `preflight.go` are not present in this tree.

## Verification

`mise exec go@1.25.8 -- make lint` (includes ADR linters and `go vet`).

Made with [Cursor](https://cursor.com)