### PR TITLE
docs: ADR 0015 docs/normative/ convention + writing-adrs skill

### DIFF
--- a/docs/ADRs/0015-normative-specifications-directory.md
+++ b/docs/ADRs/0015-normative-specifications-directory.md
@@ -1,0 +1,69 @@
+---
+title: "15. Normative implementation contracts live under docs/normative/"
+status: Proposed
+relates_to:
+  - architectural-invariants
+  - governance
+  - contributor-guidance
+topics:
+  - documentation
+  - conventions
+  - versioning
+---
+
+# 15. Normative implementation contracts live under docs/normative/
+
+Date: 2026-04-06
+
+## Status
+
+Proposed
+
+## Context
+
+This repository separates **exploration** (problem docs), **decisions** (ADRs),
+and **current narrative state** (`docs/architecture.md`). ADRs work best when
+they state one decision briefly and link out for depth
+([ADR 0001](0001-use-adrs-for-decision-making.md)).
+
+Some decisions imply **implementation contracts**: byte- or field-level rules,
+schemas, canonical examples, or golden artifacts that alternative tools must
+satisfy and that CI or tests can check. Embedding those inside an ADR makes the
+record hard to read, hard to diff, and awkward for machine consumption. A
+dedicated, **versioned** tree keeps the ADR as the ratification layer while the
+heavy artifacts evolve on their own lifecycle (for example admin-install
+contracts, whether or not present in this repo yet).
+
+## Decision
+
+We adopt **`docs/normative/<topic>/v<major>/...`** as the canonical home for
+**normative**, **versioned** material that defines what implementations must
+conform to. Typical contents include JSON Schema or equivalent, canonical YAML
+or snapshots, compatibility fixtures, and other machine-checkable or
+exhaustive human specifications.
+
+- **`<topic>`** is a short, stable slug (e.g. `admin-install`).
+- **`<major>`** is a non-negative integer. Breaking contract changes require a
+  new major directory (`v1`, `v2`, …). Non-breaking additions within a major
+  stay under the same `v<major>` unless an ADR explicitly re-versions.
+
+An **ADR** that introduces or changes such a contract must:
+
+1. State the **decision** and **rationale** at a high level (including when to
+   bump major versions).
+2. **Link** to the normative tree path (and optionally to problem docs), not
+   paste multi-page schemas or large fixture bodies into the ADR.
+
+Problem docs remain the place for trade-offs and open questions; they do not
+replace the normative tree for exhaustive contract text.
+
+## Consequences
+
+- Multiple implementations can share one **explicit, testable** contract
+  without growing ADR files into specification dumps.
+- **Versioning** is visible in the path; deprecating an old major can be
+  documented in an ADR while keeping historical trees for readers and tools.
+- Contributors have a **single convention** for where to add schemas and golden
+  files when a decision needs them.
+- **Linting and link checks** can treat `docs/normative/` as the contract root
+  without special-casing individual ADRs.

--- a/skills/writing-adrs/SKILL.md
+++ b/skills/writing-adrs/SKILL.md
@@ -93,12 +93,29 @@ The threat model establishes least-privilege as a cross-cutting principle
 
 If this decision builds on or relates to another ADR, say so in Context.
 
+### Normative specs (`docs/normative/`)
+
+- **Use** when the decision needs **byte-level or field-level** contracts, JSON
+  Schema (or equivalent), **canonical YAML** or snapshots, or **compatibility
+  / conformance** artifacts aimed at **multiple implementations** or automated
+  checks.
+- **Do not use** for open-ended trade-off exploration (that stays in **problem
+  docs**), for a **single architectural choice** with no large artifact (keep
+  that in the **ADR only**), or for duplicating
+  [ADR 0003](../../docs/ADRs/0003-org-config-repo-convention.md)-style
+  repository convention **without** a versioned contract (do not invent a
+  normative subtree for that).
+- **Relationship:** the **ADR** states the decision, high-level versioning
+  expectations, and **links** to `docs/normative/<topic>/v<major>/...`; the
+  normative folder holds the detailed, **versioned** contract (`v1`, `v2`, …).
+
 ## Checklist
 
 Follow these steps in order:
 
-1. **Find the next number.** List `docs/ADRs/` and pick the next sequential
-   four-digit number.
+1. **Find the next number.** List `docs/ADRs/` on current `main`, then scan
+   **open pull requests** for new `docs/ADRs/NNNN-*.md` files so you do not
+   collide with in-flight ADRs. Pick the lowest unused four-digit `NNNN`.
 2. **Read the template.** Use `docs/ADRs/0000-adr-template.md` exactly.
 3. **Fill in frontmatter.** `relates_to` must reference existing filenames
    (without `.md`) from `docs/problems/`. Use `"*"` only for ADRs that truly


### PR DESCRIPTION
Adds **ADR 0005 (Proposed)**: adopt `docs/normative/<topic>/v<major>/...` for versioned implementation contracts; ADRs ratify the decision and link to the tree rather than embedding large schemas.

Updates **writing-adrs** skill with a short **Normative specs** subsection (when to use `docs/normative/` vs ADR-only vs problem docs).

Made with [Cursor](https://cursor.com)