### PR TITLE
Add Slack notification workflow for merged ADR changes

### DIFF
--- a/.github/workflows/notify-adr-slack.yml
+++ b/.github/workflows/notify-adr-slack.yml
@@ -8,7 +8,6 @@ on:
       - 'docs/ADRs/**'
 
 permissions:
-  contents: read
   pull-requests: read
 
 jobs:
@@ -16,8 +15,6 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-
       - name: Identify changed ADRs
         id: changed
         env:
@@ -80,4 +77,5 @@ jobs:
             }')
 
           curl -sf -X POST -H 'Content-Type: application/json' \
-            -d "$payload" "$SLACK_WEBHOOK_URL"
+            -d "$payload" "$SLACK_WEBHOOK_URL" \
+            || echo "::warning::Slack notification failed"

--- a/.github/workflows/notify-adr-slack.yml
+++ b/.github/workflows/notify-adr-slack.yml
@@ -1,0 +1,83 @@
+name: Notify Slack on ADR merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+    paths:
+      - 'docs/ADRs/**'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Identify changed ADRs
+        id: changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          files=$(gh pr diff "${{ github.event.pull_request.number }}" --name-only \
+            | grep '^docs/ADRs/' || true)
+
+          if [ -z "$files" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          summary=""
+          for f in $files; do
+            name=$(basename "$f" .md)
+            summary="${summary}• ${name}\n"
+          done
+
+          {
+            echo "skip=false"
+            echo "file_summary<<EOF"
+            echo -e "$summary"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack notification
+        if: steps.changed.outputs.skip != 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          FILE_SUMMARY: ${{ steps.changed.outputs.file_summary }}
+        run: |
+          payload=$(jq -n \
+            --arg title "$PR_TITLE" \
+            --arg number "$PR_NUMBER" \
+            --arg url "$PR_URL" \
+            --arg author "$PR_AUTHOR" \
+            --arg files "$FILE_SUMMARY" \
+            '{
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: ("📋 *ADR updated* — <" + $url + "|#" + $number + " " + $title + ">\nMerged by *" + $author + "*")
+                  }
+                },
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: ("*Affected ADRs:*\n" + $files)
+                  }
+                }
+              ]
+            }')
+
+          curl -sf -X POST -H 'Content-Type: application/json' \
+            -d "$payload" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
When a PR touching docs/ADRs/ is merged to main, post a summary to #forum-konflux-fullsend via incoming webhook. Requires the SLACK_WEBHOOK_URL repository secret.

Closes #148

Made-with: Cursor
