### PR TITLE
fix: notify-adr-slack silently passed despite gh pr diff failure

### DIFF
--- a/.github/workflows/notify-adr-slack.yml
+++ b/.github/workflows/notify-adr-slack.yml
@@ -20,8 +20,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          files=$(gh pr diff "${{ github.event.pull_request.number }}" --name-only \
-            | grep '^docs/ADRs/' || true)
+          all_files=$(gh pr diff "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --name-only)
+          files=$(echo "$all_files" | grep '^docs/ADRs/' || true)
 
           if [ -z "$files" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -51,6 +52,11 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           FILE_SUMMARY: ${{ steps.changed.outputs.file_summary }}
         run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "::error::SLACK_WEBHOOK_URL secret is not configured"
+            exit 1
+          fi
+
           payload=$(jq -n \
             --arg title "$PR_TITLE" \
             --arg number "$PR_NUMBER" \
@@ -77,5 +83,4 @@ jobs:
             }')
 
           curl -sf -X POST -H 'Content-Type: application/json' \
-            -d "$payload" "$SLACK_WEBHOOK_URL" \
-            || echo "::warning::Slack notification failed"
+            -d "$payload" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
The first iteration had no actions/checkout and no --repo flag, so `gh pr diff` could not resolve the repository context and failed with "fatal: not a git repository". Two error-swallowing patterns hid this:

1. `gh pr diff ... | grep ... || true` — the `|| true` was meant to handle grep finding no ADR matches, but it also swallowed the gh CLI failure, leaving $files empty and setting skip=true.
2. `curl ... || echo "::warning::..."` — a failed Slack POST still exited 0, so the job appeared green even if nothing was delivered.

Fixes:
- Add `--repo "${{ github.repository }}"` so gh can resolve the repo via API without needing a local checkout.
- Split gh pr diff and grep into separate commands so bash -e catches a gh failure while || true only covers a grep no-match.
- Remove the curl || echo fallback so delivery failures surface.
- Add an explicit guard that fails the step if SLACK_WEBHOOK_URL is not configured.

Made-with: Cursor