### PR TITLE
fix: org secret visibility, e2e Makefile, redirect_url regression tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Fullsend is a living design document exploring fully autonomous agentic development for GitHub-hosted organizations. It contains no application code — only prose documents organized by problem domain. See [README.md](README.md) for the full document index.
+Fullsend is a platform for fully autonomous agentic development for GitHub-hosted organizations. It contains design documents organized by problem domain (`docs/`) and a Go CLI (`cmd/fullsend/`) that manages GitHub App setup and org configuration. See [README.md](README.md) for the full document index.
 
 ## How to work in this repo
 
@@ -12,6 +12,24 @@ Fullsend is a living design document exploring fully autonomous agentic developm
 - The target audience is any contributor community considering autonomous agents — keep language accessible, avoid presuming solutions.
 - Always run `pre-commit run --files <changed-files>` before submitting changes and fix any failures.
 - Never commit secrets (tokens, API keys, PEM keys, gcloud credentials) or sensitive data (GCP project names, service account identifiers, Model Armor template names, internal hostnames). Use environment variables with no defaults for sensitive values.
+
+## Go code
+
+When making changes to Go code under `cmd/` or `internal/`:
+
+1. **Unit tests:** Run `make go-test` (or `go test ./...`) and fix any failures before committing.
+2. **Vet:** Run `make go-vet` to catch common issues.
+3. **E2E tests:** Run `make e2e-test` if your changes touch `internal/appsetup/`, `internal/forge/`, `internal/cli/`, or `internal/layers/`. These tests exercise the full admin install/uninstall flow against a live GitHub org using Playwright browser automation.
+
+### Running e2e tests
+
+The e2e tests require GitHub credentials. There are three ways to provide them:
+
+- **`E2E_GITHUB_PASSWORD` env var:** Set directly with the password.
+- **`E2E_GITHUB_PASSWORD_FILE` env var:** Set to a file path containing the password (used in devaipod environments where secrets are mounted as files).
+- **`E2E_GITHUB_SESSION_FILE` env var:** Set to a pre-exported Playwright session file (skips login).
+
+If only `E2E_GITHUB_USERNAME` and a password source are available, `make e2e-test` will automatically generate a session file before running tests. See `make help` for all available targets.
 
 ## Key design decisions made
 

--- a/Makefile
+++ b/Makefile
@@ -96,10 +96,13 @@ go-vet:
 go-tidy:
 	go mod tidy
 
-E2E_SESSION_FILE ?= .playwright/session.json
+E2E_SESSION_FILE ?= $(CURDIR)/.playwright/session.json
 
 e2e-test: e2e-playwright
-	@if [ -z "$$E2E_GITHUB_SESSION_FILE" ] && [ -n "$$E2E_GITHUB_USERNAME" ] && [ -n "$$E2E_GITHUB_PASSWORD" ]; then \
+	@if [ -n "$$E2E_GITHUB_PASSWORD_FILE" ] && [ -z "$$E2E_GITHUB_PASSWORD" ]; then \
+		export E2E_GITHUB_PASSWORD="$$(cat "$$E2E_GITHUB_PASSWORD_FILE")"; \
+	fi; \
+	if [ -z "$$E2E_GITHUB_SESSION_FILE" ] && [ -n "$$E2E_GITHUB_USERNAME" ] && [ -n "$$E2E_GITHUB_PASSWORD" ]; then \
 		echo "==> No session file set, generating one from credentials..."; \
 		$(MAKE) e2e-export-session; \
 		export E2E_GITHUB_SESSION_FILE="$(E2E_SESSION_FILE)"; \
@@ -107,6 +110,9 @@ e2e-test: e2e-playwright
 	go test -tags e2e -v -count=1 -timeout 4m ./e2e/admin/
 
 e2e-export-session: e2e-playwright
+	@if [ -n "$$E2E_GITHUB_PASSWORD_FILE" ] && [ -z "$$E2E_GITHUB_PASSWORD" ]; then \
+		export E2E_GITHUB_PASSWORD="$$(cat "$$E2E_GITHUB_PASSWORD_FILE")"; \
+	fi; \
 	E2E_GITHUB_SESSION_FILE="$(E2E_SESSION_FILE)" go run ./e2e/cmd/export-session/
 
 e2e-upload-session: e2e-export-session

--- a/internal/appsetup/appsetup_test.go
+++ b/internal/appsetup/appsetup_test.go
@@ -2,6 +2,11 @@ package appsetup
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -175,6 +180,96 @@ func TestSetup_NoExistingApp(t *testing.T) {
 	assert.NotContains(t, err.Error(), "private key")
 	// Browser should have been asked to open a URL.
 	assert.NotEmpty(t, browser.openedURLs, "should have tried to open browser")
+}
+
+func TestManifestFlow_HTMLForm(t *testing.T) {
+	client := &forge.FakeClient{
+		Installations: []forge.Installation{},
+	}
+	browser := &fakeBrowser{}
+	printer := ui.New(&discardWriter{})
+
+	s := NewSetup(client, &fakePrompter{}, browser, printer)
+
+	// Use a short timeout — we only need the server to start and serve the
+	// HTML page, not complete the full manifest flow.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Run the manifest flow in a goroutine; it will block waiting for the
+	// GitHub callback until the context expires.
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := s.Run(ctx, "testorg", "coder")
+		errCh <- err
+	}()
+
+	// Wait for the browser to receive the URL.
+	var formURL string
+	deadline := time.After(2 * time.Second)
+	for {
+		if len(browser.openedURLs) > 0 {
+			formURL = browser.openedURLs[0]
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for browser.Open to be called")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// Fetch the HTML page from the local server.
+	resp, err := http.Get(formURL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	html := string(body)
+
+	// 1. There must be exactly one hidden input named "manifest".
+	manifestInputRe := regexp.MustCompile(`<input[^>]+name="manifest"[^>]*>`)
+	manifestInputs := manifestInputRe.FindAllString(html, -1)
+	assert.Len(t, manifestInputs, 1, "expected exactly one hidden input named 'manifest'")
+
+	// 2. There must be NO hidden input named "redirect_url".
+	redirectInputRe := regexp.MustCompile(`<input[^>]+name="redirect_url"[^>]*>`)
+	redirectInputs := redirectInputRe.FindAllString(html, -1)
+	assert.Empty(t, redirectInputs, "there must be no hidden input named 'redirect_url'")
+
+	// 3. The manifest JSON must contain redirect_url matching the callback URL.
+	valueRe := regexp.MustCompile(`<input[^>]+name="manifest"[^>]+value="([^"]*)"`)
+	matches := valueRe.FindStringSubmatch(html)
+	require.Len(t, matches, 2, "could not extract manifest value from HTML")
+
+	// The value is HTML-escaped; decode it.
+	manifestJSON := strings.NewReplacer(
+		"&amp;", "&",
+		"&lt;", "<",
+		"&gt;", ">",
+		"&#34;", "\"",
+		"&#39;", "'",
+	).Replace(matches[1])
+
+	var manifest map[string]interface{}
+	err = json.Unmarshal([]byte(manifestJSON), &manifest)
+	require.NoError(t, err, "manifest value must be valid JSON")
+
+	redirectURL, ok := manifest["redirect_url"]
+	require.True(t, ok, "manifest JSON must contain redirect_url key")
+
+	// The callback URL should point to the local server's /callback path.
+	redirectStr, isString := redirectURL.(string)
+	require.True(t, isString, "redirect_url must be a string")
+	assert.True(t, strings.HasPrefix(redirectStr, "http://127.0.0.1:"),
+		"redirect_url should start with http://127.0.0.1:, got %s", redirectStr)
+	assert.True(t, strings.HasSuffix(redirectStr, "/callback"),
+		"redirect_url should end with /callback, got %s", redirectStr)
+
+	// Wait for the flow to finish (context timeout).
+	<-errCh
 }
 
 // discardWriter implements io.Writer, discarding all output.

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -940,12 +940,18 @@ func (c *LiveClient) CreateOrgSecret(ctx context.Context, org, name, value strin
 		return fmt.Errorf("encrypt org secret: %w", err)
 	}
 
-	// Step 3: Upload the encrypted secret with selected repo visibility.
+	// Step 3: Upload the encrypted secret.
+	// When repo IDs are provided, scope the secret to those repos only.
+	// When no repos are specified, make it available to all repos in the org.
 	payload := map[string]any{
-		"encrypted_value":         base64.StdEncoding.EncodeToString(encrypted),
-		"key_id":                  pubKey.KeyID,
-		"visibility":              "selected",
-		"selected_repository_ids": selectedRepoIDs,
+		"encrypted_value": base64.StdEncoding.EncodeToString(encrypted),
+		"key_id":          pubKey.KeyID,
+	}
+	if len(selectedRepoIDs) > 0 {
+		payload["visibility"] = "selected"
+		payload["selected_repository_ids"] = selectedRepoIDs
+	} else {
+		payload["visibility"] = "all"
 	}
 
 	resp, err := c.put(ctx, fmt.Sprintf("/orgs/%s/actions/secrets/%s", org, name), payload)
@@ -996,6 +1002,9 @@ func (c *LiveClient) DeleteOrgSecret(ctx context.Context, org, name string) erro
 
 // SetOrgSecretRepos sets the list of repositories that can access an org secret.
 func (c *LiveClient) SetOrgSecretRepos(ctx context.Context, org, name string, repoIDs []int64) error {
+	if repoIDs == nil {
+		repoIDs = []int64{}
+	}
 	payload := map[string]any{
 		"selected_repository_ids": repoIDs,
 	}

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -626,6 +626,42 @@ func TestCreateOrgSecret(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCreateOrgSecret_NilRepoIDs_VisibilityAll(t *testing.T) {
+	callNum := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callNum++
+		switch callNum {
+		case 1:
+			// GET org public key
+			pubKey := make([]byte, 32)
+			for i := range pubKey {
+				pubKey[i] = byte(i + 1)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"key_id": "org-key-123",
+				"key":    base64.StdEncoding.EncodeToString(pubKey),
+			})
+		case 2:
+			// PUT org secret — should use visibility "all" with no repo IDs
+			assert.Equal(t, "PUT", r.Method)
+
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			assert.Equal(t, "all", body["visibility"],
+				"visibility should be 'all' when no repo IDs are specified")
+			assert.Nil(t, body["selected_repository_ids"],
+				"selected_repository_ids should be absent when visibility is 'all'")
+
+			w.WriteHeader(http.StatusCreated)
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.CreateOrgSecret(context.Background(), "myorg", "TOKEN", "value", nil)
+	require.NoError(t, err)
+}
+
 func TestOrgSecretExists(t *testing.T) {
 	t.Run("exists", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/forge/github/types_test.go
+++ b/internal/forge/github/types_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,4 +81,20 @@ func TestAgentAppConfig_UnknownRole(t *testing.T) {
 	assert.Empty(t, cfg.Permissions.PullRequests)
 
 	assert.Contains(t, cfg.Events, "issues")
+}
+
+func TestAppConfig_RedirectURL_InJSON(t *testing.T) {
+	cfg := AgentAppConfig("myorg", "fullsend")
+	cfg.RedirectURL = "http://127.0.0.1:12345/callback"
+
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	err = json.Unmarshal(data, &raw)
+	require.NoError(t, err)
+
+	redirectURL, ok := raw["redirect_url"]
+	assert.True(t, ok, "JSON must contain redirect_url key")
+	assert.Equal(t, "http://127.0.0.1:12345/callback", redirectURL)
 }


### PR DESCRIPTION
## Summary

- Fixes `fullsend admin install` crashing with 422 when run without `--repos`
- Fixes `make e2e-test` to work out of the box in devaipod environments
- Adds regression tests for the redirect_url manifest fix
- Documents Go development workflow in CLAUDE.md

## Changes

### fix: org secret visibility when no repos specified

When `CreateOrgSecret` is called without repo IDs (install without `--repos`), the code sent `visibility=selected` with `selected_repository_ids: null`. Go's `json.Marshal` serializes nil slices as JSON null, which GitHub rejects:

```
422 Invalid request. For 'properties/selected_repository_ids', nil is not an array.
```

Now uses `visibility=all` (omitting `selected_repository_ids`) when the repo ID list is empty, making the secret accessible to all repos in the org. When repo IDs are provided, existing `visibility=selected` behavior is preserved. Also makes `SetOrgSecretRepos` defensive against nil slices.

### fix: e2e Makefile session path

Uses `$(CURDIR)` for `E2E_SESSION_FILE` so the absolute path resolves correctly when `go test` changes working directory. Supports `E2E_GITHUB_PASSWORD_FILE` env var for devaipod secret file mounts.

### test: redirect_url regression tests

Adds `TestAppConfig_RedirectURL_InJSON` and `TestManifestFlow_HTMLForm` to prevent the redirect_url manifest bug from recurring. Verified RED/GREEN.

### docs: CLAUDE.md Go workflow

Documents expectation to run unit tests, vet, and e2e tests when modifying Go code.

## Verification

- `go test ./...` all pass
- `go vet ./...` clean
- `make e2e-test` full 4-phase e2e passes