### PR TITLE
fix: use pull_request_target for Slack ADR notification

### DIFF
--- a/.github/workflows/notify-adr-slack.yml
+++ b/.github/workflows/notify-adr-slack.yml
@@ -1,7 +1,7 @@
 name: Notify Slack on ADR merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main]
     paths:


### PR DESCRIPTION
PRs from forks (e.g. ifireball:docs/adr-0013-enrollment-v1-upstream) do not receive repository secrets under the `pull_request` trigger — this is a GitHub security restriction to prevent secret exfiltration by malicious fork PRs. This caused run #6 to fail with "SLACK_WEBHOOK_URL secret is not configured" while run #5 (from an in-repo branch) succeeded.

Switch to `pull_request_target`, which runs in the context of the base repository and has access to secrets. This is safe here because the workflow:

1. Only fires on `closed` events
2. Only proceeds when `merged == true`
3. Never checks out or executes code from the PR branch — it reads PR metadata via `gh pr diff` and posts to Slack

Made-with: Cursor