### PR TITLE
docs: add issue type requirement to filing-issues skill

### DIFF
--- a/skills/filing-issues/SKILL.md
+++ b/skills/filing-issues/SKILL.md
@@ -121,7 +121,6 @@ conservatively — a label should clearly apply, not just vaguely relate.
 
 Common label categories to look for:
 
-- **Type:** bug, enhancement, feature, question, documentation
 - **Area/component:** labels that name subsystems or modules
 - **Priority/severity:** critical, high, low
 - **Status:** triage, needs-info, good-first-issue
@@ -129,7 +128,24 @@ Common label categories to look for:
 Present your label choices to the user alongside the draft. If the repo has no
 labels or none fit, skip labeling.
 
-### 7. File the issue
+### 7. Set the issue type
+
+Every issue must have a type. Choose exactly one:
+
+- **Feature** — stories, new functionality, new capabilities, or enhancements
+  that add something that does not exist yet.
+- **Bug** — something is broken, behaving unexpectedly, or there is a gap that
+  should have been covered.
+- **Task** — research, experiments, evaluations, chores, documentation work,
+  decisions to make, or any work that is neither a feature nor a bug.
+
+When in doubt between Feature and Task, ask: "Does this add user-visible
+functionality?" If yes, Feature. If it is preparatory or exploratory work,
+Task.
+
+Present your type choice to the user alongside the draft and labels.
+
+### 8. File the issue
 
 After the user approves the draft:
 
@@ -140,11 +156,13 @@ gh issue create --repo <owner/name> \
 <body>
 EOF
 )" \
-  --label "<label1>,<label2>"
+  --label "<label1>,<label2>" \
+  --type "<Feature|Bug|Task>"
 ```
 
 Omit `--label` if no labels apply or if you lack permission to set them (the
 `gh` CLI will error; do not retry — file without labels and tell the user).
+Always include `--type`.
 
 Return the issue URL to the user.
 


### PR DESCRIPTION
## Summary

- Adds a new step (step 7) to the filing-issues skill requiring every issue to have a type set: **Feature**, **Bug**, or **Task**
- Includes decision guidance for choosing between types
- Updates the `gh issue create` command template to include `--type`
- Follows up on a bulk update that set types on all 72 existing issues that were missing them

## Context

All existing issues (open and closed) have been retroactively typed:
- **Feature** (33 issues): stories, new functionality, capabilities
- **Task** (41 issues): research, experiments, evaluations, chores, decisions, docs
- **Bug** (1 issue): #100 (pre-commit hook misconfiguration)

## Test plan

- [ ] Verify the skill renders correctly when invoked via `/filing-issues`
- [ ] Confirm `gh issue create --type` works with the repo's configured issue types

🤖 Generated with [Claude Code](https://claude.com/claude-code)