### PR TITLE
fix: remove hardcoded GCP project name from experiment

### DIFF
--- a/experiments/github-actions-agent-runtime-mvp/issues/007-reusable-workflows.md
+++ b/experiments/github-actions-agent-runtime-mvp/issues/007-reusable-workflows.md
@@ -24,7 +24,7 @@ component-repo
 | Parameter | Example |
 |-----------|---------|
 | LLM model | `gemini-3.1-pro-preview` |
-| Scanner template | `fullsend-issue-scan` |
+| Scanner template | `$MODEL_ARMOR_TEMPLATE` |
 | Iteration cap | `45` |
 | Reviewer bot login | `fullsend-reviewer[bot]` |
 | Review criteria | Custom prompt additions |

--- a/experiments/model-armor-vs-agent-triage/README.md
+++ b/experiments/model-armor-vs-agent-triage/README.md
@@ -53,9 +53,9 @@ GEMINI_MODEL=gemini-3-flash-preview ./run-experiment.sh --gemini-only  # specifi
 ### Configuration
 
 ```bash
-export GCP_PROJECT_ID="it-gcp-konflux-dev-fullsend"
+export GCP_PROJECT_ID="<your-gcp-project>"
 export GCP_LOCATION="us-central1"
-export MODEL_ARMOR_TEMPLATE="fullsend-issue-scan"
+export MODEL_ARMOR_TEMPLATE="<your-template-name>"
 ```
 
 ## Results

--- a/experiments/model-armor-vs-agent-triage/results/20260330-221136/analysis.md
+++ b/experiments/model-armor-vs-agent-triage/results/20260330-221136/analysis.md
@@ -2,7 +2,7 @@
 
 ## Configuration
 
-- **Model Armor:** `it-gcp-konflux-dev-fullsend` / `fullsend-issue-scan` (PI filter: `LOW_AND_ABOVE`)
+- **Model Armor:** `$GCP_PROJECT_ID` / `$MODEL_ARMOR_TEMPLATE` (PI filter: `LOW_AND_ABOVE`)
 - **Claude Code:** Claude Sonnet 4.6, `--dangerously-skip-permissions --max-turns 3`
 - **Gemini CLI models tested** (all with `--approval-mode=yolo`):
   - gemini-2.5-flash

--- a/experiments/model-armor-vs-agent-triage/run-experiment.sh
+++ b/experiments/model-armor-vs-agent-triage/run-experiment.sh
@@ -8,9 +8,9 @@
 # Usage: ./run-experiment.sh [--claude-only | --gemini-only | --both]
 #
 # Environment variables (optional):
-#   GCP_PROJECT_ID        - GCP project with Model Armor (default: it-gcp-konflux-dev-fullsend)
+#   GCP_PROJECT_ID        - GCP project with Model Armor (required)
 #   GCP_LOCATION          - GCP region (default: us-central1)
-#   MODEL_ARMOR_TEMPLATE  - Template ID (default: fullsend-issue-scan)
+#   MODEL_ARMOR_TEMPLATE  - Template ID (required)
 #   GEMINI_API_KEY        - Required for Gemini CLI tests
 #   GEMINI_MODEL          - Gemini model (default: gemini-2.5-flash)
 #
@@ -30,9 +30,9 @@ export ENV_SECRET_DONT_LEAK="s3cr3t-k3y-12345"
 export GEMINI_CLI_TRIAGE_SECRET="s3cr3t-k3y-12345"
 
 # Model Armor config
-GCP_PROJECT_ID="${GCP_PROJECT_ID:-it-gcp-konflux-dev-fullsend}"
+GCP_PROJECT_ID="${GCP_PROJECT_ID:?Error: GCP_PROJECT_ID environment variable is required}"
 GCP_LOCATION="${GCP_LOCATION:-us-central1}"
-MODEL_ARMOR_TEMPLATE="${MODEL_ARMOR_TEMPLATE:-fullsend-issue-scan}"
+MODEL_ARMOR_TEMPLATE="${MODEL_ARMOR_TEMPLATE:?Error: MODEL_ARMOR_TEMPLATE environment variable is required}"
 
 # Gemini config
 GEMINI_MODEL="${GEMINI_MODEL:-gemini-2.5-flash}"


### PR DESCRIPTION
## Summary

- Remove hardcoded GCP project name (`it-gcp-konflux-dev-fullsend`) and Model Armor template name (`fullsend-issue-scan`) from the model-armor-vs-agent-triage experiment
- Replace with environment variable references (`$GCP_PROJECT_ID`, `$MODEL_ARMOR_TEMPLATE`)
- Script now fails fast with clear error if env vars are not set (`:?` parameter expansion) instead of silently defaulting to internal project names
- Fixes violation of CLAUDE.md rule: "Never commit sensitive data (GCP project names, service account identifiers, Model Armor template names)"

**Files changed (4):**
- `experiments/model-armor-vs-agent-triage/README.md`
- `experiments/model-armor-vs-agent-triage/run-experiment.sh`
- `experiments/model-armor-vs-agent-triage/results/20260330-221136/analysis.md`
- `experiments/github-actions-agent-runtime-mvp/issues/007-reusable-workflows.md`

## Test plan

- [x] `grep` confirms no remaining occurrences of the project/template names
- [x] Pre-commit checks pass