### PR TITLE
Add CONTRIBUTING.md and /renumber-adr skill

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,33 @@ repos:
     rev: v1.7.11
     hooks:
       - id: actionlint
+
+  - repo: local
+    hooks:
+      - id: go-vet
+        name: go vet
+        entry: go vet ./...
+        language: system
+        types: [go]
+        pass_filenames: false
+
+      - id: lint-adr-status
+        name: lint ADR statuses
+        entry: ./hack/lint-adr-status
+        language: script
+        files: ^docs/ADRs/.*\.md$
+        pass_filenames: false
+
+      - id: lint-adr-numbers
+        name: lint ADR numbers
+        entry: ./hack/lint-adr-numbers
+        language: script
+        files: ^docs/ADRs/.*\.md$
+        pass_filenames: false
+
+      - id: lint-adr-frontmatter
+        name: lint ADR frontmatter
+        entry: uv run --script ./hack/lint-adr-frontmatter
+        language: system
+        files: ^docs/ADRs/.*\.md$
+        pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Fullsend is a platform for fully autonomous agentic development for GitHub-hoste
 - The security threat model (threat priority: external injection > insider > drift > supply chain) should inform all other documents.
 - Keep core problem documents organization-agnostic. Organization-specific details belong in `docs/problems/applied/<org-name>/`.
 - The target audience is any contributor community considering autonomous agents — keep language accessible, avoid presuming solutions.
-- Always run `pre-commit run --files <changed-files>` before submitting changes and fix any failures.
+- Always run `make lint` before submitting changes and fix any failures.
 - Never commit secrets (tokens, API keys, PEM keys, gcloud credentials) or sensitive data (GCP project names, service account identifiers, Model Armor template names, internal hostnames). Use environment variables with no defaults for sensitive values.
 
 ## Go code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to Fullsend
+
+Thank you for your interest in contributing! This document covers the social norms and processes we follow. For where to place your contribution (problem docs, ADRs, experiments, etc.), see the [README](README.md#how-to-contribute).
+
+## Pull request workflow
+
+### Opening a PR
+
+- Run `make lint` before pushing and fix any failures.
+- Keep PRs focused. One problem area or decision per PR is easier to review than a grab-bag.
+- If your change touches a problem doc, make sure the "Open questions" section still makes sense after your edit.
+
+### Review etiquette
+
+- **Comment resolution belongs to the PR author.** When a reviewer leaves a comment, the PR author is free to address the feedback and resolve the conversation themselves. This keeps the review cycle moving.
+- **If you need to block a PR on your feedback, use "Request changes."** A comment alone is advisory — the author may resolve it at their discretion. The "Request changes" review status is how a reviewer signals that the PR should not merge until their concern is addressed. This is the only mechanism for enforcing your review.
+- **Be constructive.** This is a design exploration — disagreement is expected and valuable. Critique ideas, not people. When you push back on a proposal, suggest an alternative or explain what concern drives your objection.
+
+### Merging
+
+- PRs require approval from a [CODEOWNERS](CODEOWNERS) member before merging.
+## Working with ADRs
+
+ADRs (Architecture Decision Records) are **point-in-time records**. Once accepted, their content is frozen — do not edit the Context, Decision, or Consequences sections. If a decision needs to change, write a new ADR that supersedes the old one. See the [ADR template](docs/ADRs/0000-adr-template.md) and [ADR 0001](docs/ADRs/0001-use-adrs-for-decision-making.md) for full details.
+
+### ADR numbering
+
+ADR filenames use a four-digit number (`NNNN-short-description.md`). When multiple PRs add ADRs concurrently, number collisions can happen. Before merging, use the `/renumber-adr` skill to check whether your ADR number is still available on the target branch and renumber if needed.
+
+## Issues
+
+When in doubt about whether something warrants a PR, start with an issue. Issues are low-friction and can graduate into PRs, problem docs, or ADRs later.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help bootstrap lint check fmt lint-adr-status lint-adr-numbers lint-adr-frontmatter \
+.PHONY: help bootstrap lint lint-all check fmt \
        mindmap go-build go-test go-lint go-fmt go-vet go-tidy e2e-test e2e-playwright \
        e2e-export-session e2e-upload-session
 
@@ -7,12 +7,10 @@ help:
 	@echo "Available targets:"
 	@echo "  help                 - Show this help message"
 	@echo "  bootstrap            - Install all development tools"
-	@echo "  lint                 - Run all linting and validation"
+	@echo "  lint                 - Run linting on staged changes"
+	@echo "  lint-all             - Run linting on all files"
 	@echo "  check                - Run ruff and ty checks on Python"
 	@echo "  fmt                  - Format Python code with ruff"
-	@echo "  lint-adr-status      - Validate ADR statuses in all ADR files"
-	@echo "  lint-adr-numbers     - Check for duplicate ADR numeric identifiers"
-	@echo "  lint-adr-frontmatter - Validate ADR frontmatter and cross-references"
 	@echo "  mindmap              - Open the interactive document graph in a browser"
 	@echo "  go-build             - Build the fullsend binary"
 	@echo "  go-test              - Run Go tests with race detection and coverage"
@@ -55,7 +53,11 @@ bootstrap:
 	@echo "==> Bootstrap complete!"
 	@echo "    Make sure $(BOOTSTRAP_BIN_DIR) is on your PATH."
 
-lint: check go-vet lint-adr-status lint-adr-numbers lint-adr-frontmatter
+lint:
+	pre-commit run
+
+lint-all:
+	pre-commit run --all-files
 
 check:
 	uvx ruff check .
@@ -63,15 +65,6 @@ check:
 
 fmt:
 	uvx ruff format .
-
-lint-adr-status:
-	@./hack/lint-adr-status
-
-lint-adr-numbers:
-	@./hack/lint-adr-numbers
-
-lint-adr-frontmatter:
-	@uv run --script ./hack/lint-adr-frontmatter
 
 mindmap:
 	@xdg-open docs/mindmap.html 2>/dev/null || open docs/mindmap.html 2>/dev/null || echo "Open docs/mindmap.html in your browser"

--- a/skills/renumber-adr/SKILL.md
+++ b/skills/renumber-adr/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: renumber-adr
+description: >-
+  Check whether ADR numbers in the current branch conflict with ADRs already on
+  the PR's target branch, and renumber if needed. Use before merging a PR that
+  adds new ADRs, to avoid number collisions with concurrently merged ADRs.
+---
+
+# Renumber ADR
+
+## Overview
+
+When multiple PRs add ADRs concurrently, they may pick the same four-digit
+number. This skill detects collisions against the target branch and renumbers
+the ADR file, its internal title/heading, and every reference to it across the
+repository.
+
+## When to Use
+
+- Before merging a PR that introduces one or more new ADR files.
+- When the user asks to check or fix ADR numbering.
+- When invoked via `/renumber-adr`.
+
+## Process
+
+Follow these steps in order. Do not skip steps.
+
+### 1. Identify new ADR files in this branch
+
+Determine the target branch for the PR. If the user provides it as an argument,
+use that. Otherwise:
+
+```bash
+gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null || echo main
+```
+
+Then find ADR files that are **new** in this branch (not present on the target):
+
+```bash
+git diff --name-only --diff-filter=A <target-branch>...HEAD -- docs/ADRs/
+```
+
+If no new ADR files are found, report that there is nothing to renumber and
+stop.
+
+### 2. Check for number collisions
+
+List existing ADR files on the target branch:
+
+```bash
+git ls-tree --name-only <target-branch> docs/ADRs/
+```
+
+For each new ADR file, extract its four-digit number from the filename
+(`NNNN-short-description.md`). Check whether any file with the same `NNNN`
+prefix exists on the target branch.
+
+If there are no collisions, report that all numbers are clear and stop.
+
+### 3. Find the next available number
+
+For each colliding ADR, determine the next available four-digit number.
+Consider both the target branch ADR files **and** other new ADR files in this
+branch (to avoid collisions among the branch's own ADRs). Pick the lowest
+unused number.
+
+### 4. Rename the file
+
+```bash
+git mv docs/ADRs/NNNN-old-slug.md docs/ADRs/MMMM-old-slug.md
+```
+
+### 5. Update references inside the ADR
+
+The ADR file itself contains the number in several places. Update all of them:
+
+- **Frontmatter `title`:** e.g. `title: "2. Initial Fullsend Design"` — uses
+  the number without leading zeros.
+- **Markdown heading:** e.g. `# 2. Initial Fullsend Design` — same format.
+
+Read the file and update these occurrences. The number in the title and heading
+uses the **integer** form (no leading zeros), not the four-digit padded form.
+
+### 6. Update references across the repository
+
+Search the entire repository for references to the old ADR and update them.
+There are several patterns to find:
+
+1. **Filename references** (in markdown links): `NNNN-slug.md` — update the
+   four-digit prefix to the new number.
+2. **Display text references**: `ADR NNNN` — update the four-digit number in
+   link text and plain text.
+3. **Section heading references in prose** (e.g. `## Reference workflow
+   components (ADR NNNN)`) — update the number.
+
+Search broadly:
+
+```bash
+# Find all files referencing the old filename
+grep -rl "NNNN-slug" .
+
+# Find all files referencing "ADR NNNN" (display text or plain text)
+grep -rl "ADR NNNN" .
+```
+
+For each file found, read it and update all occurrences. Be careful to match
+the exact old filename and number — do not accidentally rename unrelated
+four-digit sequences.
+
+### 7. Verify and report
+
+After all renames and reference updates:
+
+- List the changes made: old filename -> new filename, and the count of files
+  with updated references.
+- Run `pre-commit run --files <all-changed-files>` to verify nothing is broken.
+- Report the result to the user.
+
+## Constraints
+
+- **Only renumber ADRs that are new in this branch.** Never renumber ADRs that
+  already exist on the target branch.
+- **Preserve the slug.** Only the four-digit number prefix changes; the
+  descriptive slug (`short-description`) stays the same.
+- **Update every reference.** A missed reference is a broken link. Search
+  thoroughly.
+- **Handle multiple ADRs.** If the branch adds several ADRs and more than one
+  collides, renumber all of them before updating references (so cross-references
+  among the new ADRs are correct).
+- **Do not modify ADR content** beyond the number in the title and heading.
+  ADR content is immutable once accepted; this skill only fixes numbering.


### PR DESCRIPTION
  **Summary**

  - Add CONTRIBUTING.md with social norms for PR reviews: comment resolution belongs to the author, reviewers enforce feedback via "Request
  changes"
  - Document that ADRs are immutable point-in-time records and should not be edited after acceptance
  - Add /renumber-adr Claude Code skill that detects ADR number collisions against the target branch and renumbers files + all cross-references
  before merge

  **Motivation**

  We had no written guidance on PR review etiquette, which can lead to confusion about who resolves comments and how reviewers enforce their
  feedback. Similarly, concurrent ADR PRs can collide on numbers — the new skill automates detection and renumbering so contributors don't have to
   do it manually.
