### PR TITLE
feat: code agent automation layer

### DIFF
--- a/internal/cli/entrypoint.go
+++ b/internal/cli/entrypoint.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/fullsend-ai/fullsend/internal/entrypoint"
+	gh "github.com/fullsend-ai/fullsend/internal/forge/github"
+)
+
+func newEntrypointCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "entrypoint",
+		Short: "Run a pipeline stage",
+		Long:  "Entrypoint commands are invoked by the CI/CD pipeline to execute agent stages.",
+	}
+	var scm string
+	cmd.PersistentFlags().StringVar(&scm, "scm", "github", "SCM backend")
+	cmd.AddCommand(newCodeStageCmd(&scm))
+	return cmd
+}
+
+func newCodeStageCmd(scm *string) *cobra.Command {
+	return &cobra.Command{
+		Use:     "code",
+		Aliases: []string{"implementation"},
+		Short:   "Run the code agent stage",
+		Long:    "Runs the code agent against a pre-checked-out workspace, validates output, and opens a PR.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if *scm != "github" {
+				return fmt.Errorf("unsupported SCM backend: %s", *scm)
+			}
+
+			env, err := entrypoint.LoadEnv()
+			if err != nil {
+				return fmt.Errorf("load environment: %w", err)
+			}
+
+			client := gh.New(env.BotToken)
+			runner := &entrypoint.ExecRunner{}
+			safeEnv := entrypoint.SanitizeEnv(os.Environ())
+
+			result, err := entrypoint.RunCode(cmd.Context(), env, runner, client, safeEnv)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Branch: %s\nPR: %s\n", result.Branch, result.PRURL)
+			return nil
+		},
+	}
+}

--- a/internal/cli/entrypoint_test.go
+++ b/internal/cli/entrypoint_test.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntrypointCmd_Structure(t *testing.T) {
+	root := newRootCmd()
+
+	// entrypoint command exists under root.
+	ep, _, err := root.Find([]string{"entrypoint"})
+	require.NoError(t, err)
+	assert.Equal(t, "entrypoint", ep.Name())
+
+	// code subcommand exists.
+	code, _, err := root.Find([]string{"entrypoint", "code"})
+	require.NoError(t, err)
+	assert.Equal(t, "code", code.Name())
+
+	// implementation alias resolves to code.
+	impl, _, err := root.Find([]string{"entrypoint", "implementation"})
+	require.NoError(t, err)
+	assert.Equal(t, "code", impl.Name())
+}
+
+func TestEntrypointCmd_SCMFlag(t *testing.T) {
+	root := newRootCmd()
+
+	ep, _, err := root.Find([]string{"entrypoint"})
+	require.NoError(t, err)
+
+	scmFlag := ep.PersistentFlags().Lookup("scm")
+	require.NotNil(t, scmFlag)
+	assert.Equal(t, "github", scmFlag.DefValue)
+}
+
+func TestEntrypointCmd_UnsupportedSCM(t *testing.T) {
+	root := newRootCmd()
+	root.SetArgs([]string{"entrypoint", "code", "--scm", "gitlab"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported SCM backend: gitlab")
+}

--- a/internal/entrypoint/code.go
+++ b/internal/entrypoint/code.go
@@ -1,0 +1,222 @@
+package entrypoint
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
+)
+
+const (
+	labelReadyForReview = "ready-for-review"
+	labelReadyToCode    = "ready-to-code"
+	labelRequiresManual = "requires-manual-review"
+)
+
+// ReviewOutcome represents the result of a pre-push review.
+type ReviewOutcome struct {
+	Approved bool
+	Summary  string
+}
+
+// ReviewReader interprets a review agent's output into a structured outcome.
+type ReviewReader interface {
+	Read(exitCode int, workspace string) ReviewOutcome
+}
+
+// ExitCodeReader interprets exit code 0 as approved, nonzero as rejected.
+type ExitCodeReader struct{}
+
+func (r *ExitCodeReader) Read(exitCode int, _ string) ReviewOutcome {
+	if exitCode == 0 {
+		return ReviewOutcome{Approved: true, Summary: "review passed"}
+	}
+	return ReviewOutcome{Approved: false, Summary: fmt.Sprintf("review agent exited %d", exitCode)}
+}
+
+// CodeResult represents the outcome of a successful code agent run.
+type CodeResult struct {
+	Branch string
+	PRURL  string
+}
+
+// RunCode orchestrates the code agent lifecycle:
+//  1. Validate workspace (agent definition exists)
+//  2. Resolve default branch if needed
+//  3. Configure git identity and create branch
+//  4. Run code agent
+//  5. Check for commits
+//  6. Run secret scan
+//  7. Run review agent (if available)
+//  8. Push branch
+//  9. Create or update PR
+//  10. Swap labels on issue
+func RunCode(ctx context.Context, env *Env, runner Runner, client forge.Client, safeEnv []string) (*CodeResult, error) {
+	agentFile := filepath.Join(env.Workspace, env.AgentDir, "code.md")
+	if _, err := os.Stat(agentFile); err != nil {
+		return nil, fmt.Errorf("agent definition not found: %s", agentFile)
+	}
+
+	if env.DefaultBranch == "" {
+		repo, err := client.GetRepo(ctx, env.Owner, env.Repo)
+		if err != nil {
+			return nil, fmt.Errorf("get repo metadata: %w", err)
+		}
+		env.DefaultBranch = repo.DefaultBranch
+	}
+
+	branch := fmt.Sprintf("agent/%d", env.IssueNumber)
+
+	// Configure git identity and create working branch.
+	for _, args := range [][]string{
+		{"config", "user.name", "fullsend[bot]"},
+		{"config", "user.email", "fullsend[bot]@users.noreply.github.com"},
+		{"checkout", "-b", branch},
+	} {
+		code, err := runner.Run(ctx, "git", args, env.Workspace, nil)
+		if err != nil {
+			return nil, fmt.Errorf("git %s: %w", args[0], err)
+		}
+		if code != 0 {
+			return nil, fmt.Errorf("git %s exited %d", args[0], code)
+		}
+	}
+
+	// Run code agent.
+	prompt := fmt.Sprintf(
+		"Implement the changes requested in issue #%d. "+
+			"Follow the instructions in the issue description. "+
+			"Commit your changes with clear commit messages.",
+		env.IssueNumber,
+	)
+	agentCode, err := runner.Run(ctx, "claude", []string{
+		"--agent", filepath.Join(env.AgentDir, "code.md"),
+		"--print", prompt,
+	}, env.Workspace, safeEnv)
+	if err != nil {
+		return nil, fmt.Errorf("run code agent: %w", err)
+	}
+	if agentCode != 0 {
+		applyFailureLabel(ctx, client, env)
+		return nil, fmt.Errorf("code agent exited %d", agentCode)
+	}
+
+	// Check for commits. git diff --quiet returns 0 if no diff (no commits),
+	// 1 if diff exists (commits were made), or 128+ for infrastructure errors.
+	diffCode, err := runner.Run(ctx, "git", []string{
+		"diff", "--quiet", env.DefaultBranch + "..HEAD",
+	}, env.Workspace, nil)
+	if err != nil {
+		return nil, fmt.Errorf("check for commits: %w", err)
+	}
+	switch diffCode {
+	case 0:
+		applyFailureLabel(ctx, client, env)
+		return nil, fmt.Errorf("code agent produced no commits")
+	case 1:
+		// has commits, proceed
+	default:
+		return nil, fmt.Errorf("git diff exited %d", diffCode)
+	}
+
+	// Secret scan on new commits.
+	leaksCode, err := runner.Run(ctx, "gitleaks", []string{
+		"detect", "--source", ".", "--log-opts", env.DefaultBranch + "..HEAD",
+	}, env.Workspace, nil)
+	if err != nil {
+		return nil, fmt.Errorf("run secret scan: %w", err)
+	}
+	if leaksCode != 0 {
+		applyFailureLabel(ctx, client, env)
+		_ = client.AddIssueComment(ctx, env.Owner, env.Repo, env.IssueNumber,
+			"Secret scan detected potential secrets in agent commits. Requires manual review.")
+		return nil, fmt.Errorf("secret scan failed (exit %d)", leaksCode)
+	}
+
+	// Pre-push review (graceful degradation if review agent absent).
+	reviewFile := filepath.Join(env.Workspace, env.AgentDir, "review.md")
+	if _, statErr := os.Stat(reviewFile); statErr == nil {
+		reviewCode, err := runner.Run(ctx, "claude", []string{
+			"--agent", filepath.Join(env.AgentDir, "review.md"),
+			"--print", fmt.Sprintf(
+				"Review the changes on branch %s relative to %s. "+
+					"Examine the diff and provide your verdict.",
+				branch, env.DefaultBranch,
+			),
+		}, env.Workspace, safeEnv)
+		if err != nil {
+			return nil, fmt.Errorf("run review agent: %w", err)
+		}
+
+		reader := &ExitCodeReader{}
+		outcome := reader.Read(reviewCode, env.Workspace)
+		if !outcome.Approved {
+			applyFailureLabel(ctx, client, env)
+			_ = client.AddIssueComment(ctx, env.Owner, env.Repo, env.IssueNumber,
+				fmt.Sprintf("Pre-push review rejected: %s", outcome.Summary))
+			return nil, fmt.Errorf("review rejected: %s", outcome.Summary)
+		}
+	}
+
+	// Push branch using bot token.
+	authedURL := fmt.Sprintf(
+		"https://x-access-token:%s@github.com/%s/%s.git",
+		env.BotToken, env.Owner, env.Repo,
+	)
+	cleanURL := fmt.Sprintf(
+		"https://github.com/%s/%s.git",
+		env.Owner, env.Repo,
+	)
+	for _, args := range [][]string{
+		{"remote", "set-url", "origin", authedURL},
+		{"push", "--set-upstream", "origin", branch},
+		{"remote", "set-url", "origin", cleanURL},
+	} {
+		code, err := runner.Run(ctx, "git", args, env.Workspace, nil)
+		if err != nil {
+			return nil, fmt.Errorf("git %s: %w", args[0], err)
+		}
+		if code != 0 {
+			return nil, fmt.Errorf("git %s exited %d", args[0], code)
+		}
+	}
+
+	// Create or update PR.
+	var prURL string
+	existing, err := client.FindOpenPRByHead(ctx, env.Owner, env.Repo, branch)
+	if err != nil && !forge.IsNotFound(err) {
+		return nil, fmt.Errorf("find existing PR: %w", err)
+	}
+	if existing != nil {
+		prURL = existing.URL
+	} else {
+		title := fmt.Sprintf("agent: implement issue #%d", env.IssueNumber)
+		body := fmt.Sprintf(
+			"Automated implementation for #%d.\n\nGenerated by the fullsend code agent.",
+			env.IssueNumber,
+		)
+		pr, err := client.CreateDraftChangeProposal(
+			ctx, env.Owner, env.Repo, title, body, branch, env.DefaultBranch,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create PR: %w", err)
+		}
+		prURL = pr.URL
+	}
+
+	// Swap labels on issue (best-effort).
+	_ = client.AddIssueLabel(ctx, env.Owner, env.Repo, env.IssueNumber, labelReadyForReview)
+	_ = client.RemoveIssueLabel(ctx, env.Owner, env.Repo, env.IssueNumber, labelReadyToCode)
+
+	return &CodeResult{
+		Branch: branch,
+		PRURL:  prURL,
+	}, nil
+}
+
+// applyFailureLabel applies the requires-manual-review label (best-effort).
+func applyFailureLabel(ctx context.Context, client forge.Client, env *Env) {
+	_ = client.AddIssueLabel(ctx, env.Owner, env.Repo, env.IssueNumber, labelRequiresManual)
+}

--- a/internal/entrypoint/code_test.go
+++ b/internal/entrypoint/code_test.go
@@ -1,0 +1,321 @@
+package entrypoint
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
+)
+
+func setupWorkspace(t *testing.T, includeReview bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	agentsDir := filepath.Join(dir, "agents")
+	require.NoError(t, os.MkdirAll(agentsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(agentsDir, "code.md"), []byte("# Code Agent"), 0o644))
+	if includeReview {
+		require.NoError(t, os.WriteFile(filepath.Join(agentsDir, "review.md"), []byte("# Review Agent"), 0o644))
+	}
+	return dir
+}
+
+func testEnv(workspace string) *Env {
+	return &Env{
+		Owner:         "testorg",
+		Repo:          "testrepo",
+		IssueNumber:   42,
+		Workspace:     workspace,
+		DefaultBranch: "main",
+		BotToken:      "test-bot-token",
+		AgentDir:      "agents",
+	}
+}
+
+// codeRunFunc returns a RunFunc for the happy path. All git commands and
+// agents succeed; git diff returns 1 (has changes).
+func codeRunFunc(_ int, name string, args []string) (int, error) {
+	if name == "git" && len(args) > 0 && args[0] == "diff" {
+		return 1, nil // has changes
+	}
+	return 0, nil
+}
+
+func TestRunCode_HappyPath(t *testing.T) {
+	workspace := setupWorkspace(t, true)
+	env := testEnv(workspace)
+	client := forge.NewFakeClient()
+	runner := &FakeRunner{RunFunc: codeRunFunc}
+
+	result, err := RunCode(context.Background(), env, runner, client, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "agent/42", result.Branch)
+	assert.Contains(t, result.PRURL, "/pull/")
+
+	// Verify git identity was configured.
+	assert.Equal(t, "git", runner.Calls[0].Name)
+	assert.Equal(t, []string{"config", "user.name", "fullsend[bot]"}, runner.Calls[0].Args)
+
+	// Verify branch was created.
+	assert.Equal(t, []string{"checkout", "-b", "agent/42"}, runner.Calls[2].Args)
+
+	// Verify code agent was invoked with sanitized env.
+	assert.Equal(t, "claude", runner.Calls[3].Name)
+	assert.Contains(t, runner.Calls[3].Args, "agents/code.md")
+
+	// Verify secret scan ran.
+	assert.Equal(t, "gitleaks", runner.Calls[5].Name)
+
+	// Verify review agent ran.
+	assert.Equal(t, "claude", runner.Calls[6].Name)
+	assert.Contains(t, runner.Calls[6].Args, "agents/review.md")
+
+	// Verify push and URL cleanup.
+	assert.Equal(t, "git", runner.Calls[7].Name)
+	assert.Equal(t, "remote", runner.Calls[7].Args[0])
+	assert.Equal(t, "git", runner.Calls[8].Name)
+	assert.Equal(t, "push", runner.Calls[8].Args[0])
+	assert.Equal(t, "git", runner.Calls[9].Name)
+	assert.Equal(t, "remote", runner.Calls[9].Args[0])
+	assert.Contains(t, runner.Calls[9].Args[3], "https://github.com/")
+	assert.NotContains(t, runner.Calls[9].Args[3], "x-access-token")
+
+	// Verify PR was created.
+	require.Len(t, client.CreatedProposals, 1)
+	assert.True(t, client.CreatedProposals[0].Draft)
+	assert.Contains(t, client.CreatedProposals[0].Title, "#42")
+
+	// Verify labels were swapped.
+	assert.Contains(t, client.AddedLabels, "testorg/testrepo/42/ready-for-review")
+	assert.Contains(t, client.RemovedLabels, "testorg/testrepo/42/ready-to-code")
+}
+
+func TestRunCode_NoCommits(t *testing.T) {
+	workspace := setupWorkspace(t, false)
+	env := testEnv(workspace)
+	client := forge.NewFakeClient()
+	runner := &FakeRunner{
+		RunFunc: func(_ int, _ string, _ []string) (int, error) {
+			return 0, nil // git diff returns 0 = no changes
+		},
+	}
+
+	_, err := RunCode(context.Background(), env, runner, client, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no commits")
+	assert.Contains(t, client.AddedLabels, "testorg/testrepo/42/requires-manual-review")
+}
+
+func TestRunCode_GitDiffInfraError(t *testing.T) {
+	workspace := setupWorkspace(t, false)
+	env := testEnv(workspace)
+	client := forge.NewFakeClient()
+	runner := &FakeRunner{
+		RunFunc: func(_ int, name string, args []string) (int, error) {
+			if name == "git" && len(args) > 0 && args[0] == "diff" {
+				return 128, nil // infrastructure error, not "has changes"
+			}
+			return 0, nil
+		},
+	}
+
+	_, err := RunCode(context.Background(), env, runner, client, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "git diff exited 128")
+}
+
+func TestRunCode_AgentFails(t *testing.T) {
+	workspace := setupWorkspace(t, false)
+	env := testEnv(workspace)
+	client := forge.NewFakeClient()
+	runner := &FakeRunner{
+		RunFunc: func(_ int, name string, _ []string) (int, error) {
+			if name == "claude" {
+				return 1, nil
+			}
+			return 0, nil
+		},
+	}
+
+	_, err := RunCode(context.Background(), env, runner, client, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "code agent exited 1")
+	assert.Contains(t, client.AddedLabels, "testorg/testrepo/42/requires-manual-review")
+}
+
+func TestRunCode_SecretScanFails(t *testing.T) {
+	workspace := setupWorkspace(t, false)
+	env := testEnv(workspace)
+	client := forge.NewFakeClient()
+	runner := &FakeRunner{
+		RunFunc: func(_ int, name string, args []string) (int, error) {
+			if name == "git" && len(args) > 0 && args[0] == "diff" {
+				return 1, nil // has changes
+			}
+			if name == "gitleaks" {
+				return 1, nil // secrets found
+			}
+			return 0, nil
+		},
+	}
+
+	_, err := RunCode(context.Background(), env, runner, client, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret scan failed")
+	assert.Contains(t, client.AddedLabels, "testorg/testrepo/42/requires-manual-review")
+	require.Len(t, client.AddedComments, 1)
+	assert.Contains(t, client.AddedComments[0].Body, "Secret scan")
+}
+
+func TestRunCode_ReviewRejects(t *testing.T) {
+	workspace := setupWorkspace(t, true)
+	env := testEnv(workspace)
+	client := forge.NewFakeClient()
+	runner := &FakeRunner{
+		RunFunc: func(_ int, name string, args []string) (int, error) {
+			if name == "git" && len(args) > 0 && args[0] == "diff" {
+				return 1, nil // has changes
+			}
+			// Second claude call (review) rejects.
+			if name == "claude" && len(args) > 1 && strings.Contains(args[1], "review.md") {
+				return 1, nil
+			}
+			return 0, nil
+		},
+	}
+
+	_, err := RunCode(context.Background(), env, runner, client, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "review rejected")
+	assert.Contains(t, client.AddedLabels, "testorg/testrepo/42/requires-manual-review")
+	require.Len(t, client.AddedComments, 1)
+	assert.Contains(t, client.AddedComments[0].Body, "Pre-push review rejected")
+}
+
+func TestRunCode_ReviewAgentAbsent(t *testing.T) {
+	workspace := setupWorkspace(t, false) // no review.md
+	env := testEnv(workspace)
+	client := forge.NewFakeClient()
+	runner := &FakeRunner{RunFunc: codeRunFunc}
+
+	result, err := RunCode(context.Background(), env, runner, client, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "agent/42", result.Branch)
+
+	// Verify no review agent call was made — only code agent.
+	claudeCalls := 0
+	for _, c := range runner.Calls {
+		if c.Name == "claude" {
+			claudeCalls++
+		}
+	}
+	assert.Equal(t, 1, claudeCalls)
+}
+
+func TestRunCode_ExistingPR(t *testing.T) {
+	workspace := setupWorkspace(t, false)
+	env := testEnv(workspace)
+	client := forge.NewFakeClient()
+	client.PullRequests = map[string][]forge.ChangeProposal{
+		"testorg/testrepo": {{
+			URL:    "https://github.com/testorg/testrepo/pull/99",
+			Title:  "existing PR",
+			Number: 99,
+			Head:   "agent/42",
+		}},
+	}
+	runner := &FakeRunner{RunFunc: codeRunFunc}
+
+	result, err := RunCode(context.Background(), env, runner, client, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/testorg/testrepo/pull/99", result.PRURL)
+	assert.Empty(t, client.CreatedProposals)
+}
+
+func TestRunCode_AgentDefinitionMissing(t *testing.T) {
+	dir := t.TempDir() // empty workspace, no agents/code.md
+	env := testEnv(dir)
+	client := forge.NewFakeClient()
+	runner := &FakeRunner{}
+
+	_, err := RunCode(context.Background(), env, runner, client, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent definition not found")
+}
+
+func TestRunCode_ResolvesDefaultBranch(t *testing.T) {
+	workspace := setupWorkspace(t, false)
+	env := testEnv(workspace)
+	env.DefaultBranch = "" // force resolution from repo metadata
+	client := forge.NewFakeClient()
+	client.Repos = []forge.Repository{{
+		Name:          "testrepo",
+		FullName:      "testorg/testrepo",
+		DefaultBranch: "develop",
+	}}
+	runner := &FakeRunner{RunFunc: codeRunFunc}
+
+	result, err := RunCode(context.Background(), env, runner, client, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "agent/42", result.Branch)
+	assert.Equal(t, "develop", env.DefaultBranch)
+
+	// Verify git diff used "develop..HEAD".
+	for _, c := range runner.Calls {
+		if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == "diff" {
+			assert.Contains(t, c.Args, "develop..HEAD")
+		}
+	}
+}
+
+func TestRunCode_TokenIsolation(t *testing.T) {
+	workspace := setupWorkspace(t, false)
+	env := testEnv(workspace)
+	client := forge.NewFakeClient()
+	runner := &FakeRunner{RunFunc: codeRunFunc}
+
+	dirtyEnv := SanitizeEnv([]string{
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+		"LANG=en_US.UTF-8",
+		"FULLSEND_CODE_BOT_TOKEN=" + env.BotToken,
+		"GITHUB_TOKEN=ghp_should_be_stripped",
+		"GH_TOKEN=ghp_also_stripped",
+		"GITHUB_ENV=/tmp/github_env",
+		"ACTIONS_RUNTIME_TOKEN=gha_runtime_secret",
+	})
+
+	_, err := RunCode(context.Background(), env, runner, client, dirtyEnv)
+	require.NoError(t, err)
+
+	// Find the claude (code agent) call and inspect its env.
+	for _, c := range runner.Calls {
+		if c.Name == "claude" {
+			envStr := strings.Join(c.Env, "\n")
+			assert.NotContains(t, envStr, env.BotToken, "bot token must not reach the agent")
+			assert.NotContains(t, envStr, "GITHUB_TOKEN", "GITHUB_TOKEN must not reach the agent")
+			assert.NotContains(t, envStr, "GH_TOKEN", "GH_TOKEN must not reach the agent")
+			assert.NotContains(t, envStr, "GITHUB_ENV", "GITHUB_ENV must not reach the agent")
+			assert.NotContains(t, envStr, "ACTIONS_RUNTIME_TOKEN", "ACTIONS_RUNTIME_TOKEN must not reach the agent")
+			assert.Contains(t, c.Env, "PATH=/usr/bin", "safe vars should be preserved")
+			return
+		}
+	}
+	t.Fatal("expected a claude call but found none")
+}
+
+func TestExitCodeReader(t *testing.T) {
+	reader := &ExitCodeReader{}
+
+	approved := reader.Read(0, "/workspace")
+	assert.True(t, approved.Approved)
+
+	rejected := reader.Read(1, "/workspace")
+	assert.False(t, rejected.Approved)
+	assert.Contains(t, rejected.Summary, "exited 1")
+}

--- a/internal/entrypoint/env.go
+++ b/internal/entrypoint/env.go
@@ -1,0 +1,121 @@
+package entrypoint
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Env holds the parsed GHA environment needed by the code agent entrypoint.
+type Env struct {
+	Owner         string // parsed from GITHUB_REPOSITORY (before '/')
+	Repo          string // parsed from GITHUB_REPOSITORY (after '/')
+	IssueNumber   int    // parsed from event payload JSON
+	Workspace     string // GITHUB_WORKSPACE
+	DefaultBranch string // from repo metadata or GITHUB_REF_NAME fallback
+	BotToken      string // FULLSEND_CODE_BOT_TOKEN — never given to agent
+	AgentDir      string // default "agents"
+}
+
+// LoadEnv reads GHA environment variables and the event payload file to
+// construct an Env. It returns an error if any required variable is missing
+// or the event payload cannot be parsed.
+func LoadEnv() (*Env, error) {
+	ghRepo := os.Getenv("GITHUB_REPOSITORY")
+	if ghRepo == "" {
+		return nil, fmt.Errorf("GITHUB_REPOSITORY is not set")
+	}
+	parts := strings.SplitN(ghRepo, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("GITHUB_REPOSITORY %q does not contain '/'", ghRepo)
+	}
+	owner, repo := parts[0], parts[1]
+
+	workspace := os.Getenv("GITHUB_WORKSPACE")
+	if workspace == "" {
+		return nil, fmt.Errorf("GITHUB_WORKSPACE is not set")
+	}
+
+	botToken := os.Getenv("FULLSEND_CODE_BOT_TOKEN")
+	if botToken == "" {
+		return nil, fmt.Errorf("FULLSEND_CODE_BOT_TOKEN is not set")
+	}
+
+	eventPath := os.Getenv("GITHUB_EVENT_PATH")
+	if eventPath == "" {
+		return nil, fmt.Errorf("GITHUB_EVENT_PATH is not set")
+	}
+
+	data, err := os.ReadFile(eventPath)
+	if err != nil {
+		return nil, fmt.Errorf("read event payload: %w", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("parse event payload: %w", err)
+	}
+
+	issueNumber, err := extractIssueNumber(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	defaultBranch := os.Getenv("FULLSEND_DEFAULT_BRANCH")
+
+	agentDir := os.Getenv("FULLSEND_AGENT_DIR")
+	if agentDir == "" {
+		agentDir = "agents"
+	}
+
+	return &Env{
+		Owner:         owner,
+		Repo:          repo,
+		IssueNumber:   issueNumber,
+		Workspace:     workspace,
+		DefaultBranch: defaultBranch,
+		BotToken:      botToken,
+		AgentDir:      agentDir,
+	}, nil
+}
+
+// extractIssueNumber tries to get the issue number from the event payload.
+// It checks client_payload.issue_number (float64) first, then
+// inputs.issue_number (string).
+func extractIssueNumber(payload map[string]any) (int, error) {
+	if v, ok := jsonGet(payload, "client_payload", "issue_number"); ok {
+		if f, ok := v.(float64); ok {
+			return int(f), nil
+		}
+	}
+
+	if v, ok := jsonGet(payload, "inputs", "issue_number"); ok {
+		if s, ok := v.(string); ok {
+			n, err := strconv.Atoi(s)
+			if err != nil {
+				return 0, fmt.Errorf("parse inputs.issue_number %q: %w", s, err)
+			}
+			return n, nil
+		}
+	}
+
+	return 0, fmt.Errorf("event payload missing issue number at client_payload.issue_number or inputs.issue_number")
+}
+
+// jsonGet navigates nested map[string]any using the given keys.
+func jsonGet(m map[string]any, keys ...string) (any, bool) {
+	var current any = m
+	for _, k := range keys {
+		cm, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = cm[k]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}

--- a/internal/entrypoint/env_test.go
+++ b/internal/entrypoint/env_test.go
@@ -1,0 +1,149 @@
+package entrypoint
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writePayloadFile writes JSON content to a temp file and returns its path.
+func writePayloadFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "event.json")
+	err := os.WriteFile(path, []byte(content), 0o600)
+	require.NoError(t, err)
+	return path
+}
+
+// setRequiredEnv sets all required environment variables for LoadEnv and
+// returns a payload file path using client_payload.issue_number.
+func setRequiredEnv(t *testing.T, issueNumber int) string {
+	t.Helper()
+	t.Setenv("GITHUB_REPOSITORY", "acme-org/my-repo")
+	t.Setenv("GITHUB_WORKSPACE", "/workspace")
+	t.Setenv("FULLSEND_CODE_BOT_TOKEN", "ghp_test_token")
+
+	payload := fmt.Sprintf(`{"client_payload":{"issue_number":%d}}`, issueNumber)
+	path := writePayloadFile(t, payload)
+	t.Setenv("GITHUB_EVENT_PATH", path)
+	return path
+}
+
+func TestLoadEnv_HappyPath(t *testing.T) {
+	setRequiredEnv(t, 42)
+
+	env, err := LoadEnv()
+	require.NoError(t, err)
+	require.NotNil(t, env)
+
+	assert.Equal(t, "acme-org", env.Owner)
+	assert.Equal(t, "my-repo", env.Repo)
+	assert.Equal(t, 42, env.IssueNumber)
+	assert.Equal(t, "/workspace", env.Workspace)
+	assert.Equal(t, "ghp_test_token", env.BotToken)
+	assert.Equal(t, "agents", env.AgentDir)
+	assert.Empty(t, env.DefaultBranch)
+}
+
+func TestLoadEnv_InputsPayload(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "acme-org/my-repo")
+	t.Setenv("GITHUB_WORKSPACE", "/workspace")
+	t.Setenv("FULLSEND_CODE_BOT_TOKEN", "ghp_test_token")
+
+	payload := `{"inputs":{"issue_number":"99"}}`
+	path := writePayloadFile(t, payload)
+	t.Setenv("GITHUB_EVENT_PATH", path)
+
+	env, err := LoadEnv()
+	require.NoError(t, err)
+	assert.Equal(t, 99, env.IssueNumber)
+}
+
+func TestLoadEnv_MissingRepository(t *testing.T) {
+	t.Setenv("GITHUB_WORKSPACE", "/workspace")
+	t.Setenv("FULLSEND_CODE_BOT_TOKEN", "ghp_test_token")
+	// GITHUB_REPOSITORY intentionally not set
+
+	_, err := LoadEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GITHUB_REPOSITORY")
+}
+
+func TestLoadEnv_MissingWorkspace(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "acme-org/my-repo")
+	t.Setenv("FULLSEND_CODE_BOT_TOKEN", "ghp_test_token")
+	// GITHUB_WORKSPACE intentionally not set
+
+	_, err := LoadEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GITHUB_WORKSPACE")
+}
+
+func TestLoadEnv_MissingBotToken(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "acme-org/my-repo")
+	t.Setenv("GITHUB_WORKSPACE", "/workspace")
+	// FULLSEND_CODE_BOT_TOKEN intentionally not set
+
+	_, err := LoadEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "FULLSEND_CODE_BOT_TOKEN")
+}
+
+func TestLoadEnv_MissingEventPath(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "acme-org/my-repo")
+	t.Setenv("GITHUB_WORKSPACE", "/workspace")
+	t.Setenv("FULLSEND_CODE_BOT_TOKEN", "ghp_test_token")
+	// GITHUB_EVENT_PATH intentionally not set
+
+	_, err := LoadEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GITHUB_EVENT_PATH")
+}
+
+func TestLoadEnv_InvalidPayload(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "acme-org/my-repo")
+	t.Setenv("GITHUB_WORKSPACE", "/workspace")
+	t.Setenv("FULLSEND_CODE_BOT_TOKEN", "ghp_test_token")
+
+	path := writePayloadFile(t, `not valid json`)
+	t.Setenv("GITHUB_EVENT_PATH", path)
+
+	_, err := LoadEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse event payload")
+}
+
+func TestLoadEnv_MissingIssueNumber(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "acme-org/my-repo")
+	t.Setenv("GITHUB_WORKSPACE", "/workspace")
+	t.Setenv("FULLSEND_CODE_BOT_TOKEN", "ghp_test_token")
+
+	path := writePayloadFile(t, `{"something_else":{"key":"value"}}`)
+	t.Setenv("GITHUB_EVENT_PATH", path)
+
+	_, err := LoadEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "issue number")
+}
+
+func TestLoadEnv_CustomAgentDir(t *testing.T) {
+	setRequiredEnv(t, 7)
+	t.Setenv("FULLSEND_AGENT_DIR", "custom-agents")
+
+	env, err := LoadEnv()
+	require.NoError(t, err)
+	assert.Equal(t, "custom-agents", env.AgentDir)
+}
+
+func TestLoadEnv_DefaultBranch(t *testing.T) {
+	setRequiredEnv(t, 7)
+	t.Setenv("FULLSEND_DEFAULT_BRANCH", "main")
+
+	env, err := LoadEnv()
+	require.NoError(t, err)
+	assert.Equal(t, "main", env.DefaultBranch)
+}

--- a/internal/entrypoint/runner.go
+++ b/internal/entrypoint/runner.go
@@ -1,0 +1,123 @@
+package entrypoint
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Runner executes external commands. The real implementation wraps
+// exec.CommandContext; the fake records calls for testing.
+type Runner interface {
+	// Run executes a command and returns its exit code. A non-zero exit
+	// code is returned as (code, nil) — only infrastructure failures
+	// (e.g., binary not found) produce a non-nil error.
+	Run(ctx context.Context, name string, args []string, dir string, env []string) (exitCode int, err error)
+}
+
+// ExecRunner executes commands via os/exec.
+type ExecRunner struct{}
+
+func (r *ExecRunner) Run(ctx context.Context, name string, args []string, dir string, env []string) (int, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	if len(env) > 0 {
+		cmd.Env = env
+	}
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode(), nil
+		}
+		return -1, fmt.Errorf("exec %s: %w", name, err)
+	}
+	return 0, nil
+}
+
+// SanitizeEnv returns a copy of the given environment with sensitive
+// variables removed. Variables matching any of the prefixes or exact
+// names in the deny list are excluded.
+func SanitizeEnv(env []string) []string {
+	denyPrefixes := []string{
+		"FULLSEND_",
+		"GITHUB_TOKEN",
+		"ACTIONS_",
+	}
+	denyExact := map[string]bool{
+		"GH_TOKEN":             true,
+		"GITHUB_TOKEN":         true,
+		"GITHUB_ENV":           true,
+		"GITHUB_OUTPUT":        true,
+		"GITHUB_PATH":          true,
+		"GITHUB_STEP_SUMMARY":  true,
+		"GITHUB_STATE":         true,
+	}
+
+	var result []string
+	for _, e := range env {
+		key, _, _ := strings.Cut(e, "=")
+		if denyExact[key] {
+			continue
+		}
+		denied := false
+		for _, prefix := range denyPrefixes {
+			if strings.HasPrefix(key, prefix) {
+				denied = true
+				break
+			}
+		}
+		if !denied {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+// RunRecord captures a single invocation of FakeRunner.
+type RunRecord struct {
+	Name string
+	Args []string
+	Dir  string
+	Env  []string
+}
+
+// FakeRunner records calls and returns pre-configured exit codes.
+type FakeRunner struct {
+	// Calls records each invocation in order.
+	Calls []RunRecord
+	// ExitCodes maps command name to exit code. If not set, returns 0.
+	ExitCodes map[string]int
+	// Errors maps command name to error. If set, returned instead of exit code.
+	Errors map[string]error
+	// RunFunc, if set, determines the result for each invocation and takes
+	// precedence over ExitCodes/Errors. It receives the 0-based call index,
+	// command name, and args.
+	RunFunc func(call int, name string, args []string) (int, error)
+}
+
+func (r *FakeRunner) Run(_ context.Context, name string, args []string, dir string, env []string) (int, error) {
+	callIndex := len(r.Calls)
+	r.Calls = append(r.Calls, RunRecord{
+		Name: name,
+		Args: append([]string{}, args...), // copy to avoid aliasing
+		Dir:  dir,
+		Env:  append([]string{}, env...), // copy
+	})
+	if r.RunFunc != nil {
+		return r.RunFunc(callIndex, name, args)
+	}
+	if r.Errors != nil {
+		if err, ok := r.Errors[name]; ok {
+			return -1, err
+		}
+	}
+	if r.ExitCodes != nil {
+		if code, ok := r.ExitCodes[name]; ok {
+			return code, nil
+		}
+	}
+	return 0, nil
+}

--- a/internal/entrypoint/runner_test.go
+++ b/internal/entrypoint/runner_test.go
@@ -1,0 +1,93 @@
+package entrypoint
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFakeRunner_RecordsCalls(t *testing.T) {
+	runner := &FakeRunner{}
+	code, err := runner.Run(context.Background(), "claude", []string{"--agent", "code.md"}, "/workspace", []string{"PATH=/usr/bin"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+	require.Len(t, runner.Calls, 1)
+	assert.Equal(t, "claude", runner.Calls[0].Name)
+	assert.Equal(t, []string{"--agent", "code.md"}, runner.Calls[0].Args)
+	assert.Equal(t, "/workspace", runner.Calls[0].Dir)
+}
+
+func TestFakeRunner_ConfiguredExitCode(t *testing.T) {
+	runner := &FakeRunner{
+		ExitCodes: map[string]int{"claude": 1},
+	}
+	code, err := runner.Run(context.Background(), "claude", nil, "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, code)
+}
+
+func TestFakeRunner_ConfiguredError(t *testing.T) {
+	runner := &FakeRunner{
+		Errors: map[string]error{"claude": fmt.Errorf("binary not found")},
+	}
+	_, err := runner.Run(context.Background(), "claude", nil, "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "binary not found")
+}
+
+func TestFakeRunner_MultipleCalls(t *testing.T) {
+	runner := &FakeRunner{}
+	runner.Run(context.Background(), "claude", []string{"a"}, "/dir1", nil)
+	runner.Run(context.Background(), "gitleaks", []string{"b"}, "/dir2", nil)
+	require.Len(t, runner.Calls, 2)
+	assert.Equal(t, "claude", runner.Calls[0].Name)
+	assert.Equal(t, "gitleaks", runner.Calls[1].Name)
+}
+
+func TestSanitizeEnv(t *testing.T) {
+	env := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+		"FULLSEND_CODE_BOT_TOKEN=secret",
+		"FULLSEND_OTHER=value",
+		"GITHUB_TOKEN=ghp_xxx",
+		"GH_TOKEN=ghp_yyy",
+		"GITHUB_ENV=/tmp/env",
+		"GITHUB_OUTPUT=/tmp/output",
+		"GITHUB_PATH=/tmp/path",
+		"GITHUB_STEP_SUMMARY=/tmp/summary",
+		"GITHUB_STATE=/tmp/state",
+		"ACTIONS_RUNTIME_TOKEN=gha_runtime",
+		"ACTIONS_CACHE_URL=https://cache.example.com",
+		"LANG=en_US.UTF-8",
+	}
+	result := SanitizeEnv(env)
+	assert.Contains(t, result, "PATH=/usr/bin")
+	assert.Contains(t, result, "HOME=/home/user")
+	assert.Contains(t, result, "LANG=en_US.UTF-8")
+	assert.NotContains(t, result, "FULLSEND_CODE_BOT_TOKEN=secret")
+	assert.NotContains(t, result, "FULLSEND_OTHER=value")
+	assert.NotContains(t, result, "GITHUB_TOKEN=ghp_xxx")
+	assert.NotContains(t, result, "GH_TOKEN=ghp_yyy")
+	assert.NotContains(t, result, "GITHUB_ENV=/tmp/env")
+	assert.NotContains(t, result, "GITHUB_OUTPUT=/tmp/output")
+	assert.NotContains(t, result, "GITHUB_PATH=/tmp/path")
+	assert.NotContains(t, result, "GITHUB_STEP_SUMMARY=/tmp/summary")
+	assert.NotContains(t, result, "GITHUB_STATE=/tmp/state")
+	assert.NotContains(t, result, "ACTIONS_RUNTIME_TOKEN=gha_runtime")
+	assert.NotContains(t, result, "ACTIONS_CACHE_URL=https://cache.example.com")
+}
+
+func TestSanitizeEnv_Empty(t *testing.T) {
+	result := SanitizeEnv(nil)
+	assert.Nil(t, result)
+}
+
+func TestExecRunner_CommandNotFound(t *testing.T) {
+	runner := &ExecRunner{}
+	_, err := runner.Run(context.Background(), "nonexistent-binary-xyz-12345", nil, "", nil)
+	require.Error(t, err)
+}

--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -42,6 +42,13 @@ type VariableRecord struct {
 	Owner, Repo, Name, Value string
 }
 
+// CommentRecord records an issue comment creation call.
+type CommentRecord struct {
+	Owner, Repo string
+	Number      int
+	Body        string
+}
+
 // FakeClient is a thread-safe test double for forge.Client.
 // Pre-populate its fields to control return values, and inspect
 // recorder slices after the test to verify which calls were made.
@@ -79,6 +86,9 @@ type FakeClient struct {
 	Variables         []VariableRecord
 	DeletedOrgSecrets []string // "org/name"
 	CreatedOrgSecrets []OrgSecretRecord
+	AddedLabels       []string        // "owner/repo/number/label"
+	RemovedLabels     []string        // "owner/repo/number/label"
+	AddedComments     []CommentRecord
 
 	// internal counter for change proposal numbers
 	proposalCounter int
@@ -353,6 +363,86 @@ func (f *FakeClient) ListRepoPullRequests(_ context.Context, owner, repo string)
 		}
 	}
 	return []ChangeProposal{}, nil
+}
+
+func (f *FakeClient) FindOpenPRByHead(_ context.Context, owner, repo, head string) (*ChangeProposal, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if e := f.err("FindOpenPRByHead"); e != nil {
+		return nil, e
+	}
+
+	if f.PullRequests != nil {
+		for _, cp := range f.PullRequests[owner+"/"+repo] {
+			if cp.Head == head {
+				cp := cp
+				return &cp, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("%w: no open PR with head %s in %s/%s", ErrNotFound, head, owner, repo)
+}
+
+func (f *FakeClient) CreateDraftChangeProposal(_ context.Context, owner, repo, title, body, head, base string) (*ChangeProposal, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if e := f.err("CreateDraftChangeProposal"); e != nil {
+		return nil, e
+	}
+
+	f.proposalCounter++
+	cp := ChangeProposal{
+		URL:    fmt.Sprintf("https://forge.example.com/%s/%s/pull/%d", owner, repo, f.proposalCounter),
+		Title:  title,
+		Number: f.proposalCounter,
+		Head:   head,
+		Draft:  true,
+	}
+	f.CreatedProposals = append(f.CreatedProposals, cp)
+	return &cp, nil
+}
+
+func (f *FakeClient) AddIssueLabel(_ context.Context, owner, repo string, number int, label string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if e := f.err("AddIssueLabel"); e != nil {
+		return e
+	}
+
+	f.AddedLabels = append(f.AddedLabels, fmt.Sprintf("%s/%s/%d/%s", owner, repo, number, label))
+	return nil
+}
+
+func (f *FakeClient) RemoveIssueLabel(_ context.Context, owner, repo string, number int, label string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if e := f.err("RemoveIssueLabel"); e != nil {
+		return e
+	}
+
+	f.RemovedLabels = append(f.RemovedLabels, fmt.Sprintf("%s/%s/%d/%s", owner, repo, number, label))
+	return nil
+}
+
+func (f *FakeClient) AddIssueComment(_ context.Context, owner, repo string, number int, body string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if e := f.err("AddIssueComment"); e != nil {
+		return e
+	}
+
+	f.AddedComments = append(f.AddedComments, CommentRecord{
+		Owner:  owner,
+		Repo:   repo,
+		Number: number,
+		Body:   body,
+	})
+	return nil
 }
 
 func (f *FakeClient) GetAuthenticatedUser(_ context.Context) (string, error) {

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -36,6 +36,8 @@ type ChangeProposal struct {
 	URL    string
 	Title  string
 	Number int
+	Head   string
+	Draft  bool
 }
 
 // WorkflowRun represents a CI/CD workflow execution.
@@ -99,9 +101,16 @@ type Client interface {
 	// Combines SHA-aware upsert with branch targeting.
 	CreateOrUpdateFileOnBranch(ctx context.Context, owner, repo, branch, path, message string, content []byte) error
 
+	// Issue operations
+	AddIssueLabel(ctx context.Context, owner, repo string, number int, label string) error
+	RemoveIssueLabel(ctx context.Context, owner, repo string, number int, label string) error
+	AddIssueComment(ctx context.Context, owner, repo string, number int, body string) error
+
 	// Change proposals (PRs/MRs)
 	CreateChangeProposal(ctx context.Context, owner, repo, title, body, head, base string) (*ChangeProposal, error)
 	ListRepoPullRequests(ctx context.Context, owner, repo string) ([]ChangeProposal, error)
+	FindOpenPRByHead(ctx context.Context, owner, repo, head string) (*ChangeProposal, error)
+	CreateDraftChangeProposal(ctx context.Context, owner, repo, title, body, head, base string) (*ChangeProposal, error)
 
 	// Authentication
 	GetAuthenticatedUser(ctx context.Context) (string, error)

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -592,6 +592,9 @@ func (c *LiveClient) CreateChangeProposal(ctx context.Context, owner, repo, titl
 		HTMLURL string `json:"html_url"`
 		Title   string `json:"title"`
 		Number  int    `json:"number"`
+		Head    struct {
+			Ref string `json:"ref"`
+		} `json:"head"`
 	}
 	if err := decodeJSON(resp, &pr); err != nil {
 		return nil, fmt.Errorf("decode pull request: %w", err)
@@ -601,6 +604,7 @@ func (c *LiveClient) CreateChangeProposal(ctx context.Context, owner, repo, titl
 		URL:    pr.HTMLURL,
 		Title:  pr.Title,
 		Number: pr.Number,
+		Head:   pr.Head.Ref,
 	}, nil
 }
 
@@ -618,6 +622,9 @@ func (c *LiveClient) ListRepoPullRequests(ctx context.Context, owner, repo strin
 			HTMLURL string `json:"html_url"`
 			Title   string `json:"title"`
 			Number  int    `json:"number"`
+			Head    struct {
+				Ref string `json:"ref"`
+			} `json:"head"`
 		}
 		if err := decodeJSON(resp, &prs); err != nil {
 			return nil, fmt.Errorf("decode pull requests page %d: %w", page, err)
@@ -628,6 +635,7 @@ func (c *LiveClient) ListRepoPullRequests(ctx context.Context, owner, repo strin
 				URL:    pr.HTMLURL,
 				Title:  pr.Title,
 				Number: pr.Number,
+				Head:   pr.Head.Ref,
 			})
 		}
 
@@ -1210,6 +1218,126 @@ func (c *LiveClient) SetOrgSecretRepos(ctx context.Context, org, name string, re
 	}
 	resp.Body.Close()
 	return nil
+}
+
+// AddIssueLabel adds a label to an issue or pull request.
+func (c *LiveClient) AddIssueLabel(ctx context.Context, owner, repo string, number int, label string) error {
+	payload := map[string]any{
+		"labels": []string{label},
+	}
+	resp, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/issues/%d/labels", owner, repo, number), payload)
+	if err != nil {
+		return fmt.Errorf("add label %s to issue %d: %w", label, number, err)
+	}
+	if err := checkStatus(resp, http.StatusOK); err != nil {
+		return fmt.Errorf("add label %s to issue %d: %w", label, number, err)
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// RemoveIssueLabel removes a label from an issue or pull request.
+// A 404 response is treated as success (label already removed).
+func (c *LiveClient) RemoveIssueLabel(ctx context.Context, owner, repo string, number int, label string) error {
+	resp, err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%s", owner, repo, number, label), nil)
+	if err != nil {
+		return fmt.Errorf("remove label %s from issue %d: %w", label, number, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if err := checkStatus(resp, http.StatusOK, http.StatusNoContent); err != nil {
+		return fmt.Errorf("remove label %s from issue %d: %w", label, number, err)
+	}
+	return nil
+}
+
+// AddIssueComment posts a comment on an issue or pull request.
+func (c *LiveClient) AddIssueComment(ctx context.Context, owner, repo string, number int, body string) error {
+	payload := map[string]string{
+		"body": body,
+	}
+	resp, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number), payload)
+	if err != nil {
+		return fmt.Errorf("add comment to issue %d: %w", number, err)
+	}
+	if err := checkStatus(resp, http.StatusOK, http.StatusCreated); err != nil {
+		return fmt.Errorf("add comment to issue %d: %w", number, err)
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// FindOpenPRByHead returns the first open pull request whose head branch matches head.
+// Returns forge.ErrNotFound (wrapped) if no matching PR exists.
+func (c *LiveClient) FindOpenPRByHead(ctx context.Context, owner, repo, head string) (*forge.ChangeProposal, error) {
+	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/pulls?head=%s:%s&state=open&per_page=1", owner, repo, owner, head))
+	if err != nil {
+		return nil, fmt.Errorf("find open PR by head %s: %w", head, err)
+	}
+
+	var prs []struct {
+		HTMLURL string `json:"html_url"`
+		Title   string `json:"title"`
+		Number  int    `json:"number"`
+		Head    struct {
+			Ref string `json:"ref"`
+		} `json:"head"`
+	}
+	if err := decodeJSON(resp, &prs); err != nil {
+		return nil, fmt.Errorf("decode PRs for head %s: %w", head, err)
+	}
+
+	if len(prs) == 0 {
+		return nil, fmt.Errorf("%w: no open PR with head %s in %s/%s", forge.ErrNotFound, head, owner, repo)
+	}
+
+	pr := prs[0]
+	return &forge.ChangeProposal{
+		URL:    pr.HTMLURL,
+		Title:  pr.Title,
+		Number: pr.Number,
+		Head:   pr.Head.Ref,
+	}, nil
+}
+
+// CreateDraftChangeProposal creates a draft pull request.
+func (c *LiveClient) CreateDraftChangeProposal(ctx context.Context, owner, repo, title, body, head, base string) (*forge.ChangeProposal, error) {
+	payload := map[string]any{
+		"title": title,
+		"body":  body,
+		"head":  head,
+		"base":  base,
+		"draft": true,
+	}
+
+	resp, err := c.post(ctx, fmt.Sprintf("/repos/%s/%s/pulls", owner, repo), payload)
+	if err != nil {
+		return nil, fmt.Errorf("create draft pull request: %w", err)
+	}
+
+	var pr struct {
+		HTMLURL string `json:"html_url"`
+		Title   string `json:"title"`
+		Number  int    `json:"number"`
+		Draft   bool   `json:"draft"`
+		Head    struct {
+			Ref string `json:"ref"`
+		} `json:"head"`
+	}
+	if err := decodeJSON(resp, &pr); err != nil {
+		return nil, fmt.Errorf("decode draft pull request: %w", err)
+	}
+
+	return &forge.ChangeProposal{
+		URL:    pr.HTMLURL,
+		Title:  pr.Title,
+		Number: pr.Number,
+		Head:   pr.Head.Ref,
+		Draft:  true,
+	}, nil
 }
 
 // isNotFound checks whether an error is a 404 API error.

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/fullsend-ai/fullsend/internal/forge"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -818,4 +819,152 @@ func TestListOrgRepos_Pagination(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, repos, 101)
 	assert.Equal(t, 2, page) // Should have made exactly 2 requests
+}
+
+func TestAddIssueLabel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/repos/owner/repo/issues/7/labels", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		labels, ok := body["labels"].([]any)
+		require.True(t, ok)
+		require.Len(t, labels, 1)
+		assert.Equal(t, "bug", labels[0])
+
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"name": "bug"},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.AddIssueLabel(context.Background(), "owner", "repo", 7, "bug")
+	require.NoError(t, err)
+}
+
+func TestRemoveIssueLabel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/repos/owner/repo/issues/7/labels/bug", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]any{})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.RemoveIssueLabel(context.Background(), "owner", "repo", 7, "bug")
+	require.NoError(t, err)
+}
+
+func TestRemoveIssueLabel_AlreadyRemoved(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/repos/owner/repo/issues/7/labels/bug", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]any{"message": "Label does not exist"})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.RemoveIssueLabel(context.Background(), "owner", "repo", 7, "bug")
+	require.NoError(t, err)
+}
+
+func TestAddIssueComment(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/repos/owner/repo/issues/7/comments", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "Hello, world!", body["body"])
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   101,
+			"body": "Hello, world!",
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.AddIssueComment(context.Background(), "owner", "repo", 7, "Hello, world!")
+	require.NoError(t, err)
+}
+
+func TestFindOpenPRByHead(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/repos/owner/repo/pulls", r.URL.Path)
+		assert.Equal(t, "owner:feature-branch", r.URL.Query().Get("head"))
+		assert.Equal(t, "open", r.URL.Query().Get("state"))
+		assert.Equal(t, "1", r.URL.Query().Get("per_page"))
+
+		json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"html_url": "https://github.com/owner/repo/pull/55",
+				"title":    "My feature",
+				"number":   55,
+				"head":     map[string]any{"ref": "feature-branch"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	cp, err := client.FindOpenPRByHead(context.Background(), "owner", "repo", "feature-branch")
+	require.NoError(t, err)
+	assert.Equal(t, 55, cp.Number)
+	assert.Equal(t, "My feature", cp.Title)
+	assert.Equal(t, "feature-branch", cp.Head)
+	assert.Equal(t, "https://github.com/owner/repo/pull/55", cp.URL)
+}
+
+func TestFindOpenPRByHead_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		json.NewEncoder(w).Encode([]map[string]any{})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	_, err := client.FindOpenPRByHead(context.Background(), "owner", "repo", "no-such-branch")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, forge.ErrNotFound)
+}
+
+func TestCreateDraftChangeProposal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/repos/owner/repo/pulls", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "Draft PR", body["title"])
+		assert.Equal(t, "WIP", body["body"])
+		assert.Equal(t, "draft-branch", body["head"])
+		assert.Equal(t, "main", body["base"])
+		assert.Equal(t, true, body["draft"])
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"html_url": "https://github.com/owner/repo/pull/99",
+			"title":    "Draft PR",
+			"number":   99,
+			"draft":    true,
+			"head":     map[string]any{"ref": "draft-branch"},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	cp, err := client.CreateDraftChangeProposal(context.Background(), "owner", "repo", "Draft PR", "WIP", "draft-branch", "main")
+	require.NoError(t, err)
+	assert.Equal(t, 99, cp.Number)
+	assert.Equal(t, "Draft PR", cp.Title)
+	assert.Equal(t, "draft-branch", cp.Head)
+	assert.True(t, cp.Draft)
+	assert.Equal(t, "https://github.com/owner/repo/pull/99", cp.URL)
 }


### PR DESCRIPTION
## Summary

- Adds 5 new `forge.Client` methods for issue labels, comments, and PR lookup/creation (prep commit)
- Implements `fullsend entrypoint code` — the deterministic Go wrapper that orchestrates the code agent lifecycle (env parsing, git setup, code agent, commit check, secret scan, optional pre-push review, push, draft PR, label swap)
- Graceful degradation when `agents/review.md` is absent; token isolation ensures bot credentials never enter the agent's environment

Addresses task #3 from the sync-up on #127, assigned to @ben-alkov.

## Test plan

- [x] 30 new tests across 4 packages (258 total pass)
- [x] `go vet ./...` clean
- [x] `pre-commit` clean
- [ ] Review forge method implementations against GitHub API docs
- [ ] Verify composite action compatibility (`fullsend entrypoint code --scm github`)