### PR TITLE
Fix org secret visibility to always use selected

### DIFF
--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -941,17 +941,17 @@ func (c *LiveClient) CreateOrgSecret(ctx context.Context, org, name, value strin
 	}
 
 	// Step 3: Upload the encrypted secret.
-	// When repo IDs are provided, scope the secret to those repos only.
-	// When no repos are specified, make it available to all repos in the org.
-	payload := map[string]any{
-		"encrypted_value": base64.StdEncoding.EncodeToString(encrypted),
-		"key_id":          pubKey.KeyID,
+	// Always use visibility "selected" so that SetOrgSecretRepos can later
+	// update the repo access list without a 409 Conflict (which GitHub
+	// returns when trying to set selected repos on a visibility "all" secret).
+	if selectedRepoIDs == nil {
+		selectedRepoIDs = []int64{}
 	}
-	if len(selectedRepoIDs) > 0 {
-		payload["visibility"] = "selected"
-		payload["selected_repository_ids"] = selectedRepoIDs
-	} else {
-		payload["visibility"] = "all"
+	payload := map[string]any{
+		"encrypted_value":       base64.StdEncoding.EncodeToString(encrypted),
+		"key_id":                pubKey.KeyID,
+		"visibility":            "selected",
+		"selected_repository_ids": selectedRepoIDs,
 	}
 
 	resp, err := c.put(ctx, fmt.Sprintf("/orgs/%s/actions/secrets/%s", org, name), payload)

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -626,7 +626,7 @@ func TestCreateOrgSecret(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestCreateOrgSecret_NilRepoIDs_VisibilityAll(t *testing.T) {
+func TestCreateOrgSecret_NilRepoIDs_VisibilitySelected(t *testing.T) {
 	callNum := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callNum++
@@ -642,15 +642,17 @@ func TestCreateOrgSecret_NilRepoIDs_VisibilityAll(t *testing.T) {
 				"key":    base64.StdEncoding.EncodeToString(pubKey),
 			})
 		case 2:
-			// PUT org secret — should use visibility "all" with no repo IDs
+			// PUT org secret — should use visibility "selected" with empty repo IDs
+			// so that SetOrgSecretRepos can later update access without a 409 Conflict.
 			assert.Equal(t, "PUT", r.Method)
 
 			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			assert.Equal(t, "all", body["visibility"],
-				"visibility should be 'all' when no repo IDs are specified")
-			assert.Nil(t, body["selected_repository_ids"],
-				"selected_repository_ids should be absent when visibility is 'all'")
+			assert.Equal(t, "selected", body["visibility"],
+				"visibility should be 'selected' even when no repo IDs are specified")
+			repoIDs, ok := body["selected_repository_ids"].([]any)
+			require.True(t, ok, "selected_repository_ids should be an empty array, not nil")
+			assert.Empty(t, repoIDs, "selected_repository_ids should be empty")
 
 			w.WriteHeader(http.StatusCreated)
 		}
@@ -659,6 +661,44 @@ func TestCreateOrgSecret_NilRepoIDs_VisibilityAll(t *testing.T) {
 
 	client := newTestClient(t, srv)
 	err := client.CreateOrgSecret(context.Background(), "myorg", "TOKEN", "value", nil)
+	require.NoError(t, err)
+}
+
+func TestCreateOrgSecret_EmptySliceRepoIDs_VisibilitySelected(t *testing.T) {
+	callNum := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callNum++
+		switch callNum {
+		case 1:
+			// GET org public key
+			pubKey := make([]byte, 32)
+			for i := range pubKey {
+				pubKey[i] = byte(i + 1)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"key_id": "org-key-123",
+				"key":    base64.StdEncoding.EncodeToString(pubKey),
+			})
+		case 2:
+			// PUT org secret — empty slice should behave the same as nil:
+			// visibility "selected" with an empty repo ID array.
+			assert.Equal(t, "PUT", r.Method)
+
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			assert.Equal(t, "selected", body["visibility"],
+				"visibility should be 'selected' even with an empty slice")
+			repoIDs, ok := body["selected_repository_ids"].([]any)
+			require.True(t, ok, "selected_repository_ids should be an empty array, not nil")
+			assert.Empty(t, repoIDs, "selected_repository_ids should be empty")
+
+			w.WriteHeader(http.StatusCreated)
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.CreateOrgSecret(context.Background(), "myorg", "TOKEN", "value", []int64{})
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
## Summary
- When installing with no repos, `CreateOrgSecret` was setting `visibility="all"`. A subsequent install with repos would call `SetOrgSecretRepos`, which GitHub rejects with **409 Conflict** because you cannot set selected repos on a `visibility="all"` secret.
- Changed `CreateOrgSecret` to always use `visibility="selected"` with an empty repo ID array, so that later `SetOrgSecretRepos` calls succeed.

Fixes #216

## Test plan
- [x] `TestCreateOrgSecret` — verifies selected visibility with repo IDs
- [x] `TestCreateOrgSecret_NilRepoIDs_VisibilitySelected` — verifies selected visibility with empty array when no repos specified
- [x] `TestDispatchTokenLayer_Install_*` — dispatch layer tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)