### PR TITLE
Fix enrollment analyze reporting not-installed with no repos

### DIFF
--- a/internal/layers/enrollment.go
+++ b/internal/layers/enrollment.go
@@ -176,7 +176,10 @@ func (l *EnrollmentLayer) Analyze(ctx context.Context) (*LayerReport, error) {
 	}
 
 	switch {
-	case len(notEnrolled) == 0 && len(enrolled) > 0:
+	case len(l.enabledRepos) == 0:
+		report.Status = StatusInstalled
+		report.Details = append(report.Details, "no repositories enrolled")
+	case len(notEnrolled) == 0:
 		report.Status = StatusInstalled
 		for _, r := range enrolled {
 			report.Details = append(report.Details, r+" enrolled")

--- a/internal/layers/enrollment_test.go
+++ b/internal/layers/enrollment_test.go
@@ -224,6 +224,21 @@ func TestEnrollmentLayer_Analyze_Partial(t *testing.T) {
 	assert.Contains(t, report.WouldFix[0], "repo-b")
 }
 
+func TestEnrollmentLayer_Analyze_NoReposEnabled(t *testing.T) {
+	client := &forge.FakeClient{}
+	layer, _ := newEnrollmentLayer(t, client, nil, nil)
+
+	report, err := layer.Analyze(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, "enrollment", report.Name)
+	assert.Equal(t, StatusInstalled, report.Status)
+	require.Len(t, report.Details, 1)
+	assert.Equal(t, "no repositories enrolled", report.Details[0])
+	assert.Empty(t, report.WouldInstall)
+	assert.Empty(t, report.WouldFix)
+}
+
 // perRepoFileErrorClient wraps FakeClient but fails CreateOrUpdateFileOnBranch for a specific repo.
 type perRepoFileErrorClient struct {
 	*forge.FakeClient


### PR DESCRIPTION
## Summary
- When no repositories are enabled, `admin analyze` reported the enrollment layer as "not installed", which is misleading — the install succeeded, there are just no repos to enroll.
- Added an early check in `Analyze` for the no-enabled-repos case, reporting `StatusInstalled` with detail "no repositories enrolled" instead of `StatusNotInstalled`.

Fixes #214

## Test plan
- [x] `TestEnrollmentLayer_Analyze_NoReposEnabled` — new test for the empty repos case
- [x] All existing enrollment layer tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)