### PR TITLE
fix: harden entrypoint output handling in fullsend action

### DIFF
--- a/dispatch/github/actions/fullsend/action.yml
+++ b/dispatch/github/actions/fullsend/action.yml
@@ -93,13 +93,23 @@ runs:
       run: |
         set -euo pipefail
         # fullsend must print the artifact directory path on stdout (last line wins if multiple lines).
-        ARTIFACT_DIR="$(echo fullsend entrypoint "${AGENT}" | tail -n1)"
+        ARTIFACT_DIR="$(fullsend entrypoint "${AGENT}" | tail -n1)"
         ARTIFACT_DIR="$(printf '%s' "${ARTIFACT_DIR}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
         if [[ -z "${ARTIFACT_DIR}" ]]; then
           echo "::error::fullsend entrypoint did not print an artifact directory on stdout"
           exit 1
         fi
-        echo "artifact_dir=${ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"
+        # Validate path is absolute and within expected boundaries.
+        if [[ "${ARTIFACT_DIR}" != /* ]]; then
+          echo "::error::fullsend entrypoint returned a non-absolute path: ${ARTIFACT_DIR}"
+          exit 1
+        fi
+        # Use heredoc delimiter to prevent GITHUB_OUTPUT injection via newlines.
+        {
+          echo "artifact_dir<<FULLSEND_EOF"
+          echo "${ARTIFACT_DIR}"
+          echo "FULLSEND_EOF"
+        } >> "${GITHUB_OUTPUT}"
 
     - name: Upload fullsend artifacts
       uses: actions/upload-artifact@v4

--- a/dispatch/github/actions/fullsend/action.yml
+++ b/dispatch/github/actions/fullsend/action.yml
@@ -93,7 +93,7 @@ runs:
       run: |
         set -euo pipefail
         # fullsend must print the artifact directory path on stdout (last line wins if multiple lines).
-        ARTIFACT_DIR="$(fullsend entrypoint "${AGENT}" | tail -n1)"
+        ARTIFACT_DIR="$(echo fullsend entrypoint "${AGENT}" | tail -n1)"
         ARTIFACT_DIR="$(printf '%s' "${ARTIFACT_DIR}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
         if [[ -z "${ARTIFACT_DIR}" ]]; then
           echo "::error::fullsend entrypoint did not print an artifact directory on stdout"


### PR DESCRIPTION
## Summary
- **Path traversal mitigation:** validate that the CLI-returned artifact path is absolute before passing it to `actions/upload-artifact`
- **GITHUB_OUTPUT injection prevention:** use heredoc delimiter instead of inline `=` assignment, preventing newline injection from CLI stdout

Note: the `echo` in `ARTIFACT_DIR="$(echo fullsend entrypoint ...)"` is an intentional stub — the `fullsend entrypoint` CLI subcommand is not yet implemented (see also `internal/layers/workflows.go:175`). These hardening fixes prepare the action for when the real command replaces the stub.

## Test plan
- [ ] Confirm the step fails with a clear error if the CLI returns a relative or empty path
- [ ] Verify heredoc output format is correctly parsed by downstream steps

Hardens output handling introduced in #210.