### PR TITLE
Add HOW_TO skills for experiment reproducibility

### DIFF
--- a/skills/following-how-to/SKILL.md
+++ b/skills/following-how-to/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: following-how-to
+description: >-
+  Use when asked to reproduce an experiment, run an experiment's setup, or work
+  on an experiment that has a HOW_TO document. Use before making changes to an
+  experiment to understand its environment and dependencies.
+---
+
+# Following HOW_TO Documents
+
+Follow an experiment's HOW_TO document to reproduce it or to understand its
+setup before working on it. Do not improvise -- follow the steps as written.
+
+## Process
+
+Follow these steps in order. Do not skip steps.
+
+### 1. Find the HOW_TO
+
+Look for `HOW_TO.md` or `HOW_TO_*.md` files in the experiment directory.
+
+```bash
+ls experiments/<name>/HOW_TO*.md
+```
+
+**If no HOW_TO exists:** Tell the user and suggest creating one using the
+writing-how-to skill. Do not attempt to reverse-engineer setup steps from the
+README or scripts -- a missing HOW_TO means the reproduction path is not
+documented.
+
+**If multiple HOW_TO files exist:** List them and ask the user which one to
+follow, unless the task makes the choice obvious (e.g., asked to "set up the
+experiment" implies `HOW_TO_SETUP.md`).
+
+### 2. Check requirements
+
+Read the Requirements section. For each tool listed:
+
+```bash
+command -v <tool>
+```
+
+For each environment variable listed, verify it is set:
+
+```bash
+echo "${VARIABLE_NAME:?VARIABLE_NAME is not set}"
+```
+
+**If anything is missing,** report the full list of missing requirements to the
+user before proceeding. Do not install tools or set env vars without the user's
+approval. Present what is missing and what action is needed:
+
+```
+Missing requirements:
+- uv: not installed (https://docs.astral.sh/uv/getting-started/installation/)
+- GCP_PROJECT_ID: not set (GCP project ID where Model Armor templates are configured)
+```
+
+Only proceed once all requirements are satisfied.
+
+### 3. Follow the steps
+
+Execute each step in order. Do not skip steps, reorder them, or combine them.
+
+- **Script steps:** Run the script as written. Do not inline the script's
+  contents or modify it.
+- **Manual steps:** Execute the command exactly as documented.
+- **Decision steps:** If a step requires a choice (e.g., selecting a region),
+  use the documented default if one is provided. If no default exists, ask the
+  user.
+
+If a step fails, stop and report the failure with the exact error output. Do
+not attempt to fix it unless the user asks.
+
+### 4. Verify output
+
+Read the Expected Output section. Check each condition:
+
+- If it says a file should exist, verify it does.
+- If it describes terminal output, compare against what was produced.
+- If it specifies values or patterns, confirm they match.
+
+Report the verification result to the user:
+
+```
+Expected Output verification:
+- results/ directory created: YES
+- summary.md present: YES
+- terminal shows comparison table: YES
+All checks passed.
+```
+
+If any check fails, report what was expected vs. what was observed.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Skipping requirement checks | Always check before running. A missing tool mid-run wastes time. |
+| Installing tools without asking | Report what is missing. Let the user decide how to install. |
+| Improvising when no HOW_TO exists | Stop and suggest creating one. Do not guess at setup steps. |
+| Modifying scripts before running them | Run as-is first. Changes come after successful reproduction. |
+| Ignoring Expected Output | Verification is the point. Always check the results. |

--- a/skills/writing-how-to/SKILL.md
+++ b/skills/writing-how-to/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: writing-how-to
+description: >-
+  Use when creating or updating a HOW_TO document inside an experiment directory.
+  Use when an experiment needs reproducibility instructions, setup documentation,
+  or when existing reproduction steps are scattered across a README and should be
+  formalized.
+---
+
+# Writing HOW_TO Documents for Experiments
+
+A HOW_TO document gives a reader everything they need to reproduce an
+experiment from scratch on a new machine. It is not a narrative -- it is a
+checklist. Someone following it should be able to run the experiment without
+reading the README first.
+
+## When to Use
+
+- Creating a new experiment that requires setup steps
+- An experiment has reproduction instructions buried in its README that should
+  be extracted into a standalone HOW_TO
+- An experiment's setup has changed and the HOW_TO needs updating
+
+Do NOT use for experiments that are pure analysis documents with no runnable
+components (e.g., `003-agent-outage-fire-drill.md`).
+
+## File Naming
+
+- **`HOW_TO.md`** -- single document covering the whole experiment
+- **`HOW_TO_<TOPIC>.md`** -- when an experiment has multiple independent
+  procedures (e.g., `HOW_TO_SETUP.md`, `HOW_TO_EVALUATION.md`)
+
+Place the file in the experiment's root directory, next to its README.
+
+## Required Sections
+
+Every HOW_TO must have these four sections, in this order:
+
+### 1. Purpose
+
+One sentence stating what following this document achieves.
+
+```markdown
+## Purpose
+
+Reproduce the LLM Guard sentence-mode evaluation results from the guardrails
+experiment.
+```
+
+### 2. Requirements
+
+A table listing every tool, library, or service needed. Include the tool name
+and a link to its installation docs. Include the version **only** when it
+matters for reproducibility (e.g., a specific API version, a minimum Python
+version).
+
+```markdown
+## Requirements
+
+| Requirement | Link |
+|-------------|------|
+| Python 3.11+ | https://www.python.org/downloads/ |
+| uv | https://docs.astral.sh/uv/getting-started/installation/ |
+| gcloud CLI | https://cloud.google.com/sdk/docs/install |
+```
+
+After the table, list required environment variables separately. Never provide
+default values for secrets -- just describe what the variable should contain.
+
+```markdown
+### Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `GOOGLE_APPLICATION_CREDENTIALS` | Path to a GCP service account key file with Vertex AI permissions |
+| `GCP_PROJECT_ID` | GCP project ID where Model Armor templates are configured |
+```
+
+### 3. Steps
+
+Numbered steps to set up and run the experiment.
+
+**The script rule:** If a sequence has 5 or more shell commands that a reader
+would execute without making decisions, extract them into a script. Suggest
+`setup.sh` for environment/dependency setup and `run.sh` for running the
+experiment, but use experiment-specific names when they are clearer (e.g.,
+`run-evaluation.sh`, `setup-venv.sh`).
+
+When you extract commands to a script:
+- Make the script executable (`chmod +x`)
+- Add a shebang line (`#!/usr/bin/env bash`)
+- Add `set -euo pipefail` after the shebang
+- Keep the HOW_TO step as a single "run the script" command
+
+```markdown
+## Steps
+
+1. Navigate to the experiment directory:
+   ```bash
+   cd experiments/guardrails-eval
+   ```
+
+2. Run the setup script to create the virtual environment and install
+   dependencies:
+   ```bash
+   ./setup.sh
+   ```
+
+3. Run the LLM Guard evaluation against the original payloads:
+   ```bash
+   uv run python eval-llm-guard.py
+   ```
+```
+
+**What belongs in steps vs. what doesn't:**
+- Steps are actions the reader performs. Each step has a command or a short
+  instruction.
+- Explanations of why a step exists belong in the README, not the HOW_TO.
+- If a step requires a decision (e.g., choosing a GCP region), state the
+  decision clearly and provide a sensible default.
+
+### 4. Expected Output
+
+Describe what success looks like so the reader can verify the experiment ran
+correctly. This can be a file that gets produced, a terminal output pattern, or
+a specific result to check.
+
+```markdown
+## Expected Output
+
+- `results/` directory is created with timestamped subdirectories
+- Each subdirectory contains `summary.md` and per-payload result files
+- Terminal shows a comparison table with detection rates per scanner
+```
+
+## Checklist
+
+1. **Read the experiment's README** to understand what it does and how it is
+   currently run.
+2. **Identify all requirements** -- tools, libraries, services, credentials,
+   env vars.
+3. **Walk through the reproduction steps** mentally or actually. Note every
+   command.
+4. **Count sequential shell commands.** If any sequence has 5+, extract to a
+   script.
+5. **Write the four sections** in order: Purpose, Requirements, Steps,
+   Expected Output.
+6. **Verify links** in the Requirements table resolve to real installation
+   pages.
+7. **If you created scripts,** ensure they have a shebang, `set -euo pipefail`,
+   and are executable.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Mixing explanation with steps | Steps are commands. Put context in the README. |
+| Listing tools without install links | Every tool in Requirements gets a link. |
+| Hardcoding secrets or project names | Use env vars with no defaults. Describe what to put in them. |
+| Long command sequences without scripts | 5+ sequential commands = extract to a script. |
+| Forgetting Expected Output | The reader needs to know if it worked. Always include this. |
+| Duplicating the README | HOW_TO is a checklist, not a narrative. Link to the README for background. |


### PR DESCRIPTION
## Summary

- Adds `writing-how-to` skill that standardizes HOW_TO documents in `experiments/` with four required sections: Purpose, Requirements (tool + link table, env vars), Steps (with a 5+ command script extraction rule), and Expected Output
- Adds `following-how-to` skill that guides agents through reproducing an experiment: find the HOW_TO, verify requirements are installed, follow steps in order, verify output matches expectations

## Test plan

- [ ] Verify both skills appear in agent skill discovery
- [ ] Test `writing-how-to` by asking an agent to create a HOW_TO for an existing experiment (e.g., `guardrails-eval`)
- [ ] Test `following-how-to` by asking an agent to reproduce an experiment that has a HOW_TO
- [ ] Test `following-how-to` against an experiment without a HOW_TO -- agent should suggest creating one

🤖 Generated with [Claude Code](https://claude.com/claude-code)