### PR TITLE
Fix release workflow deprecation warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,8 @@ builds:
       - arm64
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
 


### PR DESCRIPTION
## Summary
- Bump `actions/setup-go` v5→v6 and `goreleaser/goreleaser-action` v6→v7 to resolve Node.js 20 deprecation (forced to Node.js 24 starting June 2, 2026)
- Migrate `archives.format` to `archives.formats` per GoReleaser v2 deprecation

## Test plan
- [x] `goreleaser check` validates config with no warnings
- [x] `goreleaser release --snapshot --clean` builds all 4 archives successfully
- [ ] Next tag push triggers clean CI run with no deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)