### PR TITLE
feat: add agent progress tracking to CLI run command

### DIFF
--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -70,6 +71,8 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
 
+	isCI := os.Getenv("GITHUB_ACTIONS") == "true"
+
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {
@@ -83,7 +86,7 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 
 		switch {
 		case evt.Type == "assistant":
-			parseAssistantToolUse(line, printer, start, metrics)
+			parseAssistantToolUse(line, printer, start, metrics, isCI)
 
 		case evt.Type == "stream_event" && evt.Event != nil:
 			if evt.Event.Type == "content_block_start" && evt.Event.ContentBlock.Type == "tool_use" {
@@ -92,7 +95,7 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 					toolName = "tool"
 				}
 				count := metrics.ToolCalls.Add(1)
-				emitToolProgress(printer, toolName, "", start, count)
+				emitToolProgress(printer, toolName, "", start, count, isCI)
 			}
 		}
 	}
@@ -100,7 +103,7 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 	return scanner.Err()
 }
 
-func parseAssistantToolUse(line []byte, printer *ui.Printer, start time.Time, metrics *RunMetrics) {
+func parseAssistantToolUse(line []byte, printer *ui.Printer, start time.Time, metrics *RunMetrics, isCI bool) {
 	var msg assistantMessage
 	if err := json.Unmarshal(line, &msg); err != nil {
 		return
@@ -123,7 +126,7 @@ func parseAssistantToolUse(line []byte, printer *ui.Printer, start time.Time, me
 			ctx = extractSafeContext(item.Name, item.Input)
 		}
 		count := metrics.ToolCalls.Add(1)
-		emitToolProgress(printer, toolName, ctx, start, count)
+		emitToolProgress(printer, toolName, ctx, start, count, isCI)
 	}
 }
 
@@ -208,7 +211,7 @@ func extractBinaryName(cmd string) string {
 	return ""
 }
 
-func emitToolProgress(printer *ui.Printer, toolName, context string, start time.Time, toolCount int32) {
+func emitToolProgress(printer *ui.Printer, toolName, context string, start time.Time, toolCount int32, isCI bool) {
 	elapsed := time.Since(start).Truncate(time.Second)
 
 	var msg string
@@ -218,7 +221,9 @@ func emitToolProgress(printer *ui.Printer, toolName, context string, start time.
 		msg = fmt.Sprintf("%s (%s, %d tools)", toolName, elapsed, toolCount)
 	}
 
-	printer.Notice(sanitizeGHA(msg))
+	if isCI {
+		fmt.Fprintf(os.Stderr, "::notice::%s\n", sanitizeGHA(msg))
+	}
 	printer.Heartbeat(msg)
 }
 

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -71,8 +70,6 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
 
-	isCI := os.Getenv("GITHUB_ACTIONS") == "true"
-
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {
@@ -86,7 +83,7 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 
 		switch {
 		case evt.Type == "assistant":
-			parseAssistantToolUse(line, printer, start, metrics, isCI)
+			parseAssistantToolUse(line, printer, start, metrics)
 
 		case evt.Type == "stream_event" && evt.Event != nil:
 			if evt.Event.Type == "content_block_start" && evt.Event.ContentBlock.Type == "tool_use" {
@@ -95,7 +92,7 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 					toolName = "tool"
 				}
 				count := metrics.ToolCalls.Add(1)
-				emitToolProgress(printer, toolName, "", start, count, isCI)
+				emitToolProgress(printer, toolName, "", start, count)
 			}
 		}
 	}
@@ -103,7 +100,7 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 	return scanner.Err()
 }
 
-func parseAssistantToolUse(line []byte, printer *ui.Printer, start time.Time, metrics *RunMetrics, isCI bool) {
+func parseAssistantToolUse(line []byte, printer *ui.Printer, start time.Time, metrics *RunMetrics) {
 	var msg assistantMessage
 	if err := json.Unmarshal(line, &msg); err != nil {
 		return
@@ -126,7 +123,7 @@ func parseAssistantToolUse(line []byte, printer *ui.Printer, start time.Time, me
 			ctx = extractSafeContext(item.Name, item.Input)
 		}
 		count := metrics.ToolCalls.Add(1)
-		emitToolProgress(printer, toolName, ctx, start, count, isCI)
+		emitToolProgress(printer, toolName, ctx, start, count)
 	}
 }
 
@@ -162,8 +159,9 @@ func extractSafeContext(toolName string, input json.RawMessage) string {
 		if err := json.Unmarshal(raw, &path); err != nil {
 			return ""
 		}
-		if len(path) > maxPathDisplay {
-			return path[:maxPathDisplay] + "…"
+		if utf8.RuneCountInString(path) > maxPathDisplay {
+			runes := []rune(path)
+			return string(runes[:maxPathDisplay]) + "…"
 		}
 		return path
 
@@ -210,7 +208,7 @@ func extractBinaryName(cmd string) string {
 	return ""
 }
 
-func emitToolProgress(printer *ui.Printer, toolName, context string, start time.Time, toolCount int32, isCI bool) {
+func emitToolProgress(printer *ui.Printer, toolName, context string, start time.Time, toolCount int32) {
 	elapsed := time.Since(start).Truncate(time.Second)
 
 	var msg string
@@ -220,9 +218,7 @@ func emitToolProgress(printer *ui.Printer, toolName, context string, start time.
 		msg = fmt.Sprintf("%s (%s, %d tools)", toolName, elapsed, toolCount)
 	}
 
-	if isCI {
-		fmt.Fprintf(os.Stderr, "::notice::%s\n", sanitizeGHA(msg))
-	}
+	printer.Notice(sanitizeGHA(msg))
 	printer.Heartbeat(msg)
 }
 

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -60,19 +60,29 @@ type RunMetrics struct {
 // (binary name for Bash, file path for Read/Write/Edit) without logging
 // potentially sensitive arguments.
 func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *RunMetrics) error {
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
-
+	br := bufio.NewReaderSize(r, 1024*1024)
 	isCI := os.Getenv("GITHUB_ACTIONS") == "true"
 
-	for scanner.Scan() {
-		line := scanner.Bytes()
+	for {
+		line, isPrefix, err := br.ReadLine()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if isPrefix {
+			for isPrefix && err == nil {
+				_, isPrefix, err = br.ReadLine()
+			}
+			continue
+		}
 		if len(line) == 0 {
 			continue
 		}
 
 		var evt streamEvent
-		if err := json.Unmarshal(line, &evt); err != nil {
+		if jsonErr := json.Unmarshal(line, &evt); jsonErr != nil {
 			continue
 		}
 
@@ -80,8 +90,6 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 			parseAssistantToolUse(line, printer, start, metrics, isCI)
 		}
 	}
-
-	return scanner.Err()
 }
 
 func parseAssistantToolUse(line []byte, printer *ui.Printer, start time.Time, metrics *RunMetrics, isCI bool) {
@@ -224,7 +232,7 @@ func sanitizeOutput(s string) string {
 	var buf strings.Builder
 	buf.Grow(len(s))
 	for _, r := range s {
-		if r >= 0x20 && r != 0x7F {
+		if (r >= 0x20 && r < 0x7F) || r > 0x9F {
 			buf.WriteRune(r)
 		} else {
 			buf.WriteByte(' ')

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -9,11 +9,15 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
-const maxPatternDisplay = 50
+const (
+	maxPatternDisplay = 50
+	maxPathDisplay    = 200
+)
 
 // streamEvent represents a single NDJSON event from Claude Code's stream-json output.
 type streamEvent struct {
@@ -63,7 +67,7 @@ type RunMetrics struct {
 // progress updates via the printer. It extracts tool names and safe context
 // (binary name for Bash, file path for Read/Write/Edit) without logging
 // potentially sensitive arguments.
-func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *RunMetrics) {
+func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *RunMetrics) error {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
 
@@ -96,9 +100,7 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 		}
 	}
 
-	if err := scanner.Err(); err != nil {
-		fmt.Fprintf(os.Stderr, "  progress parser: %v\n", err)
-	}
+	return scanner.Err()
 }
 
 func parseAssistantToolUse(line []byte, printer *ui.Printer, start time.Time, metrics *RunMetrics, isCI bool) {
@@ -117,11 +119,13 @@ func parseAssistantToolUse(line []byte, printer *ui.Printer, start time.Time, me
 			continue
 		}
 		toolName := item.Name
+		var ctx string
 		if !allowedTools[toolName] {
 			toolName = "tool"
+		} else {
+			ctx = extractSafeContext(item.Name, item.Input)
 		}
 		count := metrics.ToolCalls.Add(1)
-		ctx := extractSafeContext(item.Name, item.Input)
 		emitToolProgress(printer, toolName, ctx, start, count, isCI)
 	}
 }
@@ -158,6 +162,9 @@ func extractSafeContext(toolName string, input json.RawMessage) string {
 		if err := json.Unmarshal(raw, &path); err != nil {
 			return ""
 		}
+		if len(path) > maxPathDisplay {
+			return path[:maxPathDisplay] + "…"
+		}
 		return path
 
 	case "Grep", "Glob":
@@ -169,8 +176,9 @@ func extractSafeContext(toolName string, input json.RawMessage) string {
 		if err := json.Unmarshal(raw, &pattern); err != nil {
 			return ""
 		}
-		if len(pattern) > maxPatternDisplay {
-			return pattern[:maxPatternDisplay] + "…"
+		if utf8.RuneCountInString(pattern) > maxPatternDisplay {
+			runes := []rune(pattern)
+			return string(runes[:maxPatternDisplay]) + "…"
 		}
 		return pattern
 	}
@@ -219,10 +227,14 @@ func emitToolProgress(printer *ui.Printer, toolName, context string, start time.
 }
 
 // sanitizeGHA strips characters that could inject GitHub Actions workflow
-// commands from untrusted sandbox output.
+// commands from untrusted sandbox output, including URL-encoded variants.
 func sanitizeGHA(s string) string {
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "%0A", " ")
+	s = strings.ReplaceAll(s, "%0a", " ")
+	s = strings.ReplaceAll(s, "%0D", " ")
+	s = strings.ReplaceAll(s, "%0d", " ")
 	s = strings.ReplaceAll(s, "::", ": :")
 	return s
 }

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -22,16 +22,7 @@ const (
 
 // streamEvent represents a single NDJSON event from Claude Code's stream-json output.
 type streamEvent struct {
-	Type  string `json:"type"`
-	Event *struct {
-		Type         string       `json:"type"`
-		ContentBlock contentBlock `json:"content_block"`
-	} `json:"event,omitempty"`
-}
-
-type contentBlock struct {
 	Type string `json:"type"`
-	Name string `json:"name"`
 }
 
 // assistantMessage contains tool_use blocks from complete assistant messages.
@@ -85,19 +76,8 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 			continue
 		}
 
-		switch {
-		case evt.Type == "assistant":
+		if evt.Type == "assistant" {
 			parseAssistantToolUse(line, printer, start, metrics, isCI)
-
-		case evt.Type == "stream_event" && evt.Event != nil:
-			if evt.Event.Type == "content_block_start" && evt.Event.ContentBlock.Type == "tool_use" {
-				toolName := evt.Event.ContentBlock.Name
-				if !allowedTools[toolName] {
-					toolName = "tool"
-				}
-				count := metrics.ToolCalls.Add(1)
-				emitToolProgress(printer, toolName, "", start, count, isCI)
-			}
 		}
 	}
 

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -7,10 +7,13 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
+
+const maxPatternDisplay = 50
 
 // streamEvent represents a single NDJSON event from Claude Code's stream-json output.
 type streamEvent struct {
@@ -26,12 +29,6 @@ type contentBlock struct {
 	Name string `json:"name"`
 }
 
-// toolResult is emitted when a tool completes.
-type toolResult struct {
-	Type      string `json:"type"`
-	ToolUseID string `json:"tool_use_id"`
-}
-
 // assistantMessage contains tool_use blocks from complete assistant messages.
 type assistantMessage struct {
 	Type    string          `json:"type"`
@@ -44,9 +41,22 @@ type contentItem struct {
 	Input json.RawMessage `json:"input"`
 }
 
+// allowedTools is the set of tool names we display in progress output.
+// Unknown tools emit no context to prevent information disclosure from
+// untrusted sandbox output.
+var allowedTools = map[string]bool{
+	"Bash":  true,
+	"Read":  true,
+	"Write": true,
+	"Edit":  true,
+	"Grep":  true,
+	"Glob":  true,
+	"Agent": true,
+}
+
 // RunMetrics collects execution statistics from stream parsing.
 type RunMetrics struct {
-	ToolCalls int `json:"tool_calls"`
+	ToolCalls atomic.Int32
 }
 
 // progressParser reads NDJSON from Claude Code's stream-json output and emits
@@ -77,10 +87,17 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 		case evt.Type == "stream_event" && evt.Event != nil:
 			if evt.Event.Type == "content_block_start" && evt.Event.ContentBlock.Type == "tool_use" {
 				toolName := evt.Event.ContentBlock.Name
-				metrics.ToolCalls++
-				emitToolProgress(printer, toolName, "", start, metrics.ToolCalls, isCI)
+				if !allowedTools[toolName] {
+					toolName = "tool"
+				}
+				count := metrics.ToolCalls.Add(1)
+				emitToolProgress(printer, toolName, "", start, count, isCI)
 			}
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "  progress parser: %v\n", err)
 	}
 }
 
@@ -99,9 +116,13 @@ func parseAssistantToolUse(line []byte, printer *ui.Printer, start time.Time, me
 		if item.Type != "tool_use" {
 			continue
 		}
-		metrics.ToolCalls++
-		context := extractSafeContext(item.Name, item.Input)
-		emitToolProgress(printer, item.Name, context, start, metrics.ToolCalls, isCI)
+		toolName := item.Name
+		if !allowedTools[toolName] {
+			toolName = "tool"
+		}
+		count := metrics.ToolCalls.Add(1)
+		ctx := extractSafeContext(item.Name, item.Input)
+		emitToolProgress(printer, toolName, ctx, start, count, isCI)
 	}
 }
 
@@ -139,7 +160,7 @@ func extractSafeContext(toolName string, input json.RawMessage) string {
 		}
 		return path
 
-	case "Grep":
+	case "Grep", "Glob":
 		raw, ok := fields["pattern"]
 		if !ok {
 			return ""
@@ -148,16 +169,8 @@ func extractSafeContext(toolName string, input json.RawMessage) string {
 		if err := json.Unmarshal(raw, &pattern); err != nil {
 			return ""
 		}
-		return pattern
-
-	case "Glob":
-		raw, ok := fields["pattern"]
-		if !ok {
-			return ""
-		}
-		var pattern string
-		if err := json.Unmarshal(raw, &pattern); err != nil {
-			return ""
+		if len(pattern) > maxPatternDisplay {
+			return pattern[:maxPatternDisplay] + "…"
 		}
 		return pattern
 	}
@@ -165,21 +178,31 @@ func extractSafeContext(toolName string, input json.RawMessage) string {
 	return ""
 }
 
-// extractBinaryName returns only the first token of a shell command.
+// extractBinaryName returns only the binary name from a shell command,
+// skipping leading KEY=VALUE environment variable assignments.
 func extractBinaryName(cmd string) string {
 	cmd = strings.TrimSpace(cmd)
 	if cmd == "" {
 		return ""
 	}
-	firstWord := strings.Fields(cmd)[0]
-	// Strip path prefix if present (e.g. /usr/bin/make → make).
-	if idx := strings.LastIndex(firstWord, "/"); idx >= 0 {
-		firstWord = firstWord[idx+1:]
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return ""
 	}
-	return firstWord
+	// Skip leading KEY=VALUE env var assignments.
+	for _, f := range fields {
+		if !strings.Contains(f, "=") {
+			// Strip path prefix (e.g. /usr/bin/make → make).
+			if idx := strings.LastIndex(f, "/"); idx >= 0 {
+				f = f[idx+1:]
+			}
+			return f
+		}
+	}
+	return ""
 }
 
-func emitToolProgress(printer *ui.Printer, toolName, context string, start time.Time, toolCount int, isCI bool) {
+func emitToolProgress(printer *ui.Printer, toolName, context string, start time.Time, toolCount int32, isCI bool) {
 	elapsed := time.Since(start).Truncate(time.Second)
 
 	var msg string
@@ -190,7 +213,16 @@ func emitToolProgress(printer *ui.Printer, toolName, context string, start time.
 	}
 
 	if isCI {
-		fmt.Fprintf(os.Stderr, "::notice::%s\n", msg)
+		fmt.Fprintf(os.Stderr, "::notice::%s\n", sanitizeGHA(msg))
 	}
 	printer.Heartbeat(msg)
+}
+
+// sanitizeGHA strips characters that could inject GitHub Actions workflow
+// commands from untrusted sandbox output.
+func sanitizeGHA(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "::", ": :")
+	return s
 }

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -221,21 +222,33 @@ func emitToolProgress(printer *ui.Printer, toolName, context string, start time.
 		msg = fmt.Sprintf("%s (%s, %d tools)", toolName, elapsed, toolCount)
 	}
 
+	msg = sanitizeOutput(msg)
 	if isCI {
-		fmt.Fprintf(os.Stderr, "::notice::%s\n", sanitizeGHA(msg))
+		fmt.Fprintf(os.Stderr, "::notice::%s\n", msg)
 	}
 	printer.Heartbeat(msg)
 }
 
-// sanitizeGHA strips characters that could inject GitHub Actions workflow
-// commands from untrusted sandbox output, including URL-encoded variants.
-func sanitizeGHA(s string) string {
-	s = strings.ReplaceAll(s, "\n", " ")
-	s = strings.ReplaceAll(s, "\r", " ")
-	s = strings.ReplaceAll(s, "%0A", " ")
-	s = strings.ReplaceAll(s, "%0a", " ")
-	s = strings.ReplaceAll(s, "%0D", " ")
-	s = strings.ReplaceAll(s, "%0d", " ")
+// ansiEscRe matches ANSI CSI sequences, OSC sequences, and charset designators.
+var ansiEscRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][A-Z0-9]`)
+
+// sanitizeOutput strips ANSI escape sequences, control characters, and GHA
+// workflow command markers from untrusted sandbox output. Safe for terminals,
+// CI log viewers, and log aggregators.
+func sanitizeOutput(s string) string {
+	s = ansiEscRe.ReplaceAllString(s, "")
 	s = strings.ReplaceAll(s, "::", ": :")
-	return s
+	for _, enc := range []string{"%0A", "%0a", "%0D", "%0d"} {
+		s = strings.ReplaceAll(s, enc, " ")
+	}
+	var buf strings.Builder
+	buf.Grow(len(s))
+	for _, r := range s {
+		if r >= 0x20 && r != 0x7F {
+			buf.WriteRune(r)
+		} else {
+			buf.WriteByte(' ')
+		}
+	}
+	return buf.String()
 }

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+// streamEvent represents a single NDJSON event from Claude Code's stream-json output.
+type streamEvent struct {
+	Type  string `json:"type"`
+	Event *struct {
+		Type         string       `json:"type"`
+		ContentBlock contentBlock `json:"content_block"`
+	} `json:"event,omitempty"`
+}
+
+type contentBlock struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
+
+// toolResult is emitted when a tool completes.
+type toolResult struct {
+	Type      string `json:"type"`
+	ToolUseID string `json:"tool_use_id"`
+}
+
+// assistantMessage contains tool_use blocks from complete assistant messages.
+type assistantMessage struct {
+	Type    string          `json:"type"`
+	Content json.RawMessage `json:"content"`
+}
+
+type contentItem struct {
+	Type  string          `json:"type"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
+}
+
+// RunMetrics collects execution statistics from stream parsing.
+type RunMetrics struct {
+	ToolCalls int `json:"tool_calls"`
+}
+
+// progressParser reads NDJSON from Claude Code's stream-json output and emits
+// progress updates via the printer. It extracts tool names and safe context
+// (binary name for Bash, file path for Read/Write/Edit) without logging
+// potentially sensitive arguments.
+func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *RunMetrics) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+
+	isCI := os.Getenv("GITHUB_ACTIONS") == "true"
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var evt streamEvent
+		if err := json.Unmarshal(line, &evt); err != nil {
+			continue
+		}
+
+		switch {
+		case evt.Type == "assistant":
+			parseAssistantToolUse(line, printer, start, metrics, isCI)
+
+		case evt.Type == "stream_event" && evt.Event != nil:
+			if evt.Event.Type == "content_block_start" && evt.Event.ContentBlock.Type == "tool_use" {
+				toolName := evt.Event.ContentBlock.Name
+				metrics.ToolCalls++
+				emitToolProgress(printer, toolName, "", start, metrics.ToolCalls, isCI)
+			}
+		}
+	}
+}
+
+func parseAssistantToolUse(line []byte, printer *ui.Printer, start time.Time, metrics *RunMetrics, isCI bool) {
+	var msg assistantMessage
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return
+	}
+
+	var items []contentItem
+	if err := json.Unmarshal(msg.Content, &items); err != nil {
+		return
+	}
+
+	for _, item := range items {
+		if item.Type != "tool_use" {
+			continue
+		}
+		metrics.ToolCalls++
+		context := extractSafeContext(item.Name, item.Input)
+		emitToolProgress(printer, item.Name, context, start, metrics.ToolCalls, isCI)
+	}
+}
+
+// extractSafeContext returns a safe, non-secret string for progress display.
+func extractSafeContext(toolName string, input json.RawMessage) string {
+	if len(input) == 0 {
+		return ""
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(input, &fields); err != nil {
+		return ""
+	}
+
+	switch toolName {
+	case "Bash":
+		raw, ok := fields["command"]
+		if !ok {
+			return ""
+		}
+		var cmd string
+		if err := json.Unmarshal(raw, &cmd); err != nil {
+			return ""
+		}
+		return extractBinaryName(cmd)
+
+	case "Read", "Write", "Edit":
+		raw, ok := fields["file_path"]
+		if !ok {
+			return ""
+		}
+		var path string
+		if err := json.Unmarshal(raw, &path); err != nil {
+			return ""
+		}
+		return path
+
+	case "Grep":
+		raw, ok := fields["pattern"]
+		if !ok {
+			return ""
+		}
+		var pattern string
+		if err := json.Unmarshal(raw, &pattern); err != nil {
+			return ""
+		}
+		return pattern
+
+	case "Glob":
+		raw, ok := fields["pattern"]
+		if !ok {
+			return ""
+		}
+		var pattern string
+		if err := json.Unmarshal(raw, &pattern); err != nil {
+			return ""
+		}
+		return pattern
+	}
+
+	return ""
+}
+
+// extractBinaryName returns only the first token of a shell command.
+func extractBinaryName(cmd string) string {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return ""
+	}
+	firstWord := strings.Fields(cmd)[0]
+	// Strip path prefix if present (e.g. /usr/bin/make → make).
+	if idx := strings.LastIndex(firstWord, "/"); idx >= 0 {
+		firstWord = firstWord[idx+1:]
+	}
+	return firstWord
+}
+
+func emitToolProgress(printer *ui.Printer, toolName, context string, start time.Time, toolCount int, isCI bool) {
+	elapsed := time.Since(start).Truncate(time.Second)
+
+	var msg string
+	if context != "" {
+		msg = fmt.Sprintf("%s: %s (%s, %d tools)", toolName, context, elapsed, toolCount)
+	} else {
+		msg = fmt.Sprintf("%s (%s, %d tools)", toolName, elapsed, toolCount)
+	}
+
+	if isCI {
+		fmt.Fprintf(os.Stderr, "::notice::%s\n", msg)
+	}
+	printer.Heartbeat(msg)
+}

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -282,7 +282,7 @@ func TestProgressParserReaderError(t *testing.T) {
 	}
 }
 
-func TestSanitizeGHA(t *testing.T) {
+func TestSanitizeOutput(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
@@ -318,12 +318,47 @@ func TestSanitizeGHA(t *testing.T) {
 			input: "Read%0d%0a::error::pwned",
 			want:  "Read  : :error: :pwned",
 		},
+		{
+			name:  "ANSI CSI color escape",
+			input: "Read: /src/\x1b[31mred\x1b[0m.go",
+			want:  "Read: /src/red.go",
+		},
+		{
+			name:  "ANSI CSI clear screen",
+			input: "Bash: \x1b[2Jmake test",
+			want:  "Bash: make test",
+		},
+		{
+			name:  "ANSI OSC clipboard write",
+			input: "Read: /src/\x1b]52;c;SGVsbG8=\x07file.go",
+			want:  "Read: /src/file.go",
+		},
+		{
+			name:  "raw control characters",
+			input: "Read: /src/\x00\x01\x02file.go",
+			want:  "Read: /src/   file.go",
+		},
+		{
+			name:  "DEL character",
+			input: "Read: /src/file\x7f.go",
+			want:  "Read: /src/file .go",
+		},
+		{
+			name:  "tab character",
+			input: "Read: /src/\tfile.go",
+			want:  "Read: /src/ file.go",
+		},
+		{
+			name:  "combined ANSI and GHA injection",
+			input: "\x1b[2J\n::error::pwned",
+			want:  " : :error: :pwned",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := sanitizeGHA(tt.input)
+			got := sanitizeOutput(tt.input)
 			if got != tt.want {
-				t.Errorf("sanitizeGHA(%q) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("sanitizeOutput(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -22,6 +22,13 @@ func TestExtractBinaryName(t *testing.T) {
 		{"", ""},
 		{"gh pr create --title 'x'", "gh"},
 		{"curl -H 'Authorization: Bearer SECRET' https://api.example.com", "curl"},
+		// KEY=VALUE env var prefixes are skipped.
+		{"SECRET=val make test", "make"},
+		{"FOO=bar BAZ=qux /usr/bin/go test", "go"},
+		// All tokens are KEY=VALUE — return empty.
+		{"FOO=bar BAZ=qux", ""},
+		// Whitespace-only input.
+		{"   \t  ", ""},
 	}
 	for _, tt := range tests {
 		got := extractBinaryName(tt.cmd)
@@ -51,6 +58,12 @@ func TestExtractSafeContext(t *testing.T) {
 			want:     "curl",
 		},
 		{
+			name:     "bash with env var prefix",
+			toolName: "Bash",
+			input:    map[string]interface{}{"command": "API_KEY=secret123 curl https://api.example.com"},
+			want:     "curl",
+		},
+		{
 			name:     "read file",
 			toolName: "Read",
 			input:    map[string]interface{}{"file_path": "/src/main.go"},
@@ -69,7 +82,19 @@ func TestExtractSafeContext(t *testing.T) {
 			want:     "func main",
 		},
 		{
-			name:     "unknown tool",
+			name:     "grep long pattern truncated",
+			toolName: "Grep",
+			input:    map[string]interface{}{"pattern": "this is a very long pattern that exceeds the fifty character display limit for safety"},
+			want:     "this is a very long pattern that exceeds the fifty…",
+		},
+		{
+			name:     "glob pattern",
+			toolName: "Glob",
+			input:    map[string]interface{}{"pattern": "**/*.go"},
+			want:     "**/*.go",
+		},
+		{
+			name:     "unknown tool returns empty",
 			toolName: "Agent",
 			input:    map[string]interface{}{"prompt": "do something"},
 			want:     "",
@@ -93,7 +118,6 @@ func TestExtractSafeContext(t *testing.T) {
 }
 
 func TestProgressParser(t *testing.T) {
-	// Build NDJSON with assistant-type tool_use messages.
 	lines := []string{
 		`{"type":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/src/main.go"}}]}`,
 		`{"type":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"make test"}}]}`,
@@ -109,8 +133,8 @@ func TestProgressParser(t *testing.T) {
 
 	progressParser(input, printer, start, metrics)
 
-	if metrics.ToolCalls != 2 {
-		t.Errorf("expected 2 tool calls, got %d", metrics.ToolCalls)
+	if metrics.ToolCalls.Load() != 2 {
+		t.Errorf("expected 2 tool calls, got %d", metrics.ToolCalls.Load())
 	}
 
 	output := buf.String()
@@ -136,7 +160,105 @@ func TestProgressParserStreamEvents(t *testing.T) {
 
 	progressParser(input, printer, time.Now(), metrics)
 
-	if metrics.ToolCalls != 2 {
-		t.Errorf("expected 2 tool calls from stream events, got %d", metrics.ToolCalls)
+	if metrics.ToolCalls.Load() != 2 {
+		t.Errorf("expected 2 tool calls from stream events, got %d", metrics.ToolCalls.Load())
 	}
+}
+
+func TestProgressParserMalformedJSON(t *testing.T) {
+	lines := []string{
+		`{"type":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/a.go"}}]}`,
+		`{this is not json}`,
+		`{"type":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go test"}}]}`,
+	}
+
+	input := strings.NewReader(strings.Join(lines, "\n"))
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	metrics := &RunMetrics{}
+
+	progressParser(input, printer, time.Now(), metrics)
+
+	if metrics.ToolCalls.Load() != 2 {
+		t.Errorf("expected 2 tool calls (skip malformed), got %d", metrics.ToolCalls.Load())
+	}
+}
+
+func TestProgressParserUnknownToolAllowlisted(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","content_block":{"type":"tool_use","name":"EvilTool"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_start","content_block":{"type":"tool_use","name":"Read"}}}`,
+	}
+
+	input := strings.NewReader(strings.Join(lines, "\n"))
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	metrics := &RunMetrics{}
+
+	progressParser(input, printer, time.Now(), metrics)
+
+	if metrics.ToolCalls.Load() != 2 {
+		t.Errorf("expected 2 tool calls, got %d", metrics.ToolCalls.Load())
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "EvilTool") {
+		t.Errorf("unknown tool name should not appear in output, got: %s", output)
+	}
+	if !strings.Contains(output, "tool") {
+		t.Errorf("expected generic 'tool' label for unknown tool, got: %s", output)
+	}
+}
+
+func TestSanitizeGHA(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "clean string",
+			input: "Read: /src/main.go (3s, 1 tools)",
+			want:  "Read: /src/main.go (3s, 1 tools)",
+		},
+		{
+			name:  "newline injection",
+			input: "Read\n::error::pwned",
+			want:  "Read : :error: :pwned",
+		},
+		{
+			name:  "carriage return injection",
+			input: "Read\r\n::stop-commands::token",
+			want:  "Read  : :stop-commands: :token",
+		},
+		{
+			name:  "double colon in path",
+			input: "Edit: /src/config::default.go",
+			want:  "Edit: /src/config: :default.go",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeGHA(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeGHA(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHeartbeatConcurrency(t *testing.T) {
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	start := time.Now()
+	done := make(chan struct{})
+
+	go runHeartbeat(printer, start, 10*time.Minute, done)
+
+	// Write from main goroutine concurrently.
+	for i := 0; i < 50; i++ {
+		printer.Heartbeat("main goroutine")
+	}
+
+	close(done)
 }

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -169,11 +169,11 @@ func TestProgressParser(t *testing.T) {
 	}
 }
 
-func TestProgressParserStreamEvents(t *testing.T) {
+func TestProgressParserIgnoresStreamEvents(t *testing.T) {
 	lines := []string{
 		`{"type":"stream_event","event":{"type":"content_block_start","content_block":{"type":"tool_use","name":"Edit"}}}`,
 		`{"type":"stream_event","event":{"type":"content_block_stop"}}`,
-		`{"type":"stream_event","event":{"type":"content_block_start","content_block":{"type":"tool_use","name":"Bash"}}}`,
+		`{"type":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/src/main.go"}}]}`,
 	}
 
 	input := strings.NewReader(strings.Join(lines, "\n"))
@@ -185,8 +185,8 @@ func TestProgressParserStreamEvents(t *testing.T) {
 		t.Fatalf("progressParser returned error: %v", err)
 	}
 
-	if metrics.ToolCalls.Load() != 2 {
-		t.Errorf("expected 2 tool calls from stream events, got %d", metrics.ToolCalls.Load())
+	if metrics.ToolCalls.Load() != 1 {
+		t.Errorf("expected 1 tool call (stream_event ignored), got %d", metrics.ToolCalls.Load())
 	}
 }
 
@@ -213,8 +213,8 @@ func TestProgressParserMalformedJSON(t *testing.T) {
 
 func TestProgressParserUnknownToolAllowlisted(t *testing.T) {
 	lines := []string{
-		`{"type":"stream_event","event":{"type":"content_block_start","content_block":{"type":"tool_use","name":"EvilTool"}}}`,
-		`{"type":"stream_event","event":{"type":"content_block_start","content_block":{"type":"tool_use","name":"Read"}}}`,
+		`{"type":"assistant","content":[{"type":"tool_use","name":"EvilTool","input":{"secret":"should-not-appear"}}]}`,
+		`{"type":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/src/main.go"}}]}`,
 	}
 
 	input := strings.NewReader(strings.Join(lines, "\n"))
@@ -367,7 +367,6 @@ func TestSanitizeOutput(t *testing.T) {
 func TestHeartbeatConcurrency(t *testing.T) {
 	var buf bytes.Buffer
 	printer := ui.New(&buf)
-	start := time.Now()
 	done := make(chan struct{})
 
 	// Use a short-interval heartbeat to force actual concurrent writes.
@@ -395,8 +394,6 @@ func TestHeartbeatConcurrency(t *testing.T) {
 
 	wg.Wait()
 	close(done)
-
-	_ = start // suppress unused warning
 
 	output := buf.String()
 	if !strings.Contains(output, "main goroutine") {

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -3,7 +3,10 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -70,10 +73,22 @@ func TestExtractSafeContext(t *testing.T) {
 			want:     "/src/main.go",
 		},
 		{
+			name:     "write file",
+			toolName: "Write",
+			input:    map[string]interface{}{"file_path": "/src/out.go", "content": "package main"},
+			want:     "/src/out.go",
+		},
+		{
 			name:     "edit file",
 			toolName: "Edit",
 			input:    map[string]interface{}{"file_path": "/src/main.go", "old_string": "secret", "new_string": "redacted"},
 			want:     "/src/main.go",
+		},
+		{
+			name:     "long file path truncated",
+			toolName: "Read",
+			input:    map[string]interface{}{"file_path": "/" + strings.Repeat("a", 250)},
+			want:     "/" + strings.Repeat("a", 199) + "…",
 		},
 		{
 			name:     "grep pattern",
@@ -86,6 +101,12 @@ func TestExtractSafeContext(t *testing.T) {
 			toolName: "Grep",
 			input:    map[string]interface{}{"pattern": "this is a very long pattern that exceeds the fifty character display limit for safety"},
 			want:     "this is a very long pattern that exceeds the fifty…",
+		},
+		{
+			name:     "grep multibyte pattern truncated at rune boundary",
+			toolName: "Grep",
+			input:    map[string]interface{}{"pattern": strings.Repeat("日本語", 20)},
+			want:     strings.Repeat("日本語", 16) + "日本…",
 		},
 		{
 			name:     "glob pattern",
@@ -131,7 +152,9 @@ func TestProgressParser(t *testing.T) {
 	start := time.Now()
 	metrics := &RunMetrics{}
 
-	progressParser(input, printer, start, metrics)
+	if err := progressParser(input, printer, start, metrics); err != nil {
+		t.Fatalf("progressParser returned error: %v", err)
+	}
 
 	if metrics.ToolCalls.Load() != 2 {
 		t.Errorf("expected 2 tool calls, got %d", metrics.ToolCalls.Load())
@@ -158,7 +181,9 @@ func TestProgressParserStreamEvents(t *testing.T) {
 	printer := ui.New(&buf)
 	metrics := &RunMetrics{}
 
-	progressParser(input, printer, time.Now(), metrics)
+	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+		t.Fatalf("progressParser returned error: %v", err)
+	}
 
 	if metrics.ToolCalls.Load() != 2 {
 		t.Errorf("expected 2 tool calls from stream events, got %d", metrics.ToolCalls.Load())
@@ -177,7 +202,9 @@ func TestProgressParserMalformedJSON(t *testing.T) {
 	printer := ui.New(&buf)
 	metrics := &RunMetrics{}
 
-	progressParser(input, printer, time.Now(), metrics)
+	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+		t.Fatalf("progressParser returned error: %v", err)
+	}
 
 	if metrics.ToolCalls.Load() != 2 {
 		t.Errorf("expected 2 tool calls (skip malformed), got %d", metrics.ToolCalls.Load())
@@ -195,7 +222,9 @@ func TestProgressParserUnknownToolAllowlisted(t *testing.T) {
 	printer := ui.New(&buf)
 	metrics := &RunMetrics{}
 
-	progressParser(input, printer, time.Now(), metrics)
+	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+		t.Fatalf("progressParser returned error: %v", err)
+	}
 
 	if metrics.ToolCalls.Load() != 2 {
 		t.Errorf("expected 2 tool calls, got %d", metrics.ToolCalls.Load())
@@ -207,6 +236,49 @@ func TestProgressParserUnknownToolAllowlisted(t *testing.T) {
 	}
 	if !strings.Contains(output, "tool") {
 		t.Errorf("expected generic 'tool' label for unknown tool, got: %s", output)
+	}
+}
+
+func TestProgressParserUnknownToolAssistantNoContext(t *testing.T) {
+	lines := []string{
+		`{"type":"assistant","content":[{"type":"tool_use","name":"CustomTool","input":{"secret":"should-not-appear"}}]}`,
+	}
+
+	input := strings.NewReader(strings.Join(lines, "\n"))
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	metrics := &RunMetrics{}
+
+	_ = progressParser(input, printer, time.Now(), metrics)
+
+	output := buf.String()
+	if strings.Contains(output, "should-not-appear") {
+		t.Errorf("non-allowlisted tool should not extract context, got: %s", output)
+	}
+	if strings.Contains(output, "CustomTool") {
+		t.Errorf("non-allowlisted tool name should not appear, got: %s", output)
+	}
+}
+
+func TestProgressParserReaderError(t *testing.T) {
+	pr, pw := io.Pipe()
+
+	go func() {
+		pw.Write([]byte(`{"type":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/a.go"}}]}` + "\n"))
+		pw.CloseWithError(errors.New("connection reset"))
+	}()
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	metrics := &RunMetrics{}
+
+	err := progressParser(pr, printer, time.Now(), metrics)
+
+	if err == nil {
+		t.Error("expected error from broken reader, got nil")
+	}
+	if metrics.ToolCalls.Load() != 1 {
+		t.Errorf("expected 1 tool call before error, got %d", metrics.ToolCalls.Load())
 	}
 }
 
@@ -236,6 +308,16 @@ func TestSanitizeGHA(t *testing.T) {
 			input: "Edit: /src/config::default.go",
 			want:  "Edit: /src/config: :default.go",
 		},
+		{
+			name:  "url-encoded newline",
+			input: "Read%0A::error::pwned",
+			want:  "Read : :error: :pwned",
+		},
+		{
+			name:  "url-encoded carriage return lowercase",
+			input: "Read%0d%0a::error::pwned",
+			want:  "Read  : :error: :pwned",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -253,12 +335,36 @@ func TestHeartbeatConcurrency(t *testing.T) {
 	start := time.Now()
 	done := make(chan struct{})
 
-	go runHeartbeat(printer, start, 10*time.Minute, done)
+	// Use a short-interval heartbeat to force actual concurrent writes.
+	ticker := time.NewTicker(1 * time.Millisecond)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				printer.Heartbeat("heartbeat goroutine")
+			}
+		}
+	}()
 
-	// Write from main goroutine concurrently.
-	for i := 0; i < 50; i++ {
-		printer.Heartbeat("main goroutine")
-	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			printer.Heartbeat("main goroutine")
+		}
+	}()
 
+	wg.Wait()
 	close(done)
+
+	_ = start // suppress unused warning
+
+	output := buf.String()
+	if !strings.Contains(output, "main goroutine") {
+		t.Errorf("expected main goroutine output, got: %s", output)
+	}
 }

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -282,6 +282,33 @@ func TestProgressParserReaderError(t *testing.T) {
 	}
 }
 
+func TestProgressParserOversizedLineSkipped(t *testing.T) {
+	normalBefore := `{"type":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/before.go"}}]}`
+	oversized := `{"type":"assistant","content":[{"type":"tool_use","name":"Write","input":{"file_path":"/big.go","content":"` + strings.Repeat("x", 2*1024*1024) + `"}}]}`
+	normalAfter := `{"type":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/after.go"}}]}`
+
+	input := strings.NewReader(normalBefore + "\n" + oversized + "\n" + normalAfter + "\n")
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	metrics := &RunMetrics{}
+
+	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+		t.Fatalf("progressParser returned error: %v", err)
+	}
+
+	if metrics.ToolCalls.Load() != 2 {
+		t.Errorf("expected 2 tool calls (oversized skipped), got %d", metrics.ToolCalls.Load())
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "/before.go") {
+		t.Errorf("expected line before oversized, got: %s", output)
+	}
+	if !strings.Contains(output, "/after.go") {
+		t.Errorf("expected line after oversized, got: %s", output)
+	}
+}
+
 func TestSanitizeOutput(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -352,6 +379,21 @@ func TestSanitizeOutput(t *testing.T) {
 			name:  "combined ANSI and GHA injection",
 			input: "\x1b[2J\n::error::pwned",
 			want:  " : :error: :pwned",
+		},
+		{
+			name:  "8-bit CSI stripped",
+			input: "Read: /src/\xC2\x9B31mred.go",
+			want:  "Read: /src/ 31mred.go",
+		},
+		{
+			name:  "8-bit OSC stripped",
+			input: "Read: /src/\xC2\x9D52;c;SGVsbG8=file.go",
+			want:  "Read: /src/ 52;c;SGVsbG8=file.go",
+		},
+		{
+			name:  "all C1 control range stripped",
+			input: "a\xC2\x80b\xC2\x8Fc\xC2\x90d\xC2\x9Fe",
+			want:  "a b c d e",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+func TestExtractBinaryName(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want string
+	}{
+		{"make test", "make"},
+		{"git commit -s -m 'msg'", "git"},
+		{"/usr/bin/make lint", "make"},
+		{"  go test ./...", "go"},
+		{"", ""},
+		{"gh pr create --title 'x'", "gh"},
+		{"curl -H 'Authorization: Bearer SECRET' https://api.example.com", "curl"},
+	}
+	for _, tt := range tests {
+		got := extractBinaryName(tt.cmd)
+		if got != tt.want {
+			t.Errorf("extractBinaryName(%q) = %q, want %q", tt.cmd, got, tt.want)
+		}
+	}
+}
+
+func TestExtractSafeContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		input    map[string]interface{}
+		want     string
+	}{
+		{
+			name:     "bash command",
+			toolName: "Bash",
+			input:    map[string]interface{}{"command": "make test"},
+			want:     "make",
+		},
+		{
+			name:     "bash with secret in args",
+			toolName: "Bash",
+			input:    map[string]interface{}{"command": "curl -H 'Bearer token123' https://api.example.com"},
+			want:     "curl",
+		},
+		{
+			name:     "read file",
+			toolName: "Read",
+			input:    map[string]interface{}{"file_path": "/src/main.go"},
+			want:     "/src/main.go",
+		},
+		{
+			name:     "edit file",
+			toolName: "Edit",
+			input:    map[string]interface{}{"file_path": "/src/main.go", "old_string": "secret", "new_string": "redacted"},
+			want:     "/src/main.go",
+		},
+		{
+			name:     "grep pattern",
+			toolName: "Grep",
+			input:    map[string]interface{}{"pattern": "func main"},
+			want:     "func main",
+		},
+		{
+			name:     "unknown tool",
+			toolName: "Agent",
+			input:    map[string]interface{}{"prompt": "do something"},
+			want:     "",
+		},
+		{
+			name:     "empty input",
+			toolName: "Bash",
+			input:    map[string]interface{}{},
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, _ := json.Marshal(tt.input)
+			got := extractSafeContext(tt.toolName, raw)
+			if got != tt.want {
+				t.Errorf("extractSafeContext(%q) = %q, want %q", tt.toolName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProgressParser(t *testing.T) {
+	// Build NDJSON with assistant-type tool_use messages.
+	lines := []string{
+		`{"type":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/src/main.go"}}]}`,
+		`{"type":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"make test"}}]}`,
+		`{"type":"assistant","content":[{"type":"text","text":"Done"}]}`,
+		`{"type":"result","result":"All done"}`,
+	}
+
+	input := strings.NewReader(strings.Join(lines, "\n"))
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	start := time.Now()
+	metrics := &RunMetrics{}
+
+	progressParser(input, printer, start, metrics)
+
+	if metrics.ToolCalls != 2 {
+		t.Errorf("expected 2 tool calls, got %d", metrics.ToolCalls)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Read: /src/main.go") {
+		t.Errorf("expected Read progress, got: %s", output)
+	}
+	if !strings.Contains(output, "Bash: make") {
+		t.Errorf("expected Bash progress, got: %s", output)
+	}
+}
+
+func TestProgressParserStreamEvents(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","content_block":{"type":"tool_use","name":"Edit"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop"}}`,
+		`{"type":"stream_event","event":{"type":"content_block_start","content_block":{"type":"tool_use","name":"Bash"}}}`,
+	}
+
+	input := strings.NewReader(strings.Join(lines, "\n"))
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	metrics := &RunMetrics{}
+
+	progressParser(input, printer, time.Now(), metrics)
+
+	if metrics.ToolCalls != 2 {
+		t.Errorf("expected 2 tool calls from stream events, got %d", metrics.ToolCalls)
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -558,7 +558,9 @@ func runAgentWithProgress(sshConfigPath, sandboxName, claudeCmd string, timeout 
 	}
 	defer cancel()
 
-	progressParser(stdout, printer, start, metrics)
+	if parseErr := progressParser(stdout, printer, start, metrics); parseErr != nil {
+		fmt.Fprintf(os.Stderr, "  progress parser: %v\n", parseErr)
+	}
 
 	waitErr := cmd.Wait()
 	exitCode := -1
@@ -587,7 +589,7 @@ func runHeartbeat(printer *ui.Printer, start time.Time, timeout time.Duration, d
 			return
 		case <-ticker.C:
 			elapsed := time.Since(start).Truncate(time.Second)
-			remaining := (timeout - time.Since(start)).Truncate(time.Second)
+			remaining := (timeout - elapsed).Truncate(time.Second)
 			msg := fmt.Sprintf("Agent running (%s elapsed, %s remaining)", elapsed, remaining)
 			if isCI {
 				fmt.Fprintf(os.Stderr, "::notice::%s\n", sanitizeGHA(msg))

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -43,6 +43,9 @@ func newRunCmd() *cobra.Command {
 }
 
 func runAgent(agentName, fullsendDir, outputBase, targetRepo string, printer *ui.Printer) error {
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		printer.SetCIWriter(os.Stderr)
+	}
 	printer.Banner()
 	printer.Blank()
 	printer.Header("Running agent: " + agentName)
@@ -581,8 +584,6 @@ func runHeartbeat(printer *ui.Printer, start time.Time, timeout time.Duration, d
 	ticker := time.NewTicker(heartbeatInterval)
 	defer ticker.Stop()
 
-	isCI := os.Getenv("GITHUB_ACTIONS") == "true"
-
 	for {
 		select {
 		case <-done:
@@ -591,9 +592,7 @@ func runHeartbeat(printer *ui.Printer, start time.Time, timeout time.Duration, d
 			elapsed := time.Since(start).Truncate(time.Second)
 			remaining := (timeout - elapsed).Truncate(time.Second)
 			msg := fmt.Sprintf("Agent running (%s elapsed, %s remaining)", elapsed, remaining)
-			if isCI {
-				fmt.Fprintf(os.Stderr, "::notice::%s\n", sanitizeGHA(msg))
-			}
+			printer.Notice(sanitizeGHA(msg))
 			printer.Heartbeat(msg)
 		}
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -559,7 +560,9 @@ func runAgentWithProgress(sshConfigPath, sandboxName, claudeCmd string, timeout 
 	defer cancel()
 
 	if parseErr := progressParser(stdout, printer, start, metrics); parseErr != nil {
-		fmt.Fprintf(os.Stderr, "  progress parser: %v\n", parseErr)
+		fmt.Fprintf(os.Stderr, "  progress parser: %v\n", sanitizeOutput(parseErr.Error()))
+		cancel()
+		io.Copy(io.Discard, stdout)
 	}
 
 	waitErr := cmd.Wait()

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -43,9 +43,6 @@ func newRunCmd() *cobra.Command {
 }
 
 func runAgent(agentName, fullsendDir, outputBase, targetRepo string, printer *ui.Printer) error {
-	if os.Getenv("GITHUB_ACTIONS") == "true" {
-		printer.SetCIWriter(os.Stderr)
-	}
 	printer.Banner()
 	printer.Blank()
 	printer.Header("Running agent: " + agentName)
@@ -584,6 +581,8 @@ func runHeartbeat(printer *ui.Printer, start time.Time, timeout time.Duration, d
 	ticker := time.NewTicker(heartbeatInterval)
 	defer ticker.Stop()
 
+	isCI := os.Getenv("GITHUB_ACTIONS") == "true"
+
 	for {
 		select {
 		case <-done:
@@ -592,7 +591,9 @@ func runHeartbeat(printer *ui.Printer, start time.Time, timeout time.Duration, d
 			elapsed := time.Since(start).Truncate(time.Second)
 			remaining := (timeout - elapsed).Truncate(time.Second)
 			msg := fmt.Sprintf("Agent running (%s elapsed, %s remaining)", elapsed, remaining)
-			printer.Notice(sanitizeGHA(msg))
+			if isCI {
+				fmt.Fprintf(os.Stderr, "::notice::%s\n", sanitizeGHA(msg))
+			}
 			printer.Heartbeat(msg)
 		}
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -590,7 +590,7 @@ func runHeartbeat(printer *ui.Printer, start time.Time, timeout time.Duration, d
 			remaining := (timeout - time.Since(start)).Truncate(time.Second)
 			msg := fmt.Sprintf("Agent running (%s elapsed, %s remaining)", elapsed, remaining)
 			if isCI {
-				fmt.Fprintf(os.Stderr, "::notice::%s\n", msg)
+				fmt.Fprintf(os.Stderr, "::notice::%s\n", sanitizeGHA(msg))
 			}
 			printer.Heartbeat(msg)
 		}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -592,7 +592,7 @@ func runHeartbeat(printer *ui.Printer, start time.Time, timeout time.Duration, d
 			remaining := (timeout - elapsed).Truncate(time.Second)
 			msg := fmt.Sprintf("Agent running (%s elapsed, %s remaining)", elapsed, remaining)
 			if isCI {
-				fmt.Fprintf(os.Stderr, "::notice::%s\n", sanitizeGHA(msg))
+				fmt.Fprintf(os.Stderr, "::notice::%s\n", msg)
 			}
 			printer.Heartbeat(msg)
 		}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -312,7 +312,14 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo string, printer *ui
 		printer.StepStart("Running agent")
 		printer.Blank()
 
-		exitCode, runErr := sandbox.SSHStream(sshConfigPath, sandboxName, claudeCmd, timeout, os.Stdout, os.Stderr)
+		agentStart := time.Now()
+		heartbeatDone := make(chan struct{})
+		go runHeartbeat(printer, agentStart, timeout, heartbeatDone)
+
+		var metrics RunMetrics
+		exitCode, runErr := runAgentWithProgress(sshConfigPath, sandboxName, claudeCmd, timeout, printer, agentStart, &metrics)
+		close(heartbeatDone)
+
 		if runErr != nil {
 			printer.StepFail("Agent execution failed")
 			return fmt.Errorf("running agent (iteration %d): %w", iteration, runErr)
@@ -544,6 +551,52 @@ func envToList(env map[string]string) []string {
 	return list
 }
 
+func runAgentWithProgress(sshConfigPath, sandboxName, claudeCmd string, timeout time.Duration, printer *ui.Printer, start time.Time, metrics *RunMetrics) (int, error) {
+	stdout, cmd, cancel, err := sandbox.SSHStreamReader(sshConfigPath, sandboxName, claudeCmd, timeout, os.Stderr)
+	if err != nil {
+		return -1, err
+	}
+	defer cancel()
+
+	progressParser(stdout, printer, start, metrics)
+
+	waitErr := cmd.Wait()
+	exitCode := -1
+	if cmd.ProcessState != nil {
+		exitCode = cmd.ProcessState.ExitCode()
+	}
+
+	if waitErr != nil && cmd.ProcessState == nil {
+		return exitCode, fmt.Errorf("ssh failed: %w", waitErr)
+	}
+
+	return exitCode, nil
+}
+
+const heartbeatInterval = 30 * time.Second
+
+func runHeartbeat(printer *ui.Printer, start time.Time, timeout time.Duration, done <-chan struct{}) {
+	ticker := time.NewTicker(heartbeatInterval)
+	defer ticker.Stop()
+
+	isCI := os.Getenv("GITHUB_ACTIONS") == "true"
+
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			elapsed := time.Since(start).Truncate(time.Second)
+			remaining := (timeout - time.Since(start)).Truncate(time.Second)
+			msg := fmt.Sprintf("Agent running (%s elapsed, %s remaining)", elapsed, remaining)
+			if isCI {
+				fmt.Fprintf(os.Stderr, "::notice::%s\n", msg)
+			}
+			printer.Heartbeat(msg)
+		}
+	}
+}
+
 func buildClaudeCommand(agentName, model, repoDir string) string {
 	envFile := sandbox.SandboxWorkspace + "/.env"
 
@@ -556,7 +609,7 @@ func buildClaudeCommand(agentName, model, repoDir string) string {
 	}
 
 	return fmt.Sprintf(
-		"cd %s && source %s && claude --print %s--agent '%s' --dangerously-skip-permissions 'Run the agent task'",
+		"cd %s && source %s && claude --print --output-format stream-json %s--agent '%s' --dangerously-skip-permissions 'Run the agent task'",
 		repoDir, envFile, modelFlag, safe,
 	)
 }

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -251,6 +252,33 @@ func SSHStream(sshConfigPath, sandboxName, command string, timeout time.Duration
 	}
 
 	return exitCode, nil
+}
+
+// SSHStreamReader runs a command inside a sandbox, returning an io.ReadCloser for
+// stdout so the caller can parse structured output. Stderr is forwarded to the
+// given writer. The caller must read stdout to completion, then call cmd.Wait().
+func SSHStreamReader(sshConfigPath, sandboxName, command string, timeout time.Duration, stderrW io.Writer) (io.ReadCloser, *exec.Cmd, context.CancelFunc, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	cmd := exec.CommandContext(ctx, "ssh",
+		"-F", sshConfigPath,
+		fmt.Sprintf("openshell-%s", sandboxName),
+		command,
+	)
+	cmd.Stderr = stderrW
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, nil, nil, fmt.Errorf("creating stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, nil, nil, fmt.Errorf("starting ssh command: %w", err)
+	}
+
+	return stdout, cmd, cancel, nil
 }
 
 // RsyncFrom copies a directory from a sandbox to the local machine using rsync

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -18,9 +19,11 @@ var (
 	ColorInfo    = lipgloss.Color("#3B82F6")
 )
 
-// Printer provides styled terminal output.
+// Printer provides styled terminal output. All methods are safe for
+// concurrent use from multiple goroutines.
 type Printer struct {
-	w io.Writer
+	mu sync.Mutex
+	w  io.Writer
 }
 
 // New creates a new Printer writing to w.
@@ -30,6 +33,8 @@ func New(w io.Writer) *Printer {
 
 // Banner prints the fullsend brand banner with tagline.
 func (p *Printer) Banner() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	brand := lipgloss.NewStyle().Bold(true).Foreground(ColorBrand).Render("fullsend")
 	fmt.Fprintf(p.w, "\u26a1 %s\n", brand)
 	tagline := lipgloss.NewStyle().Foreground(ColorMuted).Render("Autonomous agentic development for GitHub organizations")
@@ -38,47 +43,63 @@ func (p *Printer) Banner() {
 
 // Header prints a section header with an arrow prefix.
 func (p *Printer) Header(text string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	styled := lipgloss.NewStyle().Bold(true).Render(text)
 	fmt.Fprintf(p.w, "\u2192 %s\n", styled)
 }
 
 // StepStart prints a step-in-progress marker.
 func (p *Printer) StepStart(text string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	fmt.Fprintf(p.w, "  \u2022 %s\n", text)
 }
 
 // StepDone prints a successful step marker in success color.
 func (p *Printer) StepDone(text string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	styled := lipgloss.NewStyle().Foreground(ColorSuccess).Render("\u2713 " + text)
 	fmt.Fprintf(p.w, "  %s\n", styled)
 }
 
 // StepFail prints a failed step marker in error color.
 func (p *Printer) StepFail(text string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	styled := lipgloss.NewStyle().Foreground(ColorError).Render("\u2717 " + text)
 	fmt.Fprintf(p.w, "  %s\n", styled)
 }
 
 // StepWarn prints a warning step marker in warning color.
 func (p *Printer) StepWarn(text string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	styled := lipgloss.NewStyle().Foreground(ColorWarning).Render("! " + text)
 	fmt.Fprintf(p.w, "  %s\n", styled)
 }
 
 // StepInfo prints indented informational text in muted color.
 func (p *Printer) StepInfo(text string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	styled := lipgloss.NewStyle().Foreground(ColorMuted).Render(text)
 	fmt.Fprintf(p.w, "    %s\n", styled)
 }
 
 // KeyValue prints a key-value pair with the key in muted color.
 func (p *Printer) KeyValue(key, value string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	k := lipgloss.NewStyle().Foreground(ColorMuted).Render(key + ":")
 	fmt.Fprintf(p.w, "    %s %s\n", k, value)
 }
 
 // Summary prints a bordered summary box with a title and list of items.
 func (p *Printer) Summary(title string, items []string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	var content strings.Builder
 	content.WriteString(lipgloss.NewStyle().Bold(true).Render(title))
 	content.WriteString("\n")
@@ -97,6 +118,8 @@ func (p *Printer) Summary(title string, items []string) {
 
 // ErrorBox prints an error-styled bordered box with title and detail.
 func (p *Printer) ErrorBox(title, detail string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	heading := lipgloss.NewStyle().Bold(true).Foreground(ColorError).Render(title)
 	body := heading + "\n" + detail
 
@@ -111,22 +134,30 @@ func (p *Printer) ErrorBox(title, detail string) {
 
 // Heartbeat prints a periodic progress line in muted color.
 func (p *Printer) Heartbeat(text string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	styled := lipgloss.NewStyle().Foreground(ColorMuted).Render("⟳ " + text)
 	fmt.Fprintf(p.w, "  %s\n", styled)
 }
 
 // Blank prints an empty line.
 func (p *Printer) Blank() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	fmt.Fprintln(p.w)
 }
 
 // Raw writes text directly to the output without any styling or indentation.
 func (p *Printer) Raw(text string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	fmt.Fprint(p.w, text)
 }
 
 // PRLink prints a pull request link with the repository name.
 func (p *Printer) PRLink(repo, url string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	repoStyled := lipgloss.NewStyle().Bold(true).Render(repo)
 	urlStyled := lipgloss.NewStyle().Foreground(ColorInfo).Render(url)
 	fmt.Fprintf(p.w, "  %s %s\n", repoStyled, urlStyled)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -22,33 +22,13 @@ var (
 // Printer provides styled terminal output. All methods are safe for
 // concurrent use from multiple goroutines.
 type Printer struct {
-	mu  sync.Mutex
-	w   io.Writer
-	ciW io.Writer
+	mu sync.Mutex
+	w  io.Writer
 }
 
 // New creates a new Printer writing to w.
 func New(w io.Writer) *Printer {
 	return &Printer{w: w}
-}
-
-// SetCIWriter sets a writer for CI annotation output (e.g., os.Stderr for
-// GitHub Actions ::notice:: lines). All CI writes are serialized under the
-// same mutex as regular output.
-func (p *Printer) SetCIWriter(w io.Writer) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.ciW = w
-}
-
-// Notice writes a GitHub Actions annotation under the mutex. No-op if no
-// CI writer is configured.
-func (p *Printer) Notice(text string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.ciW != nil {
-		fmt.Fprintf(p.ciW, "::notice::%s\n", text)
-	}
 }
 
 // Banner prints the fullsend brand banner with tagline.

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -22,13 +22,33 @@ var (
 // Printer provides styled terminal output. All methods are safe for
 // concurrent use from multiple goroutines.
 type Printer struct {
-	mu sync.Mutex
-	w  io.Writer
+	mu  sync.Mutex
+	w   io.Writer
+	ciW io.Writer
 }
 
 // New creates a new Printer writing to w.
 func New(w io.Writer) *Printer {
 	return &Printer{w: w}
+}
+
+// SetCIWriter sets a writer for CI annotation output (e.g., os.Stderr for
+// GitHub Actions ::notice:: lines). All CI writes are serialized under the
+// same mutex as regular output.
+func (p *Printer) SetCIWriter(w io.Writer) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.ciW = w
+}
+
+// Notice writes a GitHub Actions annotation under the mutex. No-op if no
+// CI writer is configured.
+func (p *Printer) Notice(text string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.ciW != nil {
+		fmt.Fprintf(p.ciW, "::notice::%s\n", text)
+	}
 }
 
 // Banner prints the fullsend brand banner with tagline.

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -109,6 +109,12 @@ func (p *Printer) ErrorBox(title, detail string) {
 	fmt.Fprintln(p.w, box)
 }
 
+// Heartbeat prints a periodic progress line in muted color.
+func (p *Printer) Heartbeat(text string) {
+	styled := lipgloss.NewStyle().Foreground(ColorMuted).Render("⟳ " + text)
+	fmt.Fprintf(p.w, "  %s\n", styled)
+}
+
 // Blank prints an empty line.
 func (p *Printer) Blank() {
 	fmt.Fprintln(p.w)


### PR DESCRIPTION
## Summary
- Replace raw `SSHStream` with `SSHStreamReader` + NDJSON stream parser to provide real-time visibility into agent execution inside OpenShell sandboxes
- Claude Code invoked with `--output-format stream-json`; parser emits tool names with safe context (binary name only for Bash to avoid leaking secrets, file paths for Read/Edit, patterns for Grep/Glob)
- 30-second heartbeat goroutine shows elapsed/remaining time; GitHub Actions receives `::notice::` annotations for CI log visibility
- Added `SSHStreamReader` to sandbox package for piped stdout parsing

## Files changed
| File | Change |
|------|--------|
| `internal/cli/progress.go` | New — NDJSON stream parser with safe context extraction |
| `internal/cli/progress_test.go` | New — tests for parser, binary name extraction, safe context |
| `internal/cli/run.go` | Modified — heartbeat goroutine, `runAgentWithProgress`, stream-json flag |
| `internal/sandbox/sandbox.go` | Modified — added `SSHStreamReader` returning `io.ReadCloser` |
| `internal/ui/ui.go` | Modified — added `Heartbeat` method |

## Security considerations
- Bash commands: only the binary name is logged (e.g. `make`, `git`, `curl`) — arguments are never shown to prevent secret leakage
- File paths and grep patterns are safe to display
- Unknown tools emit no context

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/cli/...` — 4 new tests pass (extractBinaryName, extractSafeContext, progressParser, progressParserStreamEvents)
- [x] `go vet ./internal/cli/...` clean
- [ ] Manual: run fullsend with a test agent, verify heartbeat + tool progress lines appear in CI logs