### PR TITLE
Fix model validation to accept Vertex AI @version syntax

### DIFF
--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	validAgentName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	validModelName = regexp.MustCompile(`^[a-zA-Z0-9_.@-]+$`)
 	envVarRef      = regexp.MustCompile(`\$\{([^}]+)\}`)
 )
 
@@ -139,8 +140,8 @@ func (h *Harness) Validate() error {
 	if !validAgentName.MatchString(agentBase) {
 		return fmt.Errorf("agent name %q contains invalid characters (allowed: a-z, A-Z, 0-9, _, -)", agentBase)
 	}
-	if h.Model != "" && !validAgentName.MatchString(h.Model) {
-		return fmt.Errorf("model %q contains invalid characters (allowed: a-z, A-Z, 0-9, _, -)", h.Model)
+	if h.Model != "" && !validModelName.MatchString(h.Model) {
+		return fmt.Errorf("model %q contains invalid characters (allowed: a-z, A-Z, 0-9, _, -, ., @)", h.Model)
 	}
 	if h.TimeoutMinutes < 0 {
 		return fmt.Errorf("timeout_minutes must be non-negative, got %d", h.TimeoutMinutes)

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -281,8 +281,15 @@ func TestValidate_ModelInvalid(t *testing.T) {
 }
 
 func TestValidate_ModelValid(t *testing.T) {
-	h := &Harness{Agent: "agents/test.md", Model: "claude-sonnet-4-6"}
-	require.NoError(t, h.Validate())
+	for _, model := range []string{
+		"claude-sonnet-4-6",
+		"claude-sonnet-4-6@default",
+		"claude-sonnet-4-6@20250514",
+		"claude-opus-4-1@20250805",
+	} {
+		h := &Harness{Agent: "agents/test.md", Model: model}
+		require.NoError(t, h.Validate(), "model %q should be valid", model)
+	}
 }
 
 func TestValidate_NegativeTimeout(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add separate `validModelName` regex that allows `@` and `.` characters for Vertex AI versioned model identifiers (e.g. `claude-sonnet-4-6@default`)
- Keep `validAgentName` unchanged — agent names still restricted to `[a-zA-Z0-9_-]` for shell safety
- Add test cases covering `@version` model syntax

Closes #274

## Test plan
- [x] `go test ./internal/harness/...` passes
- [x] `make go-vet` clean
- [ ] Verify `model: claude-sonnet-4-6@default` works in a harness YAML end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)