### PR TITLE
Fix hooks directory mismatch in sandbox bootstrap

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -494,8 +494,8 @@ func bootstrapSandbox(sshConfigPath, sandboxName, repoDir string, h *harness.Har
 	// Agent and skill definitions go in CLAUDE_CONFIG_DIR so `claude --agent`
 	// finds them regardless of the repo's own .claude/ directory. When
 	// CLAUDE_CONFIG_DIR is set, Claude uses it instead of ~/.claude/.
-	mkdirCmd := fmt.Sprintf("mkdir -p %s/agents %s/skills %s/hooks %s/bin %s/.env.d %s/.security %s",
-		sandbox.SandboxClaudeConfig, sandbox.SandboxClaudeConfig, sandbox.SandboxClaudeConfig, sandbox.SandboxWorkspace, sandbox.SandboxWorkspace, sandbox.SandboxWorkspace, sandbox.SandboxClaudeConfig)
+	mkdirCmd := fmt.Sprintf("mkdir -p %s/agents %s/skills %s %s/bin %s/.env.d %s/.security %s",
+		sandbox.SandboxClaudeConfig, sandbox.SandboxClaudeConfig, security.SandboxHooksDir, sandbox.SandboxWorkspace, sandbox.SandboxWorkspace, sandbox.SandboxWorkspace, sandbox.SandboxClaudeConfig)
 	if _, _, _, err := sandbox.SSH(sshConfigPath, sandboxName, mkdirCmd, 10*time.Second); err != nil {
 		return fmt.Errorf("creating workspace dirs: %w", err)
 	}
@@ -817,7 +817,7 @@ func bootstrapSecurityHooks(sshConfigPath, sandboxName string, h *harness.Harnes
 		}
 		tmpFile.Close()
 
-		remotePath := fmt.Sprintf("%s/.claude/hooks/%s", sandbox.SandboxWorkspace, name)
+		remotePath := fmt.Sprintf("%s/%s", security.SandboxHooksDir, name)
 		if err := sandbox.SCP(sshConfigPath, sandboxName, tmpFile.Name(), remotePath); err != nil {
 			os.Remove(tmpFile.Name())
 			return fmt.Errorf("copying hook %s to sandbox: %w", name, err)


### PR DESCRIPTION
## Summary
- `bootstrapSandbox` created `/tmp/claude-config/hooks` but `bootstrapSecurityHooks` wrote hook files to `/tmp/workspace/.claude/hooks/` — a directory that was never created, causing SCP failures.
- Both `mkdir` and SCP now derive the hooks path from `security.SandboxHooksDir`, the same constant used by `GenerateClaudeSettings` for settings.json hook commands.

Fixes #304

## Test plan
- [x] `make go-test` — security tests pass, no regressions
- [x] `make e2e-test` with security hooks enabled — hooks bootstrap without SCP errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)