### PR TITLE
Add --verbose flag to claude CLI invocation

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -692,7 +692,7 @@ func buildClaudeCommand(agentName, model, repoDir string) string {
 	}
 
 	return fmt.Sprintf(
-		"cd %s && source %s && claude --print --output-format stream-json %s--agent '%s' --dangerously-skip-permissions 'Run the agent task'",
+		"cd %s && source %s && claude --print --verbose --output-format stream-json %s--agent '%s' --dangerously-skip-permissions 'Run the agent task'",
 		repoDir, envFile, modelFlag, safe,
 	)
 }


### PR DESCRIPTION
## Summary
- `--output-format stream-json` requires `--verbose` when used with `--print`, causing `fullsend run` to fail at the claude CLI call.
- Added `--verbose` to `buildClaudeCommand` in `internal/cli/run.go`.

Fixes #306

## Test plan
- [ ] `fullsend run` with a harness — claude CLI starts without error
- [ ] Stream-json output is produced correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)