### PR TITLE
Add experiments repo as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "experiments"]
+	path = experiments
+	url = git@github.com:fullsend-ai/experiments.git
+	branch = main


### PR DESCRIPTION
## Summary
- Adds the `fullsend-ai/experiments` repo as a git submodule under `experiments/`, tracking the `main` branch
- This restores visibility of experiments within the fullsend tree while keeping them in their own repo
- To update the submodule pointer to latest: `git submodule update --remote experiments`

## Test plan
- [ ] Clone with `--recurse-submodules` and verify `experiments/` is populated
- [ ] Run `git submodule update --remote experiments` and confirm it pulls latest main

🤖 Generated with [Claude Code](https://claude.com/claude-code)