### PR TITLE
Add Red Hat P&D agentic SDLC experiment strategy 

### DIFF
--- a/docs/problems/applied/README.md
+++ b/docs/problems/applied/README.md
@@ -5,6 +5,8 @@ This directory contains organization-specific considerations for applying fullse
 ## Current consumers
 
 - **[konflux-ci](konflux-ci/)** — Kubernetes-native CI/CD platform. The original proving ground for fullsend.
+- **[red-hat-p-d](red-hat-p-d/)** — Red Hat Product & Delivery organization. Validating agentic SDLC model through    
+  Full Send team experiment.
 
 ## Adding a new consumer
 


### PR DESCRIPTION
Adds organization-specific application of fullsend framework for Red Hat's Product & Delivery organization.

 ## What this adds                                                                                                     
                                                                                                                        
  **New directory:** `docs/problems/applied/red-hat-p-d/`                                                               
                  
  Documents how P&D is using the Full Send team as a structured experiment to validate the agentic SDLC model.          
                  
  ## Contents                                                                                                           
                  
  - **README.md**: Combined strategy document including:                                                                
    - 5-agent SDLC framework (Discovery, Exploration, Delivery, Security, Process Improvement)
    - 3-tier agent architecture (Platform, Domain, Product)                                                             
    - 8-week proof-of-concept plan leveraging Full Send's existing work                                                 
    - Governance model and decision gates                                                                               
                                                                                                                        
  ## Why this matters                                                                                                   
                  
  Tests whether P&D can become a **learning system that builds software** — where agents handle execution while humans  
  focus on judgment, direction, and strategy.
                                             