### PR TITLE
fix: add issues:read permission to review app manifest

### DIFF
--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -96,6 +96,7 @@ func AgentAppConfig(org, role string) AppConfig {
 			PullRequests: "write",
 			Contents:     "read",
 			Checks:       "read",
+			Issues:       "read",
 		}
 		base.Events = []string{"pull_request", "pull_request_review"}
 

--- a/internal/forge/github/types_test.go
+++ b/internal/forge/github/types_test.go
@@ -68,6 +68,7 @@ func TestAgentAppConfig_Review(t *testing.T) {
 	assert.Equal(t, "write", cfg.Permissions.PullRequests)
 	assert.Equal(t, "read", cfg.Permissions.Contents)
 	assert.Equal(t, "read", cfg.Permissions.Checks)
+	assert.Equal(t, "read", cfg.Permissions.Issues)
 
 	assert.Contains(t, cfg.Events, "pull_request")
 	assert.Contains(t, cfg.Events, "pull_request_review")


### PR DESCRIPTION
## Summary
- The review agent needs `issues:read` to verify PRs address linked issues, but the app manifest in `AgentAppConfig` didn't include it.
- Token creation failed with `The permissions requested are not granted to this installation` when the review workflow requested `permission-issues: read`.
- Adds `Issues: "read"` to the review role's `AppPermissions` in the manifest.

## Test plan
- [x] `make go-test` passes
- [x] `make lint` passes
- [ ] Re-run review workflow on appdumpster to confirm token creation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)