### PR TITLE
fix: mask GCP credential paths and migrate app-id to client-id

### DIFF
--- a/docs/ADRs/0007-per-role-github-apps.md
+++ b/docs/ADRs/0007-per-role-github-apps.md
@@ -26,7 +26,7 @@ Agents need forge credentials to act on repos. A single shared credential for al
 
 Each agent role (triage, implementation, review) gets its own GitHub App, created via the [app manifest flow](https://docs.github.com/en/apps/sharing-github-apps/registering-a-github-app-from-a-manifest). Apps follow the naming convention `<org>-<role>`. The manifest defines per-role permissions (e.g., review gets read-only code access; implementation gets read-write).
 
-Private keys (PEMs) are stored as repo-level secrets on the `.fullsend` config repo. App IDs are stored as repo-level variables. Secrets never leave the config repo — agent dispatch workflows in `.fullsend` read them at runtime.
+Private keys (PEMs) are stored as repo-level secrets on the `.fullsend` config repo. Client IDs are stored as repo-level variables. Secrets never leave the config repo — agent dispatch workflows in `.fullsend` read them at runtime.
 
 The installer checks for existing app installations before creating new ones. If an app exists and its PEM secret is present, it is reused. If the PEM is lost (it is only available at creation time), the user must delete the app and re-run install.
 

--- a/docs/ADRs/0014-admin-install-github-apps-secrets-v1.md
+++ b/docs/ADRs/0014-admin-install-github-apps-secrets-v1.md
@@ -25,7 +25,7 @@ The admin CLI creates or reuses per-role GitHub Apps and must persist the minimu
 
 ## Decision
 
-**Adopt credential surface v1** as specified in [SPEC.md](../normative/admin-install/v1/adr-0014-github-apps-and-secrets/SPEC.md): expected app slugs and manifest/install behavior per role, and repository secrets `FULLSEND_<ROLE>_APP_PRIVATE_KEY` plus variables `FULLSEND_<ROLE>_APP_ID` on the `.fullsend` repo, with uppercase role suffixes matching `internal/layers/secrets.go` and `internal/cli/admin.go`.
+**Adopt credential surface v1** as specified in [SPEC.md](../normative/admin-install/v1/adr-0014-github-apps-and-secrets/SPEC.md): expected app slugs and manifest/install behavior per role, and repository secrets `FULLSEND_<ROLE>_APP_PRIVATE_KEY` plus variables `FULLSEND_<ROLE>_CLIENT_ID` on the `.fullsend` repo, with uppercase role suffixes matching `internal/layers/secrets.go` and `internal/cli/admin.go`.
 
 ## Consequences
 

--- a/docs/normative/admin-install/v1/adr-0012-fullsend-repo-files/SPEC.md
+++ b/docs/normative/admin-install/v1/adr-0012-fullsend-repo-files/SPEC.md
@@ -143,7 +143,7 @@ The following are managed via the forge API, not as committed files in
   `FULLSEND_<ROLE>_APP_PRIVATE_KEY` (PEM material), where `<ROLE>` is the
   uppercased role string (`SecretsLayer`).
 - **Repository variables** — one per role, name pattern
-  `FULLSEND_<ROLE>_APP_ID` (string app id).
+  `FULLSEND_<ROLE>_CLIENT_ID` (GitHub App Client ID).
 
 **Per-repository enrollment** (for example `.github/workflows/fullsend.yaml` in
 application repos) is performed by `EnrollmentLayer` and is intentionally not

--- a/docs/normative/admin-install/v1/adr-0014-github-apps-and-secrets/SPEC.md
+++ b/docs/normative/admin-install/v1/adr-0014-github-apps-and-secrets/SPEC.md
@@ -41,7 +41,7 @@ For each role, the setup runner (`appsetup.Setup.Run`):
 3. **If no matching installation exists:** run the **manifest flow** (local callback server, browser, exchange of manifest code for credentials), then **ensure** the app is installed on the org:
    - If not yet installed, print the GitHub “install app” URL (`https://github.com/apps/<slug>/installations/new`), optionally open the browser, wait for the user to confirm (Enter), then re-list installations and **fail** if the app still does not appear for the org.
 
-**Out of scope for this spec:** Persisting OAuth **client_secret** or **webhook_secret** from the manifest response into `.fullsend`. Current code stores only the **PEM** and **numeric App ID** in the repo (§5).
+**Out of scope for this spec:** Persisting OAuth **client_secret** or **webhook_secret** from the manifest response into `.fullsend`. Current code stores only the **PEM** and **Client ID** in the repo (§5).
 
 ## 5. Repository secrets and variables (credential surface v1)
 
@@ -50,13 +50,13 @@ All of the following are **repository-level** Actions secrets and variables on *
 | Kind     | Name pattern                          | Value | Layer |
 |----------|----------------------------------------|-------|-------|
 | Secret   | `FULLSEND_<ROLE>_APP_PRIVATE_KEY`      | PEM text of the GitHub App private key | secrets |
-| Variable | `FULLSEND_<ROLE>_APP_ID`               | Decimal string of the GitHub App numeric ID | secrets |
+| Variable | `FULLSEND_<ROLE>_CLIENT_ID`            | GitHub App Client ID (e.g. `Iv23_...`), per [GitHub recommendation](https://github.blog/changelog/2024-05-01-github-apps-can-now-use-the-client-id-to-fetch-installation-tokens/) | secrets |
 | Secret   | `FULLSEND_GCP_SA_KEY_JSON`       | GCP service account key JSON (when inference provider is `vertex`) | inference |
 | Secret   | `FULLSEND_GCP_PROJECT_ID`              | GCP project identifier (when inference provider is `vertex`) | inference |
 | Variable | `FULLSEND_GCP_REGION`                  | GCP region for Vertex AI (e.g. `us-central1`) | inference |
 
 - `<ROLE>` is the agent role in **ASCII uppercase** (e.g. `FULLSEND_TRIAGE_APP_PRIVATE_KEY`).
-- For each role processed in install, if PEM is non-empty, the implementation **must** create/update the secret and variable as above; if PEM is empty (reuse path), the implementation **must** skip writing that role’s secret/variable.
+- For each role processed in install, if PEM is non-empty, the implementation **must** create/update the secret; if PEM is empty (reuse path), the implementation **must** skip writing that role’s secret. The Client ID variable is **always** written (even on reuse) to ensure it stays current.
 - Inference secrets are only created when an inference provider is configured in `config.yaml` (see [ADR 0011](../adr-0011-org-config-yaml/SPEC.md)). When `inference.provider` is `vertex`, the implementation **must** store both `FULLSEND_GCP_SA_KEY_JSON` and `FULLSEND_GCP_PROJECT_ID`.
 
 ## 6. Analyze / health semantics for the secrets layer

--- a/docs/plans/vertex-inference-provisioning.md
+++ b/docs/plans/vertex-inference-provisioning.md
@@ -244,7 +244,7 @@ References the layer stack ordering inline. Update the installation model descri
 
 #### 5d. `docs/normative/admin-install/v1/adr-0014-github-apps-and-secrets/SPEC.md` — Extend credential surface
 
-Currently documents only GitHub App secrets (`FULLSEND_<ROLE>_APP_PRIVATE_KEY`, `FULLSEND_<ROLE>_APP_ID`). Add a new section or extend the secrets table to cover inference provider secrets stored on `.fullsend`:
+Currently documents only GitHub App secrets (`FULLSEND_<ROLE>_APP_PRIVATE_KEY`, `FULLSEND_<ROLE>_CLIENT_ID`). Add a new section or extend the secrets table to cover inference provider secrets stored on `.fullsend`:
 
 - `FULLSEND_GCP_SA_KEY_JSON` — GCP service account key JSON (repo secret)
 - `FULLSEND_GCP_PROJECT_ID` — GCP project identifier (repo secret)

--- a/docs/superpowers/specs/2026-04-06-fullsend-admin-spa-design.md
+++ b/docs/superpowers/specs/2026-04-06-fullsend-admin-spa-design.md
@@ -110,7 +110,7 @@ Steps follow CLI **install** ordering: **`.fullsend` / config** → **agent GitH
 ### Exception — agent GitHub Apps
 
 - App creation / user confirmation on **github.com** may **interrupt** the wizard; this is **expected** and **not** subject to “review before any GitHub interaction.”
-- **Staging:** after GitHub steps, the SPA may persist **intermediate credentials** (e.g. app id, slug, PEM) in **`localStorage`** on the **current origin** to **resume** the wizard.
+- **Staging:** after GitHub steps, the SPA may persist **intermediate credentials** (e.g. client id, slug, PEM) in **`localStorage`** on the **current origin** to **resume** the wizard.
 - **Policy:** clear staging on **success**, **cancel**, **sign-out**, or documented **abandon** behavior; store **only** necessary fields; never put secrets in URLs or logs.
 - **Final review** still applies to **bulk apply** to the org’s fullsend installation (secrets to GitHub, config/workflow/enrollment changes).
 

--- a/docs/superpowers/specs/2026-04-17-installer-agent-content-design.md
+++ b/docs/superpowers/specs/2026-04-17-installer-agent-content-design.md
@@ -137,7 +137,7 @@ The workflow reads `config.yaml`, iterates repos, and for each:
 - Check if the shim workflow exists.
 - If present: create branch `fullsend/offboard`, add a commit removing the shim, open a PR titled "Disconnect from fullsend agent pipeline".
 
-**Identity:** The workflow authenticates using the `fullsend` role's GitHub App (`FULLSEND_FULLSEND_APP_PRIVATE_KEY` + `FULLSEND_FULLSEND_APP_ID`) to generate an installation token. This is the admin/bootstrap persona — it has `contents: write` and `pull-requests: write` on target repos.
+**Identity:** The workflow authenticates using the `fullsend` role's GitHub App (`FULLSEND_FULLSEND_APP_PRIVATE_KEY` + `FULLSEND_FULLSEND_CLIENT_ID`) to generate an installation token. This is the admin/bootstrap persona — it has `contents: write` and `pull-requests: write` on target repos.
 
 **Concurrency:** `concurrency: { group: repo-maintenance, cancel-in-progress: false }` — only one reconciliation runs at a time; new pushes queue rather than cancel.
 

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -226,8 +226,8 @@ func runFullInstall(t *testing.T, env *e2eEnv) ([]layers.AgentCredentials, *conf
 				Name: appCreds.Name,
 				Slug: appCreds.Slug,
 			},
-			PEM:   appCreds.PEM,
-			AppID: appCreds.AppID,
+			PEM:      appCreds.PEM,
+			ClientID: appCreds.ClientID,
 		})
 
 		registerAppCleanup(t, env.page, appCreds.Slug, env.screenshotDir)

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -412,7 +412,7 @@ func verifyInstalled(t *testing.T, env *e2eEnv, orgCfg *config.OrgConfig, enable
 		assert.NoError(t, err, "checking secret %s", secretName)
 		assert.True(t, exists, "secret %s should exist", secretName)
 
-		varName := fmt.Sprintf("FULLSEND_%s_APP_ID", strings.ToUpper(role))
+		varName := fmt.Sprintf("FULLSEND_%s_CLIENT_ID", strings.ToUpper(role))
 		exists, err = env.client.RepoVariableExists(ctx, testOrg, forge.ConfigRepoName, varName)
 		assert.NoError(t, err, "checking variable %s", varName)
 		assert.True(t, exists, "variable %s should exist", varName)

--- a/internal/appsetup/appsetup.go
+++ b/internal/appsetup/appsetup.go
@@ -147,7 +147,7 @@ func (s *Setup) Run(ctx context.Context, org, role string) (*AppCredentials, err
 	}
 
 	if found {
-		return s.handleExistingApp(inst, role)
+		return s.handleExistingApp(ctx, inst, role)
 	}
 
 	// No existing app found — run the manifest flow.
@@ -213,8 +213,13 @@ func (s *Setup) findExistingInstallation(
 //
 // When an existing app is found with valid credentials, it is reused
 // automatically. To get fresh apps, run uninstall first, then install.
-func (s *Setup) handleExistingApp(inst *forge.Installation, role string) (*AppCredentials, error) {
+func (s *Setup) handleExistingApp(ctx context.Context, inst *forge.Installation, role string) (*AppCredentials, error) {
 	s.ui.StepDone(fmt.Sprintf("Found existing app: %s (ID: %d)", inst.AppSlug, inst.AppID))
+
+	clientID, err := s.client.GetAppClientID(ctx, inst.AppSlug)
+	if err != nil {
+		return nil, fmt.Errorf("looking up client ID for %s: %w", inst.AppSlug, err)
+	}
 
 	if s.secretExists != nil {
 		exists, err := s.secretExists(role)
@@ -225,9 +230,10 @@ func (s *Setup) handleExistingApp(inst *forge.Installation, role string) (*AppCr
 		if exists {
 			s.ui.StepDone(fmt.Sprintf("Reusing existing app %s (credentials present)", inst.AppSlug))
 			return &AppCredentials{
-				AppID: inst.AppID,
-				Slug:  inst.AppSlug,
-				Name:  inst.AppSlug,
+				AppID:    inst.AppID,
+				Slug:     inst.AppSlug,
+				Name:     inst.AppSlug,
+				ClientID: clientID,
 				// Empty PEM signals reuse of existing credentials.
 			}, nil
 		}
@@ -244,9 +250,10 @@ func (s *Setup) handleExistingApp(inst *forge.Installation, role string) (*AppCr
 	// No secretExists function — can't check, assume reuse.
 	s.ui.StepDone(fmt.Sprintf("Reusing existing app %s", inst.AppSlug))
 	return &AppCredentials{
-		AppID: inst.AppID,
-		Slug:  inst.AppSlug,
-		Name:  inst.AppSlug,
+		AppID:    inst.AppID,
+		Slug:     inst.AppSlug,
+		Name:     inst.AppSlug,
+		ClientID: clientID,
 	}, nil
 }
 

--- a/internal/appsetup/appsetup_test.go
+++ b/internal/appsetup/appsetup_test.go
@@ -96,6 +96,9 @@ func TestSetup_ExistingApp_SecretExists_AutoReuse(t *testing.T) {
 		Installations: []forge.Installation{
 			{ID: 100, AppID: 10, AppSlug: "myorg-fullsend"},
 		},
+		AppClientIDs: map[string]string{
+			"myorg-fullsend": "Iv1.fullsend123",
+		},
 	}
 	prompter := &fakePrompter{}
 	browser := newFakeBrowser()
@@ -112,6 +115,7 @@ func TestSetup_ExistingApp_SecretExists_AutoReuse(t *testing.T) {
 	// Should return credentials signaling reuse (empty PEM).
 	assert.Equal(t, 10, creds.AppID)
 	assert.Equal(t, "myorg-fullsend", creds.Slug)
+	assert.Equal(t, "Iv1.fullsend123", creds.ClientID)
 	assert.Empty(t, creds.PEM, "PEM should be empty to signal reuse")
 	// Should NOT have prompted — auto-reuse is silent.
 	assert.False(t, prompter.confirmCalled, "should not prompt for reuse")
@@ -121,6 +125,9 @@ func TestSetup_ExistingApp_NoSecret(t *testing.T) {
 	client := &forge.FakeClient{
 		Installations: []forge.Installation{
 			{ID: 100, AppID: 10, AppSlug: "myorg-triage"},
+		},
+		AppClientIDs: map[string]string{
+			"myorg-triage": "Iv1.triage123",
 		},
 	}
 	prompter := &fakePrompter{}
@@ -142,6 +149,9 @@ func TestSetup_KnownSlug_Match(t *testing.T) {
 		Installations: []forge.Installation{
 			{ID: 200, AppID: 20, AppSlug: "custom-slug-name"},
 		},
+		AppClientIDs: map[string]string{
+			"custom-slug-name": "Iv1.custom123",
+		},
 	}
 	prompter := &fakePrompter{}
 	browser := newFakeBrowser()
@@ -158,6 +168,7 @@ func TestSetup_KnownSlug_Match(t *testing.T) {
 
 	assert.Equal(t, 20, creds.AppID)
 	assert.Equal(t, "custom-slug-name", creds.Slug)
+	assert.Equal(t, "Iv1.custom123", creds.ClientID)
 	assert.Empty(t, creds.PEM)
 	assert.False(t, prompter.confirmCalled, "should not prompt for reuse")
 }

--- a/internal/appsetup/appsetup_test.go
+++ b/internal/appsetup/appsetup_test.go
@@ -144,6 +144,27 @@ func TestSetup_ExistingApp_NoSecret(t *testing.T) {
 	assert.Contains(t, err.Error(), "private key")
 }
 
+func TestSetup_ExistingApp_ClientIDLookupFails(t *testing.T) {
+	client := &forge.FakeClient{
+		Installations: []forge.Installation{
+			{ID: 100, AppID: 10, AppSlug: "myorg-fullsend"},
+		},
+		// No AppClientIDs entry — GetAppClientID will return ErrNotFound.
+	}
+	prompter := &fakePrompter{}
+	browser := newFakeBrowser()
+	printer := ui.New(&discardWriter{})
+
+	s := NewSetup(client, prompter, browser, printer).
+		WithSecretExists(func(_ string) (bool, error) {
+			return true, nil
+		})
+
+	_, err := s.Run(context.Background(), "myorg", "fullsend")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client ID")
+}
+
 func TestSetup_KnownSlug_Match(t *testing.T) {
 	client := &forge.FakeClient{
 		Installations: []forge.Installation{

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -387,8 +387,8 @@ func runAppSetup(ctx context.Context, client forge.Client, printer *ui.Printer, 
 				Name: appCreds.Name,
 				Slug: appCreds.Slug,
 			},
-			PEM:   appCreds.PEM,
-			AppID: appCreds.AppID,
+			PEM:      appCreds.PEM,
+			ClientID: appCreds.ClientID,
 		})
 	}
 

--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -59,6 +59,9 @@ type FakeClient struct {
 	TokenScopes       []string                    // scopes returned by GetTokenScopes
 	VariablesExist    map[string]bool             // key: "owner/repo/name"
 
+	// App client IDs for GetAppClientID
+	AppClientIDs map[string]string // key: app slug → client ID
+
 	// Org-level secret state
 	OrgSecrets       map[string]bool    // key: "org/name"
 	OrgSecretRepoIDs map[string][]int64 // key: "org/name" → repo IDs
@@ -540,6 +543,22 @@ func (f *FakeClient) ListOrgInstallations(_ context.Context, _ string) ([]Instal
 	}
 
 	return f.Installations, nil
+}
+
+func (f *FakeClient) GetAppClientID(_ context.Context, slug string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if e := f.err("GetAppClientID"); e != nil {
+		return "", e
+	}
+
+	if f.AppClientIDs != nil {
+		if id, ok := f.AppClientIDs[slug]; ok {
+			return id, nil
+		}
+	}
+	return "", fmt.Errorf("%w: app %s", ErrNotFound, slug)
 }
 
 func (f *FakeClient) CreateOrgSecret(_ context.Context, org, name, value string, selectedRepoIDs []int64) error {

--- a/internal/forge/fake_test.go
+++ b/internal/forge/fake_test.go
@@ -256,6 +256,37 @@ func TestFakeClient_Installations(t *testing.T) {
 	assert.Equal(t, "fullsend-bot", installs[0].AppSlug)
 }
 
+func TestFakeClient_GetAppClientID(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("found", func(t *testing.T) {
+		fc := &FakeClient{
+			AppClientIDs: map[string]string{
+				"myorg-fullsend": "Iv1.abc123",
+			},
+		}
+		clientID, err := fc.GetAppClientID(ctx, "myorg-fullsend")
+		require.NoError(t, err)
+		assert.Equal(t, "Iv1.abc123", clientID)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		fc := &FakeClient{}
+		_, err := fc.GetAppClientID(ctx, "nonexistent")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("error injection", func(t *testing.T) {
+		fc := &FakeClient{
+			Errors: map[string]error{"GetAppClientID": errors.New("api down")},
+		}
+		_, err := fc.GetAppClientID(ctx, "myorg-fullsend")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "api down")
+	})
+}
+
 func TestFakeClient_OrgSecretExists(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -144,4 +144,7 @@ type Client interface {
 
 	// App installation operations
 	ListOrgInstallations(ctx context.Context, org string) ([]Installation, error)
+
+	// GetAppClientID returns the Client ID for a GitHub App identified by slug.
+	GetAppClientID(ctx context.Context, slug string) (string, error)
 }

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -1093,6 +1093,9 @@ func (c *LiveClient) GetAppClientID(ctx context.Context, slug string) (string, e
 	if err := decodeJSON(resp, &app); err != nil {
 		return "", fmt.Errorf("decode app %s: %w", slug, err)
 	}
+	if app.ClientID == "" {
+		return "", fmt.Errorf("app %s has no client_id", slug)
+	}
 	return app.ClientID, nil
 }
 

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -1082,6 +1082,20 @@ func (c *LiveClient) ListOrgInstallations(ctx context.Context, org string) ([]fo
 	return installs, nil
 }
 
+func (c *LiveClient) GetAppClientID(ctx context.Context, slug string) (string, error) {
+	resp, err := c.get(ctx, fmt.Sprintf("/apps/%s", slug))
+	if err != nil {
+		return "", fmt.Errorf("get app %s: %w", slug, err)
+	}
+	var app struct {
+		ClientID string `json:"client_id"`
+	}
+	if err := decodeJSON(resp, &app); err != nil {
+		return "", fmt.Errorf("decode app %s: %w", slug, err)
+	}
+	return app.ClientID, nil
+}
+
 // CreateOrgSecret creates or updates an encrypted organization-level secret
 // scoped to the given repository IDs.
 // The value is trimmed of whitespace before encryption to prevent corruption

--- a/internal/layers/secrets.go
+++ b/internal/layers/secrets.go
@@ -13,8 +13,8 @@ import (
 // AgentCredentials extends AgentEntry with app credentials.
 type AgentCredentials struct {
 	config.AgentEntry
-	PEM   string
-	AppID int
+	PEM      string
+	ClientID string
 }
 
 // SecretsLayer manages agent app secrets and variables in the .fullsend repo.
@@ -56,26 +56,23 @@ func (s *SecretsLayer) RequiredScopes(op Operation) []string {
 	}
 }
 
-// Install stores agent app private keys as repo secrets and app IDs as
+// Install stores agent app private keys as repo secrets and client IDs as
 // repo variables in the .fullsend config repo.
 func (s *SecretsLayer) Install(ctx context.Context) error {
 	for _, agent := range s.agents {
-		if agent.PEM == "" {
-			s.ui.StepInfo(fmt.Sprintf("skipping %s (reusing existing app credentials)", agent.Role))
-			continue
+		if agent.PEM != "" {
+			sName := secretName(agent.Role)
+			s.ui.StepStart(fmt.Sprintf("storing private key for %s", agent.Role))
+			if err := s.client.CreateRepoSecret(ctx, s.org, forge.ConfigRepoName, sName, agent.PEM); err != nil {
+				s.ui.StepFail(fmt.Sprintf("failed to store secret %s", sName))
+				return fmt.Errorf("creating secret %s: %w", sName, err)
+			}
+			s.ui.StepDone(fmt.Sprintf("stored secret %s", sName))
 		}
-
-		sName := secretName(agent.Role)
-		s.ui.StepStart(fmt.Sprintf("storing private key for %s", agent.Role))
-		if err := s.client.CreateRepoSecret(ctx, s.org, forge.ConfigRepoName, sName, agent.PEM); err != nil {
-			s.ui.StepFail(fmt.Sprintf("failed to store secret %s", sName))
-			return fmt.Errorf("creating secret %s: %w", sName, err)
-		}
-		s.ui.StepDone(fmt.Sprintf("stored secret %s", sName))
 
 		vName := variableName(agent.Role)
-		s.ui.StepStart(fmt.Sprintf("storing app ID for %s", agent.Role))
-		if err := s.client.CreateOrUpdateRepoVariable(ctx, s.org, forge.ConfigRepoName, vName, fmt.Sprintf("%d", agent.AppID)); err != nil {
+		s.ui.StepStart(fmt.Sprintf("storing client ID for %s", agent.Role))
+		if err := s.client.CreateOrUpdateRepoVariable(ctx, s.org, forge.ConfigRepoName, vName, agent.ClientID); err != nil {
 			s.ui.StepFail(fmt.Sprintf("failed to store variable %s", vName))
 			return fmt.Errorf("creating variable %s: %w", vName, err)
 		}
@@ -149,5 +146,5 @@ func secretName(role string) string {
 }
 
 func variableName(role string) string {
-	return fmt.Sprintf("FULLSEND_%s_APP_ID", strings.ToUpper(role))
+	return fmt.Sprintf("FULLSEND_%s_CLIENT_ID", strings.ToUpper(role))
 }

--- a/internal/layers/secrets_test.go
+++ b/internal/layers/secrets_test.go
@@ -27,12 +27,12 @@ func twoAgents() []AgentCredentials {
 		{
 			AgentEntry: config.AgentEntry{Role: "fullsend", Name: "FullsendBot", Slug: "fullsend-bot"},
 			PEM:        "-----BEGIN RSA PRIVATE KEY-----\nfullsend-key\n-----END RSA PRIVATE KEY-----",
-			AppID:      111,
+			ClientID: "Iv1.abc111",
 		},
 		{
 			AgentEntry: config.AgentEntry{Role: "triage", Name: "TriageBot", Slug: "triage-bot"},
 			PEM:        "-----BEGIN RSA PRIVATE KEY-----\ntriage-key\n-----END RSA PRIVATE KEY-----",
-			AppID:      222,
+			ClientID: "Iv1.abc222",
 		},
 	}
 }
@@ -68,13 +68,13 @@ func TestSecretsLayer_Install_StoresSecrets(t *testing.T) {
 
 	assert.Equal(t, "test-org", client.Variables[0].Owner)
 	assert.Equal(t, ".fullsend", client.Variables[0].Repo)
-	assert.Equal(t, "FULLSEND_FULLSEND_APP_ID", client.Variables[0].Name)
-	assert.Equal(t, "111", client.Variables[0].Value)
+	assert.Equal(t, "FULLSEND_FULLSEND_CLIENT_ID", client.Variables[0].Name)
+	assert.Equal(t, "Iv1.abc111", client.Variables[0].Value)
 
 	assert.Equal(t, "test-org", client.Variables[1].Owner)
 	assert.Equal(t, ".fullsend", client.Variables[1].Repo)
-	assert.Equal(t, "FULLSEND_TRIAGE_APP_ID", client.Variables[1].Name)
-	assert.Equal(t, "222", client.Variables[1].Value)
+	assert.Equal(t, "FULLSEND_TRIAGE_CLIENT_ID", client.Variables[1].Name)
+	assert.Equal(t, "Iv1.abc222", client.Variables[1].Value)
 }
 
 func TestSecretsLayer_Install_SkipsEmptyPEM(t *testing.T) {
@@ -83,12 +83,12 @@ func TestSecretsLayer_Install_SkipsEmptyPEM(t *testing.T) {
 		{
 			AgentEntry: config.AgentEntry{Role: "fullsend", Name: "FullsendBot", Slug: "fullsend-bot"},
 			PEM:        "-----BEGIN RSA PRIVATE KEY-----\nfullsend-key\n-----END RSA PRIVATE KEY-----",
-			AppID:      111,
+			ClientID:   "Iv1.abc111",
 		},
 		{
 			AgentEntry: config.AgentEntry{Role: "triage", Name: "TriageBot", Slug: "triage-bot"},
 			PEM:        "", // empty — reused from existing app
-			AppID:      222,
+			ClientID:   "Iv1.abc222",
 		},
 	}
 	layer, _ := newSecretsLayer(t, client, agents)
@@ -96,13 +96,15 @@ func TestSecretsLayer_Install_SkipsEmptyPEM(t *testing.T) {
 	err := layer.Install(context.Background())
 	require.NoError(t, err)
 
-	// Only the first agent's secret should be created
+	// Only the first agent's secret should be created (PEM-gated)
 	require.Len(t, client.CreatedSecrets, 1)
 	assert.Equal(t, "FULLSEND_FULLSEND_APP_PRIVATE_KEY", client.CreatedSecrets[0].Name)
 
-	// Only the first agent's variable should be created
-	require.Len(t, client.Variables, 1)
-	assert.Equal(t, "FULLSEND_FULLSEND_APP_ID", client.Variables[0].Name)
+	// Both agents' variables should be created (client ID always stored)
+	require.Len(t, client.Variables, 2)
+	assert.Equal(t, "FULLSEND_FULLSEND_CLIENT_ID", client.Variables[0].Name)
+	assert.Equal(t, "FULLSEND_TRIAGE_CLIENT_ID", client.Variables[1].Name)
+	assert.Equal(t, "Iv1.abc222", client.Variables[1].Value)
 }
 
 func TestSecretsLayer_Install_Error(t *testing.T) {
@@ -138,8 +140,8 @@ func TestSecretsLayer_Analyze_AllPresent(t *testing.T) {
 			"test-org/.fullsend/FULLSEND_TRIAGE_APP_PRIVATE_KEY":   true,
 		},
 		VariablesExist: map[string]bool{
-			"test-org/.fullsend/FULLSEND_FULLSEND_APP_ID": true,
-			"test-org/.fullsend/FULLSEND_TRIAGE_APP_ID":   true,
+			"test-org/.fullsend/FULLSEND_FULLSEND_CLIENT_ID": true,
+			"test-org/.fullsend/FULLSEND_TRIAGE_CLIENT_ID":   true,
 		},
 	}
 	agents := twoAgents()
@@ -179,7 +181,7 @@ func TestSecretsLayer_Analyze_Partial(t *testing.T) {
 			// triage secret missing
 		},
 		VariablesExist: map[string]bool{
-			"test-org/.fullsend/FULLSEND_FULLSEND_APP_ID": true,
+			"test-org/.fullsend/FULLSEND_FULLSEND_CLIENT_ID": true,
 			// triage variable missing
 		},
 	}

--- a/internal/scaffold/fullsend-repo/.github/workflows/code.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/code.yml
@@ -65,7 +65,7 @@ jobs:
         id: sandbox-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.FULLSEND_CODER_APP_ID }}
+          client-id: ${{ vars.FULLSEND_CODER_CLIENT_ID }}
           private-key: ${{ secrets.FULLSEND_CODER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ steps.repo-parts.outputs.name }}
@@ -78,7 +78,7 @@ jobs:
         id: push-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.FULLSEND_CODER_APP_ID }}
+          client-id: ${{ vars.FULLSEND_CODER_CLIENT_ID }}
           private-key: ${{ secrets.FULLSEND_CODER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ steps.repo-parts.outputs.name }}
@@ -103,6 +103,15 @@ jobs:
         uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.FULLSEND_GCP_SA_KEY_JSON }}
+
+      - name: Mask GCP credential file paths
+        run: |
+          for var in GOOGLE_GHA_CREDS_PATH GOOGLE_APPLICATION_CREDENTIALS CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE; do
+            val="${!var:-}"
+            if [[ -n "${val}" ]]; then
+              echo "::add-mask::${val}"
+            fi
+          done
 
       - name: Setup agent environment
         env:

--- a/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
@@ -25,7 +25,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.FULLSEND_FULLSEND_APP_ID }}
+          client-id: ${{ vars.FULLSEND_FULLSEND_CLIENT_ID }}
           private-key: ${{ secrets.FULLSEND_FULLSEND_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/internal/scaffold/fullsend-repo/.github/workflows/review.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/review.yml
@@ -58,7 +58,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.FULLSEND_REVIEW_APP_ID }}
+          client-id: ${{ vars.FULLSEND_REVIEW_CLIENT_ID }}
           private-key: ${{ secrets.FULLSEND_REVIEW_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -74,6 +74,15 @@ jobs:
         uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.FULLSEND_GCP_SA_KEY_JSON }}
+
+      - name: Mask GCP credential file paths
+        run: |
+          for var in GOOGLE_GHA_CREDS_PATH GOOGLE_APPLICATION_CREDENTIALS CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE; do
+            val="${!var:-}"
+            if [[ -n "${val}" ]]; then
+              echo "::add-mask::${val}"
+            fi
+          done
 
       - name: Setup agent environment
         env:

--- a/internal/scaffold/fullsend-repo/.github/workflows/triage.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/triage.yml
@@ -57,7 +57,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.FULLSEND_TRIAGE_APP_ID }}
+          client-id: ${{ vars.FULLSEND_TRIAGE_CLIENT_ID }}
           private-key: ${{ secrets.FULLSEND_TRIAGE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -73,6 +73,15 @@ jobs:
         uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.FULLSEND_GCP_SA_KEY_JSON }}
+
+      - name: Mask GCP credential file paths
+        run: |
+          for var in GOOGLE_GHA_CREDS_PATH GOOGLE_APPLICATION_CREDENTIALS CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE; do
+            val="${!var:-}"
+            if [[ -n "${val}" ]]; then
+              echo "::add-mask::${val}"
+            fi
+          done
 
       - name: Setup agent environment
         env:

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -101,7 +101,7 @@ func TestCodeWorkflowContent(t *testing.T) {
 	require.NoError(t, err)
 	s := string(content)
 	assert.Contains(t, s, "workflow_dispatch")
-	assert.Contains(t, s, "FULLSEND_CODER_APP_ID")
+	assert.Contains(t, s, "FULLSEND_CODER_CLIENT_ID")
 	assert.Contains(t, s, "pre-code.sh")
 	assert.Contains(t, s, "PUSH_TOKEN")
 	assert.Contains(t, s, "github-app")


### PR DESCRIPTION
## Summary
- Mask GCP credential file paths (`GOOGLE_GHA_CREDS_PATH`, `GOOGLE_APPLICATION_CREDENTIALS`, `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE`) in all agent workflow logs using `::add-mask::` after `google-github-actions/auth@v3`
- Migrate from deprecated `app-id` to `client-id` input in `actions/create-github-app-token@v3` across all scaffold workflows
- Update Go admin install flow to store the GitHub App Client ID (`Iv23_...` string) instead of the numeric App ID, with a new `GetAppClientID` forge method for existing app reuse

## Motivation
- Observed in [job run](https://github.com/appdumpster/.fullsend/actions/runs/24744777852/job/72393463035): credential file paths with hashes were visible in "Run agent" and "Cleanup" step logs
- `actions/create-github-app-token@v3.1.0` deprecated the `app-id` input in favor of `client-id` (2026-04-11); the numeric App ID still works today but GitHub may stop accepting it as a JWT issuer in the future

## Breaking changes
- Repository variable renamed: `FULLSEND_<ROLE>_APP_ID` → `FULLSEND_<ROLE>_CLIENT_ID`
- Existing installations need a re-run of `fullsend admin install` to create the new `CLIENT_ID` variables (not yet rolled out to production)

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` — all unit tests pass (layers, appsetup, forge, scaffold, cli)
- [x] `make lint` passes
- [ ] E2E: run `fullsend admin install` on a test org to verify Client ID is stored correctly
- [ ] E2E: trigger a workflow run and confirm credential paths are masked in logs