### PR TITLE
Replace us-east5 region with global

### DIFF
--- a/docs/superpowers/specs/2026-04-17-installer-agent-content-design.md
+++ b/docs/superpowers/specs/2026-04-17-installer-agent-content-design.md
@@ -308,7 +308,7 @@ Unchanged. It still creates the `.fullsend` repo and writes `config.yaml`. The p
 
 ### 4.5 SecretsLayer / InferenceLayer
 
-Minor addition: `InferenceLayer` should store `FULLSEND_GCP_REGION` as a repo variable (the workflows reference `${{ vars.FULLSEND_GCP_REGION || 'us-east5' }}`). Check if this already happens; add if not.
+Minor addition: `InferenceLayer` should store `FULLSEND_GCP_REGION` as a repo variable (the workflows reference `${{ vars.FULLSEND_GCP_REGION || 'global' }}`). Check if this already happens; add if not.
 
 ---
 

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -257,7 +257,7 @@ func runFullInstall(t *testing.T, env *e2eEnv) ([]layers.AgentCredentials, *conf
 		}
 		gcpRegion := os.Getenv("E2E_GCP_REGION")
 		if gcpRegion == "" {
-			gcpRegion = "us-east5"
+			gcpRegion = "global"
 		}
 		inferenceProvider = vertex.New(vertex.Config{
 			ProjectID:      gcpProjectID,

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -186,7 +186,7 @@ func newInstallCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&skipAppSetup, "skip-app-setup", false, "skip GitHub App creation/setup")
 	cmd.Flags().BoolVar(&vendorBinary, "vendor-fullsend-binary", false, "cross-compile and upload the fullsend binary into .fullsend/bin/ for development iteration")
 	cmd.Flags().StringVar(&gcpProject, "gcp-project", "", "GCP project ID for Vertex AI inference")
-	cmd.Flags().StringVar(&gcpRegion, "gcp-region", "", "GCP region for Vertex AI (e.g. us-east5, required with --gcp-project)")
+	cmd.Flags().StringVar(&gcpRegion, "gcp-region", "", "GCP region for Vertex AI (e.g. global, required with --gcp-project)")
 	cmd.Flags().StringVar(&gcpServiceAccount, "gcp-service-account", "", "existing GCP service account name (optional, used with --gcp-project)")
 	cmd.Flags().StringVar(&gcpCredentialsFile, "gcp-credentials-file", "", "path to pre-made GCP service account key JSON (optional, used with --gcp-project)")
 

--- a/internal/inference/vertex/vertex.go
+++ b/internal/inference/vertex/vertex.go
@@ -43,7 +43,7 @@ type GCPClient interface {
 // Config holds the inputs for Vertex credential provisioning.
 type Config struct {
 	ProjectID          string // required
-	Region             string // required: GCP region (e.g. us-east5)
+	Region             string // required: GCP region (e.g. global)
 	ServiceAccountName string // optional: existing SA name (mode 2)
 	CredentialJSON     []byte // optional: pre-made key JSON (mode 3)
 }

--- a/internal/inference/vertex/vertex_test.go
+++ b/internal/inference/vertex/vertex_test.go
@@ -62,7 +62,7 @@ func (f *fakeGCPClient) CreateServiceAccountKey(_ context.Context, projectID, sa
 
 func TestProvision_Mode1_CreateSAAndKey(t *testing.T) {
 	gcp := newFakeGCPClient()
-	p := New(Config{ProjectID: "my-project", Region: "us-east5"}, gcp)
+	p := New(Config{ProjectID: "my-project", Region: "global"}, gcp)
 
 	secrets, err := p.Provision(context.Background())
 	require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestProvision_Mode1_CreateSAAndKey(t *testing.T) {
 func TestProvision_Mode2_ExistingSA(t *testing.T) {
 	gcp := newFakeGCPClient()
 	gcp.existingSAs["my-project/my-sa"] = true
-	p := New(Config{ProjectID: "my-project", Region: "us-east5", ServiceAccountName: "my-sa"}, gcp)
+	p := New(Config{ProjectID: "my-project", Region: "global", ServiceAccountName: "my-sa"}, gcp)
 
 	secrets, err := p.Provision(context.Background())
 	require.NoError(t, err)
@@ -102,7 +102,7 @@ func TestProvision_Mode2_ExistingSA(t *testing.T) {
 func TestProvision_Mode2_SANotFound(t *testing.T) {
 	gcp := newFakeGCPClient()
 	// SA does not exist.
-	p := New(Config{ProjectID: "my-project", Region: "us-east5", ServiceAccountName: "missing-sa"}, gcp)
+	p := New(Config{ProjectID: "my-project", Region: "global", ServiceAccountName: "missing-sa"}, gcp)
 
 	_, err := p.Provision(context.Background())
 	require.Error(t, err)
@@ -113,7 +113,7 @@ func TestProvision_Mode2_SANotFound(t *testing.T) {
 func TestProvision_Mode3_PreMadeKey(t *testing.T) {
 	gcp := newFakeGCPClient()
 	credJSON := []byte(`{"type":"service_account","project_id":"my-project","private_key":"..."}`)
-	p := New(Config{ProjectID: "my-project", Region: "us-east5", CredentialJSON: credJSON}, gcp)
+	p := New(Config{ProjectID: "my-project", Region: "global", CredentialJSON: credJSON}, gcp)
 
 	secrets, err := p.Provision(context.Background())
 	require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestProvision_Mode1_SA409Conflict(t *testing.T) {
 	gcp := newFakeGCPClient()
 	// Simulate the SA already existing (409 Conflict → treated as success).
 	gcp.alreadyExists = true
-	p := New(Config{ProjectID: "my-project", Region: "us-east5"}, gcp)
+	p := New(Config{ProjectID: "my-project", Region: "global"}, gcp)
 
 	secrets, err := p.Provision(context.Background())
 	require.NoError(t, err)
@@ -154,7 +154,7 @@ func TestProvision_MissingProjectID(t *testing.T) {
 func TestProvision_CreateSAError(t *testing.T) {
 	gcp := newFakeGCPClient()
 	gcp.createErr = fmt.Errorf("permission denied")
-	p := New(Config{ProjectID: "my-project", Region: "us-east5"}, gcp)
+	p := New(Config{ProjectID: "my-project", Region: "global"}, gcp)
 
 	_, err := p.Provision(context.Background())
 	require.Error(t, err)
@@ -164,7 +164,7 @@ func TestProvision_CreateSAError(t *testing.T) {
 func TestProvision_CreateKeyError(t *testing.T) {
 	gcp := newFakeGCPClient()
 	gcp.createKeyErr = fmt.Errorf("quota exceeded")
-	p := New(Config{ProjectID: "my-project", Region: "us-east5"}, gcp)
+	p := New(Config{ProjectID: "my-project", Region: "global"}, gcp)
 
 	_, err := p.Provision(context.Background())
 	require.Error(t, err)
@@ -172,7 +172,7 @@ func TestProvision_CreateKeyError(t *testing.T) {
 }
 
 func TestProvision_NilGCPClient_Mode1(t *testing.T) {
-	p := New(Config{ProjectID: "my-project", Region: "us-east5"}, nil)
+	p := New(Config{ProjectID: "my-project", Region: "global"}, nil)
 
 	_, err := p.Provision(context.Background())
 	require.Error(t, err)
@@ -180,7 +180,7 @@ func TestProvision_NilGCPClient_Mode1(t *testing.T) {
 }
 
 func TestProvision_NilGCPClient_Mode2(t *testing.T) {
-	p := New(Config{ProjectID: "my-project", Region: "us-east5", ServiceAccountName: "my-sa"}, nil)
+	p := New(Config{ProjectID: "my-project", Region: "global", ServiceAccountName: "my-sa"}, nil)
 
 	_, err := p.Provision(context.Background())
 	require.Error(t, err)
@@ -190,7 +190,7 @@ func TestProvision_NilGCPClient_Mode2(t *testing.T) {
 func TestProvision_NilGCPClient_Mode3_OK(t *testing.T) {
 	// Mode 3 should work fine without a GCP client.
 	credJSON := []byte(`{"type":"service_account"}`)
-	p := New(Config{ProjectID: "my-project", Region: "us-east5", CredentialJSON: credJSON}, nil)
+	p := New(Config{ProjectID: "my-project", Region: "global", CredentialJSON: credJSON}, nil)
 
 	secrets, err := p.Provision(context.Background())
 	require.NoError(t, err)
@@ -220,9 +220,9 @@ func TestSecretNames(t *testing.T) {
 }
 
 func TestVariables_WithRegion(t *testing.T) {
-	p := New(Config{Region: "us-east5"}, nil)
+	p := New(Config{Region: "global"}, nil)
 	vars := p.Variables()
-	assert.Equal(t, map[string]string{VariableRegion: "us-east5"}, vars)
+	assert.Equal(t, map[string]string{VariableRegion: "global"}, vars)
 }
 
 func TestVariables_WithoutRegion(t *testing.T) {

--- a/internal/layers/inference_test.go
+++ b/internal/layers/inference_test.go
@@ -45,7 +45,7 @@ func vertexProvider() *fakeProvider {
 			"FULLSEND_GCP_PROJECT_ID":  "my-project",
 		},
 		variables: map[string]string{
-			"FULLSEND_GCP_REGION": "us-east5",
+			"FULLSEND_GCP_REGION": "global",
 		},
 	}
 }
@@ -78,7 +78,7 @@ func TestInferenceLayer_Install_StoresSecrets(t *testing.T) {
 	// Variables should also have been set.
 	require.Len(t, client.Variables, 1)
 	assert.Equal(t, "FULLSEND_GCP_REGION", client.Variables[0].Name)
-	assert.Equal(t, "us-east5", client.Variables[0].Value)
+	assert.Equal(t, "global", client.Variables[0].Value)
 }
 
 func TestInferenceLayer_Install_NilProvider(t *testing.T) {

--- a/internal/scaffold/fullsend-repo/policies/code.yaml
+++ b/internal/scaffold/fullsend-repo/policies/code.yaml
@@ -3,7 +3,7 @@ version: 1
 # Sandbox policy for the code agent.
 #
 # Grants network access the code agent needs beyond the base sandbox:
-#   - Vertex AI (us-east5 inference + GCP auth token exchange)
+#   - Vertex AI (global inference + GCP auth token exchange)
 #   - GitHub API (gh/git only — curl intentionally excluded to prevent
 #     disallowedTools bypass via raw HTTP with the injected GH_TOKEN)
 #   - gitleaks releases (fallback download if not pre-installed in image)


### PR DESCRIPTION
## Summary
- Replaces all instances of `us-east5` with `global` across 7 files (Go source, tests, docs, scaffold policy)
- `global` is cheaper for Vertex AI inference

## Test plan
- [x] Verified zero remaining instances of `us-east5` in the repo
- [x] `make lint` passes
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)