### PR TITLE
fix: single-stack install eliminates duplicate config writes

### DIFF
--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -327,7 +327,7 @@ func runUninstall(t *testing.T, env *e2eEnv) {
 		layers.NewWorkflowsLayer(testOrg, env.client, env.printer, ""),
 		layers.NewSecretsLayer(testOrg, env.client, nil, env.printer),
 		layers.NewInferenceLayer(testOrg, env.client, nil, env.printer),
-		layers.NewDispatchTokenLayer(testOrg, env.client, "", nil, env.printer),
+		layers.NewDispatchTokenLayer(testOrg, env.client, "", nil, env.printer, nil),
 		layers.NewEnrollmentLayer(testOrg, env.client, nil, nil, env.printer),
 	)
 	errs := stack.UninstallAll(context.Background())
@@ -344,7 +344,7 @@ func runUninstallAllowNotFound(t *testing.T, env *e2eEnv) {
 		layers.NewWorkflowsLayer(testOrg, env.client, env.printer, ""),
 		layers.NewSecretsLayer(testOrg, env.client, nil, env.printer),
 		layers.NewInferenceLayer(testOrg, env.client, nil, env.printer),
-		layers.NewDispatchTokenLayer(testOrg, env.client, "", nil, env.printer),
+		layers.NewDispatchTokenLayer(testOrg, env.client, "", nil, env.printer, nil),
 		layers.NewEnrollmentLayer(testOrg, env.client, nil, nil, env.printer),
 	)
 	errs := stack.UninstallAll(context.Background())
@@ -490,7 +490,7 @@ func verifyNotInstalled(t *testing.T, env *e2eEnv) {
 		layers.NewWorkflowsLayer(testOrg, env.client, env.printer, ""),
 		layers.NewSecretsLayer(testOrg, env.client, nil, env.printer),
 		layers.NewInferenceLayer(testOrg, env.client, nil, env.printer),
-		layers.NewDispatchTokenLayer(testOrg, env.client, "", nil, env.printer),
+		layers.NewDispatchTokenLayer(testOrg, env.client, "", nil, env.printer, nil),
 		layers.NewEnrollmentLayer(testOrg, env.client, nil, nil, env.printer),
 	)
 	reports, err := stack.AnalyzeAll(ctx)
@@ -809,7 +809,7 @@ func buildTestLayerStack(
 		layers.NewWorkflowsLayer(org, client, printer, user),
 		layers.NewSecretsLayer(org, client, agentCreds, printer),
 		layers.NewInferenceLayer(org, client, inferenceProvider, printer),
-		layers.NewDispatchTokenLayer(org, client, dispatchToken, enrolledRepoIDs, printer),
+		layers.NewDispatchTokenLayer(org, client, dispatchToken, enrolledRepoIDs, printer, nil),
 		layers.NewEnrollmentLayer(org, client, enabledRepos, cfg.DisabledRepos(), printer),
 	)
 }

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -346,7 +346,7 @@ func runDryRun(ctx context.Context, client forge.Client, printer *ui.Printer, or
 	}
 
 	enrolledRepoIDs := collectEnrolledRepoIDs(allRepos, enabledRepos)
-	stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, enabledRepos, agentCreds, "", enrolledRepoIDs, inferenceProvider)
+	stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, false, nil, nil)
 
 	if err := runPreflight(ctx, stack, layers.OpInstall, client, printer); err != nil {
 		return err
@@ -431,50 +431,16 @@ func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, o
 		return fmt.Errorf("getting authenticated user: %w", err)
 	}
 
-	// Build stack with empty dispatch token for preflight — we check scopes
-	// before prompting the user so we fail early on missing admin:org.
-	stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, enabledRepos, agentCreds, "", enrolledRepoIDs, inferenceProvider)
+	stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, vendorBinary, vendorFullsendBinary, func(ctx context.Context) (string, error) {
+		return promptDispatchToken(ctx, client, printer, org)
+	})
 
 	if err := runPreflight(ctx, stack, layers.OpInstall, client, printer); err != nil {
 		return err
 	}
 	printer.Blank()
 
-	// Create the .fullsend config repo and write workflow files BEFORE
-	// prompting for the dispatch token. The user needs the repo to exist
-	// so they can select it when creating the fine-grained PAT, and the
-	// triage.yml workflow must exist so we can verify the PAT by attempting
-	// a real dispatch. Both layers are idempotent, so running them again
-	// in the full stack is harmless.
-	printer.Header("Preparing config repo")
-	printer.Blank()
-	configRepoLayer := layers.NewConfigRepoLayer(org, client, cfg, printer, hasPrivate)
-	if err := configRepoLayer.Install(ctx); err != nil {
-		return fmt.Errorf("creating config repo: %w", err)
-	}
-	workflowsLayer := layers.NewWorkflowsLayer(org, client, printer, user)
-	if err := workflowsLayer.Install(ctx); err != nil {
-		return fmt.Errorf("writing workflows: %w", err)
-	}
-
-	if vendorBinary {
-		if err := vendorFullsendBinary(ctx, client, printer, org); err != nil {
-			return fmt.Errorf("vendoring binary: %w", err)
-		}
-	}
-	printer.Blank()
-
-	// Dispatch token setup — the .fullsend repo now exists so the user
-	// can select it when creating the fine-grained PAT.
-	dispatchToken, err := promptDispatchToken(ctx, client, printer, org)
-	if err != nil {
-		return err
-	}
-
-	// Rebuild stack with the actual dispatch token.
-	stack = buildLayerStack(org, client, cfg, printer, user, hasPrivate, enabledRepos, agentCreds, dispatchToken, enrolledRepoIDs, inferenceProvider)
-
-	printer.Header("Installing layers")
+	printer.Header("Installing")
 	printer.Blank()
 
 	if err := stack.InstallAll(ctx); err != nil {
@@ -642,7 +608,7 @@ func runAnalyze(ctx context.Context, client forge.Client, printer *ui.Printer, o
 		inferenceProvider = vertex.NewAnalyzeOnly()
 	}
 
-	stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, nil, agentCreds, "", nil, inferenceProvider)
+	stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, nil, agentCreds, nil, inferenceProvider, false, nil, nil)
 
 	if err := runPreflight(ctx, stack, layers.OpAnalyze, client, printer); err != nil {
 		return err
@@ -662,16 +628,19 @@ func buildLayerStack(
 	hasPrivate bool,
 	enabledRepos []string,
 	agentCreds []layers.AgentCredentials,
-	dispatchToken string,
 	enrolledRepoIDs []int64,
 	inferenceProvider inference.Provider,
+	vendorBinary bool,
+	vendorFn layers.VendorFunc,
+	promptTokenFn layers.PromptTokenFunc,
 ) *layers.Stack {
 	return layers.NewStack(
 		layers.NewConfigRepoLayer(org, client, cfg, printer, hasPrivate),
 		layers.NewWorkflowsLayer(org, client, printer, user),
+		layers.NewVendorBinaryLayer(org, client, printer, vendorBinary, vendorFn),
 		layers.NewSecretsLayer(org, client, agentCreds, printer),
 		layers.NewInferenceLayer(org, client, inferenceProvider, printer),
-		layers.NewDispatchTokenLayer(org, client, dispatchToken, enrolledRepoIDs, printer, nil),
+		layers.NewDispatchTokenLayer(org, client, "", enrolledRepoIDs, printer, promptTokenFn),
 		layers.NewEnrollmentLayer(org, client, enabledRepos, cfg.DisabledRepos(), printer),
 	)
 }

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -523,7 +523,7 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 		layers.NewWorkflowsLayer(org, client, printer, ""),
 		layers.NewSecretsLayer(org, client, nil, printer),
 		layers.NewInferenceLayer(org, client, nil, printer),
-		layers.NewDispatchTokenLayer(org, client, "", nil, printer),
+		layers.NewDispatchTokenLayer(org, client, "", nil, printer, nil),
 		layers.NewEnrollmentLayer(org, client, nil, nil, printer),
 	)
 
@@ -671,7 +671,7 @@ func buildLayerStack(
 		layers.NewWorkflowsLayer(org, client, printer, user),
 		layers.NewSecretsLayer(org, client, agentCreds, printer),
 		layers.NewInferenceLayer(org, client, inferenceProvider, printer),
-		layers.NewDispatchTokenLayer(org, client, dispatchToken, enrolledRepoIDs, printer),
+		layers.NewDispatchTokenLayer(org, client, dispatchToken, enrolledRepoIDs, printer, nil),
 		layers.NewEnrollmentLayer(org, client, enabledRepos, cfg.DisabledRepos(), printer),
 	)
 }

--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -75,6 +75,7 @@ type FakeClient struct {
 	CreatedBranches   []string // "owner/repo/branch"
 	CreatedProposals  []ChangeProposal
 	DeletedRepos      []string // "owner/repo"
+	DeletedFiles      []FileRecord
 	CreatedSecrets    []SecretRecord
 	Variables         []VariableRecord
 	DeletedOrgSecrets []string // "org/name"
@@ -264,6 +265,29 @@ func (f *FakeClient) GetFileContent(_ context.Context, owner, repo, path string)
 		return nil, fmt.Errorf("%w: %s", ErrNotFound, key)
 	}
 	return data, nil
+}
+
+func (f *FakeClient) DeleteFile(_ context.Context, owner, repo, path, message string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if e := f.err("DeleteFile"); e != nil {
+		return e
+	}
+
+	key := owner + "/" + repo + "/" + path
+	if _, ok := f.FileContents[key]; !ok {
+		return fmt.Errorf("%w: %s", ErrNotFound, key)
+	}
+
+	delete(f.FileContents, key)
+	f.DeletedFiles = append(f.DeletedFiles, FileRecord{
+		Owner:   owner,
+		Repo:    repo,
+		Path:    path,
+		Message: message,
+	})
+	return nil
 }
 
 func (f *FakeClient) CreateBranch(_ context.Context, owner, repo, branchName string) error {

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -91,6 +91,7 @@ type Client interface {
 	CreateOrUpdateFile(ctx context.Context, owner, repo, path, message string, content []byte) error
 
 	GetFileContent(ctx context.Context, owner, repo, path string) ([]byte, error)
+	DeleteFile(ctx context.Context, owner, repo, path, message string) error
 
 	// Branch operations
 	CreateBranch(ctx context.Context, owner, repo, branchName string) error

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -533,6 +533,46 @@ func (c *LiveClient) GetFileContent(ctx context.Context, owner, repo, path strin
 	return data, nil
 }
 
+// DeleteFile deletes a file from the repository's default branch.
+// It first fetches the file to obtain its SHA (required by the GitHub Contents
+// API), then issues the DELETE. Retries on transient 404/409 errors.
+func (c *LiveClient) DeleteFile(ctx context.Context, owner, repo, path, message string) error {
+	apiPath := fmt.Sprintf("/repos/%s/%s/contents/%s", owner, repo, path)
+
+	return c.retryOnTransient(ctx, path, func() error {
+		// GET the file to obtain its SHA.
+		existingResp, err := c.do(ctx, http.MethodGet, apiPath, nil)
+		if err != nil {
+			return fmt.Errorf("get file for delete: %w", err)
+		}
+		if err := checkStatus(existingResp, http.StatusOK); err != nil {
+			return fmt.Errorf("get file %s for delete: %w", path, err)
+		}
+
+		var existing struct {
+			SHA string `json:"sha"`
+		}
+		if err := decodeJSON(existingResp, &existing); err != nil {
+			return fmt.Errorf("decode file sha: %w", err)
+		}
+
+		payload := map[string]string{
+			"message": message,
+			"sha":     existing.SHA,
+		}
+
+		resp, err := c.do(ctx, http.MethodDelete, apiPath, payload)
+		if err != nil {
+			return fmt.Errorf("delete file %s: %w", path, err)
+		}
+		defer resp.Body.Close()
+		if err := checkStatus(resp, http.StatusOK); err != nil {
+			return fmt.Errorf("delete file %s: %w", path, err)
+		}
+		return nil
+	})
+}
+
 // CreateBranch creates a new branch from the repository's default branch.
 func (c *LiveClient) CreateBranch(ctx context.Context, owner, repo, branchName string) error {
 	// Step 1: Get the default branch name.

--- a/internal/layers/dispatch.go
+++ b/internal/layers/dispatch.go
@@ -10,6 +10,11 @@ import (
 
 const dispatchTokenName = "FULLSEND_DISPATCH_TOKEN"
 
+// PromptTokenFunc is a callback that prompts the user for a dispatch token
+// interactively. It is called during Install when no token was provided at
+// construction time and the org secret doesn't already exist.
+type PromptTokenFunc func(ctx context.Context) (string, error)
+
 // DispatchTokenLayer manages the org-level dispatch token that enrolled
 // repos use to trigger workflow_dispatch events on the .fullsend repo.
 //
@@ -24,18 +29,23 @@ type DispatchTokenLayer struct {
 	dispatchToken   string  // the PAT value to store (empty if reusing existing)
 	enrolledRepoIDs []int64 // repo IDs that should have access to this secret
 	ui              *ui.Printer
+	promptFn        PromptTokenFunc // optional callback to prompt for token interactively
 }
 
 var _ Layer = (*DispatchTokenLayer)(nil)
 
 // NewDispatchTokenLayer creates a new DispatchTokenLayer.
-func NewDispatchTokenLayer(org string, client forge.Client, token string, repoIDs []int64, printer *ui.Printer) *DispatchTokenLayer {
+// If promptFn is non-nil, it will be called during Install to obtain a
+// dispatch token interactively when none was provided and the org secret
+// doesn't already exist.
+func NewDispatchTokenLayer(org string, client forge.Client, token string, repoIDs []int64, printer *ui.Printer, promptFn PromptTokenFunc) *DispatchTokenLayer {
 	return &DispatchTokenLayer{
 		org:             org,
 		client:          client,
 		dispatchToken:   token,
 		enrolledRepoIDs: repoIDs,
 		ui:              printer,
+		promptFn:        promptFn,
 	}
 }
 
@@ -55,12 +65,24 @@ func (l *DispatchTokenLayer) RequiredScopes(op Operation) []string {
 }
 
 // Install creates or updates the org-level dispatch token secret.
-// If dispatchToken is empty, the secret value is reused (not recreated),
-// but the repo access list is still updated if enrolledRepoIDs is set.
+// If dispatchToken is non-empty, the secret is created with that value.
+// If dispatchToken is empty, the method checks whether the secret already
+// exists. If it does, the repo access list is updated. If it doesn't and
+// promptFn is set, promptFn is called to obtain a token interactively.
+// If it doesn't exist and promptFn is nil, an error is returned.
 func (l *DispatchTokenLayer) Install(ctx context.Context) error {
-	if l.dispatchToken == "" {
-		l.ui.StepInfo("reusing existing dispatch token")
+	if l.dispatchToken != "" {
+		return l.createSecret(ctx, l.dispatchToken)
+	}
 
+	// No token provided — check if the secret already exists.
+	exists, err := l.client.OrgSecretExists(ctx, l.org, dispatchTokenName)
+	if err != nil {
+		return fmt.Errorf("checking org secret %s: %w", dispatchTokenName, err)
+	}
+
+	if exists {
+		l.ui.StepInfo("reusing existing dispatch token")
 		if len(l.enrolledRepoIDs) > 0 {
 			l.ui.StepStart("updating dispatch token repo access list")
 			if err := l.client.SetOrgSecretRepos(ctx, l.org, dispatchTokenName, l.enrolledRepoIDs); err != nil {
@@ -72,8 +94,22 @@ func (l *DispatchTokenLayer) Install(ctx context.Context) error {
 		return nil
 	}
 
+	// Secret doesn't exist — prompt for it if we can.
+	if l.promptFn == nil {
+		return fmt.Errorf("dispatch token not provided and org secret %s does not exist", dispatchTokenName)
+	}
+
+	token, err := l.promptFn(ctx)
+	if err != nil {
+		return fmt.Errorf("prompting for dispatch token: %w", err)
+	}
+
+	return l.createSecret(ctx, token)
+}
+
+func (l *DispatchTokenLayer) createSecret(ctx context.Context, token string) error {
 	l.ui.StepStart("creating org secret " + dispatchTokenName)
-	if err := l.client.CreateOrgSecret(ctx, l.org, dispatchTokenName, l.dispatchToken, l.enrolledRepoIDs); err != nil {
+	if err := l.client.CreateOrgSecret(ctx, l.org, dispatchTokenName, token, l.enrolledRepoIDs); err != nil {
 		l.ui.StepFail(fmt.Sprintf("failed to create org secret %s", dispatchTokenName))
 		return fmt.Errorf("creating org secret %s: %w", dispatchTokenName, err)
 	}

--- a/internal/layers/dispatch_test.go
+++ b/internal/layers/dispatch_test.go
@@ -17,7 +17,7 @@ func newDispatchLayer(t *testing.T, client *forge.FakeClient, token string, repo
 	t.Helper()
 	var buf bytes.Buffer
 	printer := ui.New(&buf)
-	layer := NewDispatchTokenLayer("test-org", client, token, repoIDs, printer)
+	layer := NewDispatchTokenLayer("test-org", client, token, repoIDs, printer, nil)
 	return layer, &buf
 }
 
@@ -41,15 +41,19 @@ func TestDispatchTokenLayer_Install_CreatesOrgSecret(t *testing.T) {
 	assert.Equal(t, repoIDs, client.CreatedOrgSecrets[0].RepoIDs)
 }
 
-func TestDispatchTokenLayer_Install_SkipsEmptyToken(t *testing.T) {
-	client := &forge.FakeClient{}
+func TestDispatchTokenLayer_Install_ReusesExistingToken(t *testing.T) {
+	client := &forge.FakeClient{
+		OrgSecrets: map[string]bool{
+			"test-org/FULLSEND_DISPATCH_TOKEN": true,
+		},
+	}
 	repoIDs := []int64{100, 200}
 	layer, _ := newDispatchLayer(t, client, "", repoIDs)
 
 	err := layer.Install(context.Background())
 	require.NoError(t, err)
 
-	// No secret should be created when token is empty
+	// No secret should be created when reusing existing
 	assert.Empty(t, client.CreatedOrgSecrets)
 
 	// But SetOrgSecretRepos should still be called to update access list
@@ -134,4 +138,58 @@ func TestDispatchTokenLayer_RequiredScopes(t *testing.T) {
 	assert.Equal(t, []string{"admin:org"}, layer.RequiredScopes(OpInstall))
 	assert.Equal(t, []string{"admin:org"}, layer.RequiredScopes(OpUninstall))
 	assert.Equal(t, []string{"admin:org"}, layer.RequiredScopes(OpAnalyze))
+}
+
+func TestDispatchTokenLayer_Install_CallsPromptFn(t *testing.T) {
+	client := &forge.FakeClient{
+		OrgSecrets: map[string]bool{}, // secret does not exist
+	}
+	repoIDs := []int64{100, 200}
+
+	promptFn := func(ctx context.Context) (string, error) {
+		return "ghp_prompted_token", nil
+	}
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	layer := NewDispatchTokenLayer("test-org", client, "", repoIDs, printer, promptFn)
+
+	err := layer.Install(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, client.CreatedOrgSecrets, 1)
+	assert.Equal(t, "test-org", client.CreatedOrgSecrets[0].Org)
+	assert.Equal(t, "FULLSEND_DISPATCH_TOKEN", client.CreatedOrgSecrets[0].Name)
+	assert.Equal(t, "ghp_prompted_token", client.CreatedOrgSecrets[0].Value)
+	assert.Equal(t, repoIDs, client.CreatedOrgSecrets[0].RepoIDs)
+}
+
+func TestDispatchTokenLayer_Install_ErrorWhenNoPromptFn(t *testing.T) {
+	client := &forge.FakeClient{
+		OrgSecrets: map[string]bool{}, // secret does not exist
+	}
+	layer, _ := newDispatchLayer(t, client, "", []int64{100})
+
+	err := layer.Install(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dispatch token not provided")
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestDispatchTokenLayer_Install_PromptFnError(t *testing.T) {
+	client := &forge.FakeClient{
+		OrgSecrets: map[string]bool{}, // secret does not exist
+	}
+
+	promptFn := func(ctx context.Context) (string, error) {
+		return "", errors.New("user cancelled")
+	}
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	layer := NewDispatchTokenLayer("test-org", client, "", []int64{100}, printer, promptFn)
+
+	err := layer.Install(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user cancelled")
 }

--- a/internal/layers/vendorbinary.go
+++ b/internal/layers/vendorbinary.go
@@ -1,0 +1,116 @@
+package layers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+const vendoredBinaryPath = "bin/fullsend"
+
+// VendorFunc is a callback that cross-compiles and uploads a vendored binary.
+type VendorFunc func(ctx context.Context, client forge.Client, printer *ui.Printer, org string) error
+
+// VendorBinaryLayer manages the vendored development binary in .fullsend/bin/.
+//
+// When enabled (--vendor-fullsend-binary flag), it calls a VendorFunc callback
+// to cross-compile and upload the binary. When disabled (the default), it
+// checks whether a vendored binary exists and deletes it to prevent a stale
+// binary from shadowing released versions.
+type VendorBinaryLayer struct {
+	org      string
+	client   forge.Client
+	ui       *ui.Printer
+	enabled  bool
+	vendorFn VendorFunc
+}
+
+// Compile-time check that VendorBinaryLayer implements Layer.
+var _ Layer = (*VendorBinaryLayer)(nil)
+
+// NewVendorBinaryLayer creates a new VendorBinaryLayer.
+func NewVendorBinaryLayer(org string, client forge.Client, printer *ui.Printer, enabled bool, vendorFn VendorFunc) *VendorBinaryLayer {
+	return &VendorBinaryLayer{
+		org:      org,
+		client:   client,
+		ui:       printer,
+		enabled:  enabled,
+		vendorFn: vendorFn,
+	}
+}
+
+func (l *VendorBinaryLayer) Name() string { return "vendor-binary" }
+
+// RequiredScopes returns the scopes needed for the given operation.
+func (l *VendorBinaryLayer) RequiredScopes(op Operation) []string {
+	switch op {
+	case OpInstall:
+		return []string{"repo"}
+	default:
+		return nil
+	}
+}
+
+// Install either vendors the binary (when enabled) or removes a stale one
+// (when disabled).
+func (l *VendorBinaryLayer) Install(ctx context.Context) error {
+	if l.enabled {
+		if l.vendorFn == nil {
+			return fmt.Errorf("vendor function not configured")
+		}
+		return l.vendorFn(ctx, l.client, l.ui, l.org)
+	}
+
+	// Disabled — clean up any vendored binary left from a previous install.
+	_, err := l.client.GetFileContent(ctx, l.org, forge.ConfigRepoName, vendoredBinaryPath)
+	if err != nil {
+		if forge.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("checking for vendored binary: %w", err)
+	}
+
+	l.ui.StepStart("removing stale vendored binary")
+	if err := l.client.DeleteFile(ctx, l.org, forge.ConfigRepoName, vendoredBinaryPath, "chore: remove vendored binary"); err != nil {
+		l.ui.StepFail("failed to remove vendored binary")
+		return fmt.Errorf("deleting vendored binary: %w", err)
+	}
+	l.ui.StepDone("removed stale vendored binary")
+	return nil
+}
+
+// Uninstall is a no-op. The vendored binary is removed when the config repo
+// is deleted by the ConfigRepoLayer.
+func (l *VendorBinaryLayer) Uninstall(_ context.Context) error { return nil }
+
+// Analyze assesses the current state of the vendored binary.
+func (l *VendorBinaryLayer) Analyze(ctx context.Context) (*LayerReport, error) {
+	report := &LayerReport{Name: l.Name()}
+
+	_, err := l.client.GetFileContent(ctx, l.org, forge.ConfigRepoName, vendoredBinaryPath)
+	if err != nil {
+		if forge.IsNotFound(err) {
+			if l.enabled {
+				report.Status = StatusNotInstalled
+				report.WouldInstall = append(report.WouldInstall, "upload vendored binary")
+			} else {
+				report.Status = StatusInstalled
+				report.Details = append(report.Details, "no vendored binary present")
+			}
+			return report, nil
+		}
+		return nil, fmt.Errorf("checking for vendored binary: %w", err)
+	}
+
+	if l.enabled {
+		report.Status = StatusInstalled
+		report.Details = append(report.Details, "vendored binary present")
+	} else {
+		report.Status = StatusDegraded
+		report.Details = append(report.Details, "stale vendored binary present")
+		report.WouldFix = append(report.WouldFix, "delete vendored binary")
+	}
+	return report, nil
+}

--- a/internal/layers/vendorbinary_test.go
+++ b/internal/layers/vendorbinary_test.go
@@ -1,0 +1,198 @@
+package layers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+func newVendorBinaryLayer(t *testing.T, client *forge.FakeClient, enabled bool, vendorFn VendorFunc) (*VendorBinaryLayer, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	layer := NewVendorBinaryLayer("test-org", client, printer, enabled, vendorFn)
+	return layer, &buf
+}
+
+func TestVendorBinaryLayer_Name(t *testing.T) {
+	layer, _ := newVendorBinaryLayer(t, &forge.FakeClient{}, false, nil)
+	assert.Equal(t, "vendor-binary", layer.Name())
+}
+
+func TestVendorBinaryLayer_RequiredScopes(t *testing.T) {
+	layer, _ := newVendorBinaryLayer(t, &forge.FakeClient{}, false, nil)
+
+	assert.Equal(t, []string{"repo"}, layer.RequiredScopes(OpInstall))
+	assert.Nil(t, layer.RequiredScopes(OpUninstall))
+	assert.Nil(t, layer.RequiredScopes(OpAnalyze))
+}
+
+func TestVendorBinaryLayer_EnabledCallsVendorFn(t *testing.T) {
+	client := &forge.FakeClient{}
+	called := false
+	vendorFn := func(ctx context.Context, c forge.Client, p *ui.Printer, org string) error {
+		called = true
+		assert.Equal(t, "test-org", org)
+		return nil
+	}
+
+	layer, _ := newVendorBinaryLayer(t, client, true, vendorFn)
+
+	err := layer.Install(context.Background())
+	require.NoError(t, err)
+	assert.True(t, called, "vendor function should have been called")
+}
+
+func TestVendorBinaryLayer_EnabledVendorFnError(t *testing.T) {
+	client := &forge.FakeClient{}
+	vendorFn := func(_ context.Context, _ forge.Client, _ *ui.Printer, _ string) error {
+		return errors.New("cross-compile failed")
+	}
+
+	layer, _ := newVendorBinaryLayer(t, client, true, vendorFn)
+
+	err := layer.Install(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-compile failed")
+}
+
+func TestVendorBinaryLayer_EnabledErrorsWithoutVendorFn(t *testing.T) {
+	client := &forge.FakeClient{}
+	layer, _ := newVendorBinaryLayer(t, client, true, nil)
+
+	err := layer.Install(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vendor function not configured")
+}
+
+func TestVendorBinaryLayer_DisabledDeletesBinary(t *testing.T) {
+	client := &forge.FakeClient{
+		FileContents: map[string][]byte{
+			"test-org/.fullsend/bin/fullsend": []byte("binary-data"),
+		},
+	}
+	layer, _ := newVendorBinaryLayer(t, client, false, nil)
+
+	err := layer.Install(context.Background())
+	require.NoError(t, err)
+
+	// Binary should have been deleted
+	require.Len(t, client.DeletedFiles, 1)
+	assert.Equal(t, "test-org", client.DeletedFiles[0].Owner)
+	assert.Equal(t, ".fullsend", client.DeletedFiles[0].Repo)
+	assert.Equal(t, "bin/fullsend", client.DeletedFiles[0].Path)
+
+	// File should no longer be in FileContents
+	_, ok := client.FileContents["test-org/.fullsend/bin/fullsend"]
+	assert.False(t, ok, "binary should have been removed from FileContents")
+}
+
+func TestVendorBinaryLayer_DisabledNoopWhenAbsent(t *testing.T) {
+	client := &forge.FakeClient{
+		FileContents: map[string][]byte{},
+	}
+	layer, _ := newVendorBinaryLayer(t, client, false, nil)
+
+	err := layer.Install(context.Background())
+	require.NoError(t, err)
+
+	assert.Empty(t, client.DeletedFiles, "no files should have been deleted")
+}
+
+func TestVendorBinaryLayer_DisabledDeleteError(t *testing.T) {
+	client := &forge.FakeClient{
+		FileContents: map[string][]byte{
+			"test-org/.fullsend/bin/fullsend": []byte("binary-data"),
+		},
+		Errors: map[string]error{
+			"DeleteFile": errors.New("permission denied"),
+		},
+	}
+	layer, _ := newVendorBinaryLayer(t, client, false, nil)
+
+	err := layer.Install(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deleting vendored binary")
+}
+
+func TestVendorBinaryLayer_Uninstall(t *testing.T) {
+	layer, _ := newVendorBinaryLayer(t, &forge.FakeClient{}, false, nil)
+	err := layer.Uninstall(context.Background())
+	require.NoError(t, err)
+}
+
+// Analyze tests — 4 combinations of enabled/disabled x present/absent.
+
+func TestVendorBinaryLayer_Analyze_EnabledPresent(t *testing.T) {
+	client := &forge.FakeClient{
+		FileContents: map[string][]byte{
+			"test-org/.fullsend/bin/fullsend": []byte("binary-data"),
+		},
+	}
+	layer, _ := newVendorBinaryLayer(t, client, true, nil)
+
+	report, err := layer.Analyze(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "vendor-binary", report.Name)
+	assert.Equal(t, StatusInstalled, report.Status)
+	assert.Contains(t, report.Details, "vendored binary present")
+}
+
+func TestVendorBinaryLayer_Analyze_EnabledAbsent(t *testing.T) {
+	client := &forge.FakeClient{
+		FileContents: map[string][]byte{},
+	}
+	layer, _ := newVendorBinaryLayer(t, client, true, nil)
+
+	report, err := layer.Analyze(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, StatusNotInstalled, report.Status)
+	assert.Contains(t, report.WouldInstall, "upload vendored binary")
+}
+
+func TestVendorBinaryLayer_Analyze_DisabledPresent(t *testing.T) {
+	client := &forge.FakeClient{
+		FileContents: map[string][]byte{
+			"test-org/.fullsend/bin/fullsend": []byte("binary-data"),
+		},
+	}
+	layer, _ := newVendorBinaryLayer(t, client, false, nil)
+
+	report, err := layer.Analyze(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, StatusDegraded, report.Status)
+	assert.Contains(t, report.Details, "stale vendored binary present")
+	assert.Contains(t, report.WouldFix, "delete vendored binary")
+}
+
+func TestVendorBinaryLayer_Analyze_DisabledAbsent(t *testing.T) {
+	client := &forge.FakeClient{
+		FileContents: map[string][]byte{},
+	}
+	layer, _ := newVendorBinaryLayer(t, client, false, nil)
+
+	report, err := layer.Analyze(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, StatusInstalled, report.Status)
+	assert.Contains(t, report.Details, "no vendored binary present")
+}
+
+func TestVendorBinaryLayer_Analyze_Error(t *testing.T) {
+	client := &forge.FakeClient{
+		Errors: map[string]error{
+			"GetFileContent": errors.New("network error"),
+		},
+	}
+	layer, _ := newVendorBinaryLayer(t, client, false, nil)
+
+	_, err := layer.Analyze(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checking for vendored binary")
+}


### PR DESCRIPTION
## Summary

- Folds the dispatch token prompt and vendor-binary step into proper layers so `runInstall` uses a single `stack.InstallAll()` call instead of the two-phase approach that wrote every config file twice
- Adds `PromptTokenFunc` callback to `DispatchTokenLayer` — prompts interactively when no token exists, skips when secret is already configured
- Adds `VendorBinaryLayer` — uploads the dev binary when `--vendor-fullsend-binary` is set, **deletes stale binaries** when unset to prevent them shadowing releases
- Adds `DeleteFile` to the `forge.Client` interface (GitHub Contents API implementation)

The install stack is now 7 layers in fixed order:
1. config-repo → 2. workflows → 3. vendor-binary → 4. secrets → 5. inference → 6. dispatch-token → 7. enrollment

Each layer runs exactly once. ~25 redundant GitHub API calls eliminated.

Fixes #312

## Test plan

- [x] `go test -race ./...` — all 13 packages pass
- [x] `go vet ./...` — clean
- [x] `make lint` — clean
- [x] `make e2e-test` — `TestAdminInstallUninstall` passes (full install/uninstall against live GitHub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)