### PR TITLE
feat(scripts): add context URL notices to agent pre scripts

### DIFF
--- a/internal/scaffold/fullsend-repo/harness/review.yaml
+++ b/internal/scaffold/fullsend-repo/harness/review.yaml
@@ -7,6 +7,8 @@ skills:
   - skills/pr-review
   - skills/code-review
 
+pre_script: scripts/pre-review.sh
+
 host_files:
   - src: env/gcp-vertex.env
     dest: /tmp/workspace/.env.d/gcp-vertex.env
@@ -29,6 +31,7 @@ runner_env:
   REVIEW_TOKEN: "${REVIEW_TOKEN}"
   REPO_FULL_NAME: "${REPO_FULL_NAME}"
   PR_NUMBER: "${PR_NUMBER}"
+  GITHUB_PR_URL: "${GITHUB_PR_URL}"
   FULLSEND_OUTPUT_SCHEMA: ${FULLSEND_DIR}/schemas/review-result.schema.json
 
 timeout_minutes: 20

--- a/internal/scaffold/fullsend-repo/scripts/pre-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-code.sh
@@ -10,6 +10,8 @@
 #   GITHUB_ISSUE_URL   — must be a valid GitHub issue URL
 set -euo pipefail
 
+echo "::notice::🔗 Code target: ${GITHUB_ISSUE_URL:-}"
+
 errors=0
 
 if [[ ! "${ISSUE_NUMBER:-}" =~ ^[1-9][0-9]*$ ]]; then

--- a/internal/scaffold/fullsend-repo/scripts/pre-review.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-review.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# pre-review.sh — Validate review inputs before the agent runs.
+#
+# Runs on the host via the harness pre_script mechanism.
+#
+# Required environment variables (set by the workflow):
+#   PR_NUMBER      — must be a positive integer
+#   REPO_FULL_NAME — must be owner/repo format
+#   GITHUB_PR_URL  — must be a valid GitHub pull request URL
+set -euo pipefail
+
+echo "::notice::🔗 Review target: ${GITHUB_PR_URL:-}"
+
+errors=0
+
+if [[ ! "${PR_NUMBER:-}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::PR_NUMBER must be a positive integer, got: '${PR_NUMBER:-}'"
+  errors=$((errors + 1))
+fi
+
+if [[ ! "${REPO_FULL_NAME:-}" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]]; then
+  echo "::error::REPO_FULL_NAME must be owner/repo format, got: '${REPO_FULL_NAME:-}'"
+  errors=$((errors + 1))
+fi
+
+if [[ ! "${GITHUB_PR_URL:-}" =~ ^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/pull/[0-9]+$ ]]; then
+  echo "::error::GITHUB_PR_URL format invalid, got: '${GITHUB_PR_URL:-}'"
+  errors=$((errors + 1))
+fi
+
+URL_REPO="$(echo "${GITHUB_PR_URL:-}" | sed -E 's|https://github.com/([^/]+/[^/]+)/pull/.*|\1|')"
+URL_PR="$(echo "${GITHUB_PR_URL:-}" | sed -E 's|.*/pull/([0-9]+)$|\1|')"
+
+if [[ -n "${URL_REPO}" && "${URL_REPO}" != "${REPO_FULL_NAME:-}" ]]; then
+  echo "::error::REPO_FULL_NAME does not match PR URL repo ('${REPO_FULL_NAME:-}' vs '${URL_REPO}')"
+  errors=$((errors + 1))
+fi
+if [[ -n "${URL_PR}" && "${URL_PR}" != "${PR_NUMBER:-}" ]]; then
+  echo "::error::PR_NUMBER does not match PR URL number ('${PR_NUMBER:-}' vs '${URL_PR}')"
+  errors=$((errors + 1))
+fi
+
+if [[ "${errors}" -gt 0 ]]; then
+  echo "::error::Input validation failed with ${errors} error(s). Aborting."
+  exit 1
+fi
+
+echo "Input validation passed:"
+echo "  PR_NUMBER=${PR_NUMBER}"
+echo "  REPO_FULL_NAME=${REPO_FULL_NAME}"
+echo "  GITHUB_PR_URL=${GITHUB_PR_URL}"

--- a/internal/scaffold/fullsend-repo/scripts/pre-triage.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-triage.sh
@@ -15,6 +15,8 @@
 
 set -euo pipefail
 
+echo "::notice::🔗 Triage target: ${GITHUB_ISSUE_URL}"
+
 if [[ ! "${GITHUB_ISSUE_URL}" =~ ^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/issues/[0-9]+$ ]]; then
   echo "ERROR: GITHUB_ISSUE_URL does not match expected pattern: ${GITHUB_ISSUE_URL}"
   exit 1

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -34,6 +34,7 @@ func TestFullsendRepoFilesExist(t *testing.T) {
 		"scripts/pre-triage.sh",
 		"scripts/scan-secrets",
 		"scripts/pre-code.sh",
+		"scripts/pre-review.sh",
 		"scripts/post-code.sh",
 		"scripts/reconcile-repos.sh",
 		"scripts/validate-output-schema.sh",
@@ -64,7 +65,7 @@ func TestWalkFullsendRepo(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
-	assert.True(t, len(paths) >= 27, "expected at least 27 files, got %d", len(paths))
+	assert.True(t, len(paths) >= 28, "expected at least 28 files, got %d", len(paths))
 }
 
 func TestTriageWorkflowContent(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `::notice::` annotations to `pre-triage.sh` and `pre-code.sh` that echo the issue URL at the top of the log
- Create new `pre-review.sh` script for the review agent that validates inputs and echoes the PR URL
- Wire `pre-review.sh` into `harness/review.yaml` with `GITHUB_PR_URL` in `runner_env`

This makes it easy for humans debugging workflow logs to click through to the relevant issue or PR.

## Test plan

- [ ] Verify `make lint` passes
- [ ] Verify scaffold tests pass (new file in expected list, walk count bumped)
- [ ] Trigger each agent workflow and confirm the `::notice::` annotation renders in the Actions log

🤖 Generated with [Claude Code](https://claude.com/claude-code)