### PR TITLE
feat: add release name_template and cutting-releases skill

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          # SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -20,6 +21,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -27,3 +31,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,5 +63,5 @@ release:
 announce:
   slack:
     enabled: true
-    channel: "#fullsend-releases"
+    channel: "#forum-konflux-fullsend"
     message_template: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,28 @@ changelog:
       - "^docs:"
       - "^test:"
       - "^chore:"
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: Refactoring
+      regexp: '^.*?refactor(\([[:word:]]+\))??!?:.+$'
+      order: 2
+    - title: Others
+      order: 999
+
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    args:
+      - "sign-blob"
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
 
 release:
   github:
@@ -37,3 +59,9 @@ release:
     name: fullsend
   name_template: "{{ .Tag }}{{ if .TagSubject }}: {{ .TagSubject }}{{ end }}"
   prerelease: auto
+
+announce:
+  slack:
+    enabled: true
+    channel: "#fullsend-releases"
+    message_template: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,8 +60,8 @@ release:
   name_template: "{{ .Tag }}{{ if .TagSubject }}: {{ .TagSubject }}{{ end }}"
   prerelease: auto
 
-announce:
-  slack:
-    enabled: true
-    channel: "#forum-konflux-fullsend"
-    message_template: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
+# announce:
+#   slack:
+#     enabled: true
+#     channel: "#forum-konflux-fullsend"
+#     message_template: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,3 +36,4 @@ release:
     owner: fullsend-ai
     name: fullsend
   name_template: "{{ .Tag }}{{ if .TagSubject }}: {{ .TagSubject }}{{ end }}"
+  prerelease: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,3 +35,4 @@ release:
   github:
     owner: fullsend-ai
     name: fullsend
+  name_template: "{{ .Tag }}{{ if .TagSubject }}: {{ .TagSubject }}{{ end }}"

--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: cutting-releases
+description: >
+  Use when the user wants to tag a release, cut a release candidate, or ship a
+  new version. Also use when asking about release process, versioning, or how
+  GoReleaser is configured.
+---
+
+# Cutting Releases
+
+Releases are driven by annotated git tags. When a tag matching `v*` is pushed,
+the `.github/workflows/release.yml` workflow runs GoReleaser, which builds
+binaries, generates a changelog, and creates the GitHub release. The release
+title comes from the tag annotation via `name_template` in `.goreleaser.yml`.
+
+## Process
+
+Follow these steps in order.
+
+### 1. Confirm the branch
+
+Releases should be cut from `main`. Verify you are on `main` and up to date:
+
+```
+git checkout main && git pull
+```
+
+### 2. Determine the version
+
+Check the latest tag:
+
+```
+git tag --sort=-v:refname | head -5
+```
+
+Decide the next version following semver:
+
+| Change type | Example bump |
+|---|---|
+| Breaking / major milestone | `v1.0.0` |
+| New functionality (MVP, feature set) | `v0.X.0` |
+| Bug fixes only | `v0.0.X` |
+| Release candidate | `v0.X.0-rc.N` |
+
+### 3. Ask for a tag subject
+
+Use `AskUserQuestion` to ask:
+
+> Any special title for this release? (e.g. "MVP Release Candidate 1")
+> Leave blank to use just the version tag.
+
+The answer becomes the tag subject line. If blank, the tag message is just the
+version number.
+
+### 4. Gather changes since last tag
+
+```
+git log --oneline <previous-tag>..HEAD
+```
+
+Summarize the changes into categories (features, fixes, refactors). Exclude
+commits that start with `docs:`, `test:`, or `chore:` — GoReleaser filters
+these from the changelog anyway.
+
+### 5. Create the annotated tag
+
+Build the tag message:
+
+- **Line 1 (subject):** The tag subject from step 3, or just the version.
+- **Lines 3+:** Summary of highlights organized by category.
+
+```
+git tag -a v0.X.0 -m "<message>"
+```
+
+The first line of the annotation flows into the GitHub release title via
+GoReleaser's `name_template: "{{ .Tag }}{{ if .TagSubject }}: {{ .TagSubject }}{{ end }}"`.
+
+### 6. Push the tag
+
+```
+git push origin <tag>
+```
+
+GoReleaser takes over from here. Verify the workflow starts:
+
+```
+gh run list --workflow=release.yml --limit=1
+```
+
+### 7. Verify the release
+
+Once the workflow completes, confirm the release was created:
+
+```
+gh release view <tag>
+```
+
+Check that the title, changelog, and binary assets look correct.
+
+## Notes
+
+- **Pre-releases:** Tags with `-rc.N`, `-alpha.N`, or `-beta.N` suffixes are
+  automatically marked as pre-releases by GoReleaser.
+- **Never delete a published tag.** If a release is bad, cut a new patch or RC.
+- **The changelog** is auto-generated from commit messages. Conventional commit
+  prefixes (`feat:`, `fix:`, etc.) produce clean changelogs.

--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -42,7 +42,18 @@ Decide the next version following semver:
 | Bug fixes only | `v0.0.X` |
 | Release candidate | `v0.X.0-rc.N` |
 
-### 3. Ask for a tag subject
+### 3. Confirm the version with the user
+
+Use `AskUserQuestion` to present your proposed version tag and the rationale
+for your choice. For example:
+
+> I'd suggest `v0.2.0` — there are 5 new `feat:` commits since `v0.1.0` and
+> no breaking changes. Does that look right, or would you prefer a different
+> version?
+
+Do not proceed until the user confirms.
+
+### 4. Ask for a tag subject
 
 Use `AskUserQuestion` to ask:
 
@@ -52,7 +63,7 @@ Use `AskUserQuestion` to ask:
 The answer becomes the tag subject line. If blank, the tag message is just the
 version number.
 
-### 4. Gather changes since last tag
+### 5. Gather changes since last tag
 
 ```
 git log --oneline <previous-tag>..HEAD
@@ -62,11 +73,11 @@ Summarize the changes into categories (features, fixes, refactors). Exclude
 commits that start with `docs:`, `test:`, or `chore:` — GoReleaser filters
 these from the changelog anyway.
 
-### 5. Create the annotated tag
+### 6. Create the annotated tag
 
 Build the tag message:
 
-- **Line 1 (subject):** The tag subject from step 3, or just the version.
+- **Line 1 (subject):** The tag subject from step 4, or just the version.
 - **Lines 3+:** Summary of highlights organized by category.
 
 ```
@@ -76,7 +87,7 @@ git tag -a v0.X.0 -m "<message>"
 The first line of the annotation flows into the GitHub release title via
 GoReleaser's `name_template: "{{ .Tag }}{{ if .TagSubject }}: {{ .TagSubject }}{{ end }}"`.
 
-### 6. Push the tag
+### 7. Push the tag
 
 ```
 git push origin <tag>
@@ -88,7 +99,7 @@ GoReleaser takes over from here. Verify the workflow starts:
 gh run list --workflow=release.yml --limit=1
 ```
 
-### 7. Verify the release
+### 8. Verify the release
 
 Once the workflow completes, confirm the release was created:
 


### PR DESCRIPTION
## Summary

- Add `name_template` to `.goreleaser.yml` so annotated tag subjects appear in GitHub release titles (e.g. "v0.1.0-rc.1: MVP Release Candidate 1")
- Add `cutting-releases` skill documenting the end-to-end release process, including prompting for a custom tag subject

## Test plan

- [ ] Push a test tag with an annotated subject and verify GoReleaser uses it in the release title
- [ ] Invoke `/cutting-releases` and verify the skill loads and the process steps are clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)