### PR TITLE
fix(sandbox): force executable bit on host_files copied into bin/

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -652,11 +652,11 @@ func bootstrapEnv(sshConfigPath, sandboxName, repoDir string, h *harness.Harness
 			}
 		}
 
-		// TODO(#312): remove this once admin install preserves the executable
+		// TODO(#345): remove this once admin install preserves the executable
 		// bit when writing files to .fullsend/. The GitHub Contents API commits
 		// everything as 100644, so scripts lose +x. Force it back for anything
 		// landing in a bin/ directory.
-		// https://github.com/fullsend-ai/fullsend/issues/312#issuecomment-4300729520
+		// https://github.com/fullsend-ai/fullsend/issues/345#issuecomment-4300740512
 		if strings.Contains(hf.Dest, "/bin/") {
 			chmodCmd := fmt.Sprintf("chmod +x %s", hf.Dest)
 			if _, _, _, sshErr := sandbox.SSH(sshConfigPath, sandboxName, chmodCmd, 10*time.Second); sshErr != nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -651,6 +651,18 @@ func bootstrapEnv(sshConfigPath, sandboxName, repoDir string, h *harness.Harness
 				return fmt.Errorf("copying host file %s to %s: %w", hf.Src, hf.Dest, err)
 			}
 		}
+
+		// TODO(#312): remove this once admin install preserves the executable
+		// bit when writing files to .fullsend/. The GitHub Contents API commits
+		// everything as 100644, so scripts lose +x. Force it back for anything
+		// landing in a bin/ directory.
+		// https://github.com/fullsend-ai/fullsend/issues/312#issuecomment-4300729520
+		if strings.Contains(hf.Dest, "/bin/") {
+			chmodCmd := fmt.Sprintf("chmod +x %s", hf.Dest)
+			if _, _, _, sshErr := sandbox.SSH(sshConfigPath, sandboxName, chmodCmd, 10*time.Second); sshErr != nil {
+				return fmt.Errorf("chmod host file %s in sandbox: %w", hf.Dest, sshErr)
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- The GitHub Contents API (used by `admin install`) commits all files as `100644`, so scripts like `scan-unicode` lose their executable bit in the `.fullsend` repo
- When `bootstrapEnv()` copies these into the sandbox via SCP, they remain non-executable — `test -x $SCAN_UNICODE` fails and the review agent aborts with `missing-context`
- Force `chmod +x` on any host_file whose destination is under a `bin/` directory
- This is a workaround until `admin install` preserves git tree modes ([#345 comment](https://github.com/fullsend-ai/fullsend/issues/345#issuecomment-4300740512))

**Verified:** triggered a review on [appdumpster/test-repo](https://github.com/appdumpster/.fullsend/actions/runs/24809228067) with the fix — agent completed successfully and approved the PR.

## Test plan

- [x] `go vet` passes
- [x] `go test ./internal/cli/...` passes
- [x] Review agent completes successfully on appdumpster/test-repo with vendored binary containing this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)