### PR TITLE
feat(action): log fullsend CLI version at workflow start

### DIFF
--- a/internal/scaffold/fullsend-repo/.github/actions/fullsend/action.yml
+++ b/internal/scaffold/fullsend-repo/.github/actions/fullsend/action.yml
@@ -91,6 +91,10 @@ runs:
         tar -xzf "/tmp/${ASSET_NAME}" -C "${RUNNER_TEMP}/fullsend"
         echo "${RUNNER_TEMP}/fullsend" >> "${GITHUB_PATH}"
 
+    - name: Print fullsend version
+      shell: bash
+      run: fullsend --version
+
     - name: Install OpenShell
       shell: bash
       run: |


### PR DESCRIPTION
## Summary

- Add a `fullsend --version` step to the composite action, right after install and before OpenShell install
- Makes the CLI version visible in every workflow run log for easier debugging
- Matches the existing pattern where `openshell --version` is already logged

## Test plan

- [x] Lint passes
- [ ] Verify version appears in workflow logs after next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)