### PR TITLE
fix: add contents:read to dispatch token for private .fullsend repos

### DIFF
--- a/e2e/admin/pat.go
+++ b/e2e/admin/pat.go
@@ -120,7 +120,7 @@ func createPAT(page playwright.Page, note, password, screenshotDir string, logf 
 }
 
 // createDispatchPAT creates a fine-grained GitHub Personal Access Token
-// scoped to the .fullsend repo with Actions read/write permission.
+// scoped to the .fullsend repo with Actions read/write and Contents read permissions.
 // This mirrors what the real CLI does in promptDispatchToken — the user
 // is guided to create a fine-grained PAT at GitHub's token creation page.
 // The e2e test automates the browser interaction instead.
@@ -391,6 +391,36 @@ func createDispatchPAT(page playwright.Page, org, password, screenshotDir string
 	logf("[dispatch-pat] Checked Actions permission")
 	time.Sleep(1 * time.Second)
 	saveDebugScreenshot(page, screenshotDir, "dispatch-pat-after-actions-check", logf)
+
+	// Also select the Contents permission (defaults to Read-only, which is
+	// what we need). This allows the dispatch token to resolve the default
+	// branch on private .fullsend repos via GraphQL.
+	_, err = page.Evaluate(`() => {
+		const items = document.querySelectorAll('*');
+		for (const el of items) {
+			if (el.textContent.trim() === 'Contents' && el.closest('[role="option"], label, li')) {
+				el.closest('[role="option"], label, li').click();
+				return true;
+			}
+		}
+		for (const el of items) {
+			if (el.textContent.trim() === 'Contents') {
+				const parent = el.parentElement;
+				const checkbox = parent.querySelector('input[type="checkbox"]');
+				if (checkbox) { checkbox.click(); return true; }
+				parent.click();
+				return true;
+			}
+		}
+		return false;
+	}`)
+	if err != nil {
+		saveDebugScreenshot(page, screenshotDir, "dispatch-pat-contents-checkbox", logf)
+		return "", fmt.Errorf("clicking Contents checkbox via JS: %w", err)
+	}
+	logf("[dispatch-pat] Checked Contents permission (Read-only)")
+	time.Sleep(1 * time.Second)
+	saveDebugScreenshot(page, screenshotDir, "dispatch-pat-after-contents-check", logf)
 
 	// Close the permissions popover by pressing Escape.
 	page.Keyboard().Press("Escape")

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -839,7 +839,7 @@ func promptDispatchToken(ctx context.Context, client forge.Client, printer *ui.P
 		"https://github.com/settings/personal-access-tokens/new"+
 			"?name=fullsend-dispatch-%s"+
 			"&description=Dispatch+token+for+fullsend+agent+pipeline+in+%s."+
-			"+Scoped+to+.fullsend+repo+with+Actions+write+only."+
+			"+Scoped+to+.fullsend+repo+with+Actions+write+and+Contents+read."+
 			"&target_name=%s",
 		escapedOrg, escapedOrg, escapedOrg,
 	)
@@ -856,10 +856,10 @@ func promptDispatchToken(ctx context.Context, client forge.Client, printer *ui.P
 	}
 
 	printer.Blank()
-	printer.StepWarn("IMPORTANT: The installer's URL tried to pre-fill actions/write")
+	printer.StepWarn("IMPORTANT: The installer's URL tried to pre-fill permissions")
 	printer.StepWarn("in the query parameters, but GitHub's fine-grained PAT page doesn't")
 	printer.StepWarn("always honor those pre-fill params. So you just have to click that")
-	printer.StepWarn("'+ Add permissions' button and add Actions manually.")
+	printer.StepWarn("'+ Add permissions' button and add Actions and Contents manually.")
 	printer.Blank()
 	printer.StepWarn("GitHub's resource owner selector has a known quirk.")
 	printer.StepWarn("If the owner is pre-filled, you may need to de-select and")
@@ -873,12 +873,13 @@ func promptDispatchToken(ctx context.Context, client forge.Client, printer *ui.P
 	printer.StepInfo("  3. Pick ONLY the .fullsend repository (not other repos)")
 	printer.StepInfo("  4. Click the '+ Add permissions' button (top right of Permissions section)")
 	printer.StepInfo("  5. Look for 'Actions' in the dropdown/list that appears")
-	printer.StepInfo("  6. Set it to 'Read and write'")
-	printer.StepInfo("  7. Click 'Generate token' (the green button at the bottom left)")
-	printer.StepInfo("  8. GitHub will show the token ONCE on the next page — copy it immediately")
+	printer.StepInfo("  6. Set Actions to 'Read and write'")
+	printer.StepInfo("  7. Also add 'Contents' and leave it at 'Read-only'")
+	printer.StepInfo("  8. Click 'Generate token' (the green button at the bottom left)")
+	printer.StepInfo("  9. GitHub will show the token ONCE on the next page — copy it immediately")
 	printer.StepInfo("     (If you navigate away before copying, you'll need to delete the token")
 	printer.StepInfo("      and create a new one — GitHub never shows it again)")
-	printer.StepInfo("  9. Paste the token below")
+	printer.StepInfo(" 10. Paste the token below")
 	printer.Blank()
 	printer.StepInfo("Paste the token here:")
 
@@ -921,7 +922,7 @@ func promptDispatchToken(ctx context.Context, client forge.Client, printer *ui.P
 				"Delete it at https://github.com/settings/tokens and recreate with:\n"+
 				"  1. Resource owner: "+org+"\n"+
 				"  2. Repository access: Only select repositories → "+forge.ConfigRepoName+"\n"+
-				"  3. Permissions: Actions → Read and write\n\n"+
+				"  3. Permissions: Actions → Read and write, Contents → Read-only\n\n"+
 				"Error: "+err.Error(),
 		)
 		return "", fmt.Errorf("dispatch token verification failed")

--- a/internal/layers/dispatch.go
+++ b/internal/layers/dispatch.go
@@ -14,7 +14,7 @@ const dispatchTokenName = "FULLSEND_DISPATCH_TOKEN"
 // repos use to trigger workflow_dispatch events on the .fullsend repo.
 //
 // The dispatch token is a fine-grained PAT scoped to the .fullsend repo
-// with actions:write permission. It is stored as an org-level Actions
+// with actions:write and contents:read permissions. It is stored as an org-level Actions
 // secret with visibility "selected", scoped to enrolled repos only.
 // This way, enrolled repos can trigger dispatches but never access the
 // App private keys (which are repo-level secrets on .fullsend).


### PR DESCRIPTION
## Summary

- Adds `contents:read` permission to the dispatch token so `gh workflow run` can resolve the default branch via GraphQL when `.fullsend` is a private repo
- Updates CLI prompts, error messages, layer docstring, and e2e browser automation to include the new permission

Closes #333

## Test plan

- [ ] Run `make go-test` and `make go-vet` — passes
- [ ] Run `make e2e-test` to verify the updated PAT creation flow selects both Actions and Contents permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)