### PR TITLE
feat(security): add unicode PostToolUse hook for runtime scanning

### DIFF
--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -111,8 +111,9 @@ type LLMGuardConfig struct {
 // that run inside the sandbox during agent execution.
 type SandboxHooks struct {
 	Tirith               *TirithConfig `yaml:"tirith,omitempty"`
-	SSRFPreTool          *bool         `yaml:"ssrf_pretool,omitempty"`          // default: true
+	SSRFPreTool          *bool         `yaml:"ssrf_pretool,omitempty"`           // default: true
 	SecretRedactPostTool *bool         `yaml:"secret_redact_posttool,omitempty"` // default: true
+	UnicodePostTool      *bool         `yaml:"unicode_posttool,omitempty"`       // default: true
 }
 
 // TirithConfig configures the Tirith Rust CLI scanner for terminal security.

--- a/internal/security/hooks.go
+++ b/internal/security/hooks.go
@@ -16,6 +16,9 @@ var SecretRedactPostToolHook []byte
 //go:embed hooks/tirith_check.py
 var TirithCheckHook []byte
 
+//go:embed hooks/unicode_posttool.py
+var UnicodePostToolHook []byte
+
 // hookEntry represents a single hook command in Claude settings.
 type hookEntry struct {
 	Type    string `json:"type"`
@@ -79,6 +82,16 @@ func GenerateClaudeSettings(h *harness.Harness) ([]byte, error) {
 		})
 	}
 
+	// Unicode scanning PostToolUse hook.
+	if unicodePostToolEnabled(sec) {
+		postToolMatchers = append(postToolMatchers, hookMatcher{
+			Matcher: "Bash|WebFetch|Read",
+			Hooks: []hookEntry{
+				{Type: "command", Command: "python3 " + SandboxHooksDir + "/unicode_posttool.py"},
+			},
+		})
+	}
+
 	if len(preToolMatchers) > 0 {
 		settings.Hooks["PreToolUse"] = preToolMatchers
 	}
@@ -102,6 +115,9 @@ func HookFiles(h *harness.Harness) map[string][]byte {
 	}
 	if secretRedactPostToolEnabled(sec) {
 		files["secret_redact_posttool.py"] = SecretRedactPostToolHook
+	}
+	if unicodePostToolEnabled(sec) {
+		files["unicode_posttool.py"] = UnicodePostToolHook
 	}
 
 	return files
@@ -134,4 +150,11 @@ func secretRedactPostToolEnabled(sec *harness.SecurityConfig) bool {
 		return true
 	}
 	return boolDefault(sec.SandboxHooks.SecretRedactPostTool, true)
+}
+
+func unicodePostToolEnabled(sec *harness.SecurityConfig) bool {
+	if sec == nil || sec.SandboxHooks == nil {
+		return true
+	}
+	return boolDefault(sec.SandboxHooks.UnicodePostTool, true)
 }

--- a/internal/security/hooks.go
+++ b/internal/security/hooks.go
@@ -72,23 +72,25 @@ func GenerateClaudeSettings(h *harness.Harness) ([]byte, error) {
 		})
 	}
 
-	// Secret redaction PostToolUse hook.
+	// PostToolUse hooks for Bash|WebFetch|Read: secret redaction then unicode
+	// scanning. Combined into a single matcher so Claude Code chains them
+	// sequentially (separate matchers run in parallel on the original result,
+	// which would cause modifications to conflict).
+	var postToolHooks []hookEntry
 	if secretRedactPostToolEnabled(sec) {
-		postToolMatchers = append(postToolMatchers, hookMatcher{
-			Matcher: "Bash|WebFetch|Read",
-			Hooks: []hookEntry{
-				{Type: "command", Command: "python3 " + SandboxHooksDir + "/secret_redact_posttool.py"},
-			},
+		postToolHooks = append(postToolHooks, hookEntry{
+			Type: "command", Command: "python3 " + SandboxHooksDir + "/secret_redact_posttool.py",
 		})
 	}
-
-	// Unicode scanning PostToolUse hook.
 	if unicodePostToolEnabled(sec) {
+		postToolHooks = append(postToolHooks, hookEntry{
+			Type: "command", Command: "python3 " + SandboxHooksDir + "/unicode_posttool.py",
+		})
+	}
+	if len(postToolHooks) > 0 {
 		postToolMatchers = append(postToolMatchers, hookMatcher{
 			Matcher: "Bash|WebFetch|Read",
-			Hooks: []hookEntry{
-				{Type: "command", Command: "python3 " + SandboxHooksDir + "/unicode_posttool.py"},
-			},
+			Hooks:   postToolHooks,
 		})
 	}
 

--- a/internal/security/hooks/unicode_posttool.py
+++ b/internal/security/hooks/unicode_posttool.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Claude Code PostToolUse hook for unicode security scanning.
+
+Intercepts tool results (Read, Bash, WebFetch) and scans for non-rendering
+Unicode characters that can encode hidden instructions: steganographic
+payloads (tag characters), invisible text (zero-width), Trojan Source
+attacks (bidi overrides), and ANSI escape injection.
+
+Critical findings (tag characters with decoded hidden text) block the tool
+result. Non-critical findings strip the invisible characters and pass
+through the sanitized text.
+
+Protocol: reads JSON from stdin, writes JSON to stdout with modified
+tool_result if findings detected.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import unicodedata
+from datetime import UTC, datetime
+
+FINDINGS_PATH = "/tmp/workspace/.security/findings.jsonl"
+
+# --- Unicode categories to detect ---
+
+_CHECKS: list[tuple[str, str, re.Pattern]] = [
+    (
+        "tag_char",
+        "critical",
+        re.compile("[\U000e0000-\U000e007f]+"),
+    ),
+    (
+        "zero_width",
+        "high",
+        re.compile("[\u200b-\u200d\ufeff\u00ad]+"),
+    ),
+    (
+        "bidi_override",
+        "high",
+        re.compile("[\u202a-\u202e]+"),
+    ),
+    (
+        "bidi_isolate",
+        "high",
+        re.compile("[\u2066-\u2069]+"),
+    ),
+    (
+        "invisible_operator",
+        "medium",
+        re.compile("[\u2060-\u2064]+"),
+    ),
+    (
+        "variation_selector",
+        "medium",
+        re.compile("[\ufe00-\ufe0f]+"),
+    ),
+    (
+        "ansi_escape",
+        "medium",
+        re.compile(r"\x1b\[[0-9;]*[a-zA-Z]"),
+    ),
+    (
+        "null_byte",
+        "high",
+        re.compile("\x00+"),
+    ),
+]
+
+
+def log_finding(name: str, severity: str, detail: str, action: str):
+    trace_id = os.environ.get("FULLSEND_TRACE_ID", "")
+    finding = {
+        "trace_id": trace_id,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "phase": "hook_posttool",
+        "scanner": "unicode_posttool",
+        "name": name,
+        "severity": severity,
+        "detail": detail,
+        "action": action,
+    }
+    try:
+        with open(FINDINGS_PATH, "a") as f:
+            f.write(json.dumps(finding) + "\n")
+    except OSError:
+        pass
+
+
+def decode_tag_chars(text: str) -> str:
+    """Decode tag characters (U+E0000-U+E007F) to reveal hidden ASCII."""
+    return "".join(chr(ord(c) - 0xE0000) for c in text if 0xE0000 <= ord(c) <= 0xE007F)
+
+
+def scan_text(text: str) -> tuple[str, list[dict]]:
+    findings: list[dict] = []
+    result = text
+
+    for name, severity, pattern in _CHECKS:
+        matches = pattern.findall(result)
+        if not matches:
+            continue
+
+        total_chars = sum(len(m) for m in matches)
+        detail = f"{total_chars} {name.replace('_', ' ')} character(s) removed"
+
+        if name == "tag_char":
+            decoded = decode_tag_chars(result)
+            if decoded.strip():
+                detail += f" (decoded hidden text: {decoded.strip()})"
+
+        findings.append(
+            {
+                "name": name,
+                "severity": severity,
+                "detail": detail,
+            }
+        )
+
+        result = pattern.sub("", result)
+
+    # NFKC normalization (fullwidth -> ASCII, compatibility decomposition).
+    nfkc = unicodedata.normalize("NFKC", result)
+    if nfkc != result:
+        diff_count = sum(1 for a, b in zip(result, nfkc) if a != b)
+        diff_count += abs(len(result) - len(nfkc))
+        diff_count = max(diff_count, 1)
+        findings.append(
+            {
+                "name": "fullwidth",
+                "severity": "high",
+                "detail": f"NFKC normalization applied ({diff_count} characters affected)",
+            }
+        )
+        result = nfkc
+
+    return result, findings
+
+
+MAX_INPUT_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def main():
+    try:
+        raw = sys.stdin.read(MAX_INPUT_BYTES + 1)
+        if len(raw) > MAX_INPUT_BYTES:
+            raw = raw[:MAX_INPUT_BYTES]
+        if not raw.strip():
+            sys.exit(0)
+        hook_input = json.loads(raw)
+    except (json.JSONDecodeError, Exception):
+        sys.exit(0)
+
+    tool_result = hook_input.get("tool_result", "")
+    if not tool_result or not isinstance(tool_result, str):
+        sys.exit(0)
+
+    try:
+        sanitized, findings = scan_text(tool_result)
+    except Exception as e:
+        log_finding("scan_error", "high", f"Unicode scan failed (passing original): {e}", "warn")
+        sys.exit(0)
+
+    if not findings:
+        sys.exit(0)
+
+    has_critical = any(f["severity"] == "critical" for f in findings)
+
+    for f in findings:
+        action = "block" if f["severity"] == "critical" else "sanitize"
+        log_finding(f["name"], f["severity"], f["detail"], action)
+
+    if has_critical:
+        json.dump(
+            {
+                "decision": "block",
+                "reason": f"Critical unicode findings: {'; '.join(f['detail'] for f in findings if f['severity'] == 'critical')}",
+            },
+            sys.stdout,
+        )
+        sys.exit(1)
+
+    json.dump(
+        {
+            "tool_result": sanitized,
+            "metadata": {
+                "unicode_findings": len(findings),
+                "categories": [f["name"] for f in findings],
+            },
+        },
+        sys.stdout,
+    )
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/security/hooks/unicode_posttool.py
+++ b/internal/security/hooks/unicode_posttool.py
@@ -51,10 +51,17 @@ _CHECKS: list[tuple[str, str, re.Pattern]] = [
         "medium",
         re.compile("[\ufe00-\ufe0f]+"),
     ),
+    # CSI: ECMA-48 compliant ranges (broader than Go's [0-9;]*[a-zA-Z]).
     (
         "ansi_escape",
         "medium",
         re.compile(r"\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]"),
+    ),
+    # OSC: terminal hyperlinks, window title injection.
+    (
+        "osc_escape",
+        "medium",
+        re.compile(r"\x1b\].*?(?:\x1b\\|\x07)"),
     ),
     (
         "null_byte",
@@ -141,20 +148,21 @@ def scan_text(text: str) -> tuple[str, list[dict]]:
     return result, findings
 
 
-MAX_INPUT_BYTES = 10 * 1024 * 1024  # 10 MB
+# sys.stdin.read(n) in text mode reads characters, not bytes.
+MAX_INPUT_CHARS = 10 * 1024 * 1024
 
 
 def main() -> None:
     try:
-        raw = sys.stdin.read(MAX_INPUT_BYTES + 1)
-        if len(raw) > MAX_INPUT_BYTES:
+        raw = sys.stdin.read(MAX_INPUT_CHARS + 1)
+        if len(raw) > MAX_INPUT_CHARS:
             log_finding(
                 "input_truncated",
                 "medium",
-                f"Input truncated from {len(raw)} to {MAX_INPUT_BYTES} bytes",
+                f"Input truncated from {len(raw)} to {MAX_INPUT_CHARS} characters",
                 "warn",
             )
-            raw = raw[:MAX_INPUT_BYTES]
+            raw = raw[:MAX_INPUT_CHARS]
         if not raw.strip():
             sys.exit(0)
         hook_input = json.loads(raw)

--- a/internal/security/hooks/unicode_posttool.py
+++ b/internal/security/hooks/unicode_posttool.py
@@ -6,12 +6,13 @@ Unicode characters that can encode hidden instructions: steganographic
 payloads (tag characters), invisible text (zero-width), Trojan Source
 attacks (bidi overrides), and ANSI escape injection.
 
-Critical findings (tag characters with decoded hidden text) block the tool
-result. Non-critical findings strip the invisible characters and pass
-through the sanitized text.
+All findings are sanitized (invisible characters stripped) and the cleaned
+text is returned. PostToolUse hooks cannot block — they sanitize only.
+Critical findings (tag characters) are logged to findings.jsonl for the
+post-script to act on.
 
 Protocol: reads JSON from stdin, writes JSON to stdout with modified
-tool_result if findings detected.
+tool_result if findings detected. Always exits 0.
 """
 
 from __future__ import annotations
@@ -24,8 +25,10 @@ import unicodedata
 from datetime import UTC, datetime
 
 FINDINGS_PATH = "/tmp/workspace/.security/findings.jsonl"
+MAX_DECODED_LOG = 200
 
 # --- Unicode categories to detect ---
+# Aligned with Go UnicodeNormalizer (internal/security/unicode.go).
 
 _CHECKS: list[tuple[str, str, re.Pattern]] = [
     (
@@ -36,22 +39,12 @@ _CHECKS: list[tuple[str, str, re.Pattern]] = [
     (
         "zero_width",
         "high",
-        re.compile("[\u200b-\u200d\ufeff\u00ad]+"),
+        re.compile("[\u200b-\u200d\ufeff\u00ad\u2060-\u2064]+"),
     ),
     (
         "bidi_override",
         "high",
-        re.compile("[\u202a-\u202e]+"),
-    ),
-    (
-        "bidi_isolate",
-        "high",
-        re.compile("[\u2066-\u2069]+"),
-    ),
-    (
-        "invisible_operator",
-        "medium",
-        re.compile("[\u2060-\u2064]+"),
+        re.compile("[\u202a-\u202e\u2066-\u2069]+"),
     ),
     (
         "variation_selector",
@@ -61,7 +54,7 @@ _CHECKS: list[tuple[str, str, re.Pattern]] = [
     (
         "ansi_escape",
         "medium",
-        re.compile(r"\x1b\[[0-9;]*[a-zA-Z]"),
+        re.compile(r"\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]"),
     ),
     (
         "null_byte",
@@ -71,7 +64,7 @@ _CHECKS: list[tuple[str, str, re.Pattern]] = [
 ]
 
 
-def log_finding(name: str, severity: str, detail: str, action: str):
+def log_finding(name: str, severity: str, detail: str, action: str) -> None:
     trace_id = os.environ.get("FULLSEND_TRACE_ID", "")
     finding = {
         "trace_id": trace_id,
@@ -92,7 +85,10 @@ def log_finding(name: str, severity: str, detail: str, action: str):
 
 def decode_tag_chars(text: str) -> str:
     """Decode tag characters (U+E0000-U+E007F) to reveal hidden ASCII."""
-    return "".join(chr(ord(c) - 0xE0000) for c in text if 0xE0000 <= ord(c) <= 0xE007F)
+    decoded = "".join(chr(ord(c) - 0xE0000) for c in text if 0xE0000 <= ord(c) <= 0xE007F)
+    if len(decoded) > MAX_DECODED_LOG:
+        return decoded[:MAX_DECODED_LOG] + "..."
+    return decoded
 
 
 def scan_text(text: str) -> tuple[str, list[dict]]:
@@ -110,6 +106,8 @@ def scan_text(text: str) -> tuple[str, list[dict]]:
         if name == "tag_char":
             decoded = decode_tag_chars(result)
             if decoded.strip():
+                # Decoded text logged to findings.jsonl only — never to stdout
+                # where it would enter the LLM context as a prompt injection vector.
                 detail += f" (decoded hidden text: {decoded.strip()})"
 
         findings.append(
@@ -125,8 +123,11 @@ def scan_text(text: str) -> tuple[str, list[dict]]:
     # NFKC normalization (fullwidth -> ASCII, compatibility decomposition).
     nfkc = unicodedata.normalize("NFKC", result)
     if nfkc != result:
-        diff_count = sum(1 for a, b in zip(result, nfkc) if a != b)
-        diff_count += abs(len(result) - len(nfkc))
+        orig_chars = list(result)
+        nfkc_chars = list(nfkc)
+        min_len = min(len(orig_chars), len(nfkc_chars))
+        diff_count = sum(1 for i in range(min_len) if orig_chars[i] != nfkc_chars[i])
+        diff_count += abs(len(orig_chars) - len(nfkc_chars))
         diff_count = max(diff_count, 1)
         findings.append(
             {
@@ -143,15 +144,28 @@ def scan_text(text: str) -> tuple[str, list[dict]]:
 MAX_INPUT_BYTES = 10 * 1024 * 1024  # 10 MB
 
 
-def main():
+def main() -> None:
     try:
         raw = sys.stdin.read(MAX_INPUT_BYTES + 1)
         if len(raw) > MAX_INPUT_BYTES:
+            log_finding(
+                "input_truncated",
+                "medium",
+                f"Input truncated from {len(raw)} to {MAX_INPUT_BYTES} bytes",
+                "warn",
+            )
             raw = raw[:MAX_INPUT_BYTES]
         if not raw.strip():
             sys.exit(0)
         hook_input = json.loads(raw)
-    except (json.JSONDecodeError, Exception):
+    except json.JSONDecodeError:
+        log_finding("parse_error", "medium", "Hook input is not valid JSON", "warn")
+        sys.exit(0)
+    except Exception as e:
+        log_finding("parse_error", "high", f"Hook input parsing failed: {type(e).__name__}", "warn")
+        sys.exit(0)
+
+    if not isinstance(hook_input, dict):
         sys.exit(0)
 
     tool_result = hook_input.get("tool_result", "")
@@ -161,28 +175,26 @@ def main():
     try:
         sanitized, findings = scan_text(tool_result)
     except Exception as e:
-        log_finding("scan_error", "high", f"Unicode scan failed (passing original): {e}", "warn")
+        log_finding(
+            "scan_error",
+            "high",
+            f"Unicode scan failed (passing original): {type(e).__name__}",
+            "warn",
+        )
         sys.exit(0)
 
     if not findings:
         sys.exit(0)
 
-    has_critical = any(f["severity"] == "critical" for f in findings)
-
     for f in findings:
-        action = "block" if f["severity"] == "critical" else "sanitize"
+        action = "sanitize"
+        if f["severity"] == "critical":
+            action = "critical_sanitize"
         log_finding(f["name"], f["severity"], f["detail"], action)
 
-    if has_critical:
-        json.dump(
-            {
-                "decision": "block",
-                "reason": f"Critical unicode findings: {'; '.join(f['detail'] for f in findings if f['severity'] == 'critical')}",
-            },
-            sys.stdout,
-        )
-        sys.exit(1)
-
+    # PostToolUse hooks always exit 0 — they sanitize, never block.
+    # Critical findings (tag chars) are stripped from tool_result and logged
+    # to findings.jsonl for the post-script to escalate.
     json.dump(
         {
             "tool_result": sanitized,

--- a/internal/security/hooks/unicode_posttool.py
+++ b/internal/security/hooks/unicode_posttool.py
@@ -160,7 +160,9 @@ def scan_text(text: str) -> tuple[str, list[dict]]:
                 {
                     "name": name,
                     "severity": severity,
-                    "detail": f"{total_chars} {name.replace('_', ' ')} character(s) removed (post-NFKC)",
+                    "detail": (
+                        f"{total_chars} {name.replace('_', ' ')} character(s) removed (post-NFKC)"
+                    ),
                 }
             )
             result = pattern.sub("", result)

--- a/internal/security/hooks/unicode_posttool.py
+++ b/internal/security/hooks/unicode_posttool.py
@@ -58,10 +58,12 @@ _CHECKS: list[tuple[str, str, re.Pattern]] = [
         re.compile(r"\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]"),
     ),
     # OSC: terminal hyperlinks, window title injection.
+    # Uses negated class [^\x1b\x07]* instead of .*? to avoid O(n^2)
+    # backtracking on dense unterminated ESC] sequences.
     (
         "osc_escape",
         "medium",
-        re.compile(r"\x1b\].*?(?:\x1b\\|\x07)"),
+        re.compile(r"\x1b\][^\x1b\x07]*(?:\x1b\\|\x07)"),
     ),
     (
         "null_byte",
@@ -144,6 +146,24 @@ def scan_text(text: str) -> tuple[str, list[dict]]:
             }
         )
         result = nfkc
+
+        # Second pass: NFKC can reconstruct escape sequences from fullwidth
+        # characters (e.g. fullwidth [ + ESC → valid CSI). Re-check ANSI/OSC.
+        for name, severity, pattern in _CHECKS:
+            if name not in ("ansi_escape", "osc_escape"):
+                continue
+            matches = pattern.findall(result)
+            if not matches:
+                continue
+            total_chars = sum(len(m) for m in matches)
+            findings.append(
+                {
+                    "name": name,
+                    "severity": severity,
+                    "detail": f"{total_chars} {name.replace('_', ' ')} character(s) removed (post-NFKC)",
+                }
+            )
+            result = pattern.sub("", result)
 
     return result, findings
 

--- a/internal/security/hooks/unicode_posttool_test.py
+++ b/internal/security/hooks/unicode_posttool_test.py
@@ -130,6 +130,15 @@ class TestAnsiEscape(unittest.TestCase):
         self.assertEqual(out["tool_result"], "hellored")
         self.assertIn("ansi_escape", out["metadata"]["categories"])
 
+    def test_osc_hyperlink_stripped(self):
+        # OSC 8 hyperlink: ESC ] 8 ; ; url BEL text ESC ] 8 ; ; BEL
+        payload = "before\x1b]8;;http://evil.com\x07click\x1b]8;;\x07after"
+        rc, stdout, _ = run_hook(payload)
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertNotIn("evil.com", out["tool_result"])
+        self.assertIn("osc_escape", out["metadata"]["categories"])
+
 
 class TestNFKC(unittest.TestCase):
     def test_fullwidth_normalized(self):

--- a/internal/security/hooks/unicode_posttool_test.py
+++ b/internal/security/hooks/unicode_posttool_test.py
@@ -159,6 +159,43 @@ class TestVariationSelector(unittest.TestCase):
         self.assertIn("variation_selector", out["metadata"]["categories"])
 
 
+class TestNFKCEscapeBypass(unittest.TestCase):
+    def test_fullwidth_bracket_csi_detected_post_nfkc(self):
+        """R2-2: Fullwidth [ + ESC must be caught after NFKC normalization."""
+        # ESC + fullwidth [ (U+FF3B) + "31m" → NFKC → ESC[31m (valid CSI)
+        payload = "\x1b\uff3b31m"
+        rc, stdout, _ = run_hook(f"text{payload}more")
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertNotIn("\x1b", out["tool_result"])
+        self.assertIn("ansi_escape", out["metadata"]["categories"])
+        self.assertIn("fullwidth", out["metadata"]["categories"])
+
+    def test_fullwidth_bracket_osc_detected_post_nfkc(self):
+        """R2-2: Fullwidth ] + ESC must be caught after NFKC normalization."""
+        # ESC + fullwidth ] (U+FF3D) + OSC payload + BEL
+        payload = "\x1b\uff3d8;;http://evil.com\x07"
+        rc, stdout, _ = run_hook(f"before{payload}after")
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertNotIn("evil.com", out["tool_result"])
+        self.assertIn("osc_escape", out["metadata"]["categories"])
+
+
+class TestOSCPerformance(unittest.TestCase):
+    def test_unterminated_osc_linear_time(self):
+        """R2-3: Dense unterminated ESC] must not cause quadratic backtracking."""
+        import time
+
+        # 10K unterminated ESC] sequences — should complete in well under 1s
+        payload = "\x1b]AAAA" * 10000
+        start = time.time()
+        rc, stdout, _ = run_hook(payload)
+        elapsed = time.time() - start
+        self.assertEqual(rc, 0)
+        self.assertLess(elapsed, 1.0, f"OSC scan took {elapsed:.2f}s, expected < 1s")
+
+
 class TestProtocol(unittest.TestCase):
     def test_no_decoded_text_in_stdout(self):
         """C1: Decoded tag char text must NOT appear in stdout (injection vector)."""

--- a/internal/security/hooks/unicode_posttool_test.py
+++ b/internal/security/hooks/unicode_posttool_test.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Unit tests for unicode_posttool.py hook."""
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+HOOK = str(Path(__file__).parent / "unicode_posttool.py")
+
+
+def run_hook(tool_result: str | None = None, stdin_raw: str | None = None) -> tuple[int, str, str]:
+    """Run the hook script and return (exit_code, stdout, stderr)."""
+    if stdin_raw is None:
+        if tool_result is None:
+            stdin_raw = ""
+        else:
+            stdin_raw = json.dumps({"tool_name": "Read", "tool_result": tool_result})
+    proc = subprocess.run(
+        [sys.executable, HOOK],
+        input=stdin_raw,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+class TestCleanInput(unittest.TestCase):
+    def test_clean_text_passes_through(self):
+        rc, stdout, _ = run_hook("Hello, world!")
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout, "")
+
+    def test_empty_stdin(self):
+        rc, stdout, _ = run_hook(stdin_raw="")
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout, "")
+
+    def test_non_json_stdin(self):
+        rc, stdout, _ = run_hook(stdin_raw="not json")
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout, "")
+
+    def test_non_dict_json(self):
+        rc, stdout, _ = run_hook(stdin_raw=json.dumps([1, 2, 3]))
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout, "")
+
+    def test_non_string_tool_result(self):
+        rc, stdout, _ = run_hook(stdin_raw=json.dumps({"tool_result": 42}))
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout, "")
+
+    def test_empty_tool_result(self):
+        rc, stdout, _ = run_hook(tool_result="")
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout, "")
+
+
+class TestZeroWidth(unittest.TestCase):
+    def test_zero_width_space_stripped(self):
+        rc, stdout, _ = run_hook("hello\u200bworld")
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertEqual(out["tool_result"], "helloworld")
+        self.assertIn("zero_width", out["metadata"]["categories"])
+
+    def test_soft_hyphen_stripped(self):
+        rc, stdout, _ = run_hook("pass\u00adword")
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertEqual(out["tool_result"], "password")
+
+    def test_word_joiner_stripped(self):
+        rc, stdout, _ = run_hook("test\u2060data")
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertEqual(out["tool_result"], "testdata")
+        self.assertIn("zero_width", out["metadata"]["categories"])
+
+
+class TestBidiOverride(unittest.TestCase):
+    def test_bidi_override_stripped(self):
+        rc, stdout, _ = run_hook("abc\u202edef")
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertEqual(out["tool_result"], "abcdef")
+        self.assertIn("bidi_override", out["metadata"]["categories"])
+
+    def test_bidi_isolate_stripped(self):
+        rc, stdout, _ = run_hook("abc\u2066def\u2069")
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertEqual(out["tool_result"], "abcdef")
+        self.assertIn("bidi_override", out["metadata"]["categories"])
+
+
+class TestTagCharacters(unittest.TestCase):
+    def test_tag_chars_stripped(self):
+        # Tag-encode "HI" (U+E0048 U+E0049)
+        payload = "clean\U000e0048\U000e0049text"
+        rc, stdout, _ = run_hook(payload)
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertEqual(out["tool_result"], "cleantext")
+        self.assertIn("tag_char", out["metadata"]["categories"])
+
+    def test_tag_chars_always_exit_zero(self):
+        payload = "\U000e0048\U000e0049"
+        rc, _, _ = run_hook(payload)
+        self.assertEqual(rc, 0)
+
+
+class TestNullBytes(unittest.TestCase):
+    def test_null_bytes_stripped(self):
+        rc, stdout, _ = run_hook("hello\x00world")
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertEqual(out["tool_result"], "helloworld")
+        self.assertIn("null_byte", out["metadata"]["categories"])
+
+
+class TestAnsiEscape(unittest.TestCase):
+    def test_ansi_color_stripped(self):
+        rc, stdout, _ = run_hook("hello\x1b[31mred\x1b[0m")
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertEqual(out["tool_result"], "hellored")
+        self.assertIn("ansi_escape", out["metadata"]["categories"])
+
+
+class TestNFKC(unittest.TestCase):
+    def test_fullwidth_normalized(self):
+        # Fullwidth A = U+FF21
+        rc, stdout, _ = run_hook("\uff21\uff22\uff23")
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertEqual(out["tool_result"], "ABC")
+        self.assertIn("fullwidth", out["metadata"]["categories"])
+
+
+class TestVariationSelector(unittest.TestCase):
+    def test_variation_selector_stripped(self):
+        rc, stdout, _ = run_hook("test\ufe0fdata")
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertEqual(out["tool_result"], "testdata")
+        self.assertIn("variation_selector", out["metadata"]["categories"])
+
+
+class TestProtocol(unittest.TestCase):
+    def test_no_decoded_text_in_stdout(self):
+        """C1: Decoded tag char text must NOT appear in stdout (injection vector)."""
+        # Tag-encode "INJECT" → U+E0049 U+E004E U+E004A U+E0045 U+E0043 U+E0054
+        payload = "\U000e0049\U000e004e\U000e004a\U000e0045\U000e0043\U000e0054"
+        rc, stdout, _ = run_hook(f"clean{payload}text")
+        self.assertEqual(rc, 0)
+        self.assertNotIn("INJECT", stdout)
+        out = json.loads(stdout)
+        self.assertEqual(out["tool_result"], "cleantext")
+
+    def test_always_returns_tool_result(self):
+        rc, stdout, _ = run_hook("has\u200bzero\u200bwidth")
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertIn("tool_result", out)
+
+    def test_metadata_present(self):
+        rc, stdout, _ = run_hook("has\u200bzero")
+        self.assertEqual(rc, 0)
+        out = json.loads(stdout)
+        self.assertIn("metadata", out)
+        self.assertIn("unicode_findings", out["metadata"])
+        self.assertIn("categories", out["metadata"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/internal/security/hooks_test.go
+++ b/internal/security/hooks_test.go
@@ -26,7 +26,7 @@ func TestGenerateClaudeSettings_AllDefaults(t *testing.T) {
 	assert.Len(t, preTools, 2) // tirith + ssrf
 
 	postTools := hooks["PostToolUse"].([]any)
-	assert.Len(t, postTools, 1) // secret_redact
+	assert.Len(t, postTools, 2) // secret_redact + unicode
 }
 
 func TestGenerateClaudeSettings_TirithDisabled(t *testing.T) {
@@ -59,6 +59,7 @@ func TestGenerateClaudeSettings_AllHooksDisabled(t *testing.T) {
 				Tirith:               &harness.TirithConfig{Enabled: &disabled},
 				SSRFPreTool:          &disabled,
 				SecretRedactPostTool: &disabled,
+				UnicodePostTool:      &disabled,
 			},
 		},
 	}
@@ -76,10 +77,11 @@ func TestGenerateClaudeSettings_AllHooksDisabled(t *testing.T) {
 func TestHookFiles_AllDefaults(t *testing.T) {
 	h := &harness.Harness{Agent: "test.md"}
 	files := HookFiles(h)
-	assert.Len(t, files, 3)
+	assert.Len(t, files, 4)
 	assert.Contains(t, files, "tirith_check.py")
 	assert.Contains(t, files, "ssrf_pretool.py")
 	assert.Contains(t, files, "secret_redact_posttool.py")
+	assert.Contains(t, files, "unicode_posttool.py")
 
 	// Verify embedded content is non-empty.
 	for name, content := range files {
@@ -98,12 +100,49 @@ func TestHookFiles_SSRFDisabled(t *testing.T) {
 		},
 	}
 	files := HookFiles(h)
-	assert.Len(t, files, 2)
+	assert.Len(t, files, 3)
 	assert.NotContains(t, files, "ssrf_pretool.py")
+}
+
+func TestHookFiles_UnicodeDisabled(t *testing.T) {
+	disabled := false
+	h := &harness.Harness{
+		Agent: "test.md",
+		Security: &harness.SecurityConfig{
+			SandboxHooks: &harness.SandboxHooks{
+				UnicodePostTool: &disabled,
+			},
+		},
+	}
+	files := HookFiles(h)
+	assert.Len(t, files, 3)
+	assert.NotContains(t, files, "unicode_posttool.py")
 }
 
 func TestEmbeddedHooksNotEmpty(t *testing.T) {
 	assert.NotEmpty(t, SSRFPreToolHook)
 	assert.NotEmpty(t, SecretRedactPostToolHook)
 	assert.NotEmpty(t, TirithCheckHook)
+	assert.NotEmpty(t, UnicodePostToolHook)
+}
+
+func TestGenerateClaudeSettings_UnicodeDisabled(t *testing.T) {
+	disabled := false
+	h := &harness.Harness{
+		Agent: "test.md",
+		Security: &harness.SecurityConfig{
+			SandboxHooks: &harness.SandboxHooks{
+				UnicodePostTool: &disabled,
+			},
+		},
+	}
+	data, err := GenerateClaudeSettings(h)
+	require.NoError(t, err)
+
+	var settings map[string]any
+	require.NoError(t, json.Unmarshal(data, &settings))
+
+	hooks := settings["hooks"].(map[string]any)
+	postTools := hooks["PostToolUse"].([]any)
+	assert.Len(t, postTools, 1) // only secret_redact
 }

--- a/internal/security/hooks_test.go
+++ b/internal/security/hooks_test.go
@@ -157,3 +157,29 @@ func TestGenerateClaudeSettings_UnicodeDisabled(t *testing.T) {
 	chainedHooks := matcher["hooks"].([]any)
 	assert.Len(t, chainedHooks, 1) // only secret_redact
 }
+
+func TestGenerateClaudeSettings_SecretRedactDisabled(t *testing.T) {
+	disabled := false
+	h := &harness.Harness{
+		Agent: "test.md",
+		Security: &harness.SecurityConfig{
+			SandboxHooks: &harness.SandboxHooks{
+				SecretRedactPostTool: &disabled,
+			},
+		},
+	}
+	data, err := GenerateClaudeSettings(h)
+	require.NoError(t, err)
+
+	var settings map[string]any
+	require.NoError(t, json.Unmarshal(data, &settings))
+
+	hooks := settings["hooks"].(map[string]any)
+	postTools := hooks["PostToolUse"].([]any)
+	assert.Len(t, postTools, 1) // single matcher
+
+	// With secret_redact disabled, only unicode hook in the chain.
+	matcher := postTools[0].(map[string]any)
+	chainedHooks := matcher["hooks"].([]any)
+	assert.Len(t, chainedHooks, 1) // only unicode
+}

--- a/internal/security/hooks_test.go
+++ b/internal/security/hooks_test.go
@@ -26,7 +26,13 @@ func TestGenerateClaudeSettings_AllDefaults(t *testing.T) {
 	assert.Len(t, preTools, 2) // tirith + ssrf
 
 	postTools := hooks["PostToolUse"].([]any)
-	assert.Len(t, postTools, 2) // secret_redact + unicode
+	assert.Len(t, postTools, 1) // single matcher with chained hooks
+
+	// Verify both hooks are chained within the single matcher.
+	matcher := postTools[0].(map[string]any)
+	assert.Equal(t, "Bash|WebFetch|Read", matcher["matcher"])
+	chainedHooks := matcher["hooks"].([]any)
+	assert.Len(t, chainedHooks, 2) // secret_redact → unicode
 }
 
 func TestGenerateClaudeSettings_TirithDisabled(t *testing.T) {
@@ -144,5 +150,10 @@ func TestGenerateClaudeSettings_UnicodeDisabled(t *testing.T) {
 
 	hooks := settings["hooks"].(map[string]any)
 	postTools := hooks["PostToolUse"].([]any)
-	assert.Len(t, postTools, 1) // only secret_redact
+	assert.Len(t, postTools, 1) // single matcher
+
+	// With unicode disabled, only secret_redact hook in the chain.
+	matcher := postTools[0].(map[string]any)
+	chainedHooks := matcher["hooks"].([]any)
+	assert.Len(t, chainedHooks, 1) // only secret_redact
 }


### PR DESCRIPTION
## Summary

- Add a Claude Code PostToolUse hook (`unicode_posttool.py`) that scans tool results for hidden Unicode characters during agent runtime, closing the enforcement gap where unicode scanning previously relied on the agent voluntarily running the bash script
- The hook detects 6 categories aligned with the Go UnicodeNormalizer: tag characters (critical), zero-width/invisible operators (high), bidi overrides/isolates (high), null bytes (high), variation selectors (medium), and ANSI escapes (medium)
- All findings are sanitized (invisible characters stripped); critical findings are logged to `findings.jsonl` for post-script escalation. PostToolUse hooks always exit 0 — they sanitize, never block.
- PostToolUse hooks (secret_redact + unicode) are combined into a single matcher with chained hooks array so Claude Code executes them sequentially, avoiding parallel execution conflicts
- Includes 20 Python unit tests and 8 Go tests covering all detection categories, protocol compliance, and a regression test verifying decoded tag character text never appears in stdout (prompt injection vector)

## Changed files

| File | Change |
|------|--------|
| `internal/security/hooks/unicode_posttool.py` | New PostToolUse hook script |
| `internal/security/hooks/unicode_posttool_test.py` | 20 Python unit tests |
| `internal/security/hooks.go` | Embed hook, register in settings, combine PostToolUse matchers |
| `internal/security/hooks_test.go` | 8 Go tests for hook wiring and chaining |
| `internal/harness/harness.go` | Add `UnicodePostTool` config field (default: true) |

## Security considerations

- **C1 (fixed)**: Decoded steganographic text from tag characters is logged only to `findings.jsonl`, never to stdout where it would enter the LLM context as a prompt injection vector
- **H3 (fixed)**: PostToolUse hooks combined into single matcher to prevent parallel execution losing modifications
- **H4 (fixed)**: PostToolUse hooks cannot block (`exit(1)` is non-blocking) — all findings sanitize and return clean text via `exit(0)`

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./internal/security/` — all 30 tests pass
- [x] `python3 unicode_posttool_test.py` — all 20 tests pass
- [x] Tag char detection and stripping verified
- [x] C1 regression: decoded text confirmed absent from stdout
- [x] Hook chaining: single matcher with 2 hooks verified in Go tests
- [ ] Integration test in sandbox environment (follow-up)