### PR TITLE
fix: copy fullsend binary to sandbox for pre-agent security scan

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -540,6 +540,22 @@ func bootstrapSandbox(sshConfigPath, sandboxName, repoDir string, h *harness.Har
 		return fmt.Errorf("creating workspace dirs: %w", err)
 	}
 
+	// Copy fullsend binary into sandbox so `fullsend scan context` works.
+	// The pre-agent security scan runs inside the sandbox and needs the
+	// fullsend CLI to scan context files.
+	fullsendBinary, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("finding fullsend executable: %w", err)
+	}
+	remoteBinary := fmt.Sprintf("%s/bin/fullsend", sandbox.SandboxWorkspace)
+	if err := sandbox.SCP(sshConfigPath, sandboxName, fullsendBinary, remoteBinary); err != nil {
+		return fmt.Errorf("copying fullsend binary to sandbox: %w", err)
+	}
+	chmodCmd := fmt.Sprintf("chmod +x %s", remoteBinary)
+	if _, _, _, err := sandbox.SSH(sshConfigPath, sandboxName, chmodCmd, 10*time.Second); err != nil {
+		return fmt.Errorf("chmod fullsend binary: %w", err)
+	}
+
 	// Copy agent definition to $CLAUDE_CONFIG_DIR/agents/.
 	if err := sandbox.SCP(sshConfigPath, sandboxName, h.Agent,
 		fmt.Sprintf("%s/agents/", sandbox.SandboxClaudeConfig)); err != nil {
@@ -787,9 +803,12 @@ func buildScanContextCommand(repoDir, traceID string) string {
 	sort.Strings(inames) // deterministic ordering
 	inameExpr := strings.Join(inames, " -o ")
 
+	// Source .env to get PATH with /tmp/workspace/bin where fullsend is installed.
+	envFile := sandbox.SandboxWorkspace + "/.env"
+
 	return fmt.Sprintf(
-		"FULLSEND_TRACE_ID='%s' find '%s' -maxdepth 3 -type f \\( %s \\) -exec fullsend scan context {} +",
-		traceID, escapedDir, inameExpr,
+		"source %s && FULLSEND_TRACE_ID='%s' find '%s' -maxdepth 3 -type f \\( %s \\) -exec fullsend scan context {} +",
+		envFile, traceID, escapedDir, inameExpr,
 	)
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -73,6 +73,14 @@ func TestBuildClaudeCommand_EscapesQuotes(t *testing.T) {
 	assert.Contains(t, cmd, "'test'\\''name'")
 }
 
+func TestBuildScanContextCommand_SourcesEnv(t *testing.T) {
+	traceID := "aabbccdd-1122-4334-8556-aabbccddeeff"
+	cmd := buildScanContextCommand("/tmp/workspace/repo", traceID)
+	assert.Contains(t, cmd, "source /tmp/workspace/.env &&")
+	assert.Contains(t, cmd, "FULLSEND_TRACE_ID='"+traceID+"'")
+	assert.Contains(t, cmd, "-exec fullsend scan context")
+}
+
 func TestEnvToList_Sorted(t *testing.T) {
 	env := map[string]string{
 		"Z_VAR": "z",


### PR DESCRIPTION
## Summary

Fixes the pre-agent security scan failure where `fullsend scan context` couldn't be found inside the sandbox.

## Problem

The triage workflow failed with:
```
find: 'fullsend': No such file or directory
Error: pre-agent security scan blocked: critical findings detected
```

The pre-agent security scan runs **inside the sandbox** and executes:
```bash
find /tmp/workspace/target-repo -maxdepth 3 -type f \( ... \) -exec fullsend scan context {} +
```

However, the fullsend binary was only installed on the **GitHub Actions runner host**, not in the sandbox image.

## Solution

### 1. Copy fullsend binary into sandbox (`bootstrapSandbox`)
- Uses `os.Executable()` to find the current fullsend binary
- Copies it to `/tmp/workspace/bin/fullsend` in the sandbox
- Makes it executable with `chmod +x`

### 2. Source .env before scanning (`buildScanContextCommand`)
- Added `source /tmp/workspace/.env &&` before the find command
- Ensures PATH includes `/tmp/workspace/bin` where fullsend is installed

This approach:
- ✅ Works for both development (vendored binary) and production (released binary)
- ✅ Ensures version match between host CLI and sandbox CLI
- ✅ Follows the same pattern as `buildClaudeCommand` which also sources `.env`

## Test Plan

Manual verification:
- [ ] Run `fullsend run triage` locally with openshell available
- [ ] Verify pre-agent scan step completes without "No such file or directory" error

E2E verification:
- [ ] Trigger triage workflow on a test issue
- [ ] Verify workflow completes successfully

## Related

Fixes: https://github.com/fullsend-ai/.fullsend/actions/runs/24842943162/job/72721816328