### PR TITLE
fix: reconcile org secret access during repo enrollment

### DIFF
--- a/docs/superpowers/plans/2026-04-23-reconcile-org-secret-access.md
+++ b/docs/superpowers/plans/2026-04-23-reconcile-org-secret-access.md
@@ -1,0 +1,598 @@
+# Reconcile Org Secret Access Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `FULLSEND_DISPATCH_TOKEN` org secret repo access management from the installer into the reconcile-repos script so newly enrolled repos automatically get access.
+
+**Architecture:** Add `organization_secrets` permission to the fullsend app so the reconcile script's app token can manage org secret visibility. Extend `reconcile-repos.sh` to grant/revoke secret access during enroll/unenroll. Remove repo ID tracking from `DispatchTokenLayer` since the reconcile loop handles it.
+
+**Tech Stack:** Go, Bash, GitHub Actions, GitHub REST API
+
+---
+
+### Task 1: Add `OrganizationSecrets` to `AppPermissions` and fullsend app config
+
+**Files:**
+- Modify: `internal/forge/github/types.go:6-14` (add field to struct)
+- Modify: `internal/forge/github/types.go:63-74` (add permission to fullsend role)
+- Modify: `internal/forge/github/types_test.go:17-35` (assert new permission)
+
+- [ ] **Step 1: Write the failing test**
+
+In `internal/forge/github/types_test.go`, add an assertion to `TestAgentAppConfig_Fullsend`:
+
+```go
+assert.Equal(t, "write", cfg.Permissions.OrganizationSecrets)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/forge/github/ -run TestAgentAppConfig_Fullsend -v`
+Expected: FAIL — `OrganizationSecrets` field doesn't exist
+
+- [ ] **Step 3: Add `OrganizationSecrets` field to `AppPermissions`**
+
+In `internal/forge/github/types.go`, add to the `AppPermissions` struct:
+
+```go
+type AppPermissions struct {
+	Issues              string `json:"issues,omitempty"`
+	PullRequests        string `json:"pull_requests,omitempty"`
+	Checks              string `json:"checks,omitempty"`
+	Contents            string `json:"contents,omitempty"`
+	Workflows           string `json:"workflows,omitempty"`
+	Administration      string `json:"administration,omitempty"`
+	Members             string `json:"members,omitempty"`
+	OrganizationSecrets string `json:"organization_secrets,omitempty"`
+}
+```
+
+- [ ] **Step 4: Add the permission to the fullsend role in `AgentAppConfig`**
+
+In `internal/forge/github/types.go`, update the `"fullsend"` case:
+
+```go
+	case "fullsend":
+		base.Description = fmt.Sprintf("Fullsend orchestrator for %s", org)
+		base.Permissions = AppPermissions{
+			Contents:            "write",
+			Workflows:           "write",
+			Issues:              "read",
+			PullRequests:        "write",
+			Checks:              "read",
+			Administration:      "write",
+			Members:             "read",
+			OrganizationSecrets: "write",
+		}
+		base.Events = []string{"issues", "push", "workflow_dispatch"}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./internal/forge/github/ -run TestAgentAppConfig_Fullsend -v`
+Expected: PASS
+
+- [ ] **Step 6: Run all types tests**
+
+Run: `go test ./internal/forge/github/ -run TestAgentAppConfig -v`
+Expected: All pass (other roles should have empty `OrganizationSecrets`)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/forge/github/types.go internal/forge/github/types_test.go
+git commit -m "feat: add organization_secrets permission to fullsend app"
+```
+
+---
+
+### Task 2: Remove repo ID management from `DispatchTokenLayer`
+
+**Files:**
+- Modify: `internal/layers/dispatch.go:26-50` (remove `enrolledRepoIDs` field and constructor param)
+- Modify: `internal/layers/dispatch.go:73-108` (simplify Install to skip `SetOrgSecretRepos`)
+- Modify: `internal/layers/dispatch_test.go` (update all tests)
+
+- [ ] **Step 1: Update test helper and tests**
+
+In `internal/layers/dispatch_test.go`, remove `repoIDs` from the helper and all tests:
+
+```go
+func newDispatchLayer(t *testing.T, client *forge.FakeClient, token string) (*DispatchTokenLayer, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	layer := NewDispatchTokenLayer("test-org", client, token, printer, nil)
+	return layer, &buf
+}
+```
+
+Update `TestDispatchTokenLayer_Install_CreatesOrgSecret`:
+
+```go
+func TestDispatchTokenLayer_Install_CreatesOrgSecret(t *testing.T) {
+	client := &forge.FakeClient{}
+	layer, _ := newDispatchLayer(t, client, "ghp_secrettoken123")
+
+	err := layer.Install(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, client.CreatedOrgSecrets, 1)
+	assert.Equal(t, "test-org", client.CreatedOrgSecrets[0].Org)
+	assert.Equal(t, "FULLSEND_DISPATCH_TOKEN", client.CreatedOrgSecrets[0].Name)
+	assert.Equal(t, "ghp_secrettoken123", client.CreatedOrgSecrets[0].Value)
+	assert.Nil(t, client.CreatedOrgSecrets[0].RepoIDs)
+}
+```
+
+Update `TestDispatchTokenLayer_Install_ReusesExistingToken` — it should no longer call `SetOrgSecretRepos`:
+
+```go
+func TestDispatchTokenLayer_Install_ReusesExistingToken(t *testing.T) {
+	client := &forge.FakeClient{
+		OrgSecrets: map[string]bool{
+			"test-org/FULLSEND_DISPATCH_TOKEN": true,
+		},
+	}
+	layer, _ := newDispatchLayer(t, client, "")
+
+	err := layer.Install(context.Background())
+	require.NoError(t, err)
+
+	// No secret should be created when reusing existing.
+	assert.Empty(t, client.CreatedOrgSecrets)
+	// No SetOrgSecretRepos call — reconcile-repos.sh handles this now.
+	assert.Empty(t, client.OrgSecretRepoIDs)
+}
+```
+
+Update `TestDispatchTokenLayer_Install_Error`:
+
+```go
+func TestDispatchTokenLayer_Install_Error(t *testing.T) {
+	client := &forge.FakeClient{
+		Errors: map[string]error{"CreateOrgSecret": errors.New("permission denied")},
+	}
+	layer, _ := newDispatchLayer(t, client, "ghp_token")
+
+	err := layer.Install(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission denied")
+}
+```
+
+Update `TestDispatchTokenLayer_Install_CallsPromptFn`:
+
+```go
+func TestDispatchTokenLayer_Install_CallsPromptFn(t *testing.T) {
+	client := &forge.FakeClient{
+		OrgSecrets: map[string]bool{}, // secret does not exist
+	}
+
+	promptFn := func(ctx context.Context) (string, error) {
+		return "ghp_prompted_token", nil
+	}
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	layer := NewDispatchTokenLayer("test-org", client, "", printer, promptFn)
+
+	err := layer.Install(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, client.CreatedOrgSecrets, 1)
+	assert.Equal(t, "test-org", client.CreatedOrgSecrets[0].Org)
+	assert.Equal(t, "FULLSEND_DISPATCH_TOKEN", client.CreatedOrgSecrets[0].Name)
+	assert.Equal(t, "ghp_prompted_token", client.CreatedOrgSecrets[0].Value)
+	assert.Nil(t, client.CreatedOrgSecrets[0].RepoIDs)
+}
+```
+
+Update `TestDispatchTokenLayer_Install_ErrorWhenNoPromptFn`:
+
+```go
+func TestDispatchTokenLayer_Install_ErrorWhenNoPromptFn(t *testing.T) {
+	client := &forge.FakeClient{
+		OrgSecrets: map[string]bool{}, // secret does not exist
+	}
+	layer, _ := newDispatchLayer(t, client, "")
+
+	err := layer.Install(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dispatch token not provided")
+	assert.Contains(t, err.Error(), "does not exist")
+}
+```
+
+Update `TestDispatchTokenLayer_Install_PromptFnError`:
+
+```go
+func TestDispatchTokenLayer_Install_PromptFnError(t *testing.T) {
+	client := &forge.FakeClient{
+		OrgSecrets: map[string]bool{}, // secret does not exist
+	}
+
+	promptFn := func(ctx context.Context) (string, error) {
+		return "", errors.New("user cancelled")
+	}
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	layer := NewDispatchTokenLayer("test-org", client, "", printer, promptFn)
+
+	err := layer.Install(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user cancelled")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/layers/ -run TestDispatchToken -v`
+Expected: FAIL — constructor signature mismatch
+
+- [ ] **Step 3: Update `DispatchTokenLayer` struct and constructor**
+
+In `internal/layers/dispatch.go`, remove `enrolledRepoIDs` from the struct and constructor:
+
+```go
+type DispatchTokenLayer struct {
+	org           string
+	client        forge.Client
+	dispatchToken string // the PAT value to store (empty if reusing existing)
+	ui            *ui.Printer
+	promptFn      PromptTokenFunc
+}
+
+func NewDispatchTokenLayer(org string, client forge.Client, token string, printer *ui.Printer, promptFn PromptTokenFunc) *DispatchTokenLayer {
+	return &DispatchTokenLayer{
+		org:           org,
+		client:        client,
+		dispatchToken: token,
+		ui:            printer,
+		promptFn:      promptFn,
+	}
+}
+```
+
+- [ ] **Step 4: Simplify `Install` method**
+
+Remove the `SetOrgSecretRepos` call from the "reuse existing" path. The method becomes:
+
+```go
+func (l *DispatchTokenLayer) Install(ctx context.Context) error {
+	if l.dispatchToken != "" {
+		return l.createSecret(ctx, l.dispatchToken)
+	}
+
+	exists, err := l.client.OrgSecretExists(ctx, l.org, dispatchTokenName)
+	if err != nil {
+		return fmt.Errorf("checking org secret %s: %w", dispatchTokenName, err)
+	}
+
+	if exists {
+		l.ui.StepInfo("reusing existing dispatch token")
+		return nil
+	}
+
+	if l.promptFn == nil {
+		return fmt.Errorf("dispatch token not provided and org secret %s does not exist", dispatchTokenName)
+	}
+
+	token, err := l.promptFn(ctx)
+	if err != nil {
+		return fmt.Errorf("prompting for dispatch token: %w", err)
+	}
+
+	return l.createSecret(ctx, token)
+}
+```
+
+Update `createSecret` to pass `nil` for repo IDs:
+
+```go
+func (l *DispatchTokenLayer) createSecret(ctx context.Context, token string) error {
+	l.ui.StepStart("creating org secret " + dispatchTokenName)
+	if err := l.client.CreateOrgSecret(ctx, l.org, dispatchTokenName, token, nil); err != nil {
+		l.ui.StepFail(fmt.Sprintf("failed to create org secret %s", dispatchTokenName))
+		return fmt.Errorf("creating org secret %s: %w", dispatchTokenName, err)
+	}
+	l.ui.StepDone("created org secret " + dispatchTokenName)
+	return nil
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/layers/ -run TestDispatchToken -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/layers/dispatch.go internal/layers/dispatch_test.go
+git commit -m "refactor: remove repo ID management from DispatchTokenLayer
+
+Repo access to the FULLSEND_DISPATCH_TOKEN org secret is now managed
+by reconcile-repos.sh instead of the installer."
+```
+
+---
+
+### Task 3: Remove `collectEnrolledRepoIDs` and plumbing from `admin.go`
+
+**Files:**
+- Modify: `internal/cli/admin.go:348-349` (remove call in analyze path)
+- Modify: `internal/cli/admin.go:418-434` (remove call in install path)
+- Modify: `internal/cli/admin.go:487-493` (update uninstall path)
+- Modify: `internal/cli/admin.go:621-646` (remove param from `buildLayerStack`)
+- Delete: `internal/cli/admin.go:770-782` (`collectEnrolledRepoIDs` function)
+
+- [ ] **Step 1: Remove `enrolledRepoIDs` param from `buildLayerStack`**
+
+Update the function signature and the `NewDispatchTokenLayer` call:
+
+```go
+func buildLayerStack(
+	org string,
+	client forge.Client,
+	cfg *config.OrgConfig,
+	printer *ui.Printer,
+	user string,
+	hasPrivate bool,
+	enabledRepos []string,
+	agentCreds []layers.AgentCredentials,
+	inferenceProvider inference.Provider,
+	vendorBinary bool,
+	vendorFn layers.VendorFunc,
+	promptTokenFn layers.PromptTokenFunc,
+) *layers.Stack {
+	return layers.NewStack(
+		layers.NewConfigRepoLayer(org, client, cfg, printer, hasPrivate),
+		layers.NewWorkflowsLayer(org, client, printer, user),
+		layers.NewVendorBinaryLayer(org, client, printer, vendorBinary, vendorFn),
+		layers.NewSecretsLayer(org, client, agentCreds, printer),
+		layers.NewInferenceLayer(org, client, inferenceProvider, printer),
+		layers.NewDispatchTokenLayer(org, client, "", printer, promptTokenFn),
+		layers.NewEnrollmentLayer(org, client, enabledRepos, cfg.DisabledRepos(), printer),
+	)
+}
+```
+
+- [ ] **Step 2: Update call sites**
+
+In the analyze path (~line 348-349), remove `enrolledRepoIDs`:
+
+```go
+stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, enabledRepos, agentCreds, inferenceProvider, false, nil, nil)
+```
+
+In the install path (~line 418-434), remove `enrolledRepoIDs`:
+
+```go
+stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, enabledRepos, agentCreds, inferenceProvider, vendorBinary, vendorFullsendBinary, func(ctx context.Context) (string, error) {
+	return promptDispatchToken(ctx, client, printer, org)
+})
+```
+
+In the uninstall path (~line 487-493), update `NewDispatchTokenLayer`:
+
+```go
+layers.NewDispatchTokenLayer(org, client, "", printer, nil),
+```
+
+- [ ] **Step 3: Delete `collectEnrolledRepoIDs`**
+
+Remove the function at lines 770-782 and its corresponding call sites (the two `enrolledRepoIDs := collectEnrolledRepoIDs(...)` lines).
+
+- [ ] **Step 4: Run all Go tests**
+
+Run: `go test ./...`
+Expected: All PASS
+
+- [ ] **Step 5: Run vet and lint**
+
+Run: `make lint && make go-vet`
+Expected: Clean
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/cli/admin.go
+git commit -m "refactor: remove enrolledRepoIDs plumbing from admin CLI
+
+The installer no longer sets per-repo access on the dispatch token
+org secret. This is now handled by the reconcile-repos script."
+```
+
+---
+
+### Task 4: Add org secret access management to `reconcile-repos.sh`
+
+**Files:**
+- Modify: `internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh`
+
+- [ ] **Step 1: Add the `DISPATCH_SECRET_NAME` constant**
+
+Near the top of the script, after the existing constants (line 21), add:
+
+```bash
+DISPATCH_SECRET_NAME="FULLSEND_DISPATCH_TOKEN"
+```
+
+- [ ] **Step 2: Add a helper function to grant org secret access**
+
+After the `close_pr_on_branch` function (after line 76), add:
+
+```bash
+# grant_secret_access adds a repo to the org secret's selected repositories.
+grant_secret_access() {
+  local repo="$1"
+  local repo_id
+  repo_id=$(gh api "repos/$ORG/$repo" --jq '.id' 2>/dev/null || true)
+  if [ -z "$repo_id" ]; then
+    echo "::warning::Could not get repo ID for $repo, skipping secret access grant"
+    return
+  fi
+  if gh api "orgs/$ORG/actions/secrets/$DISPATCH_SECRET_NAME/repositories/$repo_id" \
+    --method PUT --silent 2>/dev/null; then
+    echo "  Granted $DISPATCH_SECRET_NAME access to $repo"
+  else
+    echo "::warning::Failed to grant $DISPATCH_SECRET_NAME access to $repo"
+  fi
+}
+
+# revoke_secret_access removes a repo from the org secret's selected repositories.
+revoke_secret_access() {
+  local repo="$1"
+  local repo_id
+  repo_id=$(gh api "repos/$ORG/$repo" --jq '.id' 2>/dev/null || true)
+  if [ -z "$repo_id" ]; then
+    echo "::warning::Could not get repo ID for $repo, skipping secret access revoke"
+    return
+  fi
+  gh api "orgs/$ORG/actions/secrets/$DISPATCH_SECRET_NAME/repositories/$repo_id" \
+    --method DELETE --silent 2>/dev/null || true
+  echo "  Revoked $DISPATCH_SECRET_NAME access from $repo"
+}
+```
+
+- [ ] **Step 3: Call `grant_secret_access` after successful enrollment**
+
+In Phase 1, after `echo "✓ $REPO already enrolled"` (line 99), add:
+
+```bash
+      grant_secret_access "$REPO"
+```
+
+After `echo "✓ Created enrollment PR for $REPO: $PR_URL"` (line 192), add:
+
+```bash
+    grant_secret_access "$REPO"
+```
+
+Also after the existing-PR update path, after the `ENROLLED=$((ENROLLED + 1))` on line 119, add:
+
+```bash
+      grant_secret_access "$REPO"
+```
+
+- [ ] **Step 4: Call `revoke_secret_access` after successful unenrollment**
+
+In Phase 2, after `echo "✓ Created removal PR for $REPO: $PR_URL"` (line 302), add:
+
+```bash
+    revoke_secret_access "$REPO"
+```
+
+After `echo "✓ $REPO already unenrolled (no shim on default branch)"` (line 232), add:
+
+```bash
+      revoke_secret_access "$REPO"
+```
+
+- [ ] **Step 5: Test the script syntax**
+
+Run: `bash -n internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh`
+Expected: No syntax errors
+
+- [ ] **Step 6: Run lint**
+
+Run: `make lint`
+Expected: Clean
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh
+git commit -m "feat: reconcile-repos grants/revokes org secret access
+
+When enrolling a repo, grant it access to FULLSEND_DISPATCH_TOKEN.
+When unenrolling, revoke access. This ensures newly enrolled repos
+can use the dispatch token without manual secret configuration.
+
+Relates to: https://github.com/konflux-ci/caching/actions/runs/24844542404/job/72727757382?pr=781"
+```
+
+---
+
+### Task 5: Update `repo-maintenance.yml` comment to document the new permission requirement
+
+**Files:**
+- Modify: `internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml`
+
+- [ ] **Step 1: Update the workflow comment**
+
+Add a comment documenting that the fullsend app needs `organization_secrets: write` for secret access management. Update the `Reconcile target repos` step name to reflect both enrollment and secret access:
+
+```yaml
+name: Repo Maintenance
+
+on:
+  push:
+    branches: [main]
+    paths: [config.yaml]
+  workflow_dispatch:
+
+concurrency:
+  group: repo-maintenance
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  reconcile:
+    name: Reconcile enrollment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout .fullsend
+        uses: actions/checkout@v6
+
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.FULLSEND_FULLSEND_CLIENT_ID }}
+          private-key: ${{ secrets.FULLSEND_FULLSEND_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      # Reconciles enrollment state and org secret access for each repo.
+      # Requires the fullsend app to have organization_secrets:write permission.
+      - name: Reconcile target repos
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          WORKSPACE: ${{ github.workspace }}
+        run: bash scripts/reconcile-repos.sh "$WORKSPACE"
+```
+
+- [ ] **Step 2: Run lint**
+
+Run: `make lint`
+Expected: Clean
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
+git commit -m "docs: document organization_secrets permission requirement in repo-maintenance"
+```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Run all Go tests**
+
+Run: `make go-test`
+Expected: All PASS
+
+- [ ] **Step 2: Run vet**
+
+Run: `make go-vet`
+Expected: Clean
+
+- [ ] **Step 3: Run lint**
+
+Run: `make lint`
+Expected: Clean

--- a/docs/superpowers/specs/2026-04-23-reconcile-org-secret-access-design.md
+++ b/docs/superpowers/specs/2026-04-23-reconcile-org-secret-access-design.md
@@ -1,0 +1,60 @@
+# Reconcile Org Secret Access
+
+**Date:** 2026-04-23
+**Status:** Approved
+**Relates to:** https://github.com/konflux-ci/caching/actions/runs/24844542404/job/72727757382?pr=781
+
+## Problem
+
+The `FULLSEND_DISPATCH_TOKEN` org secret has visibility "selected", scoped to specific repos. The installer sets the repo access list at install time, but when `reconcile-repos.sh` later enrolls new repos, it never updates the access list. Newly enrolled repos cannot see the secret, so their shim workflows fail with `GH_TOKEN` not set.
+
+## Design
+
+Move org secret repo access management from the installer into the reconcile loop, so access stays in sync with enrollment state.
+
+### 1. Add `organization_secrets` permission to the fullsend app
+
+Add `OrganizationSecrets: "write"` to the `AppPermissions` struct and to the `fullsend` role in `AgentAppConfig`. This lets the app token generated in `repo-maintenance.yml` manage org secret visibility.
+
+**Files:** `internal/forge/github/types.go`
+
+### 2. Manage secret access in `reconcile-repos.sh`
+
+After enrolling a repo, grant it access to the dispatch token:
+
+```
+gh api "orgs/$ORG/actions/secrets/FULLSEND_DISPATCH_TOKEN/repositories/$REPO_ID" --method PUT --silent
+```
+
+After unenrolling a repo, revoke access:
+
+```
+gh api "orgs/$ORG/actions/secrets/FULLSEND_DISPATCH_TOKEN/repositories/$REPO_ID" --method DELETE --silent
+```
+
+The repo ID comes from the `gh api repos/{org}/{repo}` call already made to get the default branch — capture `.id` from the same response.
+
+**Files:** `internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh`
+
+### 3. Remove repo access management from the installer
+
+- `DispatchTokenLayer.Install()`: Remove the `SetOrgSecretRepos` call. The installer creates the secret with `visibility: "selected"` and no repos.
+- Remove `enrolledRepoIDs` from `DispatchTokenLayer` and its constructor.
+- Remove `collectEnrolledRepoIDs` from `admin.go` and the plumbing that passes repo IDs through `buildLayerStack`.
+
+**Files:** `internal/layers/dispatch.go`, `internal/layers/dispatch_test.go`, `internal/cli/admin.go`
+
+### 4. Update tests
+
+- Update `dispatch_test.go` to remove repo ID assertions from install tests.
+- Update any `admin.go` tests that exercise `collectEnrolledRepoIDs` or `buildLayerStack` with repo IDs.
+
+### Edge case: first install
+
+The installer creates the secret with no repos. It then dispatches `repo-maintenance.yml`, which enrolls repos and grants them secret access. The shim workflow works as soon as the enrollment PR merges.
+
+### What stays the same
+
+- `SetOrgSecretRepos` remains in the forge interface (useful for other callers).
+- The reconcile script's existing enrollment/unenrollment PR logic is unchanged.
+- `CreateOrgSecret` still uses `visibility: "selected"`.

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -345,8 +345,7 @@ func runDryRun(ctx context.Context, client forge.Client, printer *ui.Printer, or
 		})
 	}
 
-	enrolledRepoIDs := collectEnrolledRepoIDs(allRepos, enabledRepos)
-	stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, false, nil, nil)
+	stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, enabledRepos, agentCreds, inferenceProvider, false, nil, nil)
 
 	if err := runPreflight(ctx, stack, layers.OpInstall, client, printer); err != nil {
 		return err
@@ -415,9 +414,6 @@ func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, o
 	printer.StepDone(fmt.Sprintf("Found %d repositories", len(allRepos)))
 	printer.Blank()
 
-	// Collect IDs for repos that will be enrolled.
-	enrolledRepoIDs := collectEnrolledRepoIDs(allRepos, enabledRepos)
-
 	// Build agent entries for config.
 	agents := make([]config.AgentEntry, len(agentCreds))
 	for i, ac := range agentCreds {
@@ -431,7 +427,7 @@ func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, o
 		return fmt.Errorf("getting authenticated user: %w", err)
 	}
 
-	stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, vendorBinary, vendorFullsendBinary, func(ctx context.Context) (string, error) {
+	stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, enabledRepos, agentCreds, inferenceProvider, vendorBinary, vendorFullsendBinary, func(ctx context.Context) (string, error) {
 		return promptDispatchToken(ctx, client, printer, org)
 	})
 
@@ -489,7 +485,7 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 		layers.NewWorkflowsLayer(org, client, printer, ""),
 		layers.NewSecretsLayer(org, client, nil, printer),
 		layers.NewInferenceLayer(org, client, nil, printer),
-		layers.NewDispatchTokenLayer(org, client, "", nil, printer, nil),
+		layers.NewDispatchTokenLayer(org, client, "", printer, nil),
 		layers.NewEnrollmentLayer(org, client, nil, nil, printer),
 	)
 
@@ -608,7 +604,7 @@ func runAnalyze(ctx context.Context, client forge.Client, printer *ui.Printer, o
 		inferenceProvider = vertex.NewAnalyzeOnly()
 	}
 
-	stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, nil, agentCreds, nil, inferenceProvider, false, nil, nil)
+	stack := buildLayerStack(org, client, cfg, printer, user, hasPrivate, nil, agentCreds, inferenceProvider, false, nil, nil)
 
 	if err := runPreflight(ctx, stack, layers.OpAnalyze, client, printer); err != nil {
 		return err
@@ -628,7 +624,6 @@ func buildLayerStack(
 	hasPrivate bool,
 	enabledRepos []string,
 	agentCreds []layers.AgentCredentials,
-	enrolledRepoIDs []int64,
 	inferenceProvider inference.Provider,
 	vendorBinary bool,
 	vendorFn layers.VendorFunc,
@@ -640,7 +635,7 @@ func buildLayerStack(
 		layers.NewVendorBinaryLayer(org, client, printer, vendorBinary, vendorFn),
 		layers.NewSecretsLayer(org, client, agentCreds, printer),
 		layers.NewInferenceLayer(org, client, inferenceProvider, printer),
-		layers.NewDispatchTokenLayer(org, client, "", enrolledRepoIDs, printer, promptTokenFn),
+		layers.NewDispatchTokenLayer(org, client, "", printer, promptTokenFn),
 		layers.NewEnrollmentLayer(org, client, enabledRepos, cfg.DisabledRepos(), printer),
 	)
 }
@@ -763,22 +758,6 @@ func loadKnownSlugs(ctx context.Context, client forge.Client, org string) map[st
 		return nil
 	}
 	return cfg.AgentSlugs()
-}
-
-// collectEnrolledRepoIDs returns the IDs of repos whose names appear in
-// the enabledRepos list.
-func collectEnrolledRepoIDs(allRepos []forge.Repository, enabledRepos []string) []int64 {
-	enabled := make(map[string]bool, len(enabledRepos))
-	for _, name := range enabledRepos {
-		enabled[name] = true
-	}
-	var ids []int64
-	for _, r := range allRepos {
-		if enabled[r.Name] {
-			ids = append(ids, r.ID)
-		}
-	}
-	return ids
 }
 
 // promptDispatchToken checks whether the dispatch token org secret already

--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -4,13 +4,14 @@ import "fmt"
 
 // AppPermissions defines the permissions for a GitHub App.
 type AppPermissions struct {
-	Issues         string `json:"issues,omitempty"`
-	PullRequests   string `json:"pull_requests,omitempty"`
-	Checks         string `json:"checks,omitempty"`
-	Contents       string `json:"contents,omitempty"`
-	Workflows      string `json:"workflows,omitempty"`
-	Administration string `json:"administration,omitempty"`
-	Members        string `json:"members,omitempty"`
+	Issues              string `json:"issues,omitempty"`
+	PullRequests        string `json:"pull_requests,omitempty"`
+	Checks              string `json:"checks,omitempty"`
+	Contents            string `json:"contents,omitempty"`
+	Workflows           string `json:"workflows,omitempty"`
+	Administration      string `json:"administration,omitempty"`
+	Members             string `json:"members,omitempty"`
+	OrganizationSecrets string `json:"organization_secrets,omitempty"`
 }
 
 // HookAttributes configures the webhook for a GitHub App.
@@ -63,13 +64,14 @@ func AgentAppConfig(org, role string) AppConfig {
 	case "fullsend":
 		base.Description = fmt.Sprintf("Fullsend orchestrator for %s", org)
 		base.Permissions = AppPermissions{
-			Contents:       "write",
-			Workflows:      "write",
-			Issues:         "read",
-			PullRequests:   "write",
-			Checks:         "read",
-			Administration: "write",
-			Members:        "read",
+			Contents:            "write",
+			Workflows:           "write",
+			Issues:              "read",
+			PullRequests:        "write",
+			Checks:              "read",
+			Administration:      "write",
+			Members:             "read",
+			OrganizationSecrets: "write",
 		}
 		base.Events = []string{"issues", "push", "workflow_dispatch"}
 

--- a/internal/forge/github/types_test.go
+++ b/internal/forge/github/types_test.go
@@ -28,6 +28,7 @@ func TestAgentAppConfig_Fullsend(t *testing.T) {
 	assert.Equal(t, "read", cfg.Permissions.Checks)
 	assert.Equal(t, "write", cfg.Permissions.Administration)
 	assert.Equal(t, "read", cfg.Permissions.Members)
+	assert.Equal(t, "write", cfg.Permissions.OrganizationSecrets)
 
 	assert.Contains(t, cfg.Events, "issues")
 	assert.Contains(t, cfg.Events, "push")

--- a/internal/layers/dispatch.go
+++ b/internal/layers/dispatch.go
@@ -24,12 +24,11 @@ type PromptTokenFunc func(ctx context.Context) (string, error)
 // This way, enrolled repos can trigger dispatches but never access the
 // App private keys (which are repo-level secrets on .fullsend).
 type DispatchTokenLayer struct {
-	org             string
-	client          forge.Client
-	dispatchToken   string  // the PAT value to store (empty if reusing existing)
-	enrolledRepoIDs []int64 // repo IDs that should have access to this secret
-	ui              *ui.Printer
-	promptFn        PromptTokenFunc // optional callback to prompt for token interactively
+	org           string
+	client        forge.Client
+	dispatchToken string // the PAT value to store (empty if reusing existing)
+	ui            *ui.Printer
+	promptFn      PromptTokenFunc // optional callback to prompt for token interactively
 }
 
 var _ Layer = (*DispatchTokenLayer)(nil)
@@ -38,14 +37,13 @@ var _ Layer = (*DispatchTokenLayer)(nil)
 // If promptFn is non-nil, it will be called during Install to obtain a
 // dispatch token interactively when none was provided and the org secret
 // doesn't already exist.
-func NewDispatchTokenLayer(org string, client forge.Client, token string, repoIDs []int64, printer *ui.Printer, promptFn PromptTokenFunc) *DispatchTokenLayer {
+func NewDispatchTokenLayer(org string, client forge.Client, token string, printer *ui.Printer, promptFn PromptTokenFunc) *DispatchTokenLayer {
 	return &DispatchTokenLayer{
-		org:             org,
-		client:          client,
-		dispatchToken:   token,
-		enrolledRepoIDs: repoIDs,
-		ui:              printer,
-		promptFn:        promptFn,
+		org:           org,
+		client:        client,
+		dispatchToken: token,
+		ui:            printer,
+		promptFn:      promptFn,
 	}
 }
 
@@ -67,7 +65,7 @@ func (l *DispatchTokenLayer) RequiredScopes(op Operation) []string {
 // Install creates or updates the org-level dispatch token secret.
 // If dispatchToken is non-empty, the secret is created with that value.
 // If dispatchToken is empty, the method checks whether the secret already
-// exists. If it does, the repo access list is updated. If it doesn't and
+// exists. If it does, the existing secret is reused. If it doesn't and
 // promptFn is set, promptFn is called to obtain a token interactively.
 // If it doesn't exist and promptFn is nil, an error is returned.
 func (l *DispatchTokenLayer) Install(ctx context.Context) error {
@@ -83,14 +81,6 @@ func (l *DispatchTokenLayer) Install(ctx context.Context) error {
 
 	if exists {
 		l.ui.StepInfo("reusing existing dispatch token")
-		if len(l.enrolledRepoIDs) > 0 {
-			l.ui.StepStart("updating dispatch token repo access list")
-			if err := l.client.SetOrgSecretRepos(ctx, l.org, dispatchTokenName, l.enrolledRepoIDs); err != nil {
-				l.ui.StepFail("failed to update dispatch token repo access")
-				return fmt.Errorf("updating org secret repo access: %w", err)
-			}
-			l.ui.StepDone("updated dispatch token repo access list")
-		}
 		return nil
 	}
 
@@ -109,7 +99,7 @@ func (l *DispatchTokenLayer) Install(ctx context.Context) error {
 
 func (l *DispatchTokenLayer) createSecret(ctx context.Context, token string) error {
 	l.ui.StepStart("creating org secret " + dispatchTokenName)
-	if err := l.client.CreateOrgSecret(ctx, l.org, dispatchTokenName, token, l.enrolledRepoIDs); err != nil {
+	if err := l.client.CreateOrgSecret(ctx, l.org, dispatchTokenName, token, nil); err != nil {
 		l.ui.StepFail(fmt.Sprintf("failed to create org secret %s", dispatchTokenName))
 		return fmt.Errorf("creating org secret %s: %w", dispatchTokenName, err)
 	}

--- a/internal/layers/dispatch_test.go
+++ b/internal/layers/dispatch_test.go
@@ -13,23 +13,22 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
-func newDispatchLayer(t *testing.T, client *forge.FakeClient, token string, repoIDs []int64) (*DispatchTokenLayer, *bytes.Buffer) {
+func newDispatchLayer(t *testing.T, client *forge.FakeClient, token string) (*DispatchTokenLayer, *bytes.Buffer) {
 	t.Helper()
 	var buf bytes.Buffer
 	printer := ui.New(&buf)
-	layer := NewDispatchTokenLayer("test-org", client, token, repoIDs, printer, nil)
+	layer := NewDispatchTokenLayer("test-org", client, token, printer, nil)
 	return layer, &buf
 }
 
 func TestDispatchTokenLayer_Name(t *testing.T) {
-	layer, _ := newDispatchLayer(t, &forge.FakeClient{}, "", nil)
+	layer, _ := newDispatchLayer(t, &forge.FakeClient{}, "")
 	assert.Equal(t, "dispatch-token", layer.Name())
 }
 
 func TestDispatchTokenLayer_Install_CreatesOrgSecret(t *testing.T) {
 	client := &forge.FakeClient{}
-	repoIDs := []int64{100, 200, 300}
-	layer, _ := newDispatchLayer(t, client, "ghp_secrettoken123", repoIDs)
+	layer, _ := newDispatchLayer(t, client, "ghp_secrettoken123")
 
 	err := layer.Install(context.Background())
 	require.NoError(t, err)
@@ -38,7 +37,7 @@ func TestDispatchTokenLayer_Install_CreatesOrgSecret(t *testing.T) {
 	assert.Equal(t, "test-org", client.CreatedOrgSecrets[0].Org)
 	assert.Equal(t, "FULLSEND_DISPATCH_TOKEN", client.CreatedOrgSecrets[0].Name)
 	assert.Equal(t, "ghp_secrettoken123", client.CreatedOrgSecrets[0].Value)
-	assert.Equal(t, repoIDs, client.CreatedOrgSecrets[0].RepoIDs)
+	assert.Nil(t, client.CreatedOrgSecrets[0].RepoIDs)
 }
 
 func TestDispatchTokenLayer_Install_ReusesExistingToken(t *testing.T) {
@@ -47,25 +46,22 @@ func TestDispatchTokenLayer_Install_ReusesExistingToken(t *testing.T) {
 			"test-org/FULLSEND_DISPATCH_TOKEN": true,
 		},
 	}
-	repoIDs := []int64{100, 200}
-	layer, _ := newDispatchLayer(t, client, "", repoIDs)
+	layer, _ := newDispatchLayer(t, client, "")
 
 	err := layer.Install(context.Background())
 	require.NoError(t, err)
 
-	// No secret should be created when reusing existing
+	// No secret should be created when reusing existing.
 	assert.Empty(t, client.CreatedOrgSecrets)
-
-	// But SetOrgSecretRepos should still be called to update access list
-	require.Contains(t, client.OrgSecretRepoIDs, "test-org/FULLSEND_DISPATCH_TOKEN")
-	assert.Equal(t, repoIDs, client.OrgSecretRepoIDs["test-org/FULLSEND_DISPATCH_TOKEN"])
+	// No SetOrgSecretRepos call — reconcile-repos.sh handles this now.
+	assert.Empty(t, client.OrgSecretRepoIDs)
 }
 
 func TestDispatchTokenLayer_Install_Error(t *testing.T) {
 	client := &forge.FakeClient{
 		Errors: map[string]error{"CreateOrgSecret": errors.New("permission denied")},
 	}
-	layer, _ := newDispatchLayer(t, client, "ghp_token", []int64{100})
+	layer, _ := newDispatchLayer(t, client, "ghp_token")
 
 	err := layer.Install(context.Background())
 	require.Error(t, err)
@@ -78,7 +74,7 @@ func TestDispatchTokenLayer_Uninstall_DeletesSecret(t *testing.T) {
 			"test-org/FULLSEND_DISPATCH_TOKEN": true,
 		},
 	}
-	layer, _ := newDispatchLayer(t, client, "", nil)
+	layer, _ := newDispatchLayer(t, client, "")
 
 	err := layer.Uninstall(context.Background())
 	require.NoError(t, err)
@@ -91,7 +87,7 @@ func TestDispatchTokenLayer_Uninstall_AlreadyDeleted(t *testing.T) {
 	client := &forge.FakeClient{
 		OrgSecrets: map[string]bool{}, // secret doesn't exist
 	}
-	layer, _ := newDispatchLayer(t, client, "", nil)
+	layer, _ := newDispatchLayer(t, client, "")
 
 	err := layer.Uninstall(context.Background())
 	require.NoError(t, err)
@@ -106,7 +102,7 @@ func TestDispatchTokenLayer_Analyze_Installed(t *testing.T) {
 			"test-org/FULLSEND_DISPATCH_TOKEN": true,
 		},
 	}
-	layer, _ := newDispatchLayer(t, client, "", nil)
+	layer, _ := newDispatchLayer(t, client, "")
 
 	report, err := layer.Analyze(context.Background())
 	require.NoError(t, err)
@@ -121,7 +117,7 @@ func TestDispatchTokenLayer_Analyze_NotInstalled(t *testing.T) {
 	client := &forge.FakeClient{
 		OrgSecrets: map[string]bool{},
 	}
-	layer, _ := newDispatchLayer(t, client, "", nil)
+	layer, _ := newDispatchLayer(t, client, "")
 
 	report, err := layer.Analyze(context.Background())
 	require.NoError(t, err)
@@ -133,7 +129,7 @@ func TestDispatchTokenLayer_Analyze_NotInstalled(t *testing.T) {
 }
 
 func TestDispatchTokenLayer_RequiredScopes(t *testing.T) {
-	layer, _ := newDispatchLayer(t, &forge.FakeClient{}, "", nil)
+	layer, _ := newDispatchLayer(t, &forge.FakeClient{}, "")
 
 	assert.Equal(t, []string{"admin:org"}, layer.RequiredScopes(OpInstall))
 	assert.Equal(t, []string{"admin:org"}, layer.RequiredScopes(OpUninstall))
@@ -144,7 +140,6 @@ func TestDispatchTokenLayer_Install_CallsPromptFn(t *testing.T) {
 	client := &forge.FakeClient{
 		OrgSecrets: map[string]bool{}, // secret does not exist
 	}
-	repoIDs := []int64{100, 200}
 
 	promptFn := func(ctx context.Context) (string, error) {
 		return "ghp_prompted_token", nil
@@ -152,7 +147,7 @@ func TestDispatchTokenLayer_Install_CallsPromptFn(t *testing.T) {
 
 	var buf bytes.Buffer
 	printer := ui.New(&buf)
-	layer := NewDispatchTokenLayer("test-org", client, "", repoIDs, printer, promptFn)
+	layer := NewDispatchTokenLayer("test-org", client, "", printer, promptFn)
 
 	err := layer.Install(context.Background())
 	require.NoError(t, err)
@@ -161,14 +156,14 @@ func TestDispatchTokenLayer_Install_CallsPromptFn(t *testing.T) {
 	assert.Equal(t, "test-org", client.CreatedOrgSecrets[0].Org)
 	assert.Equal(t, "FULLSEND_DISPATCH_TOKEN", client.CreatedOrgSecrets[0].Name)
 	assert.Equal(t, "ghp_prompted_token", client.CreatedOrgSecrets[0].Value)
-	assert.Equal(t, repoIDs, client.CreatedOrgSecrets[0].RepoIDs)
+	assert.Nil(t, client.CreatedOrgSecrets[0].RepoIDs)
 }
 
 func TestDispatchTokenLayer_Install_ErrorWhenNoPromptFn(t *testing.T) {
 	client := &forge.FakeClient{
 		OrgSecrets: map[string]bool{}, // secret does not exist
 	}
-	layer, _ := newDispatchLayer(t, client, "", []int64{100})
+	layer, _ := newDispatchLayer(t, client, "")
 
 	err := layer.Install(context.Background())
 	require.Error(t, err)
@@ -187,7 +182,7 @@ func TestDispatchTokenLayer_Install_PromptFnError(t *testing.T) {
 
 	var buf bytes.Buffer
 	printer := ui.New(&buf)
-	layer := NewDispatchTokenLayer("test-org", client, "", []int64{100}, printer, promptFn)
+	layer := NewDispatchTokenLayer("test-org", client, "", printer, promptFn)
 
 	err := layer.Install(context.Background())
 	require.Error(t, err)

--- a/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
@@ -29,6 +29,8 @@ jobs:
           private-key: ${{ secrets.FULLSEND_FULLSEND_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
+      # Reconciles enrollment state and org secret access for each repo.
+      # Requires the fullsend app to have organization_secrets:write permission.
       - name: Reconcile target repos
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh
+++ b/internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh
@@ -25,6 +25,7 @@ Once merged, issues, PRs, and comments in this repo will be handled by the fulls
 UNENROLL_PR_BODY="This PR removes the fullsend shim workflow. The repo has been set to \`enabled: false\` in the fullsend config.
 
 Once merged, this repo will no longer dispatch events to the fullsend agent pipeline."
+DISPATCH_SECRET_NAME="FULLSEND_DISPATCH_TOKEN"
 REPO_NAME_PATTERN='^[a-zA-Z0-9._-]+$'
 
 if [ ! -f "$CONFIG_FILE" ]; then
@@ -75,6 +76,37 @@ close_pr_on_branch() {
   fi
 }
 
+# grant_secret_access adds a repo to the org secret's selected repositories.
+grant_secret_access() {
+  local repo="$1"
+  local repo_id
+  repo_id=$(gh api "repos/$ORG/$repo" --jq '.id' 2>/dev/null || true)
+  if [ -z "$repo_id" ]; then
+    echo "::warning::Could not get repo ID for $repo, skipping secret access grant"
+    return
+  fi
+  if gh api "orgs/$ORG/actions/secrets/$DISPATCH_SECRET_NAME/repositories/$repo_id" \
+    --method PUT --silent 2>/dev/null; then
+    echo "  Granted $DISPATCH_SECRET_NAME access to $repo"
+  else
+    echo "::warning::Failed to grant $DISPATCH_SECRET_NAME access to $repo"
+  fi
+}
+
+# revoke_secret_access removes a repo from the org secret's selected repositories.
+revoke_secret_access() {
+  local repo="$1"
+  local repo_id
+  repo_id=$(gh api "repos/$ORG/$repo" --jq '.id' 2>/dev/null || true)
+  if [ -z "$repo_id" ]; then
+    echo "::warning::Could not get repo ID for $repo, skipping secret access revoke"
+    return
+  fi
+  gh api "orgs/$ORG/actions/secrets/$DISPATCH_SECRET_NAME/repositories/$repo_id" \
+    --method DELETE --silent 2>/dev/null || true
+  echo "  Revoked $DISPATCH_SECRET_NAME access from $repo"
+}
+
 # ===========================
 # Phase 1: Enroll enabled repos
 # ===========================
@@ -97,6 +129,7 @@ if [ -n "$ENABLED_REPOS" ]; then
     # Check if already enrolled (shim exists on default branch).
     if gh api "repos/$ORG/$REPO/contents/$SHIM_PATH" --silent 2>/dev/null; then
       echo "✓ $REPO already enrolled"
+      grant_secret_access "$REPO"
       SKIPPED=$((SKIPPED + 1))
       continue
     fi
@@ -116,6 +149,7 @@ if [ -n "$ENABLED_REPOS" ]; then
         FAILED=$((FAILED + 1))
       else
         ENROLLED=$((ENROLLED + 1))
+        grant_secret_access "$REPO"
       fi
       continue
     fi
@@ -190,6 +224,7 @@ if [ -n "$ENABLED_REPOS" ]; then
     fi
 
     echo "✓ Created enrollment PR for $REPO: $PR_URL"
+    grant_secret_access "$REPO"
     echo "::notice::Enrollment PR: $PR_URL"
     ENROLLED=$((ENROLLED + 1))
   done <<< "$ENABLED_REPOS"
@@ -228,6 +263,7 @@ if [ -n "$DISABLED_REPOS" ]; then
     # Check if shim exists on default branch.
     if ! gh api "repos/$ORG/$REPO/contents/$SHIM_PATH" --silent 2>/dev/null; then
       echo "✓ $REPO already unenrolled (no shim on default branch)"
+      revoke_secret_access "$REPO"
       SKIPPED=$((SKIPPED + 1))
       continue
     fi
@@ -300,6 +336,7 @@ if [ -n "$DISABLED_REPOS" ]; then
     fi
 
     echo "✓ Created removal PR for $REPO: $PR_URL"
+    revoke_secret_access "$REPO"
     echo "::notice::Removal PR: $PR_URL"
     UNENROLLED=$((UNENROLLED + 1))
   done <<< "$DISABLED_REPOS"


### PR DESCRIPTION
## Summary

- Moves `FULLSEND_DISPATCH_TOKEN` org secret repo access management from the installer into `reconcile-repos.sh`
- Adds `organization_secrets: write` permission to the fullsend app so the reconcile script's app token can manage secret visibility
- Removes `enrolledRepoIDs` plumbing from `DispatchTokenLayer` and `admin.go`

## Problem

When the reconcile script enrolls new repos, it creates PRs to add the shim workflow but never grants the repo access to the `FULLSEND_DISPATCH_TOKEN` org secret. The shim workflow then fails because the secret isn't visible.

Observed at: https://github.com/konflux-ci/caching/actions/runs/24844542404/job/72727757382?pr=781

## Test plan

- [x] `go test ./...` passes (3 pre-existing failures from stale `__pycache__` in scaffold)
- [x] `go vet ./...` clean
- [x] `make lint` clean
- [x] `bash -n reconcile-repos.sh` syntax check passes
- [ ] Verify on a live org: enroll a new repo, confirm it can see `FULLSEND_DISPATCH_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)