### PR TITLE
fix: use absolute path for fullsend binary in pre-agent scan

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -327,6 +327,17 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo string, printer *ui
 	// that were just copied into the sandbox.
 	if h.SecurityEnabled() {
 		printer.StepStart("Running pre-agent security scan")
+
+		// Pre-flight: verify the fullsend binary is reachable inside the
+		// sandbox. SCP can report success before the file is visible to a
+		// subsequent SSH session (OpenShell filesystem sync race).
+		fullsendBin := fmt.Sprintf("%s/bin/fullsend", sandbox.SandboxWorkspace)
+		checkCmd := fmt.Sprintf("test -x %s", fullsendBin)
+		if _, _, rc, checkErr := sandbox.SSH(sshConfigPath, sandboxName, checkCmd, 10*time.Second); checkErr != nil || rc != 0 {
+			printer.StepFail("fullsend binary not found in sandbox at " + fullsendBin)
+			return fmt.Errorf("pre-agent scan: fullsend binary not executable in sandbox (bootstrap may have failed)")
+		}
+
 		scanCmd := buildScanContextCommand(repoDir, traceID)
 		stdout, stderr, exitCode, sshErr := sandbox.SSH(sshConfigPath, sandboxName, scanCmd, 60*time.Second)
 		if sshErr != nil {
@@ -336,6 +347,12 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo string, printer *ui
 			}
 			printer.StepWarn("Continuing despite scan failure (fail_mode: open)")
 		} else if exitCode != 0 {
+			// Distinguish infrastructure errors (scanner binary missing,
+			// find failures) from genuine injection findings.
+			if strings.Contains(stderr, "No such file or directory") || strings.Contains(stderr, "command not found") {
+				printer.StepFail("Security scan infrastructure error: " + stderr)
+				return fmt.Errorf("pre-agent scan infrastructure error (scanner not found): %s", stderr)
+			}
 			printer.StepWarn("Security scan findings:\n" + stdout)
 			if stderr != "" {
 				printer.StepWarn("Scan stderr: " + stderr)
@@ -803,12 +820,15 @@ func buildScanContextCommand(repoDir, traceID string) string {
 	sort.Strings(inames) // deterministic ordering
 	inameExpr := strings.Join(inames, " -o ")
 
-	// Source .env to get PATH with /tmp/workspace/bin where fullsend is installed.
-	envFile := sandbox.SandboxWorkspace + "/.env"
+	// Use the absolute path to the fullsend binary instead of relying on
+	// PATH resolution via `source .env`. The .env sourcing is fragile in
+	// sandboxes where the file may not yet be visible due to filesystem
+	// sync delays after SCP.
+	fullsendBin := sandbox.SandboxWorkspace + "/bin/fullsend"
 
 	return fmt.Sprintf(
-		"source %s && FULLSEND_TRACE_ID='%s' find '%s' -maxdepth 3 -type f \\( %s \\) -exec fullsend scan context {} +",
-		envFile, traceID, escapedDir, inameExpr,
+		"FULLSEND_TRACE_ID='%s' find '%s' -maxdepth 3 -type f \\( %s \\) -exec %s scan context {} +",
+		traceID, escapedDir, inameExpr, fullsendBin,
 	)
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -73,12 +73,13 @@ func TestBuildClaudeCommand_EscapesQuotes(t *testing.T) {
 	assert.Contains(t, cmd, "'test'\\''name'")
 }
 
-func TestBuildScanContextCommand_SourcesEnv(t *testing.T) {
+func TestBuildScanContextCommand_UsesAbsolutePath(t *testing.T) {
 	traceID := "aabbccdd-1122-4334-8556-aabbccddeeff"
 	cmd := buildScanContextCommand("/tmp/workspace/repo", traceID)
-	assert.Contains(t, cmd, "source /tmp/workspace/.env &&")
+	// Must NOT rely on source .env for PATH — use absolute path instead.
+	assert.NotContains(t, cmd, "source")
 	assert.Contains(t, cmd, "FULLSEND_TRACE_ID='"+traceID+"'")
-	assert.Contains(t, cmd, "-exec fullsend scan context")
+	assert.Contains(t, cmd, "-exec /tmp/workspace/bin/fullsend scan context")
 }
 
 func TestEnvToList_Sorted(t *testing.T) {


### PR DESCRIPTION
## Summary

- Use absolute path `/tmp/workspace/bin/fullsend` in the `find -exec` clause instead of relying on `source .env` for PATH resolution — eliminates intermittent failures caused by OpenShell sandbox filesystem sync delays after SCP
- Add a pre-flight `test -x` check for the binary before scanning, giving a clear error when bootstrap copy hasn't synced
- Distinguish infrastructure errors (binary/command not found) from genuine injection findings in scan error handling

## Context

[Run 24847613325](https://github.com/fullsend-ai/.fullsend/actions/runs/24847613325/job/72738986156#step:12:243) failed with:

```
Scan stderr: find: 'fullsend': No such file or directory
BLOCKED: pre-agent scan detected critical findings
```

This happened despite PR #372 (copy fullsend binary to sandbox) being included in v0.1.0-rc4. A concurrent Review run using the **same binary, same image, same target repo** passed the scan — confirming this is an intermittent infrastructure issue, not a code or image problem.

**Root cause**: `find -exec fullsend scan context {} +` relies on PATH being set by `source /tmp/workspace/.env`. When the `.env` or binary file isn't yet visible in the SSH session due to OpenShell filesystem sync delays after SCP, `find` can't locate `fullsend` and the non-zero exit is misreported as "critical findings."

## Test plan

- [x] `TestBuildScanContextCommand_UsesAbsolutePath` — verifies absolute path in `-exec` and no `source` dependency
- [x] `go test -race ./...` — all pass
- [x] `go vet ./...` — clean
- [x] `make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)