### PR TITLE
fix: remove pull_request_review trigger to stop review bot loop

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -93,8 +93,7 @@ jobs:
         github.event.comment.body == '/review' ||
         startsWith(github.event.comment.body, '/review ')
       )) ||
-      github.event_name == 'pull_request_target' ||
-      github.event_name == 'pull_request_review'
+      github.event_name == 'pull_request_target'
     steps:
       - name: Dispatch review
         env:

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
@@ -93,8 +93,7 @@ jobs:
         github.event.comment.body == '/review' ||
         startsWith(github.event.comment.body, '/review ')
       )) ||
-      github.event_name == 'pull_request_target' ||
-      github.event_name == 'pull_request_review'
+      github.event_name == 'pull_request_target'
     steps:
       - name: Dispatch review
         env:


### PR DESCRIPTION
## Summary

- Removes `pull_request_review` from the `dispatch-review` job's `if` condition in both the live workflow and the scaffold template
- Keeps the `pull_request_review` `on:` trigger for a future fix agent

## Problem

The review bot was looping on PR #379 (6 reviews on the same SHA, ~4 min apart):

1. PR opened → `pull_request_target` → `dispatch-review` → bot posts review
2. Bot review → `pull_request_review` event → `dispatch-review` fires again → bot posts another review
3. Repeat

The `pull_request_review` trigger on `dispatch-review` has no valid use case — `pull_request_target` covers initial review, `/review` covers re-review requests.

## Test plan

- [ ] Verify the bot only reviews once when a PR is opened
- [ ] Verify `/review` comment still triggers a re-review
- [ ] Apply the same change to `fullsend-ai/.fullsend/templates/shim-workflow.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)