### PR TITLE
fix: remove PATH override from code-agent.env scaffold

### DIFF
--- a/internal/scaffold/fullsend-repo/env/code-agent.env
+++ b/internal/scaffold/fullsend-repo/env/code-agent.env
@@ -24,9 +24,13 @@ export MAX_RETRIES=1
 # harness timeout.
 export TIMEOUT_SECONDS=1500
 
-# Go toolchain — sandbox doesn't inherit Docker ENV, so set PATH explicitly.
-# ${PATH} is expanded on the runner side (expand: true) before reaching sandbox.
-export PATH="/usr/local/go/bin:${PATH}"
+# Go toolchain — PATH, GOPATH, and GOMODCACHE are set in the sandbox image
+# via Containerfile ENV (images/code/Containerfile line 64). Do NOT set PATH
+# here: this file uses expand: true (harness host_files), so ${PATH} would be
+# replaced with the GitHub Actions runner's PATH by os.ExpandEnv, clobbering
+# /tmp/workspace/bin and breaking fullsend scan + any other sandbox-local
+# binaries. If OpenShell does not preserve Docker ENV, add Go to PATH via a
+# non-expanded host_file or bootstrap step instead of referencing ${PATH} here.
 export GOPATH="/sandbox/go"
 export GOMODCACHE="/sandbox/go/pkg/mod"
 


### PR DESCRIPTION
The export PATH="/usr/local/go/bin:${PATH}" line is expanded on the runner side (os.ExpandEnv via expand: true), replacing ${PATH} with the GitHub Actions runner's PATH. Inside the sandbox, this overwrites /tmp/workspace/bin set by the main .env, causing `find -exec fullsend` to fail with "No such file or directory" during the pre-agent scan.

The Containerfile already sets ENV PATH with Go bin (line 64). This removes the PATH override to test whether OpenShell preserves container ENV vars. If not, Go PATH will need to be added via a non-expanded host_file or bootstrap step.

Ref: #379
Made-with: Cursor