### PR TITLE
fix: remove pull_request_review trigger from shim to stop review loop

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -18,8 +18,6 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   dispatch-triage:

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
@@ -18,8 +18,6 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   dispatch-triage:


### PR DESCRIPTION
The review agent posts its result via `gh pr review`, which fires a `pull_request_review` event on the target repo. Unlike `pull_request_target`, `pull_request_review` runs the workflow from the PR branch HEAD — not the base branch. This means any fix to the shim's `if:` condition only takes effect after every open PR is rebased, and also defeats the security model (the shim's dispatch token is exposed to PR-branch code).

Remove `pull_request_review` from the `on:` triggers entirely so old PR branches cannot perpetuate the loop. Human reviewers who want to re-trigger a review can use the `/review` comment command instead.

Made-with: Cursor