### PR TITLE
fix: complete review agent loop prevention

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -18,8 +18,6 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   dispatch-triage:

--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -98,7 +98,7 @@ func AgentAppConfig(org, role string) AppConfig {
 			Checks:       "read",
 			Issues:       "read",
 		}
-		base.Events = []string{"pull_request", "pull_request_review"}
+		base.Events = []string{"pull_request"}
 
 	default:
 		base.Description = fmt.Sprintf("Fullsend %s agent for %s", role, org)

--- a/internal/forge/github/types_test.go
+++ b/internal/forge/github/types_test.go
@@ -71,7 +71,6 @@ func TestAgentAppConfig_Review(t *testing.T) {
 	assert.Equal(t, "read", cfg.Permissions.Issues)
 
 	assert.Contains(t, cfg.Events, "pull_request")
-	assert.Contains(t, cfg.Events, "pull_request_review")
 }
 
 func TestAgentAppConfig_UnknownRole(t *testing.T) {

--- a/internal/scaffold/fullsend-repo/scripts/post-review.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-review.sh
@@ -25,6 +25,13 @@ fi
 echo "::add-mask::${REVIEW_TOKEN}"
 export GH_TOKEN="${REVIEW_TOKEN}"
 
+# Refuse to post reviews on merged or closed PRs
+PR_STATE=$(gh pr view "${PR_NUMBER}" --repo "${REPO_FULL_NAME}" --json state --jq '.state')
+if [ "${PR_STATE}" != "OPEN" ]; then
+  echo "PR is ${PR_STATE}, skipping review"
+  exit 0
+fi
+
 # Find the agent result from the last iteration
 RESULT_FILE=$(find .  -maxdepth 4 -path '*/iteration-*/output/agent-result.json' | sort -V | tail -1)
 

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
@@ -18,8 +18,6 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   dispatch-triage:


### PR DESCRIPTION
## Summary
- Remove `pull_request_review` from the `on:` block in both the shim template and the live workflow — PR #380 removed it from the `dispatch-review` condition but left the event subscription, so the workflow still fires on every review event, evaluates all job conditions, skips them all, and wastes Actions minutes
- Remove `pull_request_review` from the review App webhook events in `types.go` so GitHub stops delivering webhooks that nothing handles
- Add a merged/closed PR guard to `post-review.sh` — observed on konflux-ci/oras-container#295 where 18 reviews were posted after the PR was already merged, looping every ~3 minutes for over an hour

## Context

PR #380 fixed the immediate infinite loop by removing `pull_request_review` from the dispatch-review `if` condition. This PR cleans up the remaining artifacts:

1. **Dead event subscription**: `pull_request_review: [submitted]` in the `on:` block causes the workflow to run (and all jobs to skip) on every review event across enrolled repos
2. **Unnecessary webhook delivery**: The review GitHub App still subscribes to `pull_request_review` events that no job handles
3. **Missing PR state check**: `post-review.sh` posts reviews on merged/closed PRs because `gh pr review` succeeds on closed PRs and nothing checks state first

The future fix agent does not need `pull_request_review` on the shim workflow — when the fix agent pushes a commit, `pull_request_target:synchronize` fires, which triggers the review agent naturally.

## Test plan
- [x] `go test ./internal/forge/github/...` passes
- [x] `go test ./internal/scaffold/...` passes
- [x] `go vet` passes (with GOTOOLCHAIN=auto)
- [x] `make lint` passes (except pre-existing go-vet hook needing Go 1.26.0)
- [ ] Verify review agent still triggers on PR open/synchronize after deployment
- [ ] Verify review agent does NOT trigger on bot-posted reviews
- [ ] Verify review agent skips posting on merged PRs