### PR TITLE
fix: disable automatic triage on issue open/edit

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -13,7 +13,7 @@ name: fullsend
 
 on:
   issues:
-    types: [opened, edited, labeled]
+    types: [labeled]
   issue_comment:
     types: [created]
   pull_request_target:
@@ -26,14 +26,7 @@ jobs:
       group: triage-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: true
     if: >-
-      (github.event_name == 'issues' && (
-        github.event.action == 'opened' ||
-        (github.event.action == 'edited' &&
-          !contains(toJSON(github.event.issue.labels.*.name), 'ready-to-code') &&
-          !contains(toJSON(github.event.issue.labels.*.name), 'needs-info') &&
-          !contains(toJSON(github.event.issue.labels.*.name), 'duplicate'))
-      )) ||
-      (github.event_name == 'issue_comment' && (
+      github.event_name == 'issue_comment' && (
         github.event.comment.body == '/triage' ||
         startsWith(github.event.comment.body, '/triage ') ||
         (
@@ -42,7 +35,7 @@ jobs:
           !endsWith(github.event.comment.user.login, '[bot]') &&
           contains(toJSON(github.event.issue.labels.*.name), 'needs-info')
         )
-      ))
+      )
     steps:
       - name: Dispatch triage
         env:

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
@@ -13,7 +13,7 @@ name: fullsend
 
 on:
   issues:
-    types: [opened, edited, labeled]
+    types: [labeled]
   issue_comment:
     types: [created]
   pull_request_target:
@@ -26,14 +26,7 @@ jobs:
       group: triage-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: true
     if: >-
-      (github.event_name == 'issues' && (
-        github.event.action == 'opened' ||
-        (github.event.action == 'edited' &&
-          !contains(toJSON(github.event.issue.labels.*.name), 'ready-to-code') &&
-          !contains(toJSON(github.event.issue.labels.*.name), 'needs-info') &&
-          !contains(toJSON(github.event.issue.labels.*.name), 'duplicate'))
-      )) ||
-      (github.event_name == 'issue_comment' && (
+      github.event_name == 'issue_comment' && (
         github.event.comment.body == '/triage' ||
         startsWith(github.event.comment.body, '/triage ') ||
         (
@@ -42,7 +35,7 @@ jobs:
           !endsWith(github.event.comment.user.login, '[bot]') &&
           contains(toJSON(github.event.issue.labels.*.name), 'needs-info')
         )
-      ))
+      )
     steps:
       - name: Dispatch triage
         env:


### PR DESCRIPTION
## Summary

- Removes `opened` and `edited` from the `issues` event types (keeps `labeled` for dispatch-code/dispatch-review)
- Removes the auto-trigger condition block from `dispatch-triage`, keeping only `/triage` command and `needs-info` response triggers
- Applied to both the live workflow and the scaffold template

## Problem

The triage bot fires immediately on every new issue, which feeds into the code → review pipeline with minimal human gatekeeping. This creates pressure to not file issues.

## Intentionally temporary

Once better controls exist at other points in the pipeline, the automatic trigger may be restored.

Closes #394

## Test plan

- [ ] File an issue — verify triage bot does NOT auto-trigger
- [ ] Comment `/triage` on an issue — verify triage bot triggers
- [ ] Respond to a `needs-info` issue — verify triage bot triggers
- [ ] Label an issue `ready-to-code` — verify code agent still triggers
- [ ] Apply same change to `konflux-ci/.fullsend/templates/shim-workflow.yaml` and enrolled repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)