### PR TITLE
fix: move protected-path enforcement from code to review agent

### DIFF
--- a/internal/scaffold/fullsend-repo/agents/code.md
+++ b/internal/scaffold/fullsend-repo/agents/code.md
@@ -83,10 +83,10 @@ the review agent — if the triage was wrong, your code will fail review.
   files you explicitly created or modified.
 - You cannot use `sed`, `awk`, or other stream editors to modify source files.
   Use the `Write` tool for all file edits.
-- You cannot modify CODEOWNERS files, CI configuration in `.github/workflows/`,
-  agent configuration in `.claude/` or `agents/`, harness definitions in
-  `harness/`, sandbox policies in `policies/`, pre/post scripts in `scripts/`,
-  or API server configurations in `api-servers/`.
+- You may propose changes to any path, including `.github/`, CODEOWNERS,
+  agent configuration, and other sensitive files. However, the review agent
+  cannot approve PRs that touch protected paths — a human reviewer must
+  approve. Protected paths are defined in `post-review.sh`.
 - Always create a **new commit**. Never amend an existing commit — even from a
   previous agent run. Amending loses attribution.
 - If the retry limit is exceeded and tests still fail, do not commit broken

--- a/internal/scaffold/fullsend-repo/scripts/post-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-code.sh
@@ -6,11 +6,14 @@
 # security-sensitive component in the pipeline.
 #
 # Security layers (defense-in-depth):
-#   1. Protected-path check — reject if agent touched forbidden paths
-#   2. Authoritative secret scan — final gate before any push
-#   3. Authoritative pre-commit — run repo hooks on changed files
-#   4. Branch validation — refuse to push main/master
-#   5. Token isolation — PUSH_TOKEN never enters the sandbox
+#   1. Authoritative secret scan — final gate before any push
+#   2. Authoritative pre-commit — run repo hooks on changed files
+#   3. Branch validation — refuse to push main/master
+#   4. Token isolation — PUSH_TOKEN never enters the sandbox
+#
+# Protected-path enforcement lives in post-review.sh: the review agent
+# cannot approve PRs that touch sensitive paths (e.g. .github/, CODEOWNERS,
+# agents/). The code agent is free to propose changes to any path.
 #
 # Required environment variables:
 #   PUSH_TOKEN        — token with contents:write + pull-requests:write on target repo
@@ -30,19 +33,6 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-PROTECTED_PATHS=(
-  ".github/"
-  ".claude/"
-  "agents/"
-  "harness/"
-  "policies/"
-  "scripts/"
-  "api-servers/"
-  "CODEOWNERS"
-  ".pre-commit-config.yaml"
-  ".gitattributes"
-)
-
 GITLEAKS_VERSION="8.30.1"
 GITLEAKS_SHA256="551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
 
@@ -80,7 +70,7 @@ echo "Branch: ${BRANCH}"
 echo "Token source: ${PUSH_TOKEN_SOURCE:-unknown}"
 
 # ---------------------------------------------------------------------------
-# 2. Protected-path check
+# 2. Compute changed files
 # ---------------------------------------------------------------------------
 MERGE_BASE="$(git merge-base "origin/${TARGET_BRANCH}" HEAD 2>/dev/null)" || MERGE_BASE=""
 if [ -n "${MERGE_BASE}" ]; then
@@ -98,17 +88,6 @@ fi
 
 echo "Changed files:"
 echo "${CHANGED_FILES}" | sed 's/^/  /'
-
-for pattern in "${PROTECTED_PATHS[@]}"; do
-  MATCHES="$(echo "${CHANGED_FILES}" | grep "^${pattern}" || true)"
-  if [ -n "${MATCHES}" ]; then
-    echo "::error::BLOCKED — agent modified protected path: ${pattern}"
-    echo "${MATCHES}" | sed 's/^/  ::error::  /'
-    exit 1
-  fi
-done
-
-echo "Protected-path check passed"
 
 # ---------------------------------------------------------------------------
 # 3. Authoritative secret scan
@@ -241,7 +220,6 @@ Closes #${ISSUE_NUMBER}
 ### Post-script verification
 
 - [x] Branch is not main/master (\`${BRANCH}\`)
-- [x] No protected paths modified
 - [x] Secret scan passed (gitleaks — \`${SCAN_RANGE}\`)
 - [x] Pre-commit hooks passed (authoritative run on runner)
 - [x] Tests ran inside sandbox

--- a/internal/scaffold/fullsend-repo/scripts/post-review.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-review.sh
@@ -4,6 +4,10 @@
 # Runs on the GitHub Actions runner AFTER the sandbox is destroyed.
 # CWD is runDir.
 #
+# This script is the sole enforcement point for protected-path checks:
+# if the PR touches sensitive paths, an "approve" action is downgraded
+# to "comment" so only a human can grant approval.
+#
 # Required environment variables:
 #   REVIEW_TOKEN    — token with pull-requests:write on the target repo
 #   PR_NUMBER       — GitHub PR number
@@ -79,6 +83,65 @@ EOF
   fi
 fi
 
+# ---------------------------------------------------------------------------
+# Protected-path check: the review agent must not approve PRs that touch
+# sensitive paths. If the PR modifies any of these, downgrade "approve" to
+# "comment" so only a human can grant approval. This is the sole enforcement
+# point — the code agent is free to propose changes to any path.
+# ---------------------------------------------------------------------------
+REVIEW_PROTECTED_PATHS=(
+  ".github/"
+  ".claude/"
+  "agents/"
+  "harness/"
+  "policies/"
+  "scripts/"
+  "api-servers/"
+  "CODEOWNERS"
+  ".pre-commit-config.yaml"
+  ".gitattributes"
+)
+
+if [ "${ACTION}" = "approve" ]; then
+  PR_FILES=$(gh pr view "${PR_NUMBER}" --repo "${REPO_FULL_NAME}" --json files --jq '.files[].path')
+  if [ -z "${PR_FILES}" ]; then
+    echo "::error::Failed to fetch PR files or PR has no changed files — refusing to approve"
+    exit 1
+  fi
+
+  PROTECTED_MATCHES=""
+  while IFS= read -r file; do
+    [ -z "${file}" ] && continue
+    for pattern in "${REVIEW_PROTECTED_PATHS[@]}"; do
+      if [[ "${file}" == "${pattern}"* ]]; then
+        PROTECTED_MATCHES="${PROTECTED_MATCHES}${file}"$'\n'
+        break
+      fi
+    done
+  done <<< "${PR_FILES}"
+
+  if [ -n "${PROTECTED_MATCHES}" ]; then
+    echo "PR touches protected paths — downgrading approve to comment"
+    echo "${PROTECTED_MATCHES}" | sed '/^$/d' | sed 's/^/  /'
+    ACTION="comment"
+
+    PROTECTED_NOTICE=$'\n\n---\n\n'
+    PROTECTED_NOTICE+=$'> **Protected paths detected** — this PR modifies files under one or more\n'
+    PROTECTED_NOTICE+=$'> protected paths. The review agent cannot approve PRs that touch these paths.\n'
+    PROTECTED_NOTICE+=$'> A human reviewer must approve this PR.\n'
+    PROTECTED_NOTICE+=$'>\n'
+    PROTECTED_NOTICE+=$'> Protected files in this PR:\n'
+    while IFS= read -r f; do
+      [ -z "${f}" ] && continue
+      PROTECTED_NOTICE+="> - \`${f}\`"$'\n'
+    done <<< "${PROTECTED_MATCHES}"
+
+    ORIGINAL_BODY=$(jq -r '.body' "${RESULT_FILE}")
+    MODIFIED_BODY="${ORIGINAL_BODY}${PROTECTED_NOTICE}"
+    export MODIFIED_REVIEW_BODY="${MODIFIED_BODY}"
+  fi
+fi
+
 BODY_FILE=$(mktemp)
 trap 'rm -f "${BODY_FILE}"' EXIT
 
@@ -113,7 +176,11 @@ EOF
     ;;
 esac
 
-jq -r '.body' "${RESULT_FILE}" > "${BODY_FILE}"
+if [ -n "${MODIFIED_REVIEW_BODY:-}" ]; then
+  printf '%s' "${MODIFIED_REVIEW_BODY}" > "${BODY_FILE}"
+else
+  jq -r '.body' "${RESULT_FILE}" > "${BODY_FILE}"
+fi
 gh pr review "${PR_NUMBER}" --repo "${REPO_FULL_NAME}" "${FLAG}" --body-file "${BODY_FILE}"
 
 echo "Review posted: ${ACTION} on ${REPO_FULL_NAME}#${PR_NUMBER}"


### PR DESCRIPTION
The code agent's post-script (post-code.sh) blocked any changes to protected paths at authoring time. This prevented the code agent from proposing useful changes to workflow files and other sensitive paths, even though those changes would still require human approval to land.

Move the enforcement to the review agent's post-script (post-review.sh): when the review agent would approve a PR that touches protected paths, the post-script downgrades "approve" to "comment" and appends a notice listing the protected files and requiring human approval. This aligns with the trust model where the repo (CODEOWNERS + branch protection) is the coordinator.

Changes:
- post-code.sh: Remove PROTECTED_PATHS array and blocking loop
- post-review.sh: Add REVIEW_PROTECTED_PATHS check that downgrades approve to comment; fail-closed on API errors; uses bash prefix matching instead of grep to avoid both regex metachar issues and substring false positives
- agents/code.md: Update constraints to reflect that the code agent may propose changes to any path

Closes #395

Made-with: Cursor