### PR TITLE
chore: add Dependabot config for experiments submodule auto-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with `gitsubmodule` ecosystem configured to check daily for new commits on the `experiments` submodule's `main` branch
- Dependabot will open PRs automatically when the submodule pin is outdated — no more stale pins causing CI failures like #405

This is also an opportunity to test fullsend's review agent and auto-merge capabilities on low-risk dependency PRs — as Ralph noted in [this comment on #336](https://github.com/fullsend-ai/fullsend/issues/336#issuecomment-4299124563), where fullsend agents can add value is when an incoming dependency update breaks something in the app, proposing both the update and the necessary fix.

## Test plan

- [ ] Verify `dependabot.yml` YAML is valid
- [ ] After merge, confirm Dependabot opens a PR when `experiments/main` advances

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)