### PR TITLE
feat: add context suppression PostToolUse hook

### DIFF
--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -110,10 +110,11 @@ type LLMGuardConfig struct {
 // SandboxHooks configures Claude Code PreToolUse/PostToolUse hooks
 // that run inside the sandbox during agent execution.
 type SandboxHooks struct {
-	Tirith               *TirithConfig `yaml:"tirith,omitempty"`
-	SSRFPreTool          *bool         `yaml:"ssrf_pretool,omitempty"`           // default: true
-	SecretRedactPostTool *bool         `yaml:"secret_redact_posttool,omitempty"` // default: true
-	UnicodePostTool      *bool         `yaml:"unicode_posttool,omitempty"`       // default: true
+	Tirith                  *TirithConfig `yaml:"tirith,omitempty"`
+	SSRFPreTool             *bool         `yaml:"ssrf_pretool,omitempty"`              // default: true
+	SecretRedactPostTool    *bool         `yaml:"secret_redact_posttool,omitempty"`    // default: true
+	UnicodePostTool         *bool         `yaml:"unicode_posttool,omitempty"`          // default: true
+	ContextSuppressPostTool *bool         `yaml:"context_suppress_posttool,omitempty"` // default: true
 }
 
 // TirithConfig configures the Tirith Rust CLI scanner for terminal security.

--- a/internal/scaffold/fullsend-repo/skills/code-implementation/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/code-implementation/SKILL.md
@@ -312,6 +312,12 @@ and how you will verify it works.
 
 Write the code change, then verify it.
 
+**Context efficiency:** A PostToolUse hook automatically compacts verification
+tool output. Successful runs of scan-secrets, pre-commit, tests, linters, and
+gitlint produce a one-line summary; only failures show full output. You do not
+need to redirect output or parse results manually — just run the commands and
+react to what you see.
+
 **Implementation:**
 
 - **Follow existing patterns.** If the repo uses a specific error handling idiom,
@@ -451,13 +457,36 @@ authoritative pre-commit check on the runner before pushing.
 echo "::notice::STEP 9c: Tests and linters"
 ```
 
-You MUST run the test suite that covers the code you changed. Determine
-which test command to use by reading the Makefile, CONTRIBUTING.md, or
-existing CI workflows.
+You MUST run the test suite that covers the code you changed.
+
+**Run targeted tests** — only test the packages/modules you changed:
+
+- **Go:** `go test ./path/to/changed/pkg/...` for each changed package.
+  Use `go test ./...` only if changes span many packages or affect shared
+  libraries.
+- **Python:** `pytest path/to/test_file.py` or
+  `pytest tests/unit/test_module.py` for the module you changed. Run
+  `pytest` (full suite) only as a final check.
+- **JS/TS:** `npm test -- --testPathPattern='changed-module'` or the
+  framework's equivalent filter flag.
+- **Makefile targets:** If the Makefile has granular test targets (e.g.,
+  `make test-unit`, `make test-pkg PKG=./internal/foo`), prefer those
+  over `make test`.
+
+Determine which packages to test from your changed files:
 
 ```bash
-# Use the repo's actual test command — check Makefile or CI config
-make test        # or: go test ./..., npm test, pytest, etc.
+git diff --name-only origin/<target-branch>..HEAD
+```
+
+Full-suite runs (`go test ./...`, `npm test`, `pytest`) are acceptable as
+a final validation after targeted tests pass, but prefer targeted runs
+first to save time and context budget.
+
+Also run linters. Determine which lint command to use by reading the
+Makefile, CONTRIBUTING.md, or existing CI workflows.
+
+```bash
 make lint        # or: golangci-lint run, eslint, ruff, etc.
 ```
 

--- a/internal/security/hooks.go
+++ b/internal/security/hooks.go
@@ -19,6 +19,9 @@ var TirithCheckHook []byte
 //go:embed hooks/unicode_posttool.py
 var UnicodePostToolHook []byte
 
+//go:embed hooks/context_suppress_posttool.py
+var ContextSuppressPostToolHook []byte
+
 // hookEntry represents a single hook command in Claude settings.
 type hookEntry struct {
 	Type    string `json:"type"`
@@ -72,11 +75,17 @@ func GenerateClaudeSettings(h *harness.Harness) ([]byte, error) {
 		})
 	}
 
-	// PostToolUse hooks for Bash|WebFetch|Read: secret redaction then unicode
-	// scanning. Combined into a single matcher so Claude Code chains them
-	// sequentially (separate matchers run in parallel on the original result,
-	// which would cause modifications to conflict).
+	// PostToolUse hooks for Bash|WebFetch|Read. Combined into a single matcher
+	// so Claude Code chains them sequentially (separate matchers run in parallel
+	// on the original result, which would cause modifications to conflict).
+	// Order: context suppress (compacts verbose success output) → secret redact
+	// → unicode scan. Suppressing first avoids scanning text we'd discard.
 	var postToolHooks []hookEntry
+	if contextSuppressPostToolEnabled(sec) {
+		postToolHooks = append(postToolHooks, hookEntry{
+			Type: "command", Command: "python3 " + SandboxHooksDir + "/context_suppress_posttool.py",
+		})
+	}
 	if secretRedactPostToolEnabled(sec) {
 		postToolHooks = append(postToolHooks, hookEntry{
 			Type: "command", Command: "python3 " + SandboxHooksDir + "/secret_redact_posttool.py",
@@ -121,6 +130,9 @@ func HookFiles(h *harness.Harness) map[string][]byte {
 	if unicodePostToolEnabled(sec) {
 		files["unicode_posttool.py"] = UnicodePostToolHook
 	}
+	if contextSuppressPostToolEnabled(sec) {
+		files["context_suppress_posttool.py"] = ContextSuppressPostToolHook
+	}
 
 	return files
 }
@@ -159,4 +171,11 @@ func unicodePostToolEnabled(sec *harness.SecurityConfig) bool {
 		return true
 	}
 	return boolDefault(sec.SandboxHooks.UnicodePostTool, true)
+}
+
+func contextSuppressPostToolEnabled(sec *harness.SecurityConfig) bool {
+	if sec == nil || sec.SandboxHooks == nil {
+		return true
+	}
+	return boolDefault(sec.SandboxHooks.ContextSuppressPostTool, true)
 }

--- a/internal/security/hooks/context_suppress_posttool.py
+++ b/internal/security/hooks/context_suppress_posttool.py
@@ -131,8 +131,6 @@ def suppress_go_test(output: str) -> str | None:
 
     ok_matches = _GO_TEST_OK_RE.findall(output)
     if not ok_matches:
-        if not output.strip():
-            return "tests: passed"
         return None
 
     total_time = sum(float(t) for t in ok_matches)
@@ -150,25 +148,30 @@ def suppress_pytest(output: str) -> str | None:
         duration = match.group(2)
         return f"tests: {passed} passed ({duration}s)"
 
-    if not output.strip():
-        return "tests: passed"
     return None
+
+
+_NPM_FAIL_RE = re.compile(r"\d+\s+failing\b", re.IGNORECASE)
 
 
 def suppress_npm_test(output: str) -> str | None:
     lower = output.lower()
-    if "fail" in lower or "error" in lower:
+    if _NPM_FAIL_RE.search(lower) or "fail" in lower:
         return None
     if "passing" in lower or "tests passed" in lower:
         return "tests: passed"
     return None
 
 
+_MAKE_TEST_OK_RE = re.compile(r"\bok\b", re.IGNORECASE)
+_MAKE_TEST_PASS_RE = re.compile(r"\bpass(?:ed)?\b", re.IGNORECASE)
+
+
 def suppress_make_test(output: str) -> str | None:
     lower = output.lower()
     if "fail" in lower or "error" in lower:
         return None
-    if "ok" in lower or "pass" in lower:
+    if _MAKE_TEST_OK_RE.search(lower) or _MAKE_TEST_PASS_RE.search(lower):
         return "tests: passed"
     return None
 

--- a/internal/security/hooks/context_suppress_posttool.py
+++ b/internal/security/hooks/context_suppress_posttool.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Claude Code PostToolUse hook for context suppression.
+
+Intercepts Bash tool results from verification commands (scan-secrets,
+pre-commit, go test, linters, etc.) and replaces verbose success output
+with compact one-line summaries. Failures pass through unchanged so the
+agent can act on them.
+
+Principle: success is silent, failure is loud.
+
+Protocol: reads JSON from stdin, writes JSON to stdout with compacted
+tool_result when suppression applies. Exit code 0 always (never blocks).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import UTC, datetime
+
+FINDINGS_PATH = "/tmp/workspace/.security/findings.jsonl"
+MAX_INPUT_BYTES = 10 * 1024 * 1024  # 10 MB
+
+# --- Command pattern matchers ---
+
+_SCAN_SECRETS_RE = re.compile(r"\bscan-secrets\b")
+_GITLEAKS_RE = re.compile(r"\bgitleaks\s+detect\b")
+_PRECOMMIT_RE = re.compile(r"\bpre-commit\s+run\b")
+_GO_TEST_RE = re.compile(r"\bgo\s+test\b")
+_MAKE_TEST_RE = re.compile(r"\bmake\s+(?:test|check)\b")
+_NPM_TEST_RE = re.compile(r"\bnpm\s+test\b")
+_PYTEST_RE = re.compile(r"\bpytest\b")
+_GO_VET_RE = re.compile(r"\bgo\s+vet\b")
+_GO_BUILD_RE = re.compile(r"\bgo\s+build\b")
+_MAKE_LINT_RE = re.compile(r"\bmake\s+lint\b")
+_GOLANGCI_RE = re.compile(r"\bgolangci-lint\s+run\b")
+_ESLINT_RE = re.compile(r"\beslint\b")
+_RUFF_RE = re.compile(r"\bruff\s+(?:check|format)\b")
+_RUFF_FORMAT_RE = re.compile(r"\bruff\s+format\b")
+_GITLINT_RE = re.compile(r"\bgitlint\b")
+
+# pre-commit output patterns
+_PRECOMMIT_HOOK_LINE_RE = re.compile(
+    r"^(.+?)\.{3,}\s*(Passed|Failed|Skipped|Fixed)\s*$", re.MULTILINE
+)
+_PRECOMMIT_FIXING_RE = re.compile(r"^(?:Fixing|Fixed)\s+(.+?)\.?$", re.MULTILINE)
+_PRECOMMIT_FILE_CHANGED_RE = re.compile(
+    r"^(?:reformatted|would reformat|fixed)\s+(.+?)$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+# go test output patterns
+_GO_TEST_OK_RE = re.compile(r"^ok\s+\S+\s+([\d.]+)s", re.MULTILINE)
+_GO_TEST_FAIL_RE = re.compile(r"^FAIL\s+", re.MULTILINE)
+
+# pytest output patterns
+_PYTEST_SUMMARY_RE = re.compile(r"=+\s+(\d+)\s+passed.*?in\s+([\d.]+)s\s+=+", re.MULTILINE)
+_PYTEST_FAIL_RE = re.compile(r"=+\s+.*?(\d+)\s+failed", re.MULTILINE)
+
+
+def log_suppression(command: str, summary: str) -> None:
+    trace_id = os.environ.get("FULLSEND_TRACE_ID", "")
+    finding = {
+        "trace_id": trace_id,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "phase": "hook_posttool",
+        "scanner": "context_suppress_posttool",
+        "name": "context_suppressed",
+        "severity": "info",
+        "detail": f"Suppressed output for: {command[:80]}",
+        "summary": summary,
+        "action": "suppress",
+    }
+    try:
+        os.makedirs(os.path.dirname(FINDINGS_PATH), exist_ok=True)
+        with open(FINDINGS_PATH, "a") as f:
+            f.write(json.dumps(finding) + "\n")
+    except OSError:
+        pass
+
+
+def suppress_scan_secrets(output: str) -> str | None:
+    if not output.strip():
+        return "scan-secrets: passed (no findings)"
+    lower = output.lower()
+    if "no leaks" in lower or "no secrets" in lower or "0 findings" in lower:
+        return "scan-secrets: passed (no findings)"
+    return None
+
+
+def suppress_gitleaks(output: str) -> str | None:
+    lower = output.lower()
+    if not output.strip() or "no leaks" in lower:
+        return "gitleaks: passed (no leaks detected)"
+    return None
+
+
+def suppress_precommit(output: str) -> str | None:
+    hook_results = _PRECOMMIT_HOOK_LINE_RE.findall(output)
+    if not hook_results:
+        if not output.strip():
+            return "pre-commit: passed"
+        return None
+
+    statuses = [status for _, status in hook_results]
+    failed = [name.strip() for name, status in hook_results if status == "Failed"]
+    passed_or_skipped = all(s in ("Passed", "Skipped") for s in statuses)
+
+    if passed_or_skipped:
+        return f"pre-commit: all {len(hook_results)} hooks passed"
+
+    fixing_files = _PRECOMMIT_FIXING_RE.findall(output)
+    reformatted = _PRECOMMIT_FILE_CHANGED_RE.findall(output)
+    auto_fixed_files = sorted(set(fixing_files + reformatted))
+
+    if auto_fixed_files and not failed:
+        file_list = ", ".join(auto_fixed_files[:10])
+        suffix = f" (+{len(auto_fixed_files) - 10} more)" if len(auto_fixed_files) > 10 else ""
+        return (
+            f"pre-commit: auto-fixed [{file_list}{suffix}]"
+            " \u2014 re-stage modified files before commit"
+        )
+
+    # Mixed auto-fix + errors, or pure errors: pass through full output
+    return None
+
+
+def suppress_go_test(output: str) -> str | None:
+    if _GO_TEST_FAIL_RE.search(output):
+        return None
+
+    ok_matches = _GO_TEST_OK_RE.findall(output)
+    if not ok_matches:
+        if not output.strip():
+            return "tests: passed"
+        return None
+
+    total_time = sum(float(t) for t in ok_matches)
+    pkg_count = len(ok_matches)
+    return f"tests: {pkg_count} packages passed ({total_time:.1f}s)"
+
+
+def suppress_pytest(output: str) -> str | None:
+    if _PYTEST_FAIL_RE.search(output):
+        return None
+
+    match = _PYTEST_SUMMARY_RE.search(output)
+    if match:
+        passed = match.group(1)
+        duration = match.group(2)
+        return f"tests: {passed} passed ({duration}s)"
+
+    if not output.strip():
+        return "tests: passed"
+    return None
+
+
+def suppress_npm_test(output: str) -> str | None:
+    lower = output.lower()
+    if "fail" in lower or "error" in lower:
+        return None
+    if "passing" in lower or "tests passed" in lower or not output.strip():
+        return "tests: passed"
+    return None
+
+
+def suppress_make_test(output: str) -> str | None:
+    lower = output.lower()
+    if "fail" in lower or "error" in lower:
+        return None
+    return "tests: passed"
+
+
+def suppress_go_vet(output: str) -> str | None:
+    if not output.strip():
+        return "go vet: clean"
+    return None
+
+
+def suppress_go_build(output: str) -> str | None:
+    if not output.strip():
+        return "go build: clean"
+    return None
+
+
+def suppress_linter(name: str, output: str) -> str | None:
+    if not output.strip():
+        return f"{name}: clean"
+    lower = output.lower()
+    if "error" in lower or "fail" in lower or "warning" in lower:
+        return None
+    return f"{name}: passed"
+
+
+def suppress_gitlint(output: str) -> str | None:
+    if not output.strip():
+        return "gitlint: passed"
+    return None
+
+
+def try_suppress(command: str, output: str) -> str | None:
+    if _SCAN_SECRETS_RE.search(command):
+        return suppress_scan_secrets(output)
+
+    if _GITLEAKS_RE.search(command):
+        return suppress_gitleaks(output)
+
+    if _PRECOMMIT_RE.search(command):
+        return suppress_precommit(output)
+
+    if _GO_TEST_RE.search(command):
+        return suppress_go_test(output)
+
+    if _PYTEST_RE.search(command):
+        return suppress_pytest(output)
+
+    if _NPM_TEST_RE.search(command):
+        return suppress_npm_test(output)
+
+    if _MAKE_TEST_RE.search(command):
+        return suppress_make_test(output)
+
+    if _GO_VET_RE.search(command):
+        return suppress_go_vet(output)
+
+    if _GO_BUILD_RE.search(command):
+        return suppress_go_build(output)
+
+    if _GOLANGCI_RE.search(command):
+        return suppress_linter("golangci-lint", output)
+
+    if _ESLINT_RE.search(command):
+        return suppress_linter("eslint", output)
+
+    if _RUFF_FORMAT_RE.search(command):
+        return suppress_linter("ruff-format", output)
+
+    if _RUFF_RE.search(command):
+        return suppress_linter("ruff", output)
+
+    if _MAKE_LINT_RE.search(command):
+        return suppress_linter("lint", output)
+
+    if _GITLINT_RE.search(command):
+        return suppress_gitlint(output)
+
+    return None
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read(MAX_INPUT_BYTES + 1)
+        if len(raw) > MAX_INPUT_BYTES:
+            raw = raw[:MAX_INPUT_BYTES]
+        if not raw.strip():
+            sys.exit(0)
+        hook_input = json.loads(raw)
+    except (json.JSONDecodeError, Exception):
+        sys.exit(0)
+
+    tool_name = hook_input.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    tool_input = hook_input.get("tool_input", {})
+    if isinstance(tool_input, str):
+        try:
+            tool_input = json.loads(tool_input)
+        except (json.JSONDecodeError, Exception):
+            sys.exit(0)
+
+    command = tool_input.get("command", "")
+    if not command:
+        sys.exit(0)
+
+    tool_result = hook_input.get("tool_result", "")
+    if not isinstance(tool_result, str):
+        sys.exit(0)
+
+    # Non-zero exit code: always pass through full output for agent to act on.
+    if tool_result.startswith("Exit code"):
+        sys.exit(0)
+
+    summary = try_suppress(command, tool_result)
+    if summary is None:
+        sys.exit(0)
+
+    log_suppression(command, summary)
+    json.dump({"tool_result": summary}, sys.stdout)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/security/hooks/context_suppress_posttool.py
+++ b/internal/security/hooks/context_suppress_posttool.py
@@ -57,7 +57,7 @@ _GO_TEST_FAIL_RE = re.compile(r"^FAIL\s+", re.MULTILINE)
 
 # pytest output patterns
 _PYTEST_SUMMARY_RE = re.compile(r"=+\s+(\d+)\s+passed.*?in\s+([\d.]+)s\s+=+", re.MULTILINE)
-_PYTEST_FAIL_RE = re.compile(r"=+\s+.*?(\d+)\s+failed", re.MULTILINE)
+_PYTEST_FAIL_RE = re.compile(r"=+\s+.*?(\d+)\s+(?:failed|error)", re.MULTILINE)
 
 
 def log_suppression(command: str, summary: str) -> None:
@@ -82,8 +82,6 @@ def log_suppression(command: str, summary: str) -> None:
 
 
 def suppress_scan_secrets(output: str) -> str | None:
-    if not output.strip():
-        return "scan-secrets: passed (no findings)"
     lower = output.lower()
     if "no leaks" in lower or "no secrets" in lower or "0 findings" in lower:
         return "scan-secrets: passed (no findings)"
@@ -92,7 +90,7 @@ def suppress_scan_secrets(output: str) -> str | None:
 
 def suppress_gitleaks(output: str) -> str | None:
     lower = output.lower()
-    if not output.strip() or "no leaks" in lower:
+    if "no leaks" in lower:
         return "gitleaks: passed (no leaks detected)"
     return None
 
@@ -161,7 +159,7 @@ def suppress_npm_test(output: str) -> str | None:
     lower = output.lower()
     if "fail" in lower or "error" in lower:
         return None
-    if "passing" in lower or "tests passed" in lower or not output.strip():
+    if "passing" in lower or "tests passed" in lower:
         return "tests: passed"
     return None
 
@@ -170,7 +168,9 @@ def suppress_make_test(output: str) -> str | None:
     lower = output.lower()
     if "fail" in lower or "error" in lower:
         return None
-    return "tests: passed"
+    if "ok" in lower or "pass" in lower:
+        return "tests: passed"
+    return None
 
 
 def suppress_go_vet(output: str) -> str | None:

--- a/internal/security/hooks/context_suppress_posttool_test.py
+++ b/internal/security/hooks/context_suppress_posttool_test.py
@@ -169,10 +169,9 @@ class TestGoTest:
         out = run_hook(make_input("go test ./...", output))
         assert out is None  # FAIL line → passthrough
 
-    def test_empty_output(self):
+    def test_empty_output_passthrough(self):
         out = run_hook(make_input("go test ./...", ""))
-        assert out is not None
-        assert "passed" in out["tool_result"]
+        assert out is None  # empty output → passthrough (runner may have crashed)
 
 
 # --- pytest ---
@@ -197,6 +196,10 @@ class TestPytest:
         out = run_hook(make_input("pytest", output))
         assert out is None  # failure → passthrough
 
+    def test_empty_output_passthrough(self):
+        out = run_hook(make_input("pytest tests/", ""))
+        assert out is None  # empty output → passthrough (runner may have crashed)
+
 
 # --- npm test ---
 
@@ -210,6 +213,12 @@ class TestNpmTest:
     def test_failure(self):
         out = run_hook(make_input("npm test", "  1 failing\n  Error: expected 1 to equal 2\n"))
         assert out is None
+
+    def test_error_in_test_name_still_passes(self):
+        output = "  should render error-boundary component\n  42 passing (3s)\n"
+        out = run_hook(make_input("npm test", output))
+        assert out is not None
+        assert "passed" in out["tool_result"]
 
 
 # --- make test ---
@@ -226,6 +235,16 @@ class TestMakeTest:
         output = "go test ./...\nFAIL error in tests\n"
         out = run_hook(make_input("make test", output))
         assert out is None
+
+    def test_ok_word_boundary(self):
+        output = "checking token validation\nlookup table ready\n"
+        out = run_hook(make_input("make test", output))
+        assert out is None  # "token"/"lookup" contain "ok" but are not the word "ok"
+
+    def test_pass_word_boundary(self):
+        output = "bypass check completed\npassword hashing verified\n"
+        out = run_hook(make_input("make test", output))
+        assert out is None  # "bypass"/"password" contain "pass" but are not the word "pass"
 
 
 # --- go vet / go build ---

--- a/internal/security/hooks/context_suppress_posttool_test.py
+++ b/internal/security/hooks/context_suppress_posttool_test.py
@@ -1,0 +1,357 @@
+"""Tests for context_suppress_posttool.py hook."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK_SCRIPT = str(Path(__file__).parent / "context_suppress_posttool.py")
+
+
+def run_hook(hook_input: dict) -> dict | None:
+    """Run the hook script with the given input and return parsed output or None."""
+    result = subprocess.run(
+        [sys.executable, HOOK_SCRIPT],
+        input=json.dumps(hook_input),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"Hook exited non-zero: {result.stderr}"
+    if not result.stdout.strip():
+        return None
+    return json.loads(result.stdout)
+
+
+def make_input(command: str, tool_result: str) -> dict:
+    return {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "tool_result": tool_result,
+    }
+
+
+# --- scan-secrets ---
+
+
+class TestScanSecrets:
+    def test_no_findings(self):
+        out = run_hook(make_input("scan-secrets foo.go bar.go", "No leaks found\n"))
+        assert out is not None
+        assert out["tool_result"] == "scan-secrets: passed (no findings)"
+
+    def test_empty_output(self):
+        out = run_hook(make_input("scan-secrets foo.go", ""))
+        assert out is not None
+        assert "passed" in out["tool_result"]
+
+    def test_failure_passthrough(self):
+        out = run_hook(
+            make_input(
+                "scan-secrets foo.go",
+                "Exit code 1\nSecret detected in foo.go:12\n",
+            )
+        )
+        assert out is None  # exit code prefix → passthrough
+
+
+# --- gitleaks ---
+
+
+class TestGitleaks:
+    def test_no_leaks(self):
+        out = run_hook(make_input("gitleaks detect --source .", "no leaks found\n"))
+        assert out is not None
+        assert "passed" in out["tool_result"]
+
+    def test_empty_output(self):
+        out = run_hook(make_input("gitleaks detect --source .", ""))
+        assert out is not None
+        assert "passed" in out["tool_result"]
+
+
+# --- pre-commit ---
+
+
+class TestPreCommit:
+    def test_all_passed(self):
+        output = (
+            "check yaml...............Passed\n"
+            "end-of-file-fixer........Passed\n"
+            "trailing-whitespace......Passed\n"
+            "detect-private-key.......Passed\n"
+            "gitleaks.................Passed\n"
+        )
+        out = run_hook(make_input("pre-commit run --files foo.go", output))
+        assert out is not None
+        assert "all 5 hooks passed" in out["tool_result"]
+
+    def test_all_passed_with_skipped(self):
+        output = (
+            "check yaml...............Passed\n"
+            "hadolint-docker..........Skipped\n"
+            "trailing-whitespace......Passed\n"
+        )
+        out = run_hook(make_input("pre-commit run --files foo.go", output))
+        assert out is not None
+        assert "all 3 hooks passed" in out["tool_result"]
+
+    def test_auto_fix_only(self):
+        output = (
+            "check yaml...............Passed\n"
+            "end-of-file-fixer........Fixed\n"
+            "Fixing foo.go\n"
+            "trailing-whitespace......Fixed\n"
+            "Fixing bar.go\n"
+            "detect-private-key.......Passed\n"
+        )
+        out = run_hook(make_input("pre-commit run --files foo.go bar.go", output))
+        assert out is not None
+        assert "auto-fixed" in out["tool_result"]
+        assert "bar.go" in out["tool_result"]
+        assert "foo.go" in out["tool_result"]
+        assert "re-stage" in out["tool_result"]
+
+    def test_real_errors(self):
+        output = (
+            "check yaml...............Passed\n"
+            "golangci-lint............Failed\n"
+            "foo.go:12:5: unused variable\n"
+        )
+        out = run_hook(make_input("pre-commit run --files foo.go", output))
+        assert out is None  # errors → passthrough
+
+    def test_mixed_autofix_and_errors(self):
+        output = (
+            "end-of-file-fixer........Fixed\n"
+            "Fixing foo.go\n"
+            "golangci-lint............Failed\n"
+            "bar.go:5:1: syntax error\n"
+        )
+        out = run_hook(make_input("pre-commit run --files foo.go bar.go", output))
+        assert out is None  # mixed → passthrough
+
+    def test_empty_output(self):
+        out = run_hook(make_input("pre-commit run --files foo.go", ""))
+        assert out is not None
+        assert "passed" in out["tool_result"]
+
+    def test_failure_exit_code(self):
+        out = run_hook(
+            make_input(
+                "pre-commit run --files foo.go",
+                "Exit code 1\ngolangci-lint............Failed\nerror details\n",
+            )
+        )
+        assert out is None  # exit code prefix → passthrough
+
+
+# --- go test ---
+
+
+class TestGoTest:
+    def test_all_pass(self):
+        output = (
+            "ok  \tgithub.com/org/repo/internal/foo\t0.123s\n"
+            "ok  \tgithub.com/org/repo/internal/bar\t1.456s\n"
+            "ok  \tgithub.com/org/repo/internal/baz\t0.789s\n"
+        )
+        out = run_hook(make_input("go test ./internal/...", output))
+        assert out is not None
+        assert "3 packages passed" in out["tool_result"]
+        assert "2.4s" in out["tool_result"]
+
+    def test_failure(self):
+        output = (
+            "ok  \tgithub.com/org/repo/internal/foo\t0.123s\n"
+            "FAIL\tgithub.com/org/repo/internal/bar\t0.456s\n"
+        )
+        out = run_hook(make_input("go test ./...", output))
+        assert out is None  # FAIL line → passthrough
+
+    def test_empty_output(self):
+        out = run_hook(make_input("go test ./...", ""))
+        assert out is not None
+        assert "passed" in out["tool_result"]
+
+
+# --- pytest ---
+
+
+class TestPytest:
+    def test_all_pass(self):
+        output = (
+            "tests/test_foo.py ...\n"
+            "tests/test_bar.py ....\n"
+            "================ 7 passed in 1.23s ================\n"
+        )
+        out = run_hook(make_input("pytest tests/", output))
+        assert out is not None
+        assert "7 passed" in out["tool_result"]
+        assert "1.23s" in out["tool_result"]
+
+    def test_failure(self):
+        output = (
+            "tests/test_foo.py .F.\n================ 2 passed, 1 failed in 0.5s ================\n"
+        )
+        out = run_hook(make_input("pytest", output))
+        assert out is None  # failure → passthrough
+
+
+# --- npm test ---
+
+
+class TestNpmTest:
+    def test_pass(self):
+        out = run_hook(make_input("npm test", "  42 passing (3s)\n"))
+        assert out is not None
+        assert "passed" in out["tool_result"]
+
+    def test_failure(self):
+        out = run_hook(make_input("npm test", "  1 failing\n  Error: expected 1 to equal 2\n"))
+        assert out is None
+
+
+# --- make test ---
+
+
+class TestMakeTest:
+    def test_pass(self):
+        output = "go test ./...\nok all tests\n"
+        out = run_hook(make_input("make test", output))
+        assert out is not None
+        assert "passed" in out["tool_result"]
+
+    def test_failure(self):
+        output = "go test ./...\nFAIL error in tests\n"
+        out = run_hook(make_input("make test", output))
+        assert out is None
+
+
+# --- go vet / go build ---
+
+
+class TestGoVetBuild:
+    def test_go_vet_clean(self):
+        out = run_hook(make_input("go vet ./...", ""))
+        assert out is not None
+        assert out["tool_result"] == "go vet: clean"
+
+    def test_go_vet_with_errors(self):
+        out = run_hook(make_input("go vet ./...", "foo.go:12: unreachable code\n"))
+        assert out is None
+
+    def test_go_build_clean(self):
+        out = run_hook(make_input("go build ./...", ""))
+        assert out is not None
+        assert out["tool_result"] == "go build: clean"
+
+    def test_go_build_with_errors(self):
+        out = run_hook(make_input("go build ./...", "foo.go:5:3: undefined: bar\n"))
+        assert out is None
+
+
+# --- linters ---
+
+
+class TestLinters:
+    def test_golangci_lint_clean(self):
+        out = run_hook(make_input("golangci-lint run ./...", ""))
+        assert out is not None
+        assert "golangci-lint: clean" in out["tool_result"]
+
+    def test_golangci_lint_errors(self):
+        out = run_hook(make_input("golangci-lint run", "foo.go:5: error: unused\n"))
+        assert out is None
+
+    def test_eslint_clean(self):
+        out = run_hook(make_input("eslint src/", ""))
+        assert out is not None
+        assert "eslint: clean" in out["tool_result"]
+
+    def test_ruff_check_clean(self):
+        out = run_hook(make_input("ruff check .", ""))
+        assert out is not None
+        assert "ruff: clean" in out["tool_result"]
+
+    def test_ruff_format_clean(self):
+        out = run_hook(make_input("ruff format --check .", ""))
+        assert out is not None
+        assert "ruff-format: clean" in out["tool_result"]
+
+    def test_make_lint_clean(self):
+        out = run_hook(make_input("make lint", "all checks passed\n"))
+        assert out is not None
+        assert "lint: passed" in out["tool_result"]
+
+    def test_make_lint_failure(self):
+        out = run_hook(make_input("make lint", "golangci-lint: error in foo.go\n"))
+        assert out is None
+
+
+# --- gitlint ---
+
+
+class TestGitlint:
+    def test_pass(self):
+        out = run_hook(make_input("gitlint --commit HEAD", ""))
+        assert out is not None
+        assert out["tool_result"] == "gitlint: passed"
+
+    def test_failure(self):
+        out = run_hook(make_input("gitlint --commit HEAD", "1: T1 Title exceeds max length\n"))
+        assert out is None
+
+
+# --- passthrough cases ---
+
+
+class TestPassthrough:
+    def test_non_bash_tool(self):
+        hook_input = {
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/tmp/foo.go"},
+            "tool_result": "package main\n",
+        }
+        out = run_hook(hook_input)
+        assert out is None
+
+    def test_non_verification_command(self):
+        out = run_hook(make_input("git diff --stat", "foo.go | 5 ++---\n"))
+        assert out is None
+
+    def test_cat_command(self):
+        out = run_hook(make_input("cat foo.go", "package main\n"))
+        assert out is None
+
+    def test_ls_command(self):
+        out = run_hook(make_input("ls -la", "total 42\ndrwxr-xr-x ...\n"))
+        assert out is None
+
+    def test_empty_input(self):
+        result = subprocess.run(
+            [sys.executable, HOOK_SCRIPT],
+            input="",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_invalid_json(self):
+        result = subprocess.run(
+            [sys.executable, HOOK_SCRIPT],
+            input="not json",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_exit_code_prefix_always_passthrough(self):
+        out = run_hook(make_input("go test ./...", "Exit code 2\nFAIL something\n"))
+        assert out is None

--- a/internal/security/hooks/context_suppress_posttool_test.py
+++ b/internal/security/hooks/context_suppress_posttool_test.py
@@ -42,10 +42,9 @@ class TestScanSecrets:
         assert out is not None
         assert out["tool_result"] == "scan-secrets: passed (no findings)"
 
-    def test_empty_output(self):
+    def test_empty_output_passthrough(self):
         out = run_hook(make_input("scan-secrets foo.go", ""))
-        assert out is not None
-        assert "passed" in out["tool_result"]
+        assert out is None  # empty output → passthrough (scanner may have crashed)
 
     def test_failure_passthrough(self):
         out = run_hook(
@@ -66,10 +65,9 @@ class TestGitleaks:
         assert out is not None
         assert "passed" in out["tool_result"]
 
-    def test_empty_output(self):
+    def test_empty_output_passthrough(self):
         out = run_hook(make_input("gitleaks detect --source .", ""))
-        assert out is not None
-        assert "passed" in out["tool_result"]
+        assert out is None  # empty output → passthrough (scanner may have crashed)
 
 
 # --- pre-commit ---

--- a/internal/security/hooks_test.go
+++ b/internal/security/hooks_test.go
@@ -32,7 +32,7 @@ func TestGenerateClaudeSettings_AllDefaults(t *testing.T) {
 	matcher := postTools[0].(map[string]any)
 	assert.Equal(t, "Bash|WebFetch|Read", matcher["matcher"])
 	chainedHooks := matcher["hooks"].([]any)
-	assert.Len(t, chainedHooks, 2) // secret_redact → unicode
+	assert.Len(t, chainedHooks, 3) // context_suppress → secret_redact → unicode
 }
 
 func TestGenerateClaudeSettings_TirithDisabled(t *testing.T) {
@@ -62,10 +62,11 @@ func TestGenerateClaudeSettings_AllHooksDisabled(t *testing.T) {
 		Agent: "test.md",
 		Security: &harness.SecurityConfig{
 			SandboxHooks: &harness.SandboxHooks{
-				Tirith:               &harness.TirithConfig{Enabled: &disabled},
-				SSRFPreTool:          &disabled,
-				SecretRedactPostTool: &disabled,
-				UnicodePostTool:      &disabled,
+				Tirith:                  &harness.TirithConfig{Enabled: &disabled},
+				SSRFPreTool:             &disabled,
+				SecretRedactPostTool:    &disabled,
+				UnicodePostTool:         &disabled,
+				ContextSuppressPostTool: &disabled,
 			},
 		},
 	}
@@ -83,11 +84,12 @@ func TestGenerateClaudeSettings_AllHooksDisabled(t *testing.T) {
 func TestHookFiles_AllDefaults(t *testing.T) {
 	h := &harness.Harness{Agent: "test.md"}
 	files := HookFiles(h)
-	assert.Len(t, files, 4)
+	assert.Len(t, files, 5)
 	assert.Contains(t, files, "tirith_check.py")
 	assert.Contains(t, files, "ssrf_pretool.py")
 	assert.Contains(t, files, "secret_redact_posttool.py")
 	assert.Contains(t, files, "unicode_posttool.py")
+	assert.Contains(t, files, "context_suppress_posttool.py")
 
 	// Verify embedded content is non-empty.
 	for name, content := range files {
@@ -106,7 +108,7 @@ func TestHookFiles_SSRFDisabled(t *testing.T) {
 		},
 	}
 	files := HookFiles(h)
-	assert.Len(t, files, 3)
+	assert.Len(t, files, 4)
 	assert.NotContains(t, files, "ssrf_pretool.py")
 }
 
@@ -121,7 +123,7 @@ func TestHookFiles_UnicodeDisabled(t *testing.T) {
 		},
 	}
 	files := HookFiles(h)
-	assert.Len(t, files, 3)
+	assert.Len(t, files, 4)
 	assert.NotContains(t, files, "unicode_posttool.py")
 }
 
@@ -130,6 +132,7 @@ func TestEmbeddedHooksNotEmpty(t *testing.T) {
 	assert.NotEmpty(t, SecretRedactPostToolHook)
 	assert.NotEmpty(t, TirithCheckHook)
 	assert.NotEmpty(t, UnicodePostToolHook)
+	assert.NotEmpty(t, ContextSuppressPostToolHook)
 }
 
 func TestGenerateClaudeSettings_UnicodeDisabled(t *testing.T) {
@@ -152,10 +155,10 @@ func TestGenerateClaudeSettings_UnicodeDisabled(t *testing.T) {
 	postTools := hooks["PostToolUse"].([]any)
 	assert.Len(t, postTools, 1) // single matcher
 
-	// With unicode disabled, only secret_redact hook in the chain.
+	// With unicode disabled: context_suppress + secret_redact in the chain.
 	matcher := postTools[0].(map[string]any)
 	chainedHooks := matcher["hooks"].([]any)
-	assert.Len(t, chainedHooks, 1) // only secret_redact
+	assert.Len(t, chainedHooks, 2) // context_suppress + secret_redact
 }
 
 func TestGenerateClaudeSettings_SecretRedactDisabled(t *testing.T) {
@@ -178,8 +181,49 @@ func TestGenerateClaudeSettings_SecretRedactDisabled(t *testing.T) {
 	postTools := hooks["PostToolUse"].([]any)
 	assert.Len(t, postTools, 1) // single matcher
 
-	// With secret_redact disabled, only unicode hook in the chain.
+	// With secret_redact disabled: context_suppress + unicode in the chain.
 	matcher := postTools[0].(map[string]any)
 	chainedHooks := matcher["hooks"].([]any)
-	assert.Len(t, chainedHooks, 1) // only unicode
+	assert.Len(t, chainedHooks, 2) // context_suppress + unicode
+}
+
+func TestGenerateClaudeSettings_ContextSuppressDisabled(t *testing.T) {
+	disabled := false
+	h := &harness.Harness{
+		Agent: "test.md",
+		Security: &harness.SecurityConfig{
+			SandboxHooks: &harness.SandboxHooks{
+				ContextSuppressPostTool: &disabled,
+			},
+		},
+	}
+	data, err := GenerateClaudeSettings(h)
+	require.NoError(t, err)
+
+	var settings map[string]any
+	require.NoError(t, json.Unmarshal(data, &settings))
+
+	hooks := settings["hooks"].(map[string]any)
+	postTools := hooks["PostToolUse"].([]any)
+	assert.Len(t, postTools, 1) // single matcher
+
+	// With context_suppress disabled: secret_redact + unicode in the chain.
+	matcher := postTools[0].(map[string]any)
+	chainedHooks := matcher["hooks"].([]any)
+	assert.Len(t, chainedHooks, 2) // secret_redact + unicode
+}
+
+func TestHookFiles_ContextSuppressDisabled(t *testing.T) {
+	disabled := false
+	h := &harness.Harness{
+		Agent: "test.md",
+		Security: &harness.SecurityConfig{
+			SandboxHooks: &harness.SandboxHooks{
+				ContextSuppressPostTool: &disabled,
+			},
+		},
+	}
+	files := HookFiles(h)
+	assert.Len(t, files, 4)
+	assert.NotContains(t, files, "context_suppress_posttool.py")
 }


### PR DESCRIPTION
## Summary
- Adds a new PostToolUse hook (`context_suppress_posttool.py`) that compacts verbose verification tool output into one-line summaries on success while passing failures through unchanged
- Supports 15+ command patterns: scan-secrets, gitleaks, pre-commit, go test, pytest, npm test, make test, go vet, go build, golangci-lint, eslint, ruff, gitlint, and make lint
- Wired into the hook chain first (before secret redact and unicode scan) to avoid scanning text that gets discarded
- Adds `ContextSuppressPostTool` toggle to `SandboxHooks` config for per-repo opt-out
- Documents context efficiency behavior in the code-implementation skill

## Design principle
Success is silent, failure is loud. When a verification tool reports clean results, the hook replaces verbose multi-line output with a compact summary (e.g., `tests: 3 packages passed (2.4s)`). When anything fails, the full output passes through so the agent can diagnose and act on the failure.

## Safety
- Non-zero exit codes always pass through unchanged
- Empty scanner output (scan-secrets, gitleaks) passes through — a crashed scanner should not be mistaken for a clean scan
- Pytest failure detection catches both "failed" and "error" summary lines
- `make test` and `npm test` require positive success indicators rather than treating unknown output as passed
- All suppressions are logged to `findings.jsonl` for audit

## Test plan
- [x] 41 Python tests covering all command patterns, success/failure/edge cases
- [x] Go tests for hook registration, ordering, and config toggle
- [x] Verified hook chain ordering: context suppress → secret redact → unicode scan