### PR TITLE
fix: address PR #447 review feedback

### DIFF
--- a/internal/scaffold/fullsend-repo/skills/code-implementation/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/code-implementation/SKILL.md
@@ -476,7 +476,7 @@ You MUST run the test suite that covers the code you changed.
 Determine which packages to test from your changed files:
 
 ```bash
-git diff --name-only origin/<target-branch>..HEAD
+git diff --name-only origin/<target-branch>
 ```
 
 Full-suite runs (`go test ./...`, `npm test`, `pytest`) are acceptable as

--- a/internal/security/hooks/context_suppress_posttool.py
+++ b/internal/security/hooks/context_suppress_posttool.py
@@ -191,10 +191,7 @@ def suppress_go_build(output: str) -> str | None:
 def suppress_linter(name: str, output: str) -> str | None:
     if not output.strip():
         return f"{name}: clean"
-    lower = output.lower()
-    if "error" in lower or "fail" in lower or "warning" in lower:
-        return None
-    return f"{name}: passed"
+    return None
 
 
 def suppress_gitlint(output: str) -> str | None:

--- a/internal/security/hooks/context_suppress_posttool_test.py
+++ b/internal/security/hooks/context_suppress_posttool_test.py
@@ -299,9 +299,13 @@ class TestLinters:
         assert "ruff-format: clean" in out["tool_result"]
 
     def test_make_lint_clean(self):
-        out = run_hook(make_input("make lint", "all checks passed\n"))
+        out = run_hook(make_input("make lint", ""))
         assert out is not None
-        assert "lint: passed" in out["tool_result"]
+        assert "lint: clean" in out["tool_result"]
+
+    def test_make_lint_nonempty_passthrough(self):
+        out = run_hook(make_input("make lint", "all checks passed\n"))
+        assert out is None
 
     def test_make_lint_failure(self):
         out = run_hook(make_input("make lint", "golangci-lint: error in foo.go\n"))


### PR DESCRIPTION
## Summary
- Fix `git diff` command in SKILL.md step 9c to use working-tree diff (`git diff --name-only origin/<target-branch>`) instead of committed-history diff (`..HEAD`), since the agent hasn't committed yet at that step
- Make `suppress_linter` conservative: only suppress empty linter output, pass through any non-empty output — many linters use terminology beyond "error"/"fail"/"warning" (e.g., "violation", "issue", raw codes like `E501`) and exit-code passthrough already provides defense-in-depth

Addresses review comments from #447:
- https://github.com/fullsend-ai/fullsend/pull/447#discussion_r3149467467
- https://github.com/fullsend-ai/fullsend/pull/447#discussion_r3149467484

## Test plan
- [x] All 46 Python tests pass (including new `test_make_lint_nonempty_passthrough`)
- [x] Go tests pass
- [x] Lint passes