### PR TITLE
fix: allow yarn/pnpm in sandbox package registry policy

### DIFF
--- a/internal/scaffold/fullsend-repo/policies/code.yaml
+++ b/internal/scaffold/fullsend-repo/policies/code.yaml
@@ -7,7 +7,7 @@ version: 1
 #   - GitHub API (gh/git only — curl intentionally excluded to prevent
 #     disallowedTools bypass via raw HTTP with the injected GH_TOKEN)
 #   - gitleaks releases (fallback download if not pre-installed in image)
-#   - npm/PyPI/Go registries (running tests may pull dev dependencies)
+#   - npm/yarn/pnpm/PyPI/Go registries (running tests may pull dev dependencies)
 #   - pre-commit binary needs github (clone hook repos), package registries
 #     (pip install hook deps), and GitHub releases (hook binaries like gitleaks)
 
@@ -82,6 +82,11 @@ network_policies:
         protocol: tcp
         enforcement: enforce
         access: allow
+      - host: "registry.yarnpkg.com"
+        port: 443
+        protocol: tcp
+        enforcement: enforce
+        access: allow
       - host: "pypi.org"
         port: 443
         protocol: tcp
@@ -109,6 +114,10 @@ network_policies:
         access: allow
     binaries:
       - path: "**/npm"
+      - path: "**/npx"
+      - path: "**/yarn"
+      - path: "**/yarnpkg"
+      - path: "**/pnpm"
       - path: "**/node"
       - path: "**/pip"
       - path: "**/pip3"


### PR DESCRIPTION
## Summary
- Add `yarn`, `yarnpkg`, `pnpm`, and `npx` to the `package_registries.binaries` allowlist in the scaffold code agent policy
- Add `registry.yarnpkg.com` to the `package_registries.endpoints` allowlist
- The OpenShell L7 proxy enforces per-binary network restrictions via `/proc/pid/exe` — only binaries in the allowlist can reach package registries. Repos using Yarn (e.g., konflux-ui) fail at `yarn install` in the sandbox, preventing the code agent from running lint/tests before pushing PRs

## Context
- konflux-ui PRs [#839](https://github.com/konflux-ci/konflux-ui/pull/839) and [#840](https://github.com/konflux-ci/konflux-ui/pull/840) were pushed without lint/test validation because the sandbox blocked yarn
- PR #840 has 3 `no-unused-vars` lint errors; PR #839 has 50% patch coverage (target 85%) — both would have been caught with working `yarn lint && yarn test`

## Test plan
- [ ] Deploy updated policy to a test org `.fullsend` repo
- [ ] Trigger code agent on a yarn-based repo, verify `yarn install` succeeds in sandbox
- [ ] Verify `yarn lint` and `yarn test` run successfully before PR creation
- [ ] Verify non-allowlisted binaries (e.g., `curl`) are still blocked from reaching registries