### PR TITLE
fix: extract minimal payload in shim to prevent dispatch input overflow

### DIFF
--- a/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
@@ -51,10 +51,11 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_HTML_URL: ${{ github.event.issue.html_url }}
         run: |
+          set -euo pipefail
           PAYLOAD=$(jq -cn \
-            --arg in "$ISSUE_NUMBER" \
-            --arg iu "$ISSUE_HTML_URL" \
-            '{issue: {number: ($in | tonumber), html_url: $iu}}')
+            --arg in "${ISSUE_NUMBER:-}" \
+            --arg iu "${ISSUE_HTML_URL:-}" \
+            '{issue: {number: (if $in != "" then ($in | tonumber) else null end), html_url: (if $iu != "" then $iu else null end)}}')
           echo "json=$PAYLOAD" >> "$GITHUB_OUTPUT"
       - name: Dispatch triage
         env:
@@ -86,10 +87,11 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_HTML_URL: ${{ github.event.issue.html_url }}
         run: |
+          set -euo pipefail
           PAYLOAD=$(jq -cn \
-            --arg in "$ISSUE_NUMBER" \
-            --arg iu "$ISSUE_HTML_URL" \
-            '{issue: {number: ($in | tonumber), html_url: $iu}}')
+            --arg in "${ISSUE_NUMBER:-}" \
+            --arg iu "${ISSUE_HTML_URL:-}" \
+            '{issue: {number: (if $in != "" then ($in | tonumber) else null end), html_url: (if $iu != "" then $iu else null end)}}')
           echo "json=$PAYLOAD" >> "$GITHUB_OUTPUT"
       - name: Dispatch code
         env:
@@ -124,6 +126,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HTML_URL: ${{ github.event.pull_request.html_url }}
         run: |
+          set -euo pipefail
           PAYLOAD=$(jq -cn \
             --arg in "${ISSUE_NUMBER:-}" \
             --arg iu "${ISSUE_HTML_URL:-}" \

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
@@ -6,9 +6,13 @@
 # This shim never checks out PR code, so it is not vulnerable to "pwn request"
 # attacks (see: Trivy CVE-2026-33634, hackerbot-claw campaign).
 #
-# The event payload is passed via an environment variable (not inline shell)
+# The event payload is built from individual context fields (not inline shell)
 # to prevent script injection from attacker-controlled fields like issue
 # titles, comment bodies, and PR descriptions.
+#
+# Only the fields consumed by downstream workflows are dispatched. The full
+# github.event can exceed GitHub's 65KB workflow_dispatch input limit on
+# large dependency-update PRs (Renovate/Mintmaker bodies alone can be ~38KB).
 name: fullsend
 
 permissions:
@@ -41,10 +45,21 @@ jobs:
         )
       )
     steps:
+      - name: Build minimal payload
+        id: payload
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_HTML_URL: ${{ github.event.issue.html_url }}
+        run: |
+          PAYLOAD=$(jq -cn \
+            --arg in "$ISSUE_NUMBER" \
+            --arg iu "$ISSUE_HTML_URL" \
+            '{issue: {number: ($in | tonumber), html_url: $iu}}')
+          echo "json=$PAYLOAD" >> "$GITHUB_OUTPUT"
       - name: Dispatch triage
         env:
           GH_TOKEN: ${{ secrets.FULLSEND_DISPATCH_TOKEN }}
-          EVENT_PAYLOAD: ${{ toJSON(github.event) }}
+          EVENT_PAYLOAD: ${{ steps.payload.outputs.json }}
           EVENT_TYPE: ${{ github.event_name }}
           SOURCE_REPO: ${{ github.repository }}
           DISPATCH_REPO: ${{ github.repository_owner }}/.fullsend
@@ -65,10 +80,21 @@ jobs:
         startsWith(github.event.comment.body, '/code ')
       ))
     steps:
+      - name: Build minimal payload
+        id: payload
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_HTML_URL: ${{ github.event.issue.html_url }}
+        run: |
+          PAYLOAD=$(jq -cn \
+            --arg in "$ISSUE_NUMBER" \
+            --arg iu "$ISSUE_HTML_URL" \
+            '{issue: {number: ($in | tonumber), html_url: $iu}}')
+          echo "json=$PAYLOAD" >> "$GITHUB_OUTPUT"
       - name: Dispatch code
         env:
           GH_TOKEN: ${{ secrets.FULLSEND_DISPATCH_TOKEN }}
-          EVENT_PAYLOAD: ${{ toJSON(github.event) }}
+          EVENT_PAYLOAD: ${{ steps.payload.outputs.json }}
           EVENT_TYPE: ${{ github.event_name }}
           SOURCE_REPO: ${{ github.repository }}
           DISPATCH_REPO: ${{ github.repository_owner }}/.fullsend
@@ -90,10 +116,26 @@ jobs:
       )) ||
       github.event_name == 'pull_request_target'
     steps:
+      - name: Build minimal payload
+        id: payload
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_HTML_URL: ${{ github.event.issue.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HTML_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          PAYLOAD=$(jq -cn \
+            --arg in "${ISSUE_NUMBER:-}" \
+            --arg iu "${ISSUE_HTML_URL:-}" \
+            --arg pn "${PR_NUMBER:-}" \
+            --arg pu "${PR_HTML_URL:-}" \
+            '{issue: {number: (if $in != "" then ($in | tonumber) else null end), html_url: (if $iu != "" then $iu else null end)},
+              pull_request: {number: (if $pn != "" then ($pn | tonumber) else null end), html_url: (if $pu != "" then $pu else null end)}}')
+          echo "json=$PAYLOAD" >> "$GITHUB_OUTPUT"
       - name: Dispatch review
         env:
           GH_TOKEN: ${{ secrets.FULLSEND_DISPATCH_TOKEN }}
-          EVENT_PAYLOAD: ${{ toJSON(github.event) }}
+          EVENT_PAYLOAD: ${{ steps.payload.outputs.json }}
           EVENT_TYPE: ${{ github.event_name }}
           SOURCE_REPO: ${{ github.repository }}
           DISPATCH_REPO: ${{ github.repository_owner }}/.fullsend


### PR DESCRIPTION
## Summary
- Replace `toJSON(github.event)` with a minimal jq-built JSON object in all three dispatch jobs (triage, code, review)
- Only dispatches the fields downstream workflows actually consume: `issue.number`, `issue.html_url`, `pull_request.number`, `pull_request.html_url`
- Reduces payload from ~71KB to ~500 bytes, well within GitHub's 65KB `workflow_dispatch` input limit

## Context
- Large dependency-update PRs (Renovate/Mintmaker) have PR bodies of ~38KB (version badges, changelogs, confidence tables)
- Combined with GitHub's standard event metadata (~33KB), the total payload exceeds the 65KB limit
- This caused HTTP 422 "inputs are too large" errors on `konflux-ci/caching` (go-openapi PR) and `konflux-ci/konflux-ui` (swc-monorepo PR)
- Event fields continue to flow through environment variables (not inline shell) to preserve script injection protection

## Test plan
- [ ] Deploy updated shim to a test repo with a large Renovate/Mintmaker PR
- [ ] Verify dispatch-review succeeds (previously failed with 422)
- [ ] Verify triage dispatch works on `/triage` comment (issue.number + issue.html_url present)
- [ ] Verify code dispatch works on `ready-to-code` label (issue.number + issue.html_url present)
- [ ] Verify review dispatch works on PR open (pull_request.number + pull_request.html_url present)
- [ ] Verify review dispatch works on `/review` comment (issue context, no pull_request fields — null handling)
- [ ] Verify concurrency groups still work in downstream workflows (`fromJSON` on the minimal payload)