### PR TITLE
fix: always print browser URLs so users can reopen closed tabs

### DIFF
--- a/internal/appsetup/appsetup.go
+++ b/internal/appsetup/appsetup.go
@@ -503,10 +503,10 @@ func (s *Setup) ensureInstalled(ctx context.Context, org, slug string) error {
 	installURL := fmt.Sprintf("https://github.com/apps/%s/installations/new", slug)
 	s.ui.StepWarn(fmt.Sprintf("App %s is not yet installed on %s", slug, org))
 	s.ui.StepStart("Opening browser for installation...")
+	s.ui.StepInfo(fmt.Sprintf("URL: %s", installURL))
 
 	if err := s.browser.Open(ctx, installURL); err != nil {
 		s.ui.StepWarn(fmt.Sprintf("Could not open browser: %v", err))
-		s.ui.StepInfo(fmt.Sprintf("Install manually at: %s", installURL))
 	}
 
 	s.ui.StepInfo("Waiting for installation (will detect automatically)...")

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -875,12 +875,11 @@ func promptDispatchToken(ctx context.Context, client forge.Client, printer *ui.P
 	)
 
 	printer.StepStart("Opening browser for dispatch token creation")
+	printer.StepInfo("URL: " + patURL)
 
 	browser := appsetup.DefaultBrowser{}
 	if err := browser.Open(ctx, patURL); err != nil {
 		printer.StepWarn(fmt.Sprintf("Could not open browser: %v", err))
-		printer.StepInfo("Open this URL manually:")
-		printer.StepInfo("  " + patURL)
 	} else {
 		printer.StepDone("Opened token creation page")
 	}


### PR DESCRIPTION
## Summary
- Always print the URL before opening the browser for app installation and dispatch token creation
- Previously URLs were only shown when `browser.Open()` failed, leaving users stuck if they accidentally closed the tab
- Two call sites fixed: `appsetup.ensureInstalled()` and `cli.promptDispatchToken()`

## Test plan
- [x] `go test ./internal/appsetup/ ./internal/cli/` — all pass
- [x] `go vet` — clean
- [x] `make lint` — clean
- [ ] Manual test: run `fullsend admin install` and verify URLs appear in terminal output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Picture of how it looks like:

<img width="1904" height="256" alt="image" src="https://github.com/user-attachments/assets/906e124b-5ff6-4a5e-82ae-3ba9bab5b3a9" />
