### PR TITLE
fix: use vars instead of secrets in workflow if conditions

### DIFF
--- a/internal/inference/vertex/vertex.go
+++ b/internal/inference/vertex/vertex.go
@@ -35,6 +35,11 @@ const (
 	// VariableRegion is the repo variable name for the GCP region.
 	VariableRegion = "FULLSEND_GCP_REGION"
 
+	// VariableAuthMode tells workflows which GCP auth method to use.
+	// Must be a variable (not a secret) because GitHub's dispatch-time
+	// validator does not recognise the secrets context.
+	VariableAuthMode = "FULLSEND_GCP_AUTH_MODE"
+
 	// SecretWIFProvider is the repo secret for the full WIF provider resource name.
 	// Stored as a secret so the value is masked in GitHub Actions logs.
 	SecretWIFProvider = "FULLSEND_GCP_WIF_PROVIDER"
@@ -108,10 +113,13 @@ func (p *Provider) SecretNames() []string {
 
 // Variables returns non-secret name/value pairs to store as repo variables.
 func (p *Provider) Variables() map[string]string {
-	if p.cfg.Region == "" {
-		return nil
+	vars := map[string]string{
+		VariableAuthMode: string(p.cfg.Mode),
 	}
-	return map[string]string{VariableRegion: p.cfg.Region}
+	if p.cfg.Region != "" {
+		vars[VariableRegion] = p.cfg.Region
+	}
+	return vars
 }
 
 // Provision acquires GCP credentials and returns them as secrets.

--- a/internal/inference/vertex/vertex_test.go
+++ b/internal/inference/vertex/vertex_test.go
@@ -284,11 +284,17 @@ func TestSecretNames(t *testing.T) {
 func TestVariables_WithRegion(t *testing.T) {
 	p := New(Config{Region: "global"}, nil)
 	vars := p.Variables()
-	assert.Equal(t, map[string]string{VariableRegion: "global"}, vars)
+	assert.Equal(t, map[string]string{VariableAuthMode: "sa_key", VariableRegion: "global"}, vars)
 }
 
 func TestVariables_WithoutRegion(t *testing.T) {
 	p := New(Config{}, nil)
 	vars := p.Variables()
-	assert.Nil(t, vars)
+	assert.Equal(t, map[string]string{VariableAuthMode: "sa_key"}, vars)
+}
+
+func TestVariables_WIFMode(t *testing.T) {
+	p := New(Config{Mode: AuthModeWIF, Region: "global"}, nil)
+	vars := p.Variables()
+	assert.Equal(t, map[string]string{VariableAuthMode: "wif", VariableRegion: "global"}, vars)
 }

--- a/internal/scaffold/fullsend-repo/.github/workflows/code.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/code.yml
@@ -101,14 +101,14 @@ jobs:
         run: bash scripts/pre-code.sh
 
       - name: Authenticate to Google Cloud (WIF)
-        if: secrets.FULLSEND_GCP_WIF_PROVIDER != ''
+        if: vars.FULLSEND_GCP_AUTH_MODE == 'wif'
         uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.FULLSEND_GCP_WIF_SA_EMAIL }}
 
       - name: Authenticate to Google Cloud (SA key)
-        if: secrets.FULLSEND_GCP_WIF_PROVIDER == ''
+        if: vars.FULLSEND_GCP_AUTH_MODE != 'wif'
         uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.FULLSEND_GCP_SA_KEY_JSON }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/review.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/review.yml
@@ -92,14 +92,14 @@ jobs:
           fetch-depth: 1
 
       - name: Authenticate to Google Cloud (WIF)
-        if: secrets.FULLSEND_GCP_WIF_PROVIDER != ''
+        if: vars.FULLSEND_GCP_AUTH_MODE == 'wif'
         uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.FULLSEND_GCP_WIF_SA_EMAIL }}
 
       - name: Authenticate to Google Cloud (SA key)
-        if: secrets.FULLSEND_GCP_WIF_PROVIDER == ''
+        if: vars.FULLSEND_GCP_AUTH_MODE != 'wif'
         uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.FULLSEND_GCP_SA_KEY_JSON }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/triage.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/triage.yml
@@ -71,14 +71,14 @@ jobs:
           fetch-depth: 1
 
       - name: Authenticate to Google Cloud (WIF)
-        if: secrets.FULLSEND_GCP_WIF_PROVIDER != ''
+        if: vars.FULLSEND_GCP_AUTH_MODE == 'wif'
         uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.FULLSEND_GCP_WIF_SA_EMAIL }}
 
       - name: Authenticate to Google Cloud (SA key)
-        if: secrets.FULLSEND_GCP_WIF_PROVIDER == ''
+        if: vars.FULLSEND_GCP_AUTH_MODE != 'wif'
         uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.FULLSEND_GCP_SA_KEY_JSON }}


### PR DESCRIPTION
## Summary

- Workflow `if:` conditions referenced `secrets.FULLSEND_GCP_WIF_PROVIDER` to choose between WIF and SA key auth. GitHub's `workflow_dispatch` API validates all expressions before accepting the dispatch, and the `secrets` context is not available during that validation — only at runtime on a runner. This caused every installation to fail at the dispatch token verification step with `Unrecognized named-value: 'secrets'`.
- Replaced the `secrets`-based conditional with a `FULLSEND_GCP_AUTH_MODE` repository variable (`wif` or `sa_key`), set at install time by the vertex provider. The `vars` context is available during dispatch-time validation.
- Updated triage.yml, code.yml, and review.yml scaffold templates to use `vars.FULLSEND_GCP_AUTH_MODE` in `if:` conditions.

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes (including new `TestVariables_WIFMode` test)
- [x] Verified manually: `fullsend admin install` with WIF flags now passes dispatch token verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)