### PR TITLE
fix: store app PEM secret immediately after creation

### DIFF
--- a/internal/appsetup/appsetup.go
+++ b/internal/appsetup/appsetup.go
@@ -47,6 +47,9 @@ type BrowserOpener interface {
 // SecretExistsFunc checks if a secret exists for a given role.
 type SecretExistsFunc func(role string) (bool, error)
 
+// StoreSecretFunc stores a PEM secret for a given role immediately after app creation.
+type StoreSecretFunc func(ctx context.Context, role, pem string) error
+
 // DefaultBrowser opens URLs using platform-specific commands.
 type DefaultBrowser struct{}
 
@@ -103,6 +106,7 @@ type Setup struct {
 	ui           *ui.Printer
 	knownSlugs   map[string]string
 	secretExists SecretExistsFunc
+	storeSecret  StoreSecretFunc
 	permErrors   []string
 }
 
@@ -130,14 +134,23 @@ func (s *Setup) WithSecretExists(fn SecretExistsFunc) *Setup {
 	return s
 }
 
+// WithStoreSecret sets the function used to store a PEM secret immediately
+// after creating a new app, before proceeding to the next role.
+func (s *Setup) WithStoreSecret(fn StoreSecretFunc) *Setup {
+	s.storeSecret = fn
+	return s
+}
+
 // Run creates or reuses a GitHub App for the given org and role.
 //
 // The flow:
 //  1. Check for an existing installation matching this org/role.
 //  2. If found and the PEM secret exists, offer to reuse.
 //  3. If found but PEM is lost, return an error.
-//  4. If not found, run the manifest flow to create a new app.
-//  5. After creation, ensure the app is installed on the org.
+//  4. If not installed but app exists (PEM stored, installation missing),
+//     resume by installing the existing app on the org.
+//  5. If not found, run the manifest flow to create a new app.
+//  6. After creation, store the PEM immediately, then install on the org.
 func (s *Setup) Run(ctx context.Context, org, role string) (*AppCredentials, error) {
 	slug := ExpectedAppSlug(org, role)
 	s.ui.StepStart(fmt.Sprintf("Checking for existing app: %s", slug))
@@ -151,11 +164,31 @@ func (s *Setup) Run(ctx context.Context, org, role string) (*AppCredentials, err
 		return s.handleExistingApp(ctx, inst, org, role)
 	}
 
+	// No installation — check if app was created in a previous run that
+	// failed before the app was installed on the org.
+	if recovered, err := s.recoverCreatedApp(ctx, org, role, slug); err != nil {
+		return nil, err
+	} else if recovered != nil {
+		if err := s.ensureInstalled(ctx, org, recovered.Slug); err != nil {
+			return nil, fmt.Errorf("ensuring installation: %w", err)
+		}
+		return recovered, nil
+	}
+
 	// No existing app found — run the manifest flow.
 	s.ui.StepStart(fmt.Sprintf("Creating new GitHub App: %s", slug))
 	creds, err := s.runManifestFlow(ctx, org, role)
 	if err != nil {
 		return nil, fmt.Errorf("manifest flow: %w", err)
+	}
+
+	// Store PEM immediately so it survives partial install failures.
+	if s.storeSecret != nil && creds.PEM != "" {
+		s.ui.StepStart(fmt.Sprintf("Storing private key for %s", role))
+		if err := s.storeSecret(ctx, role, creds.PEM); err != nil {
+			return nil, fmt.Errorf("storing secret for %s: %w", role, err)
+		}
+		s.ui.StepDone(fmt.Sprintf("Stored private key for %s", role))
 	}
 
 	// Ensure the new app is installed on the org.
@@ -164,6 +197,49 @@ func (s *Setup) Run(ctx context.Context, org, role string) (*AppCredentials, err
 	}
 
 	return creds, nil
+}
+
+// recoverCreatedApp handles partial failure recovery: the app was created
+// and its PEM stored, but the process exited before the app was installed
+// on the org. Detects this by checking if the PEM secret exists and the
+// app is reachable via GetAppClientID.
+func (s *Setup) recoverCreatedApp(ctx context.Context, org, role, slug string) (*AppCredentials, error) {
+	if s.secretExists == nil {
+		return nil, nil
+	}
+
+	exists, err := s.secretExists(role)
+	if err != nil {
+		return nil, fmt.Errorf("checking secret for role %s: %w", role, err)
+	}
+	if !exists {
+		return nil, nil
+	}
+
+	// PEM secret exists — try to find the app. Check known slug first,
+	// then expected slug convention.
+	candidates := []string{slug}
+	if s.knownSlugs != nil {
+		if ks, ok := s.knownSlugs[role]; ok {
+			candidates = []string{ks, slug}
+		}
+	}
+
+	for _, candidate := range candidates {
+		clientID, err := s.client.GetAppClientID(ctx, candidate)
+		if err != nil {
+			continue
+		}
+
+		s.ui.StepDone(fmt.Sprintf("Recovering previously created app: %s", candidate))
+		return &AppCredentials{
+			Slug:     candidate,
+			Name:     candidate,
+			ClientID: clientID,
+		}, nil
+	}
+
+	return nil, nil
 }
 
 // findExistingInstallation looks for an installation matching the role,

--- a/internal/appsetup/appsetup_test.go
+++ b/internal/appsetup/appsetup_test.go
@@ -121,6 +121,92 @@ func TestSetup_ExistingApp_SecretExists_AutoReuse(t *testing.T) {
 	assert.False(t, prompter.confirmCalled, "should not prompt for reuse")
 }
 
+func TestSetup_ExistingApp_Reuse_StoreSecretNotCalled(t *testing.T) {
+	client := &forge.FakeClient{
+		Installations: []forge.Installation{
+			{ID: 100, AppID: 10, AppSlug: "myorg-fullsend"},
+		},
+		AppClientIDs: map[string]string{
+			"myorg-fullsend": "Iv1.fullsend123",
+		},
+	}
+	printer := ui.New(&discardWriter{})
+
+	storeCalled := false
+	s := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer).
+		WithSecretExists(func(_ string) (bool, error) { return true, nil }).
+		WithStoreSecret(func(_ context.Context, _, _ string) error {
+			storeCalled = true
+			return nil
+		})
+
+	creds, err := s.Run(context.Background(), "myorg", "fullsend")
+	require.NoError(t, err)
+	assert.Empty(t, creds.PEM)
+	assert.False(t, storeCalled, "storeSecret should not be called on reuse")
+}
+
+func TestSetup_RecoverCreatedApp_PEMExists(t *testing.T) {
+	client := &forge.FakeClient{
+		AppClientIDs: map[string]string{
+			"myorg-coder": "Iv1.coder456",
+		},
+	}
+	printer := ui.New(&discardWriter{})
+
+	s := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer).
+		WithSecretExists(func(_ string) (bool, error) { return true, nil })
+
+	creds, err := s.recoverCreatedApp(context.Background(), "myorg", "coder", "myorg-coder")
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	assert.Equal(t, "myorg-coder", creds.Slug)
+	assert.Equal(t, "Iv1.coder456", creds.ClientID)
+	assert.Empty(t, creds.PEM, "PEM should be empty — already stored")
+}
+
+func TestSetup_RecoverCreatedApp_KnownSlug(t *testing.T) {
+	client := &forge.FakeClient{
+		AppClientIDs: map[string]string{
+			"custom-coder-app": "Iv1.custom789",
+		},
+	}
+	printer := ui.New(&discardWriter{})
+
+	s := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer).
+		WithKnownSlugs(map[string]string{"coder": "custom-coder-app"}).
+		WithSecretExists(func(_ string) (bool, error) { return true, nil })
+
+	creds, err := s.recoverCreatedApp(context.Background(), "myorg", "coder", "myorg-coder")
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+	assert.Equal(t, "custom-coder-app", creds.Slug)
+	assert.Equal(t, "Iv1.custom789", creds.ClientID)
+}
+
+func TestSetup_RecoverCreatedApp_NoPEM(t *testing.T) {
+	client := &forge.FakeClient{}
+	printer := ui.New(&discardWriter{})
+
+	s := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer).
+		WithSecretExists(func(_ string) (bool, error) { return false, nil })
+
+	creds, err := s.recoverCreatedApp(context.Background(), "myorg", "coder", "myorg-coder")
+	require.NoError(t, err)
+	assert.Nil(t, creds, "should return nil when no PEM exists")
+}
+
+func TestSetup_RecoverCreatedApp_NoSecretExistsFunc(t *testing.T) {
+	client := &forge.FakeClient{}
+	printer := ui.New(&discardWriter{})
+
+	s := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer)
+
+	creds, err := s.recoverCreatedApp(context.Background(), "myorg", "coder", "myorg-coder")
+	require.NoError(t, err)
+	assert.Nil(t, creds, "should return nil when no secretExists func")
+}
+
 func TestSetup_ExistingApp_NoSecret(t *testing.T) {
 	client := &forge.FakeClient{
 		Installations: []forge.Installation{

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -186,6 +186,9 @@ func newInstallCmd() *cobra.Command {
 			// Collect agent credentials via app setup.
 			var agentCreds []layers.AgentCredentials
 			if !skipAppSetup {
+				if err := ensureConfigRepoExists(ctx, client, printer, org); err != nil {
+					return err
+				}
 				creds, err := runAppSetup(ctx, client, printer, org, roles)
 				if err != nil {
 					return err
@@ -399,6 +402,12 @@ func runAppSetup(ctx context.Context, client forge.Client, printer *ui.Printer, 
 		return client.RepoSecretExists(ctx, org, forge.ConfigRepoName, secretName)
 	})
 
+	// Store PEM immediately after app creation to survive partial failures.
+	setup = setup.WithStoreSecret(func(sctx context.Context, role, pem string) error {
+		secretName := fmt.Sprintf("FULLSEND_%s_APP_PRIVATE_KEY", strings.ToUpper(role))
+		return client.CreateRepoSecret(sctx, org, forge.ConfigRepoName, secretName, pem)
+	})
+
 	var creds []layers.AgentCredentials
 	for _, role := range roles {
 		appCreds, err := setup.Run(ctx, org, role)
@@ -422,6 +431,33 @@ func runAppSetup(ctx context.Context, client forge.Client, printer *ui.Printer, 
 
 	printer.Blank()
 	return creds, nil
+}
+
+// ensureConfigRepoExists creates the .fullsend config repo if it doesn't
+// already exist. This is called before app setup so PEM secrets can be
+// stored immediately after each app is created.
+func ensureConfigRepoExists(ctx context.Context, client forge.Client, printer *ui.Printer, org string) error {
+	_, err := client.GetRepo(ctx, org, forge.ConfigRepoName)
+	if err == nil {
+		return nil
+	}
+	if !forge.IsNotFound(err) {
+		return fmt.Errorf("checking for config repo: %w", err)
+	}
+
+	printer.StepStart("Creating " + forge.ConfigRepoName + " repository")
+	desc := fmt.Sprintf("fullsend configuration for %s", org)
+	if _, err := client.CreateRepo(ctx, org, forge.ConfigRepoName, desc, true); err != nil {
+		recheck, recheckErr := client.GetRepo(ctx, org, forge.ConfigRepoName)
+		if recheckErr == nil && recheck != nil {
+			printer.StepInfo(forge.ConfigRepoName + " repository already exists")
+			return nil
+		}
+		printer.StepFail("Failed to create " + forge.ConfigRepoName + " repository")
+		return fmt.Errorf("creating config repo: %w", err)
+	}
+	printer.StepDone("Created " + forge.ConfigRepoName + " repository")
+	return nil
 }
 
 // validateEnabledRepos checks that every --repo value exists in the

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -1,10 +1,15 @@
 package cli
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
+	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
 func TestAdminCommand_HasSubcommands(t *testing.T) {
@@ -165,4 +170,41 @@ func TestResolveToken_GitHubTokenFallback(t *testing.T) {
 	token, err := resolveToken()
 	require.NoError(t, err)
 	assert.Equal(t, "github-token-456", token)
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestEnsureConfigRepoExists_CreatesWhenMissing(t *testing.T) {
+	client := forge.NewFakeClient()
+	printer := ui.New(&discardWriter{})
+
+	err := ensureConfigRepoExists(context.Background(), client, printer, "myorg")
+	require.NoError(t, err)
+	require.Len(t, client.CreatedRepos, 1)
+	assert.Equal(t, ".fullsend", client.CreatedRepos[0].Name)
+	assert.True(t, client.CreatedRepos[0].Private)
+}
+
+func TestEnsureConfigRepoExists_NoOpWhenExists(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.Repos = []forge.Repository{
+		{Name: ".fullsend", FullName: "myorg/.fullsend"},
+	}
+	printer := ui.New(&discardWriter{})
+
+	err := ensureConfigRepoExists(context.Background(), client, printer, "myorg")
+	require.NoError(t, err)
+	assert.Empty(t, client.CreatedRepos)
+}
+
+func TestEnsureConfigRepoExists_ReturnsError(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.Errors["GetRepo"] = fmt.Errorf("network error")
+	printer := ui.New(&discardWriter{})
+
+	err := ensureConfigRepoExists(context.Background(), client, printer, "myorg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checking for config repo")
 }


### PR DESCRIPTION
## Summary

- Store each app's PEM secret on the `.fullsend` repo immediately after creation (via `StoreSecretFunc` callback), instead of deferring to `SecretsLayer` — survives partial install failures
- Ensure `.fullsend` config repo exists before app setup begins so secrets have a storage target
- Recover from a related partial failure: if the process exits after creating an app but before installing it on the org, re-runs detect the existing app (PEM secret + `GetAppClientID` lookup) and resume installation instead of trying to recreate

Closes #324

## Test plan

- [x] `TestSetup_ExistingApp_Reuse_StoreSecretNotCalled` — reuse path skips store callback
- [x] `TestSetup_RecoverCreatedApp_PEMExists` — detects app created in previous run
- [x] `TestSetup_RecoverCreatedApp_KnownSlug` — recovery works with non-standard slug
- [x] `TestSetup_RecoverCreatedApp_NoPEM` — no false recovery when PEM absent
- [x] `TestSetup_RecoverCreatedApp_NoSecretExistsFunc` — graceful nil when no checker
- [x] `TestEnsureConfigRepoExists_CreatesWhenMissing` — creates repo when absent
- [x] `TestEnsureConfigRepoExists_NoOpWhenExists` — idempotent when repo exists
- [x] `TestEnsureConfigRepoExists_ReturnsError` — propagates non-404 errors
- [x] `go vet` clean, `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)