### PR TITLE
fix: exclude gitignored files from scaffold sync

### DIFF
--- a/hack/patch-fullsend-repo
+++ b/hack/patch-fullsend-repo
@@ -48,7 +48,7 @@ CLONE_DIR="$WORKDIR/repo"
 # Copy scaffold files into the clone
 # ---------------------------------------------------------------------------
 echo "Syncing scaffold files..."
-rsync -a --checksum "$SCAFFOLD_DIR/" "$CLONE_DIR/"
+rsync -a --checksum --exclude-from="${SCRIPT_DIR}/../.gitignore" "$SCAFFOLD_DIR/" "$CLONE_DIR/"
 
 # ---------------------------------------------------------------------------
 # Check for changes


### PR DESCRIPTION
## Summary

- Add `--exclude-from` to the `rsync` command in `hack/patch-fullsend-repo` so files matching `.gitignore` patterns (`bin/`, `.venv/`, `__pycache__/`, etc.) are not copied into the target `.fullsend` repo during scaffold sync.

## Test plan

- [x] Run `hack/patch-fullsend-repo` against a test org and verify no gitignored files appear in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)