### PR TITLE
fix: accept pull request URLs in pre-code validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ go-tidy:
 	go mod tidy
 
 script-test:
+	bash internal/scaffold/fullsend-repo/scripts/pre-code-test.sh
 	bash internal/scaffold/fullsend-repo/scripts/post-triage-test.sh
 	bash internal/scaffold/fullsend-repo/scripts/validate-output-schema-test.sh
 

--- a/internal/scaffold/fullsend-repo/scripts/pre-code-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-code-test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# pre-code-test.sh — Test pre-code.sh input validation.
+#
+# Run from the repo root: bash internal/scaffold/fullsend-repo/scripts/pre-code-test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRE_SCRIPT="${SCRIPT_DIR}/pre-code.sh"
+FAILURES=0
+
+run_test() {
+  local test_name="$1"
+  local issue_number="$2"
+  local repo_full_name="$3"
+  local github_issue_url="$4"
+  local expect_failure="${5:-false}"
+
+  local exit_code=0
+  ISSUE_NUMBER="${issue_number}" \
+  REPO_FULL_NAME="${repo_full_name}" \
+  GITHUB_ISSUE_URL="${github_issue_url}" \
+    bash "${PRE_SCRIPT}" > /dev/null 2>&1 || exit_code=$?
+
+  if [[ "${expect_failure}" == "true" ]]; then
+    if [[ ${exit_code} -eq 0 ]]; then
+      echo "FAIL: ${test_name} — expected failure but got success"
+      FAILURES=$((FAILURES + 1))
+      return
+    fi
+    echo "PASS: ${test_name} (expected failure)"
+    return
+  fi
+
+  if [[ ${exit_code} -ne 0 ]]; then
+    echo "FAIL: ${test_name} — exit code ${exit_code}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  echo "PASS: ${test_name}"
+}
+
+# --- Valid inputs ---
+
+run_test "issue-url-passes" \
+  "42" "org/repo" "https://github.com/org/repo/issues/42"
+
+run_test "pull-request-url-passes" \
+  "839" "konflux-ci/konflux-ui" "https://github.com/konflux-ci/konflux-ui/pull/839"
+
+run_test "large-issue-number" \
+  "99999" "org/repo" "https://github.com/org/repo/issues/99999"
+
+run_test "repo-with-dots-and-hyphens" \
+  "1" "my-org/my.repo-name" "https://github.com/my-org/my.repo-name/issues/1"
+
+# --- Invalid URL format ---
+
+run_test "rejects-commits-url" \
+  "42" "org/repo" "https://github.com/org/repo/commits/42" "true"
+
+run_test "rejects-discussions-url" \
+  "42" "org/repo" "https://github.com/org/repo/discussions/42" "true"
+
+run_test "rejects-pulls-plural" \
+  "42" "org/repo" "https://github.com/org/repo/pulls/42" "true"
+
+run_test "rejects-trailing-path" \
+  "42" "org/repo" "https://github.com/org/repo/issues/42/files" "true"
+
+run_test "rejects-empty-url" \
+  "42" "org/repo" "" "true"
+
+run_test "rejects-non-github-host" \
+  "42" "org/repo" "https://gitlab.com/org/repo/issues/42" "true"
+
+# --- Cross-validation ---
+
+run_test "rejects-repo-mismatch" \
+  "42" "org/other-repo" "https://github.com/org/repo/issues/42" "true"
+
+run_test "rejects-number-mismatch" \
+  "99" "org/repo" "https://github.com/org/repo/issues/42" "true"
+
+run_test "rejects-number-mismatch-pr" \
+  "99" "org/repo" "https://github.com/org/repo/pull/42" "true"
+
+# --- Invalid ISSUE_NUMBER ---
+
+run_test "rejects-zero-issue-number" \
+  "0" "org/repo" "https://github.com/org/repo/issues/0" "true"
+
+run_test "rejects-non-numeric-issue-number" \
+  "abc" "org/repo" "https://github.com/org/repo/issues/42" "true"
+
+run_test "rejects-empty-issue-number" \
+  "" "org/repo" "https://github.com/org/repo/issues/42" "true"
+
+# --- Invalid REPO_FULL_NAME ---
+
+run_test "rejects-empty-repo" \
+  "42" "" "https://github.com/org/repo/issues/42" "true"
+
+run_test "rejects-repo-no-slash" \
+  "42" "noslash" "https://github.com/org/repo/issues/42" "true"
+
+# --- Summary ---
+
+echo ""
+if [[ ${FAILURES} -gt 0 ]]; then
+  echo "${FAILURES} test(s) failed"
+  exit 1
+fi
+echo "All tests passed"

--- a/internal/scaffold/fullsend-repo/scripts/pre-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-code.sh
@@ -7,7 +7,7 @@
 # Required environment variables (set by the workflow):
 #   ISSUE_NUMBER       — must be a positive integer
 #   REPO_FULL_NAME     — must be owner/repo format
-#   GITHUB_ISSUE_URL   — must be a valid GitHub issue URL
+#   GITHUB_ISSUE_URL   — must be a valid GitHub issue or pull request URL
 set -euo pipefail
 
 echo "::notice::🔗 Code target: ${GITHUB_ISSUE_URL:-}"
@@ -24,20 +24,20 @@ if [[ ! "${REPO_FULL_NAME:-}" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]]; then
   errors=$((errors + 1))
 fi
 
-if [[ ! "${GITHUB_ISSUE_URL:-}" =~ ^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/issues/[0-9]+$ ]]; then
+if [[ ! "${GITHUB_ISSUE_URL:-}" =~ ^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+/(issues|pull)/[0-9]+$ ]]; then
   echo "::error::GITHUB_ISSUE_URL format invalid, got: '${GITHUB_ISSUE_URL:-}'"
   errors=$((errors + 1))
 fi
 
-URL_REPO="$(echo "${GITHUB_ISSUE_URL:-}" | sed -E 's|https://github.com/([^/]+/[^/]+)/issues/.*|\1|')"
-URL_ISSUE="$(echo "${GITHUB_ISSUE_URL:-}" | sed -E 's|.*/issues/([0-9]+)$|\1|')"
+URL_REPO="$(echo "${GITHUB_ISSUE_URL:-}" | sed -E 's|https://github.com/([^/]+/[^/]+)/[^/]+/.*|\1|')"
+URL_NUMBER="$(echo "${GITHUB_ISSUE_URL:-}" | sed -E 's|.*/([0-9]+)$|\1|')"
 
 if [[ -n "${URL_REPO}" && "${URL_REPO}" != "${REPO_FULL_NAME:-}" ]]; then
   echo "::error::REPO_FULL_NAME does not match issue URL repo ('${REPO_FULL_NAME:-}' vs '${URL_REPO}')"
   errors=$((errors + 1))
 fi
-if [[ -n "${URL_ISSUE}" && "${URL_ISSUE}" != "${ISSUE_NUMBER:-}" ]]; then
-  echo "::error::ISSUE_NUMBER does not match issue URL number ('${ISSUE_NUMBER:-}' vs '${URL_ISSUE}')"
+if [[ -n "${URL_NUMBER}" && "${URL_NUMBER}" != "${ISSUE_NUMBER:-}" ]]; then
+  echo "::error::ISSUE_NUMBER does not match issue URL number ('${ISSUE_NUMBER:-}' vs '${URL_NUMBER}')"
   errors=$((errors + 1))
 fi
 


### PR DESCRIPTION
## Summary

- `pre-code.sh` only accepted `/issues/` URLs but the code agent can be triggered via `/code` on pull requests, where `github.event.issue.html_url` contains `/pull/`
- All PR-triggered code agent runs failed with `GITHUB_ISSUE_URL format invalid` before the sandbox was created
- Accept both `/issues/` and `/pull/` URL paths, simplify sed extraction to avoid BSD/GNU alternation differences

## Failed runs this fixes

- https://github.com/konflux-ci/.fullsend/actions/runs/25101172616 (konflux-ui PR 839)
- https://github.com/konflux-ci/.fullsend/actions/runs/25068054449 (konflux-ci PR 6550)

## Test plan

- [x] Issue URL (`/issues/839`) passes validation
- [x] Pull request URL (`/pull/839`) passes validation
- [x] Invalid URL path (`/commits/839`) rejected
- [x] Repo mismatch detected
- [x] Number mismatch detected
- [x] `make lint` passes