### PR TITLE
fix: increase code agent timeout from 25 to 35 minutes

### DIFF
--- a/internal/scaffold/fullsend-repo/harness/code.yaml
+++ b/internal/scaffold/fullsend-repo/harness/code.yaml
@@ -41,4 +41,4 @@ runner_env:
   REPO_DIR: "${GITHUB_WORKSPACE}/target-repo"
   TARGET_BRANCH: "${TARGET_BRANCH}"
 
-timeout_minutes: 25
+timeout_minutes: 35


### PR DESCRIPTION
## Summary

- Increase code agent sandbox timeout from 25 to 35 minutes
- Yarn-based repos (e.g., konflux-ui with Yarn Berry 4.12.0) need extra time for dependency installation and test execution inside the sandbox

## Test plan

- [x] `make lint` passes