### PR TITLE
fix: sync TIMEOUT_SECONDS with 35-minute harness timeout

### DIFF
--- a/internal/scaffold/fullsend-repo/env/code-agent.env
+++ b/internal/scaffold/fullsend-repo/env/code-agent.env
@@ -22,7 +22,7 @@ export MAX_RETRIES=1
 # check remaining time and avoid burning the budget on retries. Must match
 # timeout_minutes in harness/code.yaml. Update this if you change the
 # harness timeout.
-export TIMEOUT_SECONDS=1500
+export TIMEOUT_SECONDS=2100
 
 # Go toolchain — PATH, GOPATH, and GOMODCACHE are set in the sandbox image
 # via Containerfile ENV (images/code/Containerfile line 64). Do NOT set PATH


### PR DESCRIPTION
## Summary
- Updates `TIMEOUT_SECONDS` from 1500 to 2100 in `env/code-agent.env` to match the `timeout_minutes: 35` set in `harness/code.yaml` (PR #527)
- The stale value would cause premature retry budget exhaustion since the agent checks remaining time against `TIMEOUT_SECONDS`

## Context
Flagged by fullsend-ai-review[bot] on PR #527 — the harness timeout was bumped but the corresponding env var was not updated.

## Test plan
- [ ] Verify `TIMEOUT_SECONDS` (2100) equals `timeout_minutes` (35) × 60
- [ ] Confirm agent retry budget calculations use the correct remaining time