### PR TITLE
feat: include review comment URL in formal PR review

### DIFF
--- a/internal/cli/postcomment.go
+++ b/internal/cli/postcomment.go
@@ -67,7 +67,8 @@ The --result flag accepts a file path or "-" for stdin.`,
 				Marker: marker,
 				DryRun: dryRun,
 			}
-			return sticky.Post(cmd.Context(), client, owner, repoName, number, body, cfg, printer)
+			_, err = sticky.Post(cmd.Context(), client, owner, repoName, number, body, cfg, printer)
+			return err
 		},
 	}
 

--- a/internal/cli/postreview.go
+++ b/internal/cli/postreview.go
@@ -114,11 +114,12 @@ has moved, a stale-head failure is posted instead.`,
 				return postFailureNotice(cmd.Context(), client, owner, repoName, pr, parsed, cfg, printer)
 			}
 
-			if err := sticky.Post(cmd.Context(), client, owner, repoName, pr, parsed.Body, cfg, printer); err != nil {
+			commentURL, err := sticky.Post(cmd.Context(), client, owner, repoName, pr, parsed.Body, cfg, printer)
+			if err != nil {
 				return err
 			}
 
-			return submitFormalReview(cmd.Context(), client, owner, repoName, pr, parsed.Action, parsed.HeadSHA, dryRun, printer)
+			return submitFormalReview(cmd.Context(), client, owner, repoName, pr, parsed.Action, parsed.HeadSHA, commentURL, dryRun, printer)
 		},
 	}
 
@@ -192,7 +193,7 @@ func postStaleHeadNotice(ctx context.Context, client forge.Client, owner, repo s
 
 The review agent reviewed commit `+"`%s`"+` but the PR HEAD is now `+"`%s`"+`. This review was discarded to avoid approving unreviewed code.`, reviewedSHA, currentSHA)
 
-	if err := sticky.Post(ctx, client, owner, repo, pr, body, cfg, printer); err != nil {
+	if _, err := sticky.Post(ctx, client, owner, repo, pr, body, cfg, printer); err != nil {
 		return fmt.Errorf("posting stale-head notice: %w", err)
 	}
 	return fmt.Errorf("review stale: reviewed %s but HEAD is now %s", reviewedSHA, currentSHA)
@@ -221,7 +222,7 @@ func postFailureNotice(ctx context.Context, client forge.Client, owner, repo str
 This PR was NOT reviewed. Do not count this as an approval.`, reason)
 	}
 
-	if err := sticky.Post(ctx, client, owner, repo, pr, body, cfg, printer); err != nil {
+	if _, err := sticky.Post(ctx, client, owner, repo, pr, body, cfg, printer); err != nil {
 		return fmt.Errorf("posting failure notice: %w", err)
 	}
 	printer.StepDone("Failure notice posted")
@@ -232,7 +233,9 @@ This PR was NOT reviewed. Do not count this as an approval.`, reason)
 // submits a new GitHub PR review. When commitSHA is non-empty, the
 // review is pinned to that commit via the commit_id field, closing
 // the TOCTOU gap between the stale-head check and review submission.
-func submitFormalReview(ctx context.Context, client forge.Client, owner, repo string, pr int, action, commitSHA string, dryRun bool, printer *ui.Printer) error {
+// When commentURL is non-empty, it is included in the review body
+// so reviewers can navigate directly to the full review comment.
+func submitFormalReview(ctx context.Context, client forge.Client, owner, repo string, pr int, action, commitSHA, commentURL string, dryRun bool, printer *ui.Printer) error {
 	event, ok := reviewActionToEvent(action)
 	if !ok {
 		printer.StepInfo(fmt.Sprintf("Unknown review action %q, skipping formal review", action))
@@ -250,6 +253,9 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 
 	printer.StepStart(fmt.Sprintf("Submitting %s review", event))
 	reviewBody := "See the review comment above for full details."
+	if commentURL != "" {
+		reviewBody = fmt.Sprintf("See the [review comment](%s) for full details.", commentURL)
+	}
 	if err := client.CreatePullRequestReview(ctx, owner, repo, pr, event, reviewBody, commitSHA); err != nil {
 		return fmt.Errorf("submitting review: %w", err)
 	}

--- a/internal/cli/postreview_test.go
+++ b/internal/cli/postreview_test.go
@@ -201,7 +201,7 @@ func TestSubmitFormalReview_CreatesAndMinimizesStale(t *testing.T) {
 	}
 
 	printer := ui.New(io.Discard)
-	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "approve", "abc123def456", false, printer)
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "approve", "abc123def456", "", false, printer)
 	require.NoError(t, err)
 
 	require.Len(t, fc.CreatedReviews, 1)
@@ -219,7 +219,7 @@ func TestSubmitFormalReview_DryRun(t *testing.T) {
 	fc := forge.NewFakeClient()
 	printer := ui.New(io.Discard)
 
-	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "approve", "", true, printer)
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "approve", "", "", true, printer)
 	require.NoError(t, err)
 	assert.Empty(t, fc.CreatedReviews)
 }
@@ -228,7 +228,7 @@ func TestSubmitFormalReview_UnknownAction(t *testing.T) {
 	fc := forge.NewFakeClient()
 	printer := ui.New(io.Discard)
 
-	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "unknown-action", "", false, printer)
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "unknown-action", "", "", false, printer)
 	require.NoError(t, err)
 	assert.Empty(t, fc.CreatedReviews)
 }
@@ -327,7 +327,7 @@ func TestSubmitFormalReview_PassesCommitSHA(t *testing.T) {
 	fc.AuthenticatedUser = "fullsend-bot"
 	printer := ui.New(io.Discard)
 
-	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "comment", "deadbeef1234", false, printer)
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "comment", "deadbeef1234", "", false, printer)
 	require.NoError(t, err)
 	require.Len(t, fc.CreatedReviews, 1)
 	assert.Equal(t, "COMMENT", fc.CreatedReviews[0].Event)
@@ -339,8 +339,32 @@ func TestSubmitFormalReview_EmptyCommitSHA(t *testing.T) {
 	fc.AuthenticatedUser = "fullsend-bot"
 	printer := ui.New(io.Discard)
 
-	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "approve", "", false, printer)
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "approve", "", "", false, printer)
 	require.NoError(t, err)
 	require.Len(t, fc.CreatedReviews, 1)
 	assert.Equal(t, "", fc.CreatedReviews[0].CommitSHA)
+}
+
+func TestSubmitFormalReview_IncludesCommentURL(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "fullsend-bot"
+	printer := ui.New(io.Discard)
+
+	commentURL := "https://github.com/acme/repo/pull/1#issuecomment-42"
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "approve", "", commentURL, false, printer)
+	require.NoError(t, err)
+	require.Len(t, fc.CreatedReviews, 1)
+	assert.Contains(t, fc.CreatedReviews[0].Body, commentURL)
+	assert.Contains(t, fc.CreatedReviews[0].Body, "[review comment]")
+}
+
+func TestSubmitFormalReview_FallbackWithoutCommentURL(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "fullsend-bot"
+	printer := ui.New(io.Discard)
+
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "approve", "", "", false, printer)
+	require.NoError(t, err)
+	require.Len(t, fc.CreatedReviews, 1)
+	assert.Equal(t, "See the review comment above for full details.", fc.CreatedReviews[0].Body)
 }

--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -580,6 +580,7 @@ func (f *FakeClient) CreateIssueComment(_ context.Context, owner, repo string, n
 	comment := IssueComment{
 		ID:        f.commentCounter,
 		NodeID:    fmt.Sprintf("IC_fake_%d", f.commentCounter),
+		HTMLURL:   fmt.Sprintf("https://github.com/%s/%s/issues/%d#issuecomment-%d", owner, repo, number, f.commentCounter),
 		Body:      body,
 		Author:    f.AuthenticatedUser,
 		CreatedAt: "2026-01-01T00:00:00Z",

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -59,6 +59,7 @@ type Issue struct {
 type IssueComment struct {
 	ID        int
 	NodeID    string
+	HTMLURL   string
 	Body      string
 	Author    string
 	CreatedAt string

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -972,10 +972,11 @@ func (c *LiveClient) ListIssueComments(ctx context.Context, owner, repo string, 
 			return nil, fmt.Errorf("list issue comments page %d: %w", page, err)
 		}
 		var raw []struct {
-			ID     int    `json:"id"`
-			NodeID string `json:"node_id"`
-			Body   string `json:"body"`
-			User   struct {
+			ID      int    `json:"id"`
+			NodeID  string `json:"node_id"`
+			HTMLURL string `json:"html_url"`
+			Body    string `json:"body"`
+			User    struct {
 				Login string `json:"login"`
 			} `json:"user"`
 			CreatedAt string `json:"created_at"`
@@ -988,6 +989,7 @@ func (c *LiveClient) ListIssueComments(ctx context.Context, owner, repo string, 
 			result = append(result, forge.IssueComment{
 				ID:        r.ID,
 				NodeID:    r.NodeID,
+				HTMLURL:   r.HTMLURL,
 				Body:      r.Body,
 				Author:    r.User.Login,
 				CreatedAt: r.CreatedAt,
@@ -1009,10 +1011,11 @@ func (c *LiveClient) CreateIssueComment(ctx context.Context, owner, repo string,
 		return nil, fmt.Errorf("create issue comment on #%d: %w", number, err)
 	}
 	var result struct {
-		ID     int    `json:"id"`
-		NodeID string `json:"node_id"`
-		Body   string `json:"body"`
-		User   struct {
+		ID      int    `json:"id"`
+		NodeID  string `json:"node_id"`
+		HTMLURL string `json:"html_url"`
+		Body    string `json:"body"`
+		User    struct {
 			Login string `json:"login"`
 		} `json:"user"`
 		CreatedAt string `json:"created_at"`
@@ -1023,6 +1026,7 @@ func (c *LiveClient) CreateIssueComment(ctx context.Context, owner, repo string,
 	return &forge.IssueComment{
 		ID:        result.ID,
 		NodeID:    result.NodeID,
+		HTMLURL:   result.HTMLURL,
 		Body:      result.Body,
 		Author:    result.User.Login,
 		CreatedAt: result.CreatedAt,

--- a/internal/sticky/sticky.go
+++ b/internal/sticky/sticky.go
@@ -31,13 +31,13 @@ func (c Config) maxSize() int {
 
 // Post implements the sticky comment lifecycle: find an existing comment
 // bearing the marker, collapse old content into history, and create or
-// update in-place.
-func Post(ctx context.Context, client forge.Client, owner, repo string, number int, body string, cfg Config, printer *ui.Printer) error {
+// update in-place. Returns the HTML URL of the comment (empty on dry run).
+func Post(ctx context.Context, client forge.Client, owner, repo string, number int, body string, cfg Config, printer *ui.Printer) (string, error) {
 	if strings.TrimSpace(body) == "" {
-		return fmt.Errorf("comment body is empty")
+		return "", fmt.Errorf("comment body is empty")
 	}
 	if strings.TrimSpace(cfg.Marker) == "" {
-		return fmt.Errorf("marker is empty")
+		return "", fmt.Errorf("marker is empty")
 	}
 
 	botUser, err := client.GetAuthenticatedUser(ctx)
@@ -47,7 +47,7 @@ func Post(ctx context.Context, client forge.Client, owner, repo string, number i
 
 	comments, err := client.ListIssueComments(ctx, owner, repo, number)
 	if err != nil {
-		return fmt.Errorf("listing comments: %w", err)
+		return "", fmt.Errorf("listing comments: %w", err)
 	}
 
 	existing := FindMarkedComment(comments, cfg.Marker, botUser)
@@ -61,29 +61,30 @@ func Post(ctx context.Context, client forge.Client, owner, repo string, number i
 		if cfg.DryRun {
 			printer.StepInfo("Dry run — would update comment " + strconv.Itoa(existing.ID))
 			printer.StepInfo("Body length: " + strconv.Itoa(len(newBody)))
-			return nil
+			return "", nil
 		}
 
 		if err := client.UpdateIssueComment(ctx, owner, repo, existing.ID, newBody); err != nil {
-			return fmt.Errorf("updating comment: %w", err)
+			return "", fmt.Errorf("updating comment: %w", err)
 		}
 		printer.StepDone("Comment updated")
-	} else {
-		printer.StepStart("No existing comment found, creating new one")
-
-		if cfg.DryRun {
-			printer.StepInfo("Dry run — would create new comment")
-			printer.StepInfo("Body length: " + strconv.Itoa(len(markedBody)))
-			return nil
-		}
-
-		if _, err := client.CreateIssueComment(ctx, owner, repo, number, markedBody); err != nil {
-			return fmt.Errorf("creating comment: %w", err)
-		}
-		printer.StepDone("Comment created")
+		return existing.HTMLURL, nil
 	}
 
-	return nil
+	printer.StepStart("No existing comment found, creating new one")
+
+	if cfg.DryRun {
+		printer.StepInfo("Dry run — would create new comment")
+		printer.StepInfo("Body length: " + strconv.Itoa(len(markedBody)))
+		return "", nil
+	}
+
+	created, err := client.CreateIssueComment(ctx, owner, repo, number, markedBody)
+	if err != nil {
+		return "", fmt.Errorf("creating comment: %w", err)
+	}
+	printer.StepDone("Comment created")
+	return created.HTMLURL, nil
 }
 
 // FindMarkedComment returns the first comment whose body contains the

--- a/internal/sticky/sticky_test.go
+++ b/internal/sticky/sticky_test.go
@@ -211,8 +211,9 @@ func TestPost_CreateNew(t *testing.T) {
 	printer := ui.New(io.Discard)
 
 	cfg := Config{Marker: "<!-- test -->"}
-	err := Post(context.Background(), client, "o", "r", 1, "Body.", cfg, printer)
+	commentURL, err := Post(context.Background(), client, "o", "r", 1, "Body.", cfg, printer)
 	require.NoError(t, err)
+	assert.Contains(t, commentURL, "issuecomment-")
 
 	comments := client.IssueComments["o/r/1"]
 	require.Len(t, comments, 1)
@@ -224,13 +225,14 @@ func TestPost_UpdateExisting(t *testing.T) {
 	client := forge.NewFakeClient()
 	client.AuthenticatedUser = "bot"
 	client.IssueComments = map[string][]forge.IssueComment{
-		"o/r/1": {{ID: 100, Body: "<!-- test -->\nOld.", Author: "bot"}},
+		"o/r/1": {{ID: 100, HTMLURL: "https://github.com/o/r/issues/1#issuecomment-100", Body: "<!-- test -->\nOld.", Author: "bot"}},
 	}
 	printer := ui.New(io.Discard)
 
 	cfg := Config{Marker: "<!-- test -->"}
-	err := Post(context.Background(), client, "o", "r", 1, "New.", cfg, printer)
+	commentURL, err := Post(context.Background(), client, "o", "r", 1, "New.", cfg, printer)
 	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/o/r/issues/1#issuecomment-100", commentURL)
 
 	require.Len(t, client.UpdatedComments, 1)
 	assert.Equal(t, 100, client.UpdatedComments[0].CommentID)
@@ -244,8 +246,9 @@ func TestPost_DryRun(t *testing.T) {
 	printer := ui.New(io.Discard)
 
 	cfg := Config{Marker: "<!-- test -->", DryRun: true}
-	err := Post(context.Background(), client, "o", "r", 1, "Body.", cfg, printer)
+	commentURL, err := Post(context.Background(), client, "o", "r", 1, "Body.", cfg, printer)
 	require.NoError(t, err)
+	assert.Empty(t, commentURL)
 
 	assert.Empty(t, client.IssueComments)
 	assert.Empty(t, client.UpdatedComments)
@@ -256,7 +259,7 @@ func TestPost_EmptyBody(t *testing.T) {
 	printer := ui.New(io.Discard)
 
 	cfg := Config{Marker: "<!-- test -->"}
-	err := Post(context.Background(), client, "o", "r", 1, "", cfg, printer)
+	_, err := Post(context.Background(), client, "o", "r", 1, "", cfg, printer)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty")
 }
@@ -266,7 +269,7 @@ func TestPost_WhitespaceBody(t *testing.T) {
 	printer := ui.New(io.Discard)
 
 	cfg := Config{Marker: "<!-- test -->"}
-	err := Post(context.Background(), client, "o", "r", 1, "  \n\t  ", cfg, printer)
+	_, err := Post(context.Background(), client, "o", "r", 1, "  \n\t  ", cfg, printer)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty")
 }
@@ -276,9 +279,26 @@ func TestPost_EmptyMarker(t *testing.T) {
 	printer := ui.New(io.Discard)
 
 	cfg := Config{Marker: ""}
-	err := Post(context.Background(), client, "o", "r", 1, "Body.", cfg, printer)
+	_, err := Post(context.Background(), client, "o", "r", 1, "Body.", cfg, printer)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "marker")
+}
+
+func TestPost_UpdateExisting_EmptyHTMLURL(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.AuthenticatedUser = "bot"
+	client.IssueComments = map[string][]forge.IssueComment{
+		"o/r/1": {{ID: 100, Body: "<!-- test -->\nOld.", Author: "bot"}},
+	}
+	printer := ui.New(io.Discard)
+
+	cfg := Config{Marker: "<!-- test -->"}
+	commentURL, err := Post(context.Background(), client, "o", "r", 1, "New.", cfg, printer)
+	require.NoError(t, err)
+	assert.Empty(t, commentURL, "should return empty URL when existing comment has no HTMLURL")
+
+	require.Len(t, client.UpdatedComments, 1)
+	assert.Contains(t, client.UpdatedComments[0].Body, "New.")
 }
 
 func TestPost_DryRunExisting(t *testing.T) {
@@ -289,8 +309,9 @@ func TestPost_DryRunExisting(t *testing.T) {
 	printer := ui.New(io.Discard)
 
 	cfg := Config{Marker: "<!-- test -->", DryRun: true}
-	err := Post(context.Background(), client, "o", "r", 1, "New.", cfg, printer)
+	commentURL, err := Post(context.Background(), client, "o", "r", 1, "New.", cfg, printer)
 	require.NoError(t, err)
+	assert.Empty(t, commentURL)
 
 	assert.Empty(t, client.UpdatedComments)
 }


### PR DESCRIPTION
## Summary
- Adds `HTMLURL` field to `forge.IssueComment` and parses `html_url` from the GitHub API
- Changes `sticky.Post()` to return the comment URL so callers can reference it
- Embeds the sticky comment URL as a clickable markdown link in the formal PR review body, with graceful fallback when the URL is unavailable

## Test plan
- [x] `make go-test` passes for all `internal/` packages
- [x] New tests: `TestSubmitFormalReview_IncludesCommentURL`, `TestSubmitFormalReview_FallbackWithoutCommentURL`, `TestPost_UpdateExisting_EmptyHTMLURL`
- [x] Existing tests updated for new `sticky.Post()` return signature
- [x] 4-agent code review: cursor, gemini, security, quality — all APPROVE