### PR TITLE
chore: enable Slack announcements on new releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,8 +60,8 @@ release:
   name_template: "{{ .Tag }}{{ if .TagSubject }}: {{ .TagSubject }}{{ end }}"
   prerelease: auto
 
-# announce:
-#   slack:
-#     enabled: true
-#     channel: "#forum-konflux-fullsend"
-#     message_template: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'
+announce:
+  slack:
+    enabled: true
+    channel: "#forum-konflux-fullsend"
+    message_template: '{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}'


### PR DESCRIPTION
## Summary

- Uncomments the GoReleaser `announce.slack` block so releases post to `#forum-konflux-fullsend`
- Uncomments the `SLACK_WEBHOOK` env var in the release workflow, mapping it to the existing `SLACK_WEBHOOK_URL` secret

## Test plan

- [ ] Verify `SLACK_WEBHOOK_URL` secret is configured in the repo
- [ ] Cut a release and confirm the Slack message arrives in `#forum-konflux-fullsend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)