### PR TITLE
fix(e2e): stabilize manifest flow callback timeout handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ e2e-test: e2e-playwright
 		$(MAKE) e2e-export-session; \
 		export E2E_GITHUB_SESSION_FILE="$(E2E_SESSION_FILE)"; \
 	fi; \
-	go test -tags e2e -v -count=1 -timeout 10m ./e2e/admin/
+	go test -tags e2e -v -count=1 -timeout 30m ./e2e/admin/
 
 e2e-export-session: e2e-playwright
 	@if [ -n "$$E2E_GITHUB_PASSWORD_FILE" ] && [ -z "$$E2E_GITHUB_PASSWORD" ]; then \

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -215,14 +215,14 @@ func runFullInstall(t *testing.T, env *e2eEnv) ([]layers.AgentCredentials, *conf
 		t.Logf("Setting up app for role: %s", role)
 
 		var appCreds *appsetup.AppCredentials
-		// Retry the manifest flow once per role to handle transient callback
-		// timeouts (see #287). On failure, delete any partially-created app
-		// before retrying so the second attempt starts clean.
-		const maxAttempts = 2
+		// Retry the manifest flow to handle transient callback timeouts
+		// (see #287). On failure, delete any partially-created app and
+		// wait before retrying so the next attempt starts clean.
+		const maxAttempts = 3
 		for attempt := 1; attempt <= maxAttempts; attempt++ {
 			// Use a per-role timeout so a failed manifest flow doesn't hang
 			// until the Go test timeout (which produces an unhelpful panic).
-			roleCtx, roleCancel := context.WithTimeout(ctx, 2*time.Minute)
+			roleCtx, roleCancel := context.WithTimeout(ctx, 3*time.Minute)
 			var runErr error
 			appCreds, runErr = setup.Run(roleCtx, testOrg, role)
 			roleCancel()
@@ -233,12 +233,13 @@ func runFullInstall(t *testing.T, env *e2eEnv) ([]layers.AgentCredentials, *conf
 
 			t.Logf("Attempt %d/%d for role %s failed: %v", attempt, maxAttempts, role, runErr)
 			if attempt < maxAttempts {
-				// Clean up any partially-created app before retrying.
 				slug := appsetup.ExpectedAppSlug(testOrg, role)
 				t.Logf("Cleaning up potentially stale app %s before retry", slug)
 				if delErr := deleteAppViaPlaywright(env.page, slug, t.Logf, env.screenshotDir); delErr != nil {
 					t.Logf("Warning: cleanup of %s failed (may not exist): %v", slug, delErr)
 				}
+				t.Logf("Waiting 10s before retry to let GitHub settle...")
+				time.Sleep(10 * time.Second)
 				continue
 			}
 			require.NoError(t, runErr, "setting up app for role %s", role)

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -220,8 +220,9 @@ func runFullInstall(t *testing.T, env *e2eEnv) ([]layers.AgentCredentials, *conf
 		// wait before retrying so the next attempt starts clean.
 		const maxAttempts = 3
 		for attempt := 1; attempt <= maxAttempts; attempt++ {
-			// 5min covers worst case: 3 attempts × (90s callback + cleanup) + inter-retry delays.
-			roleCtx, roleCancel := context.WithTimeout(ctx, 5*time.Minute)
+			// 6min covers worst case: 3 attempts × (90s callback + ~20s cleanup)
+			// + 2 × 10s inter-retry delays ≈ 350s, with margin for overhead.
+			roleCtx, roleCancel := context.WithTimeout(ctx, 6*time.Minute)
 			var runErr error
 			appCreds, runErr = setup.Run(roleCtx, testOrg, role)
 			roleCancel()

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -220,8 +220,8 @@ func runFullInstall(t *testing.T, env *e2eEnv) ([]layers.AgentCredentials, *conf
 		// wait before retrying so the next attempt starts clean.
 		const maxAttempts = 3
 		for attempt := 1; attempt <= maxAttempts; attempt++ {
-			// 6min covers worst case: 3 attempts × (90s callback + ~20s cleanup)
-			// + 2 × 10s inter-retry delays ≈ 350s, with margin for overhead.
+			// Per-attempt timeout: generous to handle slow manifest flows
+			// (90s callback wait + page navigation overhead).
 			roleCtx, roleCancel := context.WithTimeout(ctx, 6*time.Minute)
 			var runErr error
 			appCreds, runErr = setup.Run(roleCtx, testOrg, role)

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -220,9 +220,8 @@ func runFullInstall(t *testing.T, env *e2eEnv) ([]layers.AgentCredentials, *conf
 		// wait before retrying so the next attempt starts clean.
 		const maxAttempts = 3
 		for attempt := 1; attempt <= maxAttempts; attempt++ {
-			// Use a per-role timeout so a failed manifest flow doesn't hang
-			// until the Go test timeout (which produces an unhelpful panic).
-			roleCtx, roleCancel := context.WithTimeout(ctx, 3*time.Minute)
+			// 5min covers worst case: 3 attempts × (90s callback + cleanup) + inter-retry delays.
+			roleCtx, roleCancel := context.WithTimeout(ctx, 5*time.Minute)
 			var runErr error
 			appCreds, runErr = setup.Run(roleCtx, testOrg, role)
 			roleCancel()

--- a/e2e/admin/browser.go
+++ b/e2e/admin/browser.go
@@ -187,12 +187,18 @@ func (b *PlaywrightBrowserOpener) handleCreateAppPage() error {
 		Timeout: playwright.Float(90000),
 	}); err != nil {
 		pageURL := b.page.URL()
-		b.logf("[browser] Timeout waiting for callback, current URL: %s", pageURL)
+		// Strip query params before logging — the callback URL contains a
+		// temporary authorization code that should not appear in CI logs.
+		safeURL := pageURL
+		if idx := strings.Index(safeURL, "?"); idx != -1 {
+			safeURL = safeURL[:idx]
+		}
+		b.logf("[browser] Timeout waiting for callback, current URL: %s", safeURL)
 		if strings.Contains(pageURL, "/callback") {
 			return nil
 		}
 		saveDebugScreenshot(b.page, b.screenshotDir, "browser-callback-failed", b.logf)
-		return fmt.Errorf("waiting for callback (current URL: %s): %w", pageURL, err)
+		return fmt.Errorf("waiting for callback (current URL: %s): %w", safeURL, err)
 	}
 
 	return nil

--- a/e2e/admin/browser.go
+++ b/e2e/admin/browser.go
@@ -170,20 +170,22 @@ func (b *PlaywrightBrowserOpener) handleCreateAppPage() error {
 		saveDebugScreenshot(b.page, b.screenshotDir, "browser-create-btn-failed", b.logf)
 		return fmt.Errorf("waiting for 'Create GitHub App' button: %w", err)
 	}
-	if err := btn.First().Click(playwright.LocatorClickOptions{
-		Timeout: playwright.Float(5000),
-	}); err != nil {
-		saveDebugScreenshot(b.page, b.screenshotDir, "browser-create-btn-failed", b.logf)
-		return fmt.Errorf("clicking 'Create GitHub App': %w", err)
-	}
 
-	// Wait for redirect back to our callback URL.
+	// Use ExpectNavigation to start listening BEFORE clicking, preventing
+	// the race where the redirect completes before WaitForURL is called.
 	// GitHub's manifest flow can be slow (app creation, key generation),
-	// so use a generous timeout.
-	if err := b.page.WaitForURL("**/callback**", playwright.PageWaitForURLOptions{
-		Timeout: playwright.Float(30000),
-	}); err != nil {
+	// so use a 90-second timeout (increased from 30s per #287).
+	_, err := b.page.ExpectNavigation(func() error {
+		return btn.First().Click(playwright.LocatorClickOptions{
+			Timeout: playwright.Float(5000),
+		})
+	}, playwright.PageExpectNavigationOptions{
+		URL:     "**/callback**",
+		Timeout: playwright.Float(90000),
+	})
+	if err != nil {
 		pageURL := b.page.URL()
+		b.logf("[browser] Post-click URL: %s", pageURL)
 		if strings.Contains(pageURL, "/callback") || strings.Contains(pageURL, "127.0.0.1") {
 			return nil
 		}

--- a/e2e/admin/browser.go
+++ b/e2e/admin/browser.go
@@ -198,7 +198,7 @@ func (b *PlaywrightBrowserOpener) handleCreateAppPage() error {
 			return nil
 		}
 		saveDebugScreenshot(b.page, b.screenshotDir, "browser-callback-failed", b.logf)
-		return fmt.Errorf("waiting for callback (current URL: %s): %w", safeURL, err)
+		return fmt.Errorf("waiting for callback timed out (current URL: %s)", safeURL)
 	}
 
 	return nil

--- a/e2e/admin/browser.go
+++ b/e2e/admin/browser.go
@@ -171,26 +171,28 @@ func (b *PlaywrightBrowserOpener) handleCreateAppPage() error {
 		return fmt.Errorf("waiting for 'Create GitHub App' button: %w", err)
 	}
 
-	// Use ExpectNavigation to start listening BEFORE clicking, preventing
-	// the race where the redirect completes before WaitForURL is called.
-	// GitHub's manifest flow can be slow (app creation, key generation),
-	// so use a 90-second timeout (increased from 30s per #287).
-	_, err := b.page.ExpectNavigation(func() error {
-		return btn.First().Click(playwright.LocatorClickOptions{
-			Timeout: playwright.Float(5000),
-		})
-	}, playwright.PageExpectNavigationOptions{
-		URL:     "**/callback**",
+	if err := btn.First().Click(playwright.LocatorClickOptions{
+		Timeout: playwright.Float(5000),
+	}); err != nil {
+		saveDebugScreenshot(b.page, b.screenshotDir, "browser-create-btn-click-failed", b.logf)
+		return fmt.Errorf("clicking 'Create GitHub App': %w", err)
+	}
+
+	// WaitForURL checks the current URL first (no race if redirect already
+	// completed), then listens for future navigations. GitHub's manifest
+	// flow can be slow (app creation, key generation), so use a 90-second
+	// timeout (increased from 30s per #287).
+	b.logf("[browser] Clicked 'Create GitHub App', waiting up to 90s for callback redirect...")
+	if err := b.page.WaitForURL("**/callback**", playwright.PageWaitForURLOptions{
 		Timeout: playwright.Float(90000),
-	})
-	if err != nil {
+	}); err != nil {
 		pageURL := b.page.URL()
-		b.logf("[browser] Post-click URL: %s", pageURL)
-		if strings.Contains(pageURL, "/callback") || strings.Contains(pageURL, "127.0.0.1") {
+		b.logf("[browser] Timeout waiting for callback, current URL: %s", pageURL)
+		if strings.Contains(pageURL, "/callback") {
 			return nil
 		}
 		saveDebugScreenshot(b.page, b.screenshotDir, "browser-callback-failed", b.logf)
-		return fmt.Errorf("waiting for callback: %w", err)
+		return fmt.Errorf("waiting for callback (current URL: %s): %w", pageURL, err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Increase `WaitForURL` callback timeout from 30s to 90s to handle GitHub's slow manifest flow (app creation + key generation + redirect)
- Increase retry attempts from 2 to 3 with 10s inter-retry delay and stale app cleanup between attempts
- Sanitize callback URL in logs and error messages by stripping query parameters (temporary authorization code)
- Tighten fallback URL check: require `/callback` in path instead of broad `127.0.0.1` match
- Differentiate screenshot filenames for wait vs click failures to aid debugging

Fixes #287

## Details

The e2e `TestAdminInstallUninstall` intermittently fails because GitHub's manifest flow (app creation, key generation, redirect) can exceed the previous 30s `WaitForURL` timeout. The fix addresses this with:

1. **Increased callback timeout** (30s → 90s): Gives GitHub enough time for slow manifest processing.
2. **More retries with cleanup** (2 → 3 attempts): On failure, deletes any partially-created app and waits 10s before retrying so the next attempt starts clean.
3. **Per-attempt context** (2min → 6min): Each attempt gets a fresh 6min context, generous for the 90s callback wait + page navigation overhead.
4. **Auth code sanitization**: Strips `?code=XXXXX` query parameters from callback URLs before logging or including in error messages. Error no longer wraps the Playwright error (which may contain the full URL).
5. **Tightened fallback check**: Removed `strings.Contains(pageURL, "127.0.0.1")` which was overly broad — the callback URL always contains `/callback` per `appsetup.go:327`.

## Test plan
- [ ] CI e2e tests pass on this branch
- [ ] Verify callback timeout no longer causes intermittent failures in `TestAdminInstallUninstall`
- [ ] Confirm CI logs do not contain authorization codes in callback URLs