### PR TITLE
fix: pre-mask GCP credential file path in auth step logs

### DIFF
--- a/internal/scaffold/fullsend-repo/.github/workflows/code.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/code.yml
@@ -101,6 +101,9 @@ jobs:
           GITHUB_ISSUE_URL: ${{ fromJSON(inputs.event_payload).issue.html_url }}
         run: bash scripts/pre-code.sh
 
+      - name: Pre-mask GCP credential file path
+        run: echo "::add-mask::${GITHUB_WORKSPACE}/gha-creds-"
+
       - name: Authenticate to Google Cloud (WIF)
         if: vars.FULLSEND_GCP_AUTH_MODE == 'wif'
         uses: google-github-actions/auth@v3

--- a/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
@@ -270,6 +270,9 @@ jobs:
           HUMAN_INSTRUCTION: ${{ steps.context.outputs.instruction }}
         run: bash scripts/pre-fix.sh
 
+      - name: Pre-mask GCP credential file path
+        run: echo "::add-mask::${GITHUB_WORKSPACE}/gha-creds-"
+
       - name: Authenticate to Google Cloud (WIF)
         if: vars.FULLSEND_GCP_AUTH_MODE == 'wif'
         uses: google-github-actions/auth@v3

--- a/internal/scaffold/fullsend-repo/.github/workflows/review.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/review.yml
@@ -92,6 +92,9 @@ jobs:
           path: target-repo
           fetch-depth: 1
 
+      - name: Pre-mask GCP credential file path
+        run: echo "::add-mask::${GITHUB_WORKSPACE}/gha-creds-"
+
       - name: Authenticate to Google Cloud (WIF)
         if: vars.FULLSEND_GCP_AUTH_MODE == 'wif'
         uses: google-github-actions/auth@v3

--- a/internal/scaffold/fullsend-repo/.github/workflows/triage.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/triage.yml
@@ -71,6 +71,9 @@ jobs:
           path: target-repo
           fetch-depth: 1
 
+      - name: Pre-mask GCP credential file path
+        run: echo "::add-mask::${GITHUB_WORKSPACE}/gha-creds-"
+
       - name: Authenticate to Google Cloud (WIF)
         if: vars.FULLSEND_GCP_AUTH_MODE == 'wif'
         uses: google-github-actions/auth@v3


### PR DESCRIPTION
## Summary
- The `google-github-actions/auth@v3` action prints `Created credentials file at "<path>"` in its own log output during execution
- The existing "Mask GCP credential file paths" step runs **after** auth, so it only masks the path for subsequent steps — the auth step's own output already leaked the full credential file path (e.g. `/home/runner/work/.fullsend/.fullsend/gha-creds-a4006a13ab58d436.json`)
- Adds a "Pre-mask GCP credential file path" step **before** the auth steps in all four scaffold workflows (code, review, fix, triage) that registers `${GITHUB_WORKSPACE}/gha-creds-` with `::add-mask::` so the path is masked when the auth action prints it

## Test plan
- [ ] Verify the "Authenticate to Google Cloud (WIF)" step output shows `Created credentials file at "***..."` instead of the full path
- [ ] Verify the "Post Authenticate to Google Cloud (WIF)" cleanup step continues to show `Removed exported credentials at "***"`
- [ ] Verify downstream steps (prepare-sandbox-credentials, agent run) still authenticate correctly