### PR TITLE
feat(images): multi-arch (amd64 + arm64) sandbox images

### DIFF
--- a/.github/workflows/sandbox-images.yml
+++ b/.github/workflows/sandbox-images.yml
@@ -40,6 +40,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
@@ -60,6 +63,7 @@ jobs:
         with:
           context: images/sandbox
           file: images/sandbox/Containerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -101,6 +105,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
@@ -120,6 +127,7 @@ jobs:
         with:
           context: images/code
           file: images/code/Containerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             BASE_IMAGE=${{ needs.build-base.outputs.image-ref }}
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/sandbox-images.yml
+++ b/.github/workflows/sandbox-images.yml
@@ -71,10 +71,15 @@ jobs:
           cache-to: type=gha,mode=max,scope=sandbox
 
       # Compute a single image reference for the build-code job.
-      # On push: use the immutable digest from the pushed image.
+      # On push: use the immutable digest from the pushed manifest list.
       # On PR: use the latest published image (the PR build validates
       # the Containerfile compiles but doesn't push, so build-code
       # needs an already-published base to FROM).
+      #
+      # NOTE: Until the first multi-arch push lands on main, :latest is
+      # amd64-only. PR builds of build-code will fail the arm64 leg
+      # against this single-arch base. This is transient — once main
+      # publishes a multi-arch :latest, PR builds work for both platforms.
       - name: Compute base image ref
         id: ref
         env:

--- a/.github/workflows/sandbox-images.yml
+++ b/.github/workflows/sandbox-images.yml
@@ -76,10 +76,6 @@ jobs:
       # the Containerfile compiles but doesn't push, so build-code
       # needs an already-published base to FROM).
       #
-      # NOTE: Until the first multi-arch push lands on main, :latest is
-      # amd64-only. PR builds of build-code will fail the arm64 leg
-      # against this single-arch base. This is transient — once main
-      # publishes a multi-arch :latest, PR builds work for both platforms.
       - name: Compute base image ref
         id: ref
         env:
@@ -100,6 +96,10 @@ jobs:
       packages: write
     env:
       CODE_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/fullsend-code
+      # On PRs the base image is not pushed, so build-code falls back to
+      # :latest which may be amd64-only. Build amd64 only on PRs to avoid
+      # a platform mismatch error; push events get the full multi-arch build.
+      CODE_PLATFORMS: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -132,7 +132,7 @@ jobs:
         with:
           context: images/code
           file: images/code/Containerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.CODE_PLATFORMS }}
           build-args: |
             BASE_IMAGE=${{ needs.build-base.outputs.image-ref }}
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/sandbox-images.yml
+++ b/.github/workflows/sandbox-images.yml
@@ -41,7 +41,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -106,7 +106,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4

--- a/.github/workflows/sandbox-images.yml
+++ b/.github/workflows/sandbox-images.yml
@@ -56,7 +56,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=dev,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=dev,enable=${{ github.event_name != 'pull_request' }}
 
       - name: Build and push
         id: push
@@ -121,7 +121,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=dev,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=dev,enable=${{ github.event_name != 'pull_request' }}
 
       - name: Build and push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7

--- a/.github/workflows/sandbox-images.yml
+++ b/.github/workflows/sandbox-images.yml
@@ -56,6 +56,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=dev,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
         id: push
@@ -71,11 +72,9 @@ jobs:
           cache-to: type=gha,mode=max,scope=sandbox
 
       # Compute a single image reference for the build-code job.
-      # On push: use the immutable digest from the pushed manifest list.
-      # On PR: use the latest published image (the PR build validates
-      # the Containerfile compiles but doesn't push, so build-code
-      # needs an already-published base to FROM).
-      #
+      # On push/dispatch: use the immutable digest from the pushed manifest list.
+      # On PR: use the :dev tag (multi-arch, published by workflow_dispatch)
+      # so that both platform legs can resolve a base image.
       - name: Compute base image ref
         id: ref
         env:
@@ -85,7 +84,7 @@ jobs:
           if [ -n "$DIGEST" ]; then
             echo "value=${IMAGE_NAME}@${DIGEST}" >> "$GITHUB_OUTPUT"
           else
-            echo "value=${IMAGE_NAME}:latest" >> "$GITHUB_OUTPUT"
+            echo "value=${IMAGE_NAME}:dev" >> "$GITHUB_OUTPUT"
           fi
 
   build-code:
@@ -96,10 +95,6 @@ jobs:
       packages: write
     env:
       CODE_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/fullsend-code
-      # On PRs the base image is not pushed, so build-code falls back to
-      # :latest which may be amd64-only. Build amd64 only on PRs to avoid
-      # a platform mismatch error; push events get the full multi-arch build.
-      CODE_PLATFORMS: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -126,13 +121,14 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=dev,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: images/code
           file: images/code/Containerfile
-          platforms: ${{ env.CODE_PLATFORMS }}
+          platforms: linux/amd64,linux/arm64
           build-args: |
             BASE_IMAGE=${{ needs.build-base.outputs.image-ref }}
           push: ${{ github.event_name != 'pull_request' }}

--- a/images/README.md
+++ b/images/README.md
@@ -15,7 +15,7 @@ ghcr.io/nvidia/openshell-community/sandboxes/base  (upstream, multi-arch)
 | Image | Directory | Description |
 |-------|-----------|-------------|
 | `fullsend-sandbox` | [`images/sandbox/`](sandbox/) | Base sandbox with Claude Code, rsync, gitleaks, tirith, pre-commit, gitlint, and the ProtectAI DeBERTa-v3 ONNX model for prompt injection detection. |
-| `fullsend-code` | [`images/code/`](code/) | Extends `fullsend-sandbox` with Go toolchain, scan-secrets wrapper, and additional pre-commit/gitlint symlinks. Used by the code-implementation agent. |
+| `fullsend-code` | [`images/code/`](code/) | Extends `fullsend-sandbox` with Go toolchain and scan-secrets wrapper. Used by the code-implementation agent. |
 
 Both images are built for **linux/amd64** and **linux/arm64**.
 
@@ -37,11 +37,12 @@ the Containerfile without publishing unreleased images.
 
 ### Tag lifecycle
 
+`:latest` is added whenever the ref is the default branch (`main`),
+regardless of trigger event.
+
 ```
-  workflow_dispatch ──┐
-                      ├──► :dev  :sha
-  push to main ───────┤
-                      └──► :latest  :sha
+  workflow_dispatch ──────► :dev  :sha  (+:latest if ref=main)
+  push to main ───────────► :dev  :sha  :latest
   tag push (v*) ──────────► :dev  :sha  :X.Y.Z  :X.Y
   pull_request ───────────► (build only, no push)
 ```
@@ -105,7 +106,7 @@ Every binary downloaded during the build is **version-pinned** and
 | Tirith | `TIRITH_VERSION` + `TIRITH_SHA256_{AMD64,ARM64}` | `sha256sum -c` |
 | Go toolchain | `GO_VERSION` + `GO_SHA256_{AMD64,ARM64}` | `sha256sum -c` |
 | ProtectAI DeBERTa model | `PROTECTAI_MODEL_REV` + per-file SHA256 | `sha256sum -c` |
-| Claude Code | Official installer script | HTTPS |
+| Claude Code | Official installer script | HTTPS only (no checksum, version floats) |
 | pre-commit, gitlint | pip version pins | pip integrity check |
 
 GitHub Actions are pinned to full commit SHAs (not floating tags).

--- a/images/README.md
+++ b/images/README.md
@@ -30,7 +30,7 @@ following tags depending on the trigger event:
 | `dev` | Any non-PR event (push to `main`, tag push, `workflow_dispatch`) | Pre-release tag for CI and local testing. PR builds use this as the base image fallback when no digest is available. |
 | `<version>` (e.g. `1.2.3`) | Tag push matching `v*` | Immutable release tag extracted from the git tag via semver. |
 | `<major>.<minor>` (e.g. `1.2`) | Tag push matching `v*` | Floating minor-version tag for consumers that want automatic patch updates. |
-| `<commit-sha>` | Every non-PR build | Immutable per-commit reference for debugging and rollback. |
+| `<commit-sha>` (e.g. `a1b2c3d`) | Every non-PR build | Immutable per-commit reference for debugging and rollback. |
 
 On **pull requests**, images are built but **not pushed** — this validates
 the Containerfile without publishing unreleased images.

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,151 @@
+# Sandbox Images
+
+Fullsend agents run inside sandboxed container images managed by
+[OpenShell](https://github.com/nvidia/openshell-community).  This directory
+contains the Containerfiles and supporting scripts for those images.
+
+## Image hierarchy
+
+```
+ghcr.io/nvidia/openshell-community/sandboxes/base  (upstream, multi-arch)
+  └── ghcr.io/fullsend-ai/fullsend-sandbox          (base sandbox)
+        └── ghcr.io/fullsend-ai/fullsend-code        (code agent)
+```
+
+| Image | Directory | Description |
+|-------|-----------|-------------|
+| `fullsend-sandbox` | [`images/sandbox/`](sandbox/) | Base sandbox with Claude Code, rsync, gitleaks, tirith, pre-commit, gitlint, and the ProtectAI DeBERTa-v3 ONNX model for prompt injection detection. |
+| `fullsend-code` | [`images/code/`](code/) | Extends `fullsend-sandbox` with Go toolchain, scan-secrets wrapper, and additional pre-commit/gitlint symlinks. Used by the code-implementation agent. |
+
+Both images are built for **linux/amd64** and **linux/arm64**.
+
+## Tags and versioning
+
+The CI workflow (`.github/workflows/sandbox-images.yml`) produces the
+following tags depending on the trigger event:
+
+| Tag | When produced | Purpose |
+|-----|---------------|---------|
+| `latest` | Push to `main` branch | Production tag. Harness configs and downstream consumers reference this. |
+| `dev` | Any non-PR event (push to `main`, tag push, `workflow_dispatch`) | Pre-release tag for CI and local testing. PR builds use this as the base image fallback when no digest is available. |
+| `<version>` (e.g. `1.2.3`) | Tag push matching `v*` | Immutable release tag extracted from the git tag via semver. |
+| `<major>.<minor>` (e.g. `1.2`) | Tag push matching `v*` | Floating minor-version tag for consumers that want automatic patch updates. |
+| `<commit-sha>` | Every non-PR build | Immutable per-commit reference for debugging and rollback. |
+
+On **pull requests**, images are built but **not pushed** — this validates
+the Containerfile without publishing unreleased images.
+
+### Tag lifecycle
+
+```
+  workflow_dispatch ──┐
+                      ├──► :dev  :sha
+  push to main ───────┤
+                      └──► :latest  :sha
+  tag push (v*) ──────────► :dev  :sha  :X.Y.Z  :X.Y
+  pull_request ───────────► (build only, no push)
+```
+
+## How images are built
+
+The workflow has two jobs that run sequentially:
+
+1. **`build-base`** builds `fullsend-sandbox` from `images/sandbox/Containerfile`.
+   On push/dispatch, it pushes the multi-arch manifest list and outputs the
+   immutable digest (`@sha256:...`) for the next job.
+
+2. **`build-code`** builds `fullsend-code` from `images/code/Containerfile`,
+   passing the base image reference as `--build-arg BASE_IMAGE=<ref>`.
+   On push/dispatch it uses the digest from step 1.  On PRs (where no
+   digest is available because nothing was pushed), it falls back to the
+   `:dev` tag on the registry.
+
+Cross-platform builds use [QEMU](https://github.com/docker/setup-qemu-action)
+for user-mode emulation and [Docker Buildx](https://github.com/docker/setup-buildx-action)
+with GitHub Actions cache (`type=gha`).
+
+### PR build and the `:dev` fallback
+
+PR builds set `push: false`, so `build-base` produces no registry digest.
+The `build-code` job needs a base image reference to build against.  It
+falls back to `fullsend-sandbox:dev` — a multi-arch image that is always
+kept current by non-PR builds.
+
+This avoids a chicken-and-egg problem: if the fallback pointed to `:latest`
+(which may be amd64-only before the multi-arch work lands), the arm64 build
+leg would fail with `no match for platform in manifest`.
+
+### Bootstrapping `:dev` for the first time
+
+When adding multi-arch support to a repo that previously published
+amd64-only images, the `:dev` tag does not yet exist on the registry.
+Bootstrap it by triggering a manual `workflow_dispatch` run from the
+feature branch:
+
+```bash
+gh workflow run sandbox-images.yml \
+  --repo fullsend-ai/fullsend \
+  --ref <feature-branch>
+```
+
+This builds and pushes `:dev` (and `:sha`) without touching `:latest`.
+Subsequent PR builds on the feature branch can then resolve the `:dev`
+base image for both platforms.
+
+## Supply chain security
+
+Every binary downloaded during the build is **version-pinned** and
+**SHA256-verified** per architecture:
+
+| Tool | Pinning | Verification |
+|------|---------|-------------|
+| OpenShell base image | Manifest list digest (`@sha256:...`) | Immutable OCI content hash |
+| ONNX Runtime | `ORT_VERSION` + `ORT_SHA256_{AMD64,ARM64}` | `sha256sum -c` |
+| Gitleaks | `GITLEAKS_VERSION` + `GITLEAKS_SHA256_{AMD64,ARM64}` | `sha256sum -c` |
+| Tirith | `TIRITH_VERSION` + `TIRITH_SHA256_{AMD64,ARM64}` | `sha256sum -c` |
+| Go toolchain | `GO_VERSION` + `GO_SHA256_{AMD64,ARM64}` | `sha256sum -c` |
+| ProtectAI DeBERTa model | `PROTECTAI_MODEL_REV` + per-file SHA256 | `sha256sum -c` |
+| Claude Code | Official installer script | HTTPS |
+| pre-commit, gitlint | pip version pins | pip integrity check |
+
+GitHub Actions are pinned to full commit SHAs (not floating tags).
+
+### Updating pinned versions
+
+Each tool section in the Containerfile has an update comment with the
+source URL for checksums.  When bumping a version:
+
+1. Download the new release checksums from the URL in the comment.
+2. Update both `*_SHA256_AMD64` and `*_SHA256_ARM64` ARGs.
+3. The base image digest can be updated by running
+   `podman manifest inspect <image>:<tag>` and extracting the index digest.
+
+## Local builds
+
+Build for your native architecture:
+
+```bash
+podman build -t fullsend-sandbox:local \
+  -f images/sandbox/Containerfile images/sandbox/
+
+podman build -t fullsend-code:local \
+  --build-arg BASE_IMAGE=fullsend-sandbox:local \
+  -f images/code/Containerfile images/code/
+```
+
+Build for a specific platform (requires QEMU registration):
+
+```bash
+podman build --platform linux/arm64 -t fullsend-sandbox:arm64 \
+  -f images/sandbox/Containerfile images/sandbox/
+```
+
+## Extending the base image
+
+Per-org images that need additional tools should extend `fullsend-sandbox`
+or `fullsend-code`:
+
+```dockerfile
+FROM ghcr.io/fullsend-ai/fullsend-sandbox:latest
+RUN apt-get update && apt-get install -y --no-install-recommends rustc && rm -rf /var/lib/apt/lists/*
+```

--- a/images/code/Containerfile
+++ b/images/code/Containerfile
@@ -24,6 +24,9 @@ FROM ${BASE_IMAGE}
 
 USER root
 
+# BuildKit automatic platform ARG — set by --platform during multi-arch builds.
+ARG TARGETARCH
+
 # ---------------------------------------------------------------------------
 # CA certificates — git 2.43 on Ubuntu Noble is linked against
 # libcurl-gnutls which does NOT read SSL_CERT_FILE. It needs either
@@ -52,7 +55,6 @@ RUN git config --system http.sslCAInfo /etc/ssl/certs/ca-certificates.crt 2>/dev
 #
 # Pinned version + SHA256 checksum for supply chain safety.
 # To update: get the latest linux-{amd64,arm64} archive + sha256 from https://go.dev/dl/?mode=json
-ARG TARGETARCH
 ARG GO_VERSION=1.24.13
 ARG GO_SHA256_AMD64=1fc94b57134d51669c72173ad5d49fd62afb0f1db9bf3f798fd98ee423f8d730
 ARG GO_SHA256_ARM64=74d97be1cc3a474129590c67ebf748a96e72d9f3a2b6fef3ed3275de591d49b3
@@ -76,7 +78,6 @@ ENV PATH="/usr/local/go/bin:${PATH}" \
 #
 # To update: bump GITLEAKS_VERSION and GITLEAKS_SHA256_{AMD64,ARM64} from:
 #   https://github.com/gitleaks/gitleaks/releases/download/v<VERSION>/gitleaks_<VERSION>_checksums.txt
-ARG TARGETARCH
 ARG GITLEAKS_VERSION=8.30.1
 ARG GITLEAKS_SHA256_AMD64=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
 ARG GITLEAKS_SHA256_ARM64=e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080

--- a/images/code/Containerfile
+++ b/images/code/Containerfile
@@ -2,7 +2,6 @@
 #
 # Extends the base fullsend sandbox image with tools needed by the code agent:
 #   - Go (compile + test target repos written in Go)
-#   - gitleaks (secret scanner, SHA256-verified)
 #   - pre-commit + gitlint (runs repo-defined hooks and validates commit messages)
 #
 # The base image already provides Claude Code, rsync, tirith, and LLM Guard.
@@ -71,26 +70,8 @@ ENV PATH="/usr/local/go/bin:${PATH}" \
     GOMODCACHE="/sandbox/go/pkg/mod"
 
 # ---------------------------------------------------------------------------
-# gitleaks — secret scanner used by scripts/scan-secrets.
-# When gitleaks is on PATH, the scan-secrets script uses it directly
-# with zero download latency. Without it, scan-secrets falls back to
-# downloading and verifying at runtime (slower, needs network).
-#
-# To update: bump GITLEAKS_VERSION and GITLEAKS_SHA256_{AMD64,ARM64} from:
-#   https://github.com/gitleaks/gitleaks/releases/download/v<VERSION>/gitleaks_<VERSION>_checksums.txt
-ARG GITLEAKS_VERSION=8.30.1
-ARG GITLEAKS_SHA256_AMD64=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
-ARG GITLEAKS_SHA256_ARM64=e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080
-
-RUN GL_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "x64") \
-    && GL_SHA=$([ "$TARGETARCH" = "arm64" ] && echo "$GITLEAKS_SHA256_ARM64" || echo "$GITLEAKS_SHA256_AMD64") \
-    && curl -fsSL \
-      "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_${GL_ARCH}.tar.gz" \
-      -o /tmp/gitleaks.tar.gz \
-    && echo "${GL_SHA}  /tmp/gitleaks.tar.gz" | sha256sum -c - \
-    && tar xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks \
-    && chmod +x /usr/local/bin/gitleaks \
-    && rm /tmp/gitleaks.tar.gz
+# gitleaks is already installed in the base sandbox image.
+# See images/sandbox/Containerfile for the pinned version and checksums.
 
 # ---------------------------------------------------------------------------
 # pre-commit + gitlint — pre-commit runs repo-defined hooks (formatting,

--- a/images/code/Containerfile
+++ b/images/code/Containerfile
@@ -60,7 +60,8 @@ ARG GO_SHA256_AMD64=1fc94b57134d51669c72173ad5d49fd62afb0f1db9bf3f798fd98ee423f8
 ARG GO_SHA256_ARM64=74d97be1cc3a474129590c67ebf748a96e72d9f3a2b6fef3ed3275de591d49b3
 
 RUN case "$TARGETARCH" in \
-      amd64|arm64) GO_SHA=$([ "$TARGETARCH" = "arm64" ] && echo "$GO_SHA256_ARM64" || echo "$GO_SHA256_AMD64") ;; \
+      amd64) GO_SHA="$GO_SHA256_AMD64" ;; \
+      arm64) GO_SHA="$GO_SHA256_ARM64" ;; \
       *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
     esac \
     && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \

--- a/images/code/Containerfile
+++ b/images/code/Containerfile
@@ -80,7 +80,7 @@ ENV PATH="/usr/local/go/bin:${PATH}" \
 
 # ---------------------------------------------------------------------------
 # pre-commit + gitlint are already installed in the base sandbox image
-# (system-level pip install places binaries at /usr/local/bin).
+# (pip install into /sandbox/.venv; the venv bin dir is on PATH).
 # See images/sandbox/Containerfile for the pinned versions.
 
 # ---------------------------------------------------------------------------

--- a/images/code/Containerfile
+++ b/images/code/Containerfile
@@ -79,17 +79,9 @@ ENV PATH="/usr/local/go/bin:${PATH}" \
 # See images/sandbox/Containerfile for the pinned version and checksums.
 
 # ---------------------------------------------------------------------------
-# pre-commit + gitlint are already installed in the base sandbox image.
+# pre-commit + gitlint are already installed in the base sandbox image
+# (system-level pip install places binaries at /usr/local/bin).
 # See images/sandbox/Containerfile for the pinned versions.
-#
-# The venv's bin dir (/sandbox/.venv/bin) is not on PATH inside the
-# sandbox Bash shell. Symlink the binaries into /usr/local/bin so the
-# agent can find them without PATH manipulation.
-RUN for bin in pre-commit gitlint; do \
-      if [ -x "/sandbox/.venv/bin/$bin" ]; then \
-        ln -sf "/sandbox/.venv/bin/$bin" "/usr/local/bin/$bin"; \
-      fi; \
-    done
 
 # ---------------------------------------------------------------------------
 # scan-secrets — gitleaks wrapper used by the code-implementation skill.

--- a/images/code/Containerfile
+++ b/images/code/Containerfile
@@ -51,13 +51,16 @@ RUN git config --system http.sslCAInfo /etc/ssl/certs/ca-certificates.crt 2>/dev
 # `go test`, or `go vet`), wasting ~4 tool calls trying to find Go.
 #
 # Pinned version + SHA256 checksum for supply chain safety.
-# To update: get the latest linux-amd64 archive + sha256 from https://go.dev/dl/?mode=json
+# To update: get the latest linux-{amd64,arm64} archive + sha256 from https://go.dev/dl/?mode=json
+ARG TARGETARCH
 ARG GO_VERSION=1.24.13
-ARG GO_SHA256=1fc94b57134d51669c72173ad5d49fd62afb0f1db9bf3f798fd98ee423f8d730
+ARG GO_SHA256_AMD64=1fc94b57134d51669c72173ad5d49fd62afb0f1db9bf3f798fd98ee423f8d730
+ARG GO_SHA256_ARM64=74d97be1cc3a474129590c67ebf748a96e72d9f3a2b6fef3ed3275de591d49b3
 
-RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
+RUN GO_SHA=$([ "$TARGETARCH" = "arm64" ] && echo "$GO_SHA256_ARM64" || echo "$GO_SHA256_AMD64") \
+    && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
       -o /tmp/go.tar.gz \
-    && echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \
+    && echo "${GO_SHA}  /tmp/go.tar.gz" | sha256sum -c - \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm /tmp/go.tar.gz
 
@@ -71,15 +74,19 @@ ENV PATH="/usr/local/go/bin:${PATH}" \
 # with zero download latency. Without it, scan-secrets falls back to
 # downloading and verifying at runtime (slower, needs network).
 #
-# To update: bump GITLEAKS_VERSION and GITLEAKS_SHA256 from:
+# To update: bump GITLEAKS_VERSION and GITLEAKS_SHA256_{AMD64,ARM64} from:
 #   https://github.com/gitleaks/gitleaks/releases/download/v<VERSION>/gitleaks_<VERSION>_checksums.txt
+ARG TARGETARCH
 ARG GITLEAKS_VERSION=8.30.1
-ARG GITLEAKS_SHA256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+ARG GITLEAKS_SHA256_AMD64=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+ARG GITLEAKS_SHA256_ARM64=e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080
 
-RUN curl -fsSL \
-      "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+RUN GL_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "x64") \
+    && GL_SHA=$([ "$TARGETARCH" = "arm64" ] && echo "$GITLEAKS_SHA256_ARM64" || echo "$GITLEAKS_SHA256_AMD64") \
+    && curl -fsSL \
+      "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_${GL_ARCH}.tar.gz" \
       -o /tmp/gitleaks.tar.gz \
-    && echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c - \
+    && echo "${GL_SHA}  /tmp/gitleaks.tar.gz" | sha256sum -c - \
     && tar xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks \
     && chmod +x /usr/local/bin/gitleaks \
     && rm /tmp/gitleaks.tar.gz

--- a/images/code/Containerfile
+++ b/images/code/Containerfile
@@ -2,9 +2,10 @@
 #
 # Extends the base fullsend sandbox image with tools needed by the code agent:
 #   - Go (compile + test target repos written in Go)
-#   - pre-commit + gitlint (runs repo-defined hooks and validates commit messages)
+#   - scan-secrets (gitleaks wrapper for code-implementation skill)
 #
-# The base image already provides Claude Code, rsync, tirith, and LLM Guard.
+# The base image already provides Claude Code, rsync, gitleaks, tirith,
+# pre-commit, gitlint, and the ProtectAI DeBERTa-v3 ONNX model.
 # See images/sandbox/Containerfile in fullsend-ai/fullsend for the base definition.
 #
 # This image is built AUTOMATICALLY by .github/workflows/sandbox-image.yml
@@ -58,7 +59,10 @@ ARG GO_VERSION=1.24.13
 ARG GO_SHA256_AMD64=1fc94b57134d51669c72173ad5d49fd62afb0f1db9bf3f798fd98ee423f8d730
 ARG GO_SHA256_ARM64=74d97be1cc3a474129590c67ebf748a96e72d9f3a2b6fef3ed3275de591d49b3
 
-RUN GO_SHA=$([ "$TARGETARCH" = "arm64" ] && echo "$GO_SHA256_ARM64" || echo "$GO_SHA256_AMD64") \
+RUN case "$TARGETARCH" in \
+      amd64|arm64) GO_SHA=$([ "$TARGETARCH" = "arm64" ] && echo "$GO_SHA256_ARM64" || echo "$GO_SHA256_AMD64") ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac \
     && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
       -o /tmp/go.tar.gz \
     && echo "${GO_SHA}  /tmp/go.tar.gz" | sha256sum -c - \
@@ -74,14 +78,9 @@ ENV PATH="/usr/local/go/bin:${PATH}" \
 # See images/sandbox/Containerfile for the pinned version and checksums.
 
 # ---------------------------------------------------------------------------
-# pre-commit + gitlint — pre-commit runs repo-defined hooks (formatting,
-# linting, etc.) on changed files before committing. gitlint validates
-# commit message format. Baking them into the image avoids pip installs
-# on every run and ensures they're available even if pip is restricted.
-ARG PRECOMMIT_VERSION=4.5.1
-ARG GITLINT_VERSION=0.19.1
-RUN pip install "pre-commit==${PRECOMMIT_VERSION}" "gitlint-core==${GITLINT_VERSION}" 2>/dev/null \
-    || pip3 install "pre-commit==${PRECOMMIT_VERSION}" "gitlint-core==${GITLINT_VERSION}"
+# pre-commit + gitlint are already installed in the base sandbox image.
+# See images/sandbox/Containerfile for the pinned versions.
+#
 # The venv's bin dir (/sandbox/.venv/bin) is not on PATH inside the
 # sandbox Bash shell. Symlink the binaries into /usr/local/bin so the
 # agent can find them without PATH manipulation.

--- a/images/sandbox/Containerfile
+++ b/images/sandbox/Containerfile
@@ -76,8 +76,11 @@ RUN mkdir -p "${PROTECTAI_MODEL_DIR}" \
 ARG ORT_VERSION=1.24.1
 ARG ORT_SHA256_AMD64=9142552248b735920f9390027e4512a2cacf8946a1ffcbe9071a5c210531026f
 ARG ORT_SHA256_ARM64=0f56edd68f7602df790b68b874a46b115add037e88385c6c842bb763b39b9f89
-RUN ORT_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x64") \
-    && ORT_SHA=$([ "$TARGETARCH" = "arm64" ] && echo "$ORT_SHA256_ARM64" || echo "$ORT_SHA256_AMD64") \
+RUN case "$TARGETARCH" in \
+      amd64) ORT_ARCH="x64";     ORT_SHA="$ORT_SHA256_AMD64" ;; \
+      arm64) ORT_ARCH="aarch64"; ORT_SHA="$ORT_SHA256_ARM64" ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac \
     && curl -fsSL \
       "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-${ORT_ARCH}-${ORT_VERSION}.tgz" \
       -o /tmp/ort.tgz \
@@ -96,8 +99,11 @@ RUN ORT_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x64") \
 ARG GITLEAKS_VERSION=8.30.1
 ARG GITLEAKS_SHA256_AMD64=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
 ARG GITLEAKS_SHA256_ARM64=e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080
-RUN GL_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "x64") \
-    && GL_SHA=$([ "$TARGETARCH" = "arm64" ] && echo "$GITLEAKS_SHA256_ARM64" || echo "$GITLEAKS_SHA256_AMD64") \
+RUN case "$TARGETARCH" in \
+      amd64) GL_ARCH="x64";   GL_SHA="$GITLEAKS_SHA256_AMD64" ;; \
+      arm64) GL_ARCH="arm64"; GL_SHA="$GITLEAKS_SHA256_ARM64" ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac \
     && curl -fsSL \
       "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_${GL_ARCH}.tar.gz" \
       -o /tmp/gitleaks.tar.gz \
@@ -130,8 +136,11 @@ RUN apt-get update \
 ARG TIRITH_VERSION=0.2.12
 ARG TIRITH_SHA256_AMD64=0ecc5430d9d9a78f4df95e14c920897b7ceda1c7102ac132bf6063440e92ef96
 ARG TIRITH_SHA256_ARM64=88121146c91857b1bc74360fb2a320fc1f6feb848e1a3531ee84f5a16f83a9cc
-RUN TI_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
-    && TI_SHA=$([ "$TARGETARCH" = "arm64" ] && echo "$TIRITH_SHA256_ARM64" || echo "$TIRITH_SHA256_AMD64") \
+RUN case "$TARGETARCH" in \
+      amd64) TI_ARCH="x86_64";  TI_SHA="$TIRITH_SHA256_AMD64" ;; \
+      arm64) TI_ARCH="aarch64"; TI_SHA="$TIRITH_SHA256_ARM64" ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac \
     && curl -fsSL "https://github.com/sheeki03/tirith/releases/download/v${TIRITH_VERSION}/tirith-${TI_ARCH}-unknown-linux-gnu.tar.gz" \
       -o /tmp/tirith.tar.gz \
     && echo "${TI_SHA}  /tmp/tirith.tar.gz" | sha256sum -c - \

--- a/images/sandbox/Containerfile
+++ b/images/sandbox/Containerfile
@@ -22,7 +22,7 @@
 #   FROM <registry>/fullsend-sandbox:v1
 #   RUN apt-get install -y golang
 
-FROM ghcr.io/nvidia/openshell-community/sandboxes/base@sha256:f0d1ec92bf219759c1e863c0fa6b1f432ec827331e79ab9e31dab91a3b86b413
+FROM ghcr.io/nvidia/openshell-community/sandboxes/base@sha256:11c73b5a90297f59172abc1b0cd36dc87a2be3a942c4ed604a4da653a4c67c68
 
 # The base image runs as the sandbox user (998). Switch to root for
 # package installation and switch back at the end.
@@ -70,29 +70,37 @@ RUN mkdir -p "${PROTECTAI_MODEL_DIR}" \
 # Pinned version for supply chain safety.
 # To update: bump ORT_VERSION from:
 #   https://github.com/microsoft/onnxruntime/releases
+ARG TARGETARCH
 ARG ORT_VERSION=1.24.1
-ARG ORT_SHA256=9142552248b735920f9390027e4512a2cacf8946a1ffcbe9071a5c210531026f
-RUN curl -fsSL \
-      "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
+ARG ORT_SHA256_AMD64=9142552248b735920f9390027e4512a2cacf8946a1ffcbe9071a5c210531026f
+ARG ORT_SHA256_ARM64=0f56edd68f7602df790b68b874a46b115add037e88385c6c842bb763b39b9f89
+RUN ORT_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x64") \
+    && ORT_SHA=$([ "$TARGETARCH" = "arm64" ] && echo "$ORT_SHA256_ARM64" || echo "$ORT_SHA256_AMD64") \
+    && curl -fsSL \
+      "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-${ORT_ARCH}-${ORT_VERSION}.tgz" \
       -o /tmp/ort.tgz \
-    && echo "${ORT_SHA256}  /tmp/ort.tgz" | sha256sum -c - \
+    && echo "${ORT_SHA}  /tmp/ort.tgz" | sha256sum -c - \
     && tar xzf /tmp/ort.tgz -C /tmp/ \
-    && cp "/tmp/onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so.${ORT_VERSION}" /usr/lib/ \
+    && cp "/tmp/onnxruntime-linux-${ORT_ARCH}-${ORT_VERSION}/lib/libonnxruntime.so.${ORT_VERSION}" /usr/lib/ \
     && ln -sf "/usr/lib/libonnxruntime.so.${ORT_VERSION}" /usr/lib/libonnxruntime.so \
     && /sbin/ldconfig \
-    && rm -rf /tmp/ort.tgz "/tmp/onnxruntime-linux-x64-${ORT_VERSION}"
+    && rm -rf /tmp/ort.tgz "/tmp/onnxruntime-linux-${ORT_ARCH}-${ORT_VERSION}"
 
 # ---------------------------------------------------------------------------
 # gitleaks — secret scanner used by scan-secrets and post-scripts.
 # Pinned version + SHA256 checksum for supply chain safety.
 # To update: bump version and checksum from:
 #   https://github.com/gitleaks/gitleaks/releases/download/v<VERSION>/gitleaks_<VERSION>_checksums.txt
+ARG TARGETARCH
 ARG GITLEAKS_VERSION=8.30.1
-ARG GITLEAKS_SHA256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
-RUN curl -fsSL \
-      "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+ARG GITLEAKS_SHA256_AMD64=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+ARG GITLEAKS_SHA256_ARM64=e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080
+RUN GL_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "x64") \
+    && GL_SHA=$([ "$TARGETARCH" = "arm64" ] && echo "$GITLEAKS_SHA256_ARM64" || echo "$GITLEAKS_SHA256_AMD64") \
+    && curl -fsSL \
+      "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_${GL_ARCH}.tar.gz" \
       -o /tmp/gitleaks.tar.gz \
-    && echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c - \
+    && echo "${GL_SHA}  /tmp/gitleaks.tar.gz" | sha256sum -c - \
     && tar xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks \
     && chmod +x /usr/local/bin/gitleaks \
     && rm /tmp/gitleaks.tar.gz
@@ -118,11 +126,15 @@ RUN apt-get update \
 # Pinned version + sha256 checksum for supply chain safety.
 # To update: bump TIRITH_VERSION and TIRITH_SHA256 from the checksums.txt
 # in the GitHub release: https://github.com/sheeki03/tirith/releases
+ARG TARGETARCH
 ARG TIRITH_VERSION=0.2.12
-ARG TIRITH_SHA256=0ecc5430d9d9a78f4df95e14c920897b7ceda1c7102ac132bf6063440e92ef96
-RUN curl -fsSL "https://github.com/sheeki03/tirith/releases/download/v${TIRITH_VERSION}/tirith-x86_64-unknown-linux-gnu.tar.gz" \
+ARG TIRITH_SHA256_AMD64=0ecc5430d9d9a78f4df95e14c920897b7ceda1c7102ac132bf6063440e92ef96
+ARG TIRITH_SHA256_ARM64=88121146c91857b1bc74360fb2a320fc1f6feb848e1a3531ee84f5a16f83a9cc
+RUN TI_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
+    && TI_SHA=$([ "$TARGETARCH" = "arm64" ] && echo "$TIRITH_SHA256_ARM64" || echo "$TIRITH_SHA256_AMD64") \
+    && curl -fsSL "https://github.com/sheeki03/tirith/releases/download/v${TIRITH_VERSION}/tirith-${TI_ARCH}-unknown-linux-gnu.tar.gz" \
       -o /tmp/tirith.tar.gz \
-    && echo "${TIRITH_SHA256}  /tmp/tirith.tar.gz" | sha256sum -c - \
+    && echo "${TI_SHA}  /tmp/tirith.tar.gz" | sha256sum -c - \
     && tar xzf /tmp/tirith.tar.gz -C /usr/local/bin tirith \
     && chmod +x /usr/local/bin/tirith \
     && rm /tmp/tirith.tar.gz

--- a/images/sandbox/Containerfile
+++ b/images/sandbox/Containerfile
@@ -71,7 +71,7 @@ RUN mkdir -p "${PROTECTAI_MODEL_DIR}" \
 # ---------------------------------------------------------------------------
 # ONNX Runtime shared library — loaded by hugot at runtime.
 # Pinned version for supply chain safety.
-# To update: bump ORT_VERSION from:
+# To update: bump ORT_VERSION and ORT_SHA256_{AMD64,ARM64} from:
 #   https://github.com/microsoft/onnxruntime/releases
 ARG ORT_VERSION=1.24.1
 ARG ORT_SHA256_AMD64=9142552248b735920f9390027e4512a2cacf8946a1ffcbe9071a5c210531026f
@@ -91,7 +91,7 @@ RUN ORT_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x64") \
 # ---------------------------------------------------------------------------
 # gitleaks — secret scanner used by scan-secrets and post-scripts.
 # Pinned version + SHA256 checksum for supply chain safety.
-# To update: bump version and checksum from:
+# To update: bump GITLEAKS_VERSION and GITLEAKS_SHA256_{AMD64,ARM64} from:
 #   https://github.com/gitleaks/gitleaks/releases/download/v<VERSION>/gitleaks_<VERSION>_checksums.txt
 ARG GITLEAKS_VERSION=8.30.1
 ARG GITLEAKS_SHA256_AMD64=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
@@ -125,7 +125,7 @@ RUN apt-get update \
 # ---------------------------------------------------------------------------
 # tirith — terminal security scanner for PreToolUse hooks.
 # Pinned version + sha256 checksum for supply chain safety.
-# To update: bump TIRITH_VERSION and TIRITH_SHA256 from the checksums.txt
+# To update: bump TIRITH_VERSION and TIRITH_SHA256_{AMD64,ARM64} from the checksums.txt
 # in the GitHub release: https://github.com/sheeki03/tirith/releases
 ARG TIRITH_VERSION=0.2.12
 ARG TIRITH_SHA256_AMD64=0ecc5430d9d9a78f4df95e14c920897b7ceda1c7102ac132bf6063440e92ef96

--- a/images/sandbox/Containerfile
+++ b/images/sandbox/Containerfile
@@ -28,6 +28,9 @@ FROM ghcr.io/nvidia/openshell-community/sandboxes/base@sha256:11c73b5a90297f5917
 # package installation and switch back at the end.
 USER root
 
+# BuildKit automatic platform ARG — set by --platform during multi-arch builds.
+ARG TARGETARCH
+
 # ---------------------------------------------------------------------------
 # Install rsync (for safe repo write-back).
 RUN apt-get update \
@@ -70,7 +73,6 @@ RUN mkdir -p "${PROTECTAI_MODEL_DIR}" \
 # Pinned version for supply chain safety.
 # To update: bump ORT_VERSION from:
 #   https://github.com/microsoft/onnxruntime/releases
-ARG TARGETARCH
 ARG ORT_VERSION=1.24.1
 ARG ORT_SHA256_AMD64=9142552248b735920f9390027e4512a2cacf8946a1ffcbe9071a5c210531026f
 ARG ORT_SHA256_ARM64=0f56edd68f7602df790b68b874a46b115add037e88385c6c842bb763b39b9f89
@@ -91,7 +93,6 @@ RUN ORT_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x64") \
 # Pinned version + SHA256 checksum for supply chain safety.
 # To update: bump version and checksum from:
 #   https://github.com/gitleaks/gitleaks/releases/download/v<VERSION>/gitleaks_<VERSION>_checksums.txt
-ARG TARGETARCH
 ARG GITLEAKS_VERSION=8.30.1
 ARG GITLEAKS_SHA256_AMD64=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
 ARG GITLEAKS_SHA256_ARM64=e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080
@@ -126,7 +127,6 @@ RUN apt-get update \
 # Pinned version + sha256 checksum for supply chain safety.
 # To update: bump TIRITH_VERSION and TIRITH_SHA256 from the checksums.txt
 # in the GitHub release: https://github.com/sheeki03/tirith/releases
-ARG TARGETARCH
 ARG TIRITH_VERSION=0.2.12
 ARG TIRITH_SHA256_AMD64=0ecc5430d9d9a78f4df95e14c920897b7ceda1c7102ac132bf6063440e92ef96
 ARG TIRITH_SHA256_ARM64=88121146c91857b1bc74360fb2a320fc1f6feb848e1a3531ee84f5a16f83a9cc


### PR DESCRIPTION
## Summary

Add linux/arm64 support to the fullsend sandbox and code agent container images, enabling agents to run natively on Apple Silicon Macs via Podman + OpenShell.

### Container images

- Pin the OpenShell base image to its **manifest list (index) digest** (`sha256:11c73b5a90...`) instead of the amd64-only platform digest. The index resolves to the same amd64 image currently used plus the arm64 variant — no version bump, same security guarantees.
- Use BuildKit `TARGETARCH` in both Containerfiles to download architecture-appropriate binaries for ONNX Runtime, gitleaks, tirith, and Go. Each has per-arch SHA256 checksums for supply chain safety.
- All arch-dependent `RUN` blocks use explicit `case "$TARGETARCH" in amd64)...;; arm64)...;; *) exit 1` to reject unsupported architectures at build time.
- Remove duplicate `pip install` of pre-commit/gitlint from the code image (already installed in the base sandbox image via `/sandbox/.venv`, which is on PATH).
- Remove dead symlink block that tried to symlink from `/sandbox/.venv/bin/` to `/usr/local/bin/` — both are already on PATH.

### CI workflow (`.github/workflows/sandbox-images.yml`)

- Add `docker/setup-qemu-action` for cross-platform user-mode emulation.
- Add `platforms: linux/amd64,linux/arm64` to both `build-push-action` steps so published images are manifest lists covering both architectures.
- Add `:dev` tag on all non-PR events. PR builds fall back to the `:dev` base image (multi-arch) when no digest is available from `build-base` (which doesn't push on PRs). This avoids the chicken-and-egg problem where `:latest` may be amd64-only.

### Documentation (`images/README.md`)

- New file documenting image hierarchy, tag lifecycle (`:latest`, `:dev`, semver, commit SHA), build workflow, `:dev` bootstrap instructions, supply chain security (per-tool verification methods), and local build commands.

### Architecture-specific binary mappings

| Binary | amd64 asset | arm64 asset |
|--------|------------|------------|
| ONNX Runtime 1.24.1 | `onnxruntime-linux-x64-1.24.1.tgz` | `onnxruntime-linux-aarch64-1.24.1.tgz` |
| Gitleaks 8.30.1 | `gitleaks_8.30.1_linux_x64.tar.gz` | `gitleaks_8.30.1_linux_arm64.tar.gz` |
| Tirith 0.2.12 | `tirith-x86_64-unknown-linux-gnu.tar.gz` | `tirith-aarch64-unknown-linux-gnu.tar.gz` |
| Go 1.24.13 | `go1.24.13.linux-amd64.tar.gz` | `go1.24.13.linux-arm64.tar.gz` |

### No changes needed

- **CLI / sandbox driver** — image string passed as-is to Podman, which resolves the correct platform from manifest lists automatically.
- **Harness YAML files** — continue using `:latest` tag; no hardcoded tool paths.
- **ProtectAI DeBERTa model** — ONNX model files are architecture-independent.
- **Claude Code installer** — `install.sh` is architecture-aware.
- **pre-commit / gitlint** — pure Python, installed in base image venv.

### Local build verification

Built the code image locally on Apple Silicon against the remote `:dev` base image. All tools verified working on arm64:

```
go version go1.24.13 linux/arm64
gitleaks 8.30.1
tirith 0.2.12
pre-commit 4.5.1  (/sandbox/.venv/bin/pre-commit)
gitlint 0.19.1    (/sandbox/.venv/bin/gitlint)
scan-secrets      (/usr/local/bin/scan-secrets)
```

## Test plan

- [ ] CI workflow builds and pushes both `linux/amd64` and `linux/arm64` manifests
- [ ] `podman manifest inspect ghcr.io/fullsend-ai/fullsend-sandbox:latest` shows both platform entries
- [ ] `podman manifest inspect ghcr.io/fullsend-ai/fullsend-code:latest` shows both platform entries
- [ ] amd64 regression: existing CI runners continue to work
- [ ] arm64 validation: `fullsend run triage` on Apple Silicon Mac with Podman + OpenShell
- [ ] pre-commit and gitlint accessible inside code image (verified locally — in `/sandbox/.venv/bin/`, on PATH)