### PR TITLE
feat(cli): add --env-file flag and FULLSEND_SANDBOX_IMAGE override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ bin/
 .playwright/
 .claude/settings.local.json
 .vscode/
+*.env
+.env.*
+!.env.example

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -15,3 +15,9 @@ Guides for org administrators who install, configure, and manage fullsend.
 Guides for developers working in repositories where fullsend is active.
 
 - [Bugfix workflow](user/bugfix-workflow.md) — End-to-end guide to how fullsend handles a bug report from issue to merge
+
+## Development
+
+Guides for contributors developing and testing fullsend itself.
+
+- [Local development](dev/local-dev.md) — Run fullsend agents locally on macOS and Linux (amd64 + arm64)

--- a/docs/guides/dev/local-dev.md
+++ b/docs/guides/dev/local-dev.md
@@ -1,0 +1,96 @@
+# Local development
+
+This guide walks through running fullsend agents locally on macOS and Linux. PR [#612](https://github.com/fullsend-ai/fullsend/pull/612) added multi-arch (amd64 + arm64) sandbox image support, so both architectures are covered.
+
+## Prerequisites
+
+| Requirement | macOS | Linux |
+|-------------|-------|-------|
+| Container runtime | Podman Desktop with a running machine | Podman |
+| OpenShell | 0.0.37-dev+ (Podman support) | 0.0.37-dev+ |
+| GCP credentials | Service account key (`Vertex AI User` role) | Same |
+| GitHub PAT | `repo` scope for the target org | Same |
+| Go toolchain | For building the CLI from source | Same |
+
+> **arm64 note**: Apple Silicon Macs and arm64 Linux hosts must use the `:dev` multi-arch sandbox images. The default `:latest` tag is amd64-only until multi-arch merges to main. See step 3 below.
+
+## 1. Build the fullsend CLI
+
+```bash
+make go-build
+```
+
+The binary is written to `./bin/fullsend`.
+
+## 2. Set up the .fullsend directory
+
+Clone the `.fullsend` config repo for your org:
+
+```bash
+gh repo clone <org>/.fullsend /tmp/fullsend-dot
+```
+
+## 3. Create an env file
+
+Env files contain secrets and must never be committed. The repo `.gitignore` already excludes `*.env` and `.env.*`. Keep your env file outside the repo (e.g. `/tmp/fullsend.env`) or use a name that matches these patterns.
+
+Create a file with the required environment variables:
+
+```bash
+ANTHROPIC_VERTEX_PROJECT_ID=<gcp-project-with-vertex-ai>
+CLOUD_ML_REGION=global
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa-key.json
+GH_TOKEN=<github-pat>
+```
+
+Each agent requires additional variables via its harness `runner_env`. Add the ones needed for the agent you are running:
+
+| Variable | Agent(s) | Description |
+|----------|----------|-------------|
+| `GITHUB_ISSUE_URL` | triage | Full URL of the GitHub issue to triage |
+| `REPO_FULL_NAME` | triage, code, review, fix | `owner/repo` of the target repository |
+| `ISSUE_NUMBER` | code | Issue number the code agent should implement |
+| `TARGET_BRANCH` | code, fix | Branch to base work on (e.g. `main`) |
+| `PUSH_TOKEN` | code, fix | GitHub token with push access for the post-script |
+| `PR_NUMBER` | review, fix | Pull request number to review or fix |
+| `GITHUB_PR_URL` | review | Full URL of the pull request to review |
+| `REVIEW_TOKEN` | review | GitHub token for posting review comments |
+
+See the harness definitions in `harness/*.yaml` within your `.fullsend` config directory for the complete list per agent.
+
+### arm64 image override
+
+On arm64 hosts (Apple Silicon, Graviton, etc.), add the sandbox image override to your env file:
+
+```bash
+FULLSEND_SANDBOX_IMAGE=ghcr.io/fullsend-ai/fullsend-sandbox:dev
+```
+
+This switches from the default `:latest` tag (amd64-only) to the `:dev` multi-arch image that includes arm64 support. On amd64 hosts this line is not needed — `:latest` works directly.
+
+## 4. Run an agent
+
+```bash
+./bin/fullsend run triage \
+  --fullsend-dir /tmp/fullsend-dot \
+  --target-repo /path/to/repo \
+  --env-file /tmp/fullsend.env
+```
+
+The `--env-file` flag loads environment variables before the harness is parsed, so variables are available for harness YAML expansion. The flag is repeatable — later files override earlier ones.
+
+## Known issues
+
+### macOS (Apple Silicon)
+
+- **Podman entrypoint**: the container entrypoint `/bin/bash` may fail with "cannot execute binary file". OpenShell handles this internally, but standalone `podman run` needs `--entrypoint ""` with `/usr/bin/env sh -c`.
+- **Podman machine**: ensure the Podman machine is running (`podman machine start`) before invoking fullsend. The CLI does not start it automatically.
+
+### Linux
+
+- **Docker socket permissions**: if using Docker, your user must be in the `docker` group or you need to run with `sudo`. Podman runs rootless by default.
+- **SELinux**: on Fedora/RHEL, bind-mounted volumes may need the `:z` suffix for standalone `podman run`. OpenShell handles this automatically.
+
+### Both platforms
+
+- **Image tags**: harness YAMLs ship with `:latest` which is amd64-only until multi-arch merges to main. Use `FULLSEND_SANDBOX_IMAGE` to override to `:dev` for local testing on arm64.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/fullsend-ai/fullsend/internal/envfile"
 	"github.com/fullsend-ai/fullsend/internal/harness"
 	"github.com/fullsend-ai/fullsend/internal/sandbox"
 	"github.com/fullsend-ai/fullsend/internal/security"
@@ -23,6 +24,7 @@ func newRunCmd() *cobra.Command {
 	var outputBase string
 	var targetRepo string
 	var fullsendBinary string
+	var envFiles []string
 
 	cmd := &cobra.Command{
 		Use:   "run <agent-name>",
@@ -32,7 +34,7 @@ func newRunCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agentName := args[0]
 			printer := ui.New(os.Stdout)
-			return runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary, printer)
+			return runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary, envFiles, printer)
 		},
 	}
 
@@ -40,17 +42,25 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&outputBase, "output-dir", "", "base directory for run output (default: /tmp/fullsend)")
 	cmd.Flags().StringVar(&targetRepo, "target-repo", "", "path to the target repository")
 	cmd.Flags().StringVar(&fullsendBinary, "fullsend-binary", "", "path to a Linux fullsend binary to copy into the sandbox (default: current executable)")
+	cmd.Flags().StringArrayVar(&envFiles, "env-file", nil, "load environment variables from a dotenv file (repeatable)")
 	_ = cmd.MarkFlagRequired("fullsend-dir")
 	_ = cmd.MarkFlagRequired("target-repo")
 
 	return cmd
 }
 
-func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary string, printer *ui.Printer) (runErr error) {
+func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary string, envFiles []string, printer *ui.Printer) (runErr error) {
 	printer.Banner()
 	printer.Blank()
 	printer.Header("Running agent: " + agentName)
 	printer.Blank()
+
+	// 0. Load env files before anything else so vars are available for harness expansion.
+	for _, ef := range envFiles {
+		if err := envfile.Load(ef); err != nil {
+			return fmt.Errorf("loading env file %s: %w", ef, err)
+		}
+	}
 
 	// 1. Resolve and load harness.
 	harnessPath := filepath.Join(fullsendDir, "harness", agentName+".yaml")
@@ -70,6 +80,11 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary str
 	if err := h.ResolveRelativeTo(absFullsendDir); err != nil {
 		printer.StepFail("Path validation failed")
 		return fmt.Errorf("resolving paths: %w", err)
+	}
+
+	if resolved, overridden := applySandboxImageOverride(h.Image); overridden {
+		printer.StepInfo(fmt.Sprintf("Image override via FULLSEND_SANDBOX_IMAGE: %s -> %s", h.Image, resolved))
+		h.Image = resolved
 	}
 
 	// Expand env vars in runner_env values. FULLSEND_DIR is injected so
@@ -1217,4 +1232,13 @@ func injectTraceID(sshConfigPath, sandboxName, traceID string) error {
 	cmd := fmt.Sprintf("echo 'export FULLSEND_TRACE_ID=%s' >> %s/.env", traceID, sandbox.SandboxWorkspace)
 	_, _, _, err := sandbox.SSH(sshConfigPath, sandboxName, cmd, 10*time.Second)
 	return err
+}
+
+// applySandboxImageOverride replaces image with the FULLSEND_SANDBOX_IMAGE env
+// var value when set. Returns the resolved image and whether an override was applied.
+func applySandboxImageOverride(image string) (string, bool) {
+	if override := os.Getenv("FULLSEND_SANDBOX_IMAGE"); override != "" {
+		return override, true
+	}
+	return image, false
 }

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -109,6 +109,37 @@ func TestCollectOpenshellLogs_CreatesLogsDir(t *testing.T) {
 	assert.NoError(t, err, "logs directory should exist")
 }
 
+func TestRunCommand_HasEnvFileFlag(t *testing.T) {
+	cmd := newRunCmd()
+	flag := cmd.Flags().Lookup("env-file")
+	require.NotNil(t, flag)
+	assert.Equal(t, "[]", flag.DefValue)
+
+	// Repeatable: set twice and verify both values are captured.
+	require.NoError(t, cmd.Flags().Set("env-file", "/tmp/a.env"))
+	require.NoError(t, cmd.Flags().Set("env-file", "/tmp/b.env"))
+
+	val, err := cmd.Flags().GetStringArray("env-file")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/tmp/a.env", "/tmp/b.env"}, val)
+}
+
+func TestApplySandboxImageOverride_Applied(t *testing.T) {
+	t.Setenv("FULLSEND_SANDBOX_IMAGE", "ghcr.io/fullsend-ai/fullsend-sandbox:dev")
+
+	resolved, overridden := applySandboxImageOverride("ghcr.io/fullsend-ai/fullsend-sandbox:latest")
+	assert.True(t, overridden)
+	assert.Equal(t, "ghcr.io/fullsend-ai/fullsend-sandbox:dev", resolved)
+}
+
+func TestApplySandboxImageOverride_NotSet(t *testing.T) {
+	t.Setenv("FULLSEND_SANDBOX_IMAGE", "")
+
+	resolved, overridden := applySandboxImageOverride("ghcr.io/fullsend-ai/fullsend-sandbox:latest")
+	assert.False(t, overridden)
+	assert.Equal(t, "ghcr.io/fullsend-ai/fullsend-sandbox:latest", resolved)
+}
+
 func TestEnvToList_Sorted(t *testing.T) {
 	env := map[string]string{
 		"Z_VAR": "z",

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -1,0 +1,92 @@
+// Package envfile provides a simple dotenv file parser.
+//
+// Supported syntax:
+//
+//	KEY=value
+//	KEY="quoted value"
+//	KEY='single quoted'
+//	export KEY=value
+//	KEY=value # inline comment (stripped for unquoted values)
+//	# full-line comments
+//
+// Inline comments require a space before # (KEY=val#tag is preserved).
+// Mismatched quotes are treated as literal characters.
+//
+// Not supported: multiline values, escape sequences (\n, \t),
+// variable expansion (${VAR}).
+package envfile
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+const maxEnvFileSize = 1 << 20 // 1 MB
+
+var validKeyRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// Load reads a dotenv file and sets each entry in the process environment.
+// It permanently modifies the process environment via os.Setenv.
+func Load(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening env file: %w", err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat env file: %w", err)
+	}
+	if info.Size() > maxEnvFileSize {
+		return fmt.Errorf("env file %s exceeds maximum size (%d bytes)", path, maxEnvFileSize)
+	}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), "\r")
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+
+		idx := strings.Index(line, "=")
+		if idx < 0 {
+			continue
+		}
+		key := line[:idx]
+		value := line[idx+1:]
+
+		if !validKeyRe.MatchString(key) {
+			return fmt.Errorf("invalid env var name %q in %s", key, path)
+		}
+
+		quoted := false
+		if len(value) >= 2 && (value[0] == '"' || value[0] == '\'') {
+			if end := strings.IndexByte(value[1:], value[0]); end >= 0 {
+				value = value[1 : end+1]
+				quoted = true
+			}
+		}
+
+		// Strip inline comments from unquoted values only.
+		if !quoted {
+			if ci := strings.Index(value, " #"); ci >= 0 {
+				value = strings.TrimRight(value[:ci], " ")
+			}
+		}
+
+		if err := os.Setenv(key, value); err != nil {
+			return fmt.Errorf("setting %s: %w", key, err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading env file %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -1,0 +1,194 @@
+package envfile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeEnvFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".env")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestLoad_KeyValue(t *testing.T) {
+	t.Setenv("ENVTEST_KV", "")
+	path := writeEnvFile(t, "ENVTEST_KV=bar\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "bar", os.Getenv("ENVTEST_KV"))
+}
+
+func TestLoad_DoubleQuoted(t *testing.T) {
+	t.Setenv("ENVTEST_DQ", "")
+	path := writeEnvFile(t, `ENVTEST_DQ="hello world"`+"\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "hello world", os.Getenv("ENVTEST_DQ"))
+}
+
+func TestLoad_SingleQuoted(t *testing.T) {
+	t.Setenv("ENVTEST_SQ", "")
+	path := writeEnvFile(t, `ENVTEST_SQ='hello world'`+"\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "hello world", os.Getenv("ENVTEST_SQ"))
+}
+
+func TestLoad_ExportPrefix(t *testing.T) {
+	t.Setenv("ENVTEST_EXPORTED", "")
+	path := writeEnvFile(t, "export ENVTEST_EXPORTED=yes\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "yes", os.Getenv("ENVTEST_EXPORTED"))
+}
+
+func TestLoad_CommentsAndBlanks(t *testing.T) {
+	t.Setenv("ENVTEST_C1", "")
+	t.Setenv("ENVTEST_C2", "")
+	content := "# a comment\nENVTEST_C1=val1\n\n# another comment\nENVTEST_C2=val2\n"
+	path := writeEnvFile(t, content)
+	require.NoError(t, Load(path))
+	assert.Equal(t, "val1", os.Getenv("ENVTEST_C1"))
+	assert.Equal(t, "val2", os.Getenv("ENVTEST_C2"))
+}
+
+func TestLoad_EmptyValue(t *testing.T) {
+	t.Setenv("ENVTEST_EMPTY", "placeholder")
+	path := writeEnvFile(t, "ENVTEST_EMPTY=\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "", os.Getenv("ENVTEST_EMPTY"))
+}
+
+func TestLoad_NoEquals(t *testing.T) {
+	t.Setenv("ENVTEST_VALID", "")
+	path := writeEnvFile(t, "NOEQUALS\nENVTEST_VALID=ok\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "ok", os.Getenv("ENVTEST_VALID"))
+}
+
+func TestLoad_FileNotFound(t *testing.T) {
+	err := Load("/nonexistent/.env")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opening env file")
+}
+
+func TestLoad_InlineComment(t *testing.T) {
+	t.Setenv("ENVTEST_IC", "")
+	path := writeEnvFile(t, "ENVTEST_IC=value # this is a comment\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "value", os.Getenv("ENVTEST_IC"))
+}
+
+func TestLoad_InlineCommentPreservedInQuotes(t *testing.T) {
+	t.Setenv("ENVTEST_ICQ", "")
+	path := writeEnvFile(t, `ENVTEST_ICQ="value # not a comment"`+"\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "value # not a comment", os.Getenv("ENVTEST_ICQ"))
+}
+
+func TestLoad_WindowsLineEndings(t *testing.T) {
+	t.Setenv("ENVTEST_CRLF", "")
+	path := writeEnvFile(t, "ENVTEST_CRLF=value\r\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "value", os.Getenv("ENVTEST_CRLF"))
+}
+
+func TestLoad_WindowsLineEndingsQuoted(t *testing.T) {
+	t.Setenv("ENVTEST_CRLFQ", "")
+	path := writeEnvFile(t, "ENVTEST_CRLFQ=\"quoted\"\r\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "quoted", os.Getenv("ENVTEST_CRLFQ"))
+}
+
+func TestLoad_InvalidKeyName(t *testing.T) {
+	path := writeEnvFile(t, "INVALID-KEY=value\n")
+	err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid env var name")
+}
+
+func TestLoad_InvalidKeyNameWithSpaces(t *testing.T) {
+	path := writeEnvFile(t, "KEY WITH SPACES=value\n")
+	err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid env var name")
+}
+
+func TestLoad_ValidKeyWithUnderscore(t *testing.T) {
+	t.Setenv("_ENVTEST_UNDER", "")
+	path := writeEnvFile(t, "_ENVTEST_UNDER=yes\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "yes", os.Getenv("_ENVTEST_UNDER"))
+}
+
+func TestLoad_MultipleEquals(t *testing.T) {
+	t.Setenv("ENVTEST_URL", "")
+	path := writeEnvFile(t, "ENVTEST_URL=https://example.com?a=b&c=d\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "https://example.com?a=b&c=d", os.Getenv("ENVTEST_URL"))
+}
+
+func TestLoad_FileTooLarge(t *testing.T) {
+	large := strings.Repeat("A=B\n", 400000)
+	path := writeEnvFile(t, large)
+	err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum size")
+}
+
+func TestLoad_EmptyKey(t *testing.T) {
+	path := writeEnvFile(t, "=value\n")
+	err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid env var name")
+}
+
+func TestLoad_HashWithoutSpace(t *testing.T) {
+	t.Setenv("ENVTEST_HASH", "")
+	path := writeEnvFile(t, "ENVTEST_HASH=value#tag\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "value#tag", os.Getenv("ENVTEST_HASH"))
+}
+
+func TestLoad_MismatchedQuotesLiteral(t *testing.T) {
+	t.Setenv("ENVTEST_MQ", "")
+	path := writeEnvFile(t, `ENVTEST_MQ="value'`+"\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, `"value'`, os.Getenv("ENVTEST_MQ"))
+}
+
+func TestLoad_QuotedValueWithTrailingComment(t *testing.T) {
+	t.Setenv("ENVTEST_QTC", "")
+	path := writeEnvFile(t, `ENVTEST_QTC="value" # trailing comment`+"\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "value", os.Getenv("ENVTEST_QTC"))
+}
+
+func TestLoad_SingleQuotedValueWithTrailingComment(t *testing.T) {
+	t.Setenv("ENVTEST_SQTC", "")
+	path := writeEnvFile(t, `ENVTEST_SQTC='value' # trailing comment`+"\n")
+	require.NoError(t, Load(path))
+	assert.Equal(t, "value", os.Getenv("ENVTEST_SQTC"))
+}
+
+func TestLoad_ExportDoubleSpace(t *testing.T) {
+	path := writeEnvFile(t, "export  ENVTEST_DS=value\n")
+	err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid env var name")
+}
+
+func TestLoad_MultiFileOverrideOrder(t *testing.T) {
+	t.Setenv("ENVTEST_ORDER", "")
+	path1 := writeEnvFile(t, "ENVTEST_ORDER=first\n")
+	dir2 := t.TempDir()
+	path2 := filepath.Join(dir2, ".env")
+	require.NoError(t, os.WriteFile(path2, []byte("ENVTEST_ORDER=second\n"), 0o644))
+
+	require.NoError(t, Load(path1))
+	require.NoError(t, Load(path2))
+	assert.Equal(t, "second", os.Getenv("ENVTEST_ORDER"))
+}


### PR DESCRIPTION
## Summary

- Add repeatable `--env-file` flag to `fullsend run` that loads dotenv files into the process environment before the harness is parsed, enabling operators to inject secrets and configuration without modifying harness YAML
- Add `FULLSEND_SANDBOX_IMAGE` env var support to override the sandbox container image at runtime for local development and testing
- New `internal/envfile` package with a minimal dotenv parser supporting key=value pairs, quoted values, export prefix, inline comments, POSIX key validation, 1MB size limit, and Windows line endings
- Add contributor guide for local development on macOS and Linux (`docs/guides/dev/local-dev.md`) covering both amd64 and arm64 architectures, using the new `--env-file` flag and `FULLSEND_SANDBOX_IMAGE` override

## Test plan

- [x] 24 unit tests for `internal/envfile` covering: basic key=value, double/single quotes, export prefix, comments and blanks, empty values, no-equals lines, file not found, inline comments (stripped and preserved in quotes), quoted values with trailing comments, Windows line endings, invalid key names (hyphens, spaces, empty, export double space), underscore keys, multiple equals signs, file size limit, hash without space, mismatched quotes, multi-file override order
- [x] 5 unit tests for CLI changes covering: flag registration and repeatability, sandbox image override (applied and not set), env-to-list sorting
- [x] `make go-test` passes
- [x] `make go-vet` clean
- [x] `make lint` passes
- [x] 4 independent code review agents (security, quality, cursor, gemini) report no medium+ issues across 2 rounds