### PR TITLE
fix: support newline-delimited bodies in slash command dispatch

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -20,6 +20,7 @@
 #
 # Command matching: exact, space-delimited args, or newline-delimited body.
 # fromJSON('"\n"') produces a literal newline (GHA strings lack escape support).
+# Assumes LF line endings; GitHub's web UI normalizes to LF (CRLF only via API).
 name: fullsend
 
 permissions:

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -17,6 +17,9 @@
 # Only the fields consumed by downstream workflows are dispatched. The full
 # github.event can exceed GitHub's 65KB workflow_dispatch input limit on
 # large dependency-update PRs (Renovate/Mintmaker bodies alone can be ~38KB).
+#
+# Command matching: exact, space-delimited args, or newline-delimited body.
+# fromJSON('"\n"') produces a literal newline (GHA strings lack escape support).
 name: fullsend
 
 permissions:
@@ -42,6 +45,7 @@ jobs:
       github.event_name == 'issue_comment' && (
         github.event.comment.body == '/triage' ||
         startsWith(github.event.comment.body, '/triage ') ||
+        startsWith(github.event.comment.body, format('{0}{1}', '/triage', fromJSON('"\n"'))) ||
         (
           (github.event.comment.author_association != 'NONE' ||
             github.event.comment.user.login == github.event.issue.user.login) &&
@@ -87,7 +91,8 @@ jobs:
         && !github.event.issue.pull_request
         && (
           github.event.comment.body == '/code' ||
-          startsWith(github.event.comment.body, '/code ')
+          startsWith(github.event.comment.body, '/code ') ||
+          startsWith(github.event.comment.body, format('{0}{1}', '/code', fromJSON('"\n"')))
         ))
     steps:
       - name: Build minimal payload
@@ -128,7 +133,8 @@ jobs:
         && github.event.label.name == 'ready-for-review') ||
       (github.event_name == 'issue_comment' && (
         github.event.comment.body == '/review' ||
-        startsWith(github.event.comment.body, '/review ')
+        startsWith(github.event.comment.body, '/review ') ||
+        startsWith(github.event.comment.body, format('{0}{1}', '/review', fromJSON('"\n"')))
       )) ||
       github.event_name == 'pull_request_target'
     steps:
@@ -222,6 +228,7 @@ jobs:
         && (
           github.event.comment.body == '/fix'
           || startsWith(github.event.comment.body, '/fix ')
+          || startsWith(github.event.comment.body, format('{0}{1}', '/fix', fromJSON('"\n"')))
         )
         && (
           github.event.comment.author_association == 'OWNER'

--- a/docs/normative/admin-install/v1/adr-0013-enrollment/SPEC.md
+++ b/docs/normative/admin-install/v1/adr-0013-enrollment/SPEC.md
@@ -55,7 +55,7 @@ The shim file MUST match the content embedded in `internal/scaffold/fullsend-rep
 
 1. **Event payload via environment variables** — All GitHub Actions context values (`toJSON(github.event)`, `github.event_name`, `github.repository`, `github.repository_owner`) are assigned to environment variables (`EVENT_PAYLOAD`, `EVENT_TYPE`, `SOURCE_REPO`, `DISPATCH_REPO`) and referenced as `"$VAR"` in the `run:` script. This prevents script injection from attacker-controlled fields (issue titles, comment bodies, PR descriptions).
 
-2. **Slash-command matching** — Uses exact equality (`github.event.comment.body == '/triage'`) for bare commands and `startsWith(github.event.comment.body, '/triage ')` (with trailing space) for commands with arguments (e.g. `/triage this issue is ready`). This avoids false positives from partial matches like `/triagefoo` while allowing natural-language arguments after the command.
+2. **Slash-command matching** — Uses a three-condition pattern per command: (1) exact equality for bare commands (`github.event.comment.body == '/triage'`), (2) `startsWith` with a trailing space for same-line arguments (`startsWith(github.event.comment.body, '/triage ')`), and (3) `startsWith` with a trailing newline for multi-line bodies (`startsWith(github.event.comment.body, format('{0}{1}', '/triage', fromJSON('"\n"')))`). The `fromJSON('"\n"')` expression produces a literal newline character, which GitHub Actions expression strings cannot represent directly. This avoids false positives from partial matches like `/triagefoo` while supporting both inline arguments and newline-separated bodies.
 
 3. **Label matching** — Uses `github.event.action == 'labeled' && github.event.label.name == 'ready-to-code'` (exact match on the triggering label) rather than `contains(github.event.issue.labels.*.name, ...)` (which scans all labels). This ensures dispatch fires only on the labeling action that matters, not on unrelated label additions to an issue that already has the label.
 
@@ -84,7 +84,8 @@ jobs:
       github.event_name == 'issues' ||
       (github.event_name == 'issue_comment' && (
         github.event.comment.body == '/triage' ||
-        startsWith(github.event.comment.body, '/triage ')
+        startsWith(github.event.comment.body, '/triage ') ||
+        startsWith(github.event.comment.body, format('{0}{1}', '/triage', fromJSON('"\n"')))
       ))
     steps:
       - name: Dispatch triage

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
@@ -20,6 +20,7 @@
 #
 # Command matching: exact, space-delimited args, or newline-delimited body.
 # fromJSON('"\n"') produces a literal newline (GHA strings lack escape support).
+# Assumes LF line endings; GitHub's web UI normalizes to LF (CRLF only via API).
 name: fullsend
 
 permissions:

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
@@ -17,6 +17,9 @@
 # Only the fields consumed by downstream workflows are dispatched. The full
 # github.event can exceed GitHub's 65KB workflow_dispatch input limit on
 # large dependency-update PRs (Renovate/Mintmaker bodies alone can be ~38KB).
+#
+# Command matching: exact, space-delimited args, or newline-delimited body.
+# fromJSON('"\n"') produces a literal newline (GHA strings lack escape support).
 name: fullsend
 
 permissions:
@@ -42,6 +45,7 @@ jobs:
       github.event_name == 'issue_comment' && (
         github.event.comment.body == '/triage' ||
         startsWith(github.event.comment.body, '/triage ') ||
+        startsWith(github.event.comment.body, format('{0}{1}', '/triage', fromJSON('"\n"'))) ||
         (
           (github.event.comment.author_association != 'NONE' ||
             github.event.comment.user.login == github.event.issue.user.login) &&
@@ -87,7 +91,8 @@ jobs:
         && !github.event.issue.pull_request
         && (
           github.event.comment.body == '/code' ||
-          startsWith(github.event.comment.body, '/code ')
+          startsWith(github.event.comment.body, '/code ') ||
+          startsWith(github.event.comment.body, format('{0}{1}', '/code', fromJSON('"\n"')))
         ))
     steps:
       - name: Build minimal payload
@@ -128,7 +133,8 @@ jobs:
         && github.event.label.name == 'ready-for-review') ||
       (github.event_name == 'issue_comment' && (
         github.event.comment.body == '/review' ||
-        startsWith(github.event.comment.body, '/review ')
+        startsWith(github.event.comment.body, '/review ') ||
+        startsWith(github.event.comment.body, format('{0}{1}', '/review', fromJSON('"\n"')))
       )) ||
       github.event_name == 'pull_request_target'
     steps:
@@ -222,6 +228,7 @@ jobs:
         && (
           github.event.comment.body == '/fix'
           || startsWith(github.event.comment.body, '/fix ')
+          || startsWith(github.event.comment.body, format('{0}{1}', '/fix', fromJSON('"\n"')))
         )
         && (
           github.event.comment.author_association == 'OWNER'


### PR DESCRIPTION
## Summary

Slash commands followed by a newline (e.g., `/fix\nplan details`) were silently skipped because the `if:` conditions only matched bare commands (`== '/fix'`) or space-delimited arguments (`startsWith('/fix ')`). This adds a third `startsWith` condition using `fromJSON('"\n"')` to produce a literal newline character, which GHA expression strings cannot represent directly.

- Applied to all four commands (`/triage`, `/code`, `/review`, `/fix`) in both the deployed workflow and the scaffold template
- Updated normative spec (SPEC.md section 5.2) to document the three-condition pattern
- Both workflow files verified byte-identical after the change

## Test plan

- [ ] Comment `/fix` (bare) on a test PR triggers dispatch
- [ ] Comment `/fix rebase and fix tests` (space-delimited) triggers dispatch
- [ ] Comment with `/fix` followed by newline and multi-line body triggers dispatch
- [ ] Comment `/fixfoo` does NOT trigger dispatch (no false positives)
- [ ] `make lint` passes (verified locally)