### PR TITLE
feat: add kill switch, role-gating, and fix-agent PR protection

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,17 +41,18 @@ type RepoConfig struct {
 
 // OrgConfig is the top-level configuration for a fullsend organization.
 type OrgConfig struct {
-	Version   string                `yaml:"version"`
-	Dispatch  DispatchConfig        `yaml:"dispatch"`
-	Inference InferenceConfig       `yaml:"inference,omitempty"`
-	Defaults  RepoDefaults          `yaml:"defaults"`
-	Agents    []AgentEntry          `yaml:"agents"`
-	Repos     map[string]RepoConfig `yaml:"repos"`
+	Version    string                `yaml:"version"`
+	KillSwitch bool                  `yaml:"kill_switch,omitempty"`
+	Dispatch   DispatchConfig        `yaml:"dispatch"`
+	Inference  InferenceConfig       `yaml:"inference,omitempty"`
+	Defaults   RepoDefaults          `yaml:"defaults"`
+	Agents     []AgentEntry          `yaml:"agents"`
+	Repos      map[string]RepoConfig `yaml:"repos"`
 }
 
 // ValidRoles returns the set of recognized agent roles.
 func ValidRoles() []string {
-	return []string{"fullsend", "triage", "coder", "review"}
+	return []string{"fullsend", "triage", "coder", "review", "fix"}
 }
 
 // ValidProviders returns the set of recognized inference providers.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,11 +10,12 @@ import (
 
 func TestValidRoles(t *testing.T) {
 	roles := ValidRoles()
-	assert.Len(t, roles, 4)
+	assert.Len(t, roles, 5)
 	assert.Contains(t, roles, "fullsend")
 	assert.Contains(t, roles, "triage")
 	assert.Contains(t, roles, "coder")
 	assert.Contains(t, roles, "review")
+	assert.Contains(t, roles, "fix")
 }
 
 func TestNewOrgConfig(t *testing.T) {
@@ -343,4 +344,92 @@ func TestOrgConfigMarshal_WithInference(t *testing.T) {
 func TestValidProviders(t *testing.T) {
 	providers := ValidProviders()
 	assert.Equal(t, []string{"vertex"}, providers)
+}
+
+func TestParseOrgConfig_KillSwitch(t *testing.T) {
+	yamlData := `
+version: "1"
+kill_switch: true
+dispatch:
+  platform: github-actions
+defaults:
+  roles:
+    - fullsend
+  max_implementation_retries: 2
+agents: []
+repos: {}
+`
+	cfg, err := ParseOrgConfig([]byte(yamlData))
+	require.NoError(t, err)
+	assert.True(t, cfg.KillSwitch)
+}
+
+func TestParseOrgConfig_KillSwitchDefault(t *testing.T) {
+	yamlData := `
+version: "1"
+dispatch:
+  platform: github-actions
+defaults:
+  roles:
+    - fullsend
+  max_implementation_retries: 2
+agents: []
+repos: {}
+`
+	cfg, err := ParseOrgConfig([]byte(yamlData))
+	require.NoError(t, err)
+	assert.False(t, cfg.KillSwitch)
+}
+
+func TestOrgConfigMarshal_KillSwitch(t *testing.T) {
+	cfg := &OrgConfig{
+		Version:    "1",
+		KillSwitch: true,
+		Dispatch:   DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend"},
+			MaxImplementationRetries: 2,
+		},
+		Agents: []AgentEntry{},
+		Repos:  map[string]RepoConfig{},
+	}
+
+	data, err := cfg.Marshal()
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "kill_switch: true")
+}
+
+func TestOrgConfigValidate_FixRole(t *testing.T) {
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend", "review", "fix"},
+			MaxImplementationRetries: 2,
+		},
+	}
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestNewOrgConfig_KillSwitchDefaultFalse(t *testing.T) {
+	cfg := NewOrgConfig(nil, nil, []string{"fullsend"}, nil, "")
+	assert.False(t, cfg.KillSwitch)
+}
+
+func TestOrgConfigMarshal_KillSwitchOmitEmpty(t *testing.T) {
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend"},
+			MaxImplementationRetries: 2,
+		},
+		Agents: []AgentEntry{},
+		Repos:  map[string]RepoConfig{},
+	}
+
+	data, err := cfg.Marshal()
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "kill_switch")
 }

--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -36,7 +36,7 @@ type AppConfig struct {
 
 // DefaultAgentRoles returns the standard set of agent roles.
 func DefaultAgentRoles() []string {
-	return []string{"fullsend", "triage", "coder", "review"}
+	return []string{"fullsend", "triage", "coder", "review", "fix"}
 }
 
 // AgentAppConfig returns the GitHub App configuration for a given agent role.

--- a/internal/forge/github/types_test.go
+++ b/internal/forge/github/types_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestDefaultAgentRoles(t *testing.T) {
 	roles := DefaultAgentRoles()
-	require.Len(t, roles, 4)
-	assert.Equal(t, []string{"fullsend", "triage", "coder", "review"}, roles)
+	require.Len(t, roles, 5)
+	assert.Equal(t, []string{"fullsend", "triage", "coder", "review", "fix"}, roles)
 }
 
 func TestAgentAppConfig_Fullsend(t *testing.T) {

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -74,6 +74,34 @@ jobs:
             fi
           fi
 
+      - name: Check kill switch
+        # Intentionally fail-closed: if config.yaml is missing or corrupt,
+        # set -euo pipefail aborts the step → job fails → dispatch blocked.
+        run: |
+          set -euo pipefail
+          KILL_SWITCH=$(yq '.kill_switch // false' config.yaml)
+          if [[ "$KILL_SWITCH" == "true" ]]; then
+            echo "::error::Kill switch is active — all agent dispatch halted"
+            echo "::error::Set kill_switch: false in config.yaml to resume"
+            exit 1
+          fi
+
+      - name: Check role is enabled
+        env:
+          STAGE: ${{ inputs.stage }}
+        run: |
+          set -euo pipefail
+          STAGE_ROLE="$STAGE"
+          case "$STAGE" in
+            code) STAGE_ROLE="coder" ;;
+          esac
+
+          ROLES=$(yq '.defaults.roles[]' config.yaml 2>/dev/null || echo "")
+          if [[ -n "$ROLES" ]] && ! echo "$ROLES" | grep -Fqx "$STAGE_ROLE"; then
+            echo "::error::Stage '$STAGE' (role: $STAGE_ROLE) is not in defaults.roles — dispatch blocked"
+            exit 1
+          fi
+
       - name: Find and trigger agent workflows for stage
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
@@ -205,6 +205,22 @@ jobs:
           echo "Fix iteration: ${ITERATION} (${FIX_COMMITS} previous fix commits)" >&2
           echo "iteration=${ITERATION}" >> "${GITHUB_OUTPUT}"
 
+      - name: Check fullsend-no-fix label
+        env:
+          GH_TOKEN: ${{ steps.sandbox-token.outputs.token }}
+          TRIGGER_SOURCE: ${{ inputs.trigger_source }}
+          PR_NUM: ${{ steps.context.outputs.pr_number }}
+          SOURCE_REPO: ${{ inputs.source_repo }}
+        run: |
+          if [[ "${TRIGGER_SOURCE}" =~ \[bot\]$ ]]; then
+            HAS_NO_FIX=$(gh pr view "${PR_NUM}" --repo "${SOURCE_REPO}" \
+              --json labels --jq '[.labels[].name] | any(. == "fullsend-no-fix")' 2>/dev/null || echo "false")
+            if [[ "${HAS_NO_FIX}" == "true" ]]; then
+              echo "::warning::PR #${PR_NUM} has 'fullsend-no-fix' label — skipping bot-triggered fix"
+              exit 1
+            fi
+          fi
+
       - name: Generate push token (write)
         id: push-token
         uses: actions/create-github-app-token@v3

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
@@ -174,6 +174,7 @@ jobs:
         && github.event.review.state == 'changes_requested'
         && github.event.review.user.login == format('{0}-review[bot]', github.repository_owner)
         && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+        && !contains(github.event.pull_request.labels.*.name, 'fullsend-no-fix')
     steps:
       - name: Build minimal payload
         id: payload
@@ -268,3 +269,36 @@ jobs:
             -f source_repo="$SOURCE_REPO" \
             -f event_payload="$EVENT_PAYLOAD" \
             -f trigger_source="$TRIGGER_USER"
+
+  dispatch-stop-fix:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && github.event.comment.user.type != 'Bot'
+        && github.event.comment.body == '/stop-fix'
+        && (
+          github.event.comment.author_association == 'OWNER'
+          || github.event.comment.author_association == 'MEMBER'
+          || github.event.comment.author_association == 'COLLABORATOR'
+          || github.event.comment.author_association == 'CONTRIBUTOR'
+          || github.event.comment.user.login == github.event.issue.user.login
+        )
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add fullsend-no-fix label and notify
+        env:
+          GH_TOKEN: ${{ secrets.FULLSEND_DISPATCH_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "fullsend-no-fix" --repo "$REPO" \
+            --description "Skip bot-triggered fix agent runs" --color "FBCA04" \
+            --force 2>/dev/null || true
+          gh pr edit "$PR_NUMBER" --repo "$REPO" \
+            --add-label "fullsend-no-fix"
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "Fix agent disabled for this PR. Remove the \`fullsend-no-fix\` label or use \`/fix\` to re-engage."


### PR DESCRIPTION
## Summary

Adds layered controls for halting autonomous agent behavior, addressing two problems surfaced during live rollouts:

1. **No emergency stop** — when agents misbehave, the only recourse was disabling the GitHub App installation, which requires admin access (#420)
2. **Fix agent corrupts human PRs** — the review bot sometimes gives incorrect `changes_requested` feedback on human-authored PRs, and the fix agent pushes unwanted changes (#490)

### Controls added

- **Org-level kill switch:** `kill_switch: true` in config.yaml halts all agent dispatch. Fail-closed — missing or corrupt config blocks dispatch.
- **Per-agent disable:** Remove a role from `defaults.roles` in config.yaml to block that agent's stage (e.g., remove `fix` to disable fix agent org-wide)
- **PR-level `fullsend-no-fix` label:** Blocks bot-triggered fix runs with defense-in-depth checks in both shim workflow and fix.yml
- **`/stop-fix` comment command:** Org members, contributors, and PR authors can add the label via PR comment. Human `/fix` overrides the label.
- **`fix` role:** Added to `ValidRoles()` for role-gating support

### Design decisions

- Label only blocks **bot-triggered** fix runs — human `/fix` commands always bypass
- CONTRIBUTOR association allowed for `/stop-fix` (lower bar to stop than to start)
- PR authors can `/stop-fix` their own PRs regardless of association
- Kill switch enforced at dispatcher level; `.fullsend` repo write access controls direct workflow_dispatch
- Role-gating fails open for empty/missing `defaults.roles` (backward compatibility)

Closes #420
Closes #490

## Test plan

- [x] `go test ./internal/config/` — 26 tests pass (kill switch parsing, marshaling, omitempty, fix role validation)
- [ ] Add `fullsend-no-fix` label to a PR → `dispatch-fix-bot` skips dispatch
- [ ] Post `/stop-fix` on a PR → label applied, confirmation comment posted
- [ ] Post `/fix` on a PR with `fullsend-no-fix` label → fix agent still runs
- [ ] Set `kill_switch: true` in config.yaml → dispatch.yml rejects all stages
- [ ] Remove `fix` from `defaults.roles` → dispatch.yml rejects fix stage