### PR TITLE
refactor(#561): drop "enhancement" triage category, auto-promote docs…

### DIFF
--- a/internal/scaffold/fullsend-repo/agents/triage.md
+++ b/internal/scaffold/fullsend-repo/agents/triage.md
@@ -166,6 +166,8 @@ Only use `blocked` when you can identify a specific open issue or PR that must b
 
 Information is sufficient for a developer to investigate and fix.
 
+**Choosing a category:** the `feature` category covers issues that describe desired new behavior rather than a defect in existing functionality — the reporter expects something that has never been implemented. Use `feature` only when the described behavior clearly never existed in the product. If there is _any_ possibility the behavior is a regression (it used to work, or the reporter references a specific version where it worked), use `insufficient` instead and ask for version or timeline information. When in doubt, ask — do not prematurely reclassify.
+
 ```json
 {
   "action": "sufficient",
@@ -180,7 +182,7 @@ Information is sufficient for a developer to investigate and fix.
   "triage_summary": {
     "title": "Refined issue title (clear, specific, actionable)",
     "severity": "critical | high | medium | low",
-    "category": "bug | performance | security | documentation | enhancement | other",
+    "category": "bug | performance | security | documentation | feature | other",
     "problem": "Clear description of the problem",
     "root_cause_hypothesis": "Most likely root cause",
     "reproduction_steps": ["step 1", "step 2"],
@@ -190,22 +192,6 @@ Information is sufficient for a developer to investigate and fix.
     "proposed_test_case": "Conceptual description of a test that would verify the fix — what to test, expected vs actual behavior, and edge cases to cover. Do not assume a specific test framework or file layout."
   },
   "comment": "A triage summary comment formatted in markdown, presenting the assessment to the maintainers. Include the proposed test case as a fenced code block."
-}
-```
-
-### Action: `feature-request`
-
-The issue describes desired new behavior rather than a defect in existing functionality. The reporter expects something that has never been implemented.
-
-**When to use:** The described behavior clearly never existed in the product. This is not a regression — no prior version had this capability.
-
-**When NOT to use:** If there is _any_ possibility the behavior is a regression (it used to work, or the reporter references a specific version where it worked), use `insufficient` instead and ask for version or timeline information. When in doubt, ask — do not prematurely reclassify.
-
-```json
-{
-  "action": "feature-request",
-  "reasoning": "Brief explanation of why this is a feature request, not a bug — what behavior the reporter expects and why it has never existed",
-  "comment": "A professional, non-dismissive comment explaining that this describes new functionality rather than a defect. Acknowledge the request is reasonable and explain it will be relabeled for product/engineering prioritization."
 }
 ```
 

--- a/internal/scaffold/fullsend-repo/schemas/triage-result.schema.json
+++ b/internal/scaffold/fullsend-repo/schemas/triage-result.schema.json
@@ -9,7 +9,7 @@
   "properties": {
     "action": {
       "type": "string",
-      "enum": ["insufficient", "duplicate", "sufficient", "blocked", "feature-request"]
+      "enum": ["insufficient", "duplicate", "sufficient", "blocked"]
     },
     "reasoning": {
       "type": "string",
@@ -52,18 +52,6 @@
     {
       "if": { "properties": { "action": { "const": "blocked" } }, "required": ["action"] },
       "then": { "required": ["blocked_by"] }
-    },
-    {
-      "if": { "properties": { "action": { "const": "feature-request" } }, "required": ["action"] },
-      "then": {
-        "not": {
-          "anyOf": [
-            { "required": ["clarity_scores"] },
-            { "required": ["triage_summary"] },
-            { "required": ["duplicate_of"] }
-          ]
-        }
-      }
     }
   ],
   "$defs": {
@@ -86,7 +74,7 @@
       "properties": {
         "title": { "type": "string", "minLength": 1 },
         "severity": { "type": "string", "enum": ["critical", "high", "medium", "low"] },
-        "category": { "type": "string", "enum": ["bug", "performance", "security", "documentation", "enhancement", "other"] },
+        "category": { "type": "string", "enum": ["bug", "performance", "security", "documentation", "feature", "other"] },
         "problem": { "type": "string", "minLength": 1 },
         "root_cause_hypothesis": { "type": "string", "minLength": 1 },
         "reproduction_steps": { "type": "array", "items": { "type": "string" }, "minItems": 1 },

--- a/internal/scaffold/fullsend-repo/scripts/post-triage-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-triage-test.sh
@@ -98,17 +98,21 @@ run_test "sufficient-bug-gets-ready-to-code" \
   '{"action":"sufficient","reasoning":"all clear","clarity_scores":{"symptom":0.9,"cause":0.85,"reproduction":0.9,"impact":0.8,"overall":0.87},"triage_summary":{"title":"Fix crash on save","severity":"high","category":"bug","problem":"Crash","root_cause_hypothesis":"Buffer overflow","reproduction_steps":["step 1"],"environment":"Linux","impact":"All users","recommended_fix":"Fix buffer","proposed_test_case":"test_save_crash"},"comment":"## Triage Summary\n\nThis is ready."}' \
   "gh api repos/test-org/test-repo/issues/42/labels -f labels[]=ready-to-code --silent"
 
-run_test "sufficient-enhancement-gets-triaged" \
-  '{"action":"sufficient","reasoning":"all clear","clarity_scores":{"symptom":0.9,"cause":0.85,"reproduction":0.9,"impact":0.8,"overall":0.87},"triage_summary":{"title":"Add dark mode","severity":"medium","category":"enhancement","problem":"No dark mode","root_cause_hypothesis":"Not implemented","reproduction_steps":["step 1"],"environment":"Linux","impact":"All users","recommended_fix":"Add theme toggle","proposed_test_case":"test_dark_mode"},"comment":"## Triage Summary\n\nThis is an enhancement."}' \
+run_test "sufficient-feature-gets-triaged" \
+  '{"action":"sufficient","reasoning":"all clear","clarity_scores":{"symptom":0.9,"cause":0.85,"reproduction":0.9,"impact":0.8,"overall":0.87},"triage_summary":{"title":"Add dark mode","severity":"medium","category":"feature","problem":"No dark mode","root_cause_hypothesis":"Not implemented","reproduction_steps":["step 1"],"environment":"Linux","impact":"All users","recommended_fix":"Add theme toggle","proposed_test_case":"test_dark_mode"},"comment":"## Triage Summary\n\nThis is a feature."}' \
   "gh api repos/test-org/test-repo/issues/42/labels -f labels[]=triaged --silent"
 
-run_test "sufficient-performance-gets-triaged" \
+run_test "sufficient-other-gets-triaged" \
+  '{"action":"sufficient","reasoning":"all clear","clarity_scores":{"symptom":0.9,"cause":0.85,"reproduction":0.9,"impact":0.8,"overall":0.87},"triage_summary":{"title":"Misc","severity":"low","category":"other","problem":"Misc","root_cause_hypothesis":"Unclear","reproduction_steps":["step 1"],"environment":"Linux","impact":"Some","recommended_fix":"Investigate","proposed_test_case":"test_misc"},"comment":"## Triage Summary\n\nMisc."}' \
+  "gh api repos/test-org/test-repo/issues/42/labels -f labels[]=triaged --silent"
+
+run_test "sufficient-performance-gets-ready-to-code" \
   '{"action":"sufficient","reasoning":"all clear","clarity_scores":{"symptom":0.9,"cause":0.85,"reproduction":0.9,"impact":0.8,"overall":0.87},"triage_summary":{"title":"Slow query","severity":"medium","category":"performance","problem":"Slow","root_cause_hypothesis":"Missing index","reproduction_steps":["step 1"],"environment":"Linux","impact":"All users","recommended_fix":"Add index","proposed_test_case":"test_query_speed"},"comment":"## Triage Summary\n\nThis is a performance issue."}' \
-  "gh api repos/test-org/test-repo/issues/42/labels -f labels[]=triaged --silent"
+  "gh api repos/test-org/test-repo/issues/42/labels -f labels[]=ready-to-code --silent"
 
-run_test "sufficient-documentation-gets-triaged" \
+run_test "sufficient-documentation-gets-ready-to-code" \
   '{"action":"sufficient","reasoning":"all clear","clarity_scores":{"symptom":0.9,"cause":0.85,"reproduction":0.9,"impact":0.8,"overall":0.87},"triage_summary":{"title":"Update docs","severity":"low","category":"documentation","problem":"Outdated docs","root_cause_hypothesis":"Not updated","reproduction_steps":["step 1"],"environment":"Linux","impact":"Contributors","recommended_fix":"Update README","proposed_test_case":"test_docs"},"comment":"## Triage Summary\n\nThis is a documentation issue."}' \
-  "gh api repos/test-org/test-repo/issues/42/labels -f labels[]=triaged --silent"
+  "gh api repos/test-org/test-repo/issues/42/labels -f labels[]=ready-to-code --silent"
 
 run_test "sufficient-with-empty-info-gaps-passes" \
   '{"action":"sufficient","reasoning":"all clear","clarity_scores":{"symptom":0.9,"cause":0.85,"reproduction":0.9,"impact":0.8,"overall":0.87},"triage_summary":{"title":"Fix crash on save","severity":"high","category":"bug","problem":"Crash","root_cause_hypothesis":"Buffer overflow","reproduction_steps":["step 1"],"environment":"Linux","impact":"All users","recommended_fix":"Fix buffer","proposed_test_case":"test_save_crash","information_gaps":[]},"comment":"## Triage Summary\n\nThis is ready."}' \
@@ -174,23 +178,6 @@ run_test "missing-json-fails" \
 
 run_test "invalid-json-fails" \
   "this is not json" \
-  "" \
-  "true"
-
-run_test "feature-request-posts-comment" \
-  '{"action":"feature-request","reasoning":"CSV export has never existed","comment":"This describes a new feature rather than a bug. The ability to export to CSV is not part of the current functionality. Relabeling for prioritization."}' \
-  "gh issue comment 42 --repo test-org/test-repo --body-file -"
-
-run_test "feature-request-applies-label" \
-  '{"action":"feature-request","reasoning":"CSV export has never existed","comment":"This describes a new feature rather than a bug."}' \
-  "gh api repos/test-org/test-repo/issues/42/labels -f labels[]=type/feature --silent"
-
-run_test "feature-request-removes-bug-labels" \
-  '{"action":"feature-request","reasoning":"CSV export has never existed","comment":"This describes a new feature rather than a bug."}' \
-  "gh api repos/test-org/test-repo/issues/42/labels/bug -X DELETE --silent"
-
-run_test "feature-request-no-comment-fails" \
-  '{"action":"feature-request","reasoning":"CSV export has never existed"}' \
   "" \
   "true"
 

--- a/internal/scaffold/fullsend-repo/scripts/post-triage.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-triage.sh
@@ -149,36 +149,22 @@ case "${ACTION}" in
     remove_label "blocked"
     remove_label "needs-info"
 
-    # Only bugs get the ready-to-code label (which triggers the code agent).
-    # Non-bug sufficient results (enhancement, performance, documentation, etc.)
-    # receive the triaged label instead and wait for human prioritization.
+    # Low-risk categories (bug, documentation, performance) auto-promote to
+    # ready-to-code, which triggers the code agent. Feature work and anything
+    # else receives the triaged label and waits for human prioritization
+    # (per #561, only feature issues should require human review before coding).
     CATEGORY=$(jq -r '.triage_summary.category // "unknown"' "${RESULT_FILE}")
     echo "Category: ${CATEGORY}"
-    if [[ "${CATEGORY}" == "bug" ]]; then
-      echo "Applying ready-to-code label (bug)..."
-      add_label "ready-to-code"
-    else
-      echo "Applying triaged label (non-bug: ${CATEGORY})..."
-      add_label "triaged"
-    fi
-    ;;
-
-  feature-request)
-    if [[ -z "${COMMENT}" ]]; then
-      echo "ERROR: action is 'feature-request' but no comment provided"
-      exit 1
-    fi
-    echo "Posting feature-request comment..."
-    printf '%s' "${COMMENT}" | gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" --body-file -
-
-    echo "Removing bug-related labels..."
-    remove_label "blocked"
-    for label in bug bug-report type/bug; do
-      gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/labels/${label}" -X DELETE --silent 2>/dev/null || true
-    done
-
-    echo "Applying type/feature label..."
-    add_label "type/feature"
+    case "${CATEGORY}" in
+      bug|documentation|performance)
+        echo "Applying ready-to-code label (${CATEGORY})..."
+        add_label "ready-to-code"
+        ;;
+      *)
+        echo "Applying triaged label (${CATEGORY})..."
+        add_label "triaged"
+        ;;
+    esac
     ;;
 
   *)


### PR DESCRIPTION
Collapses redundant `enhancement` and `feature` triage categories into a single `feature` category in the triage agent prompt and JSON schema. Eliminates a path where legitimate feature work could be mis-categorized as `enhancement` and slip past human review.

Also auto-promotes `documentation` and `performance` to `ready-to-code` alongside `bug`, since these are low-risk categories that don't need human prioritization before coding. Per #557, only `feature` issues should require gated review.

Files changed:
- agents/triage.md — category enum: `enhancement` → `feature`
- schemas/triage-result.schema.json — same enum change
- scripts/post-triage.sh — `bug|documentation|performance` → `ready-to-code`; everything else → `triaged`
- scripts/post-triage-test.sh — test cases updated to match

Closes #561.
Closes #562 — note that the `enhancement` label itself was applied by humans (verified via labeling events on #458, #534, #607, #608), not the triage agent. The label deletion + relabeling of those four issues is a follow-up admin action; no code change needed for that part.