### PR TITLE
feat(#461): add /fullsend namespace prefix for slash commands

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -42,6 +42,8 @@ jobs:
       github.event_name == 'issue_comment' && (
         github.event.comment.body == '/triage' ||
         startsWith(github.event.comment.body, '/triage ') ||
+        github.event.comment.body == '/fullsend triage' ||
+        startsWith(github.event.comment.body, '/fullsend triage ') ||
         (
           (github.event.comment.author_association != 'NONE' ||
             github.event.comment.user.login == github.event.issue.user.login) &&
@@ -87,7 +89,9 @@ jobs:
         && !github.event.issue.pull_request
         && (
           github.event.comment.body == '/code' ||
-          startsWith(github.event.comment.body, '/code ')
+          startsWith(github.event.comment.body, '/code ') ||
+          github.event.comment.body == '/fullsend code' ||
+          startsWith(github.event.comment.body, '/fullsend code ')
         ))
     steps:
       - name: Build minimal payload
@@ -128,7 +132,9 @@ jobs:
         && github.event.label.name == 'ready-for-review') ||
       (github.event_name == 'issue_comment' && (
         github.event.comment.body == '/review' ||
-        startsWith(github.event.comment.body, '/review ')
+        startsWith(github.event.comment.body, '/review ') ||
+        github.event.comment.body == '/fullsend review' ||
+        startsWith(github.event.comment.body, '/fullsend review ')
       )) ||
       github.event_name == 'pull_request_target'
     steps:
@@ -222,6 +228,8 @@ jobs:
         && (
           github.event.comment.body == '/fix'
           || startsWith(github.event.comment.body, '/fix ')
+          || github.event.comment.body == '/fullsend fix'
+          || startsWith(github.event.comment.body, '/fullsend fix ')
         )
         && (
           github.event.comment.author_association == 'OWNER'

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -152,7 +152,7 @@ See [ADR 0002](ADRs/0002-initial-fullsend-design.md).
 
 ### Slash Command
 
-A GitHub comment in the form `/triage`, `/code`, `/review`, etc., that manually triggers an agent workflow. Slash commands are parsed by the entry point and gated by an ACL — not every user can invoke every command. They provide an explicit human-initiated trigger alongside the automatic label-based triggers.
+A GitHub comment in the form `/fullsend triage`, `/fullsend code`, `/fullsend review`, `/fullsend fix`, etc., that manually triggers an agent workflow. The bare forms (`/triage`, `/code`, `/review`, `/fix`) are also accepted as aliases. The namespaced form is recommended to avoid collisions with other AI tools. Slash commands are parsed by the entry point and gated by an ACL — not every user can invoke every command. They provide an explicit human-initiated trigger alongside the automatic label-based triggers.
 See [ADR 0002](ADRs/0002-initial-fullsend-design.md) building block 2.
 
 ## T

--- a/docs/guides/user/bugfix-workflow.md
+++ b/docs/guides/user/bugfix-workflow.md
@@ -33,7 +33,7 @@ The triage agent reads the issue title, body, comments, and GitHub-native attach
 - Put key information in the issue body — expected behavior, actual behavior, steps to reproduce, version/environment.
 - Use GitHub's native file attachments for logs, screenshots, or reproduction scripts.
 - You can add details via comments — the triage agent reads those too. Other users can also comment with additional context (e.g., confirming the bug on a different platform).
-- Editing the issue title or body triggers triage automatically. You can also use `/triage` to force a fresh run.
+- Editing the issue title or body triggers triage automatically. You can also use `/fullsend triage` (or `/triage`) to force a fresh run.
 
 ### Labels are the state machine
 
@@ -58,9 +58,12 @@ You can control the pipeline from issue or PR comments:
 
 | Command | Where | Effect |
 |---------|-------|--------|
-| `/triage` | Issue comment | Re-runs triage from scratch (clears all labels, reopens if closed) |
-| `/code` | Issue comment | Hands off to the code agent (expects `ready-to-code` or forces with human ack) |
-| `/review` | PR comment | Enqueues a new review round for the current PR head |
+| `/fullsend triage` | Issue comment | Re-runs triage from scratch (clears all labels, reopens if closed) |
+| `/fullsend code` | Issue comment | Hands off to the code agent (expects `ready-to-code` or forces with human ack) |
+| `/fullsend review` | PR comment | Enqueues a new review round for the current PR head |
+| `/fullsend fix` | PR comment | Requests the fix agent to address review feedback (OWNER/MEMBER/COLLABORATOR only) |
+
+> **Aliases:** The bare forms `/triage`, `/code`, `/review`, and `/fix` also work. The namespaced `/fullsend <command>` form is recommended to avoid collisions with other AI tools that respond to generic command names.
 
 ### What to expect from agent PRs
 
@@ -96,7 +99,7 @@ Every push to a PR in the review stage triggers a new review round. This means `
 
 ### Stage 1: Triage
 
-**Triggered by:** issue creation, issue title/body edit, or `/triage` command.
+**Triggered by:** issue creation, issue title/body edit, or `/fullsend triage` command.
 
 The triage agent:
 
@@ -107,11 +110,11 @@ The triage agent:
 5. **Produces a test artifact.** When possible, writes a failing test case aligned with the repo's test framework.
 6. **Hands off.** Labels `ready-to-code` with a summary comment.
 
-**If triage gets it wrong:** Add a comment with the missing information, or edit the issue body. Edits to the title or body trigger triage automatically. You can also use `/triage` to force a fresh run — this clears all previous labels and starts from scratch.
+**If triage gets it wrong:** Add a comment with the missing information, or edit the issue body. Edits to the title or body trigger triage automatically. You can also use `/fullsend triage` to force a fresh run — this clears all previous labels and starts from scratch.
 
 ### Stage 2: Code
 
-**Triggered by:** `ready-to-code` label or `/code` command.
+**Triggered by:** `ready-to-code` label or `/fullsend code` command.
 
 The code agent:
 
@@ -124,7 +127,7 @@ The code agent:
 
 ### Stage 3: Review
 
-**Triggered by:** `pull_request_target` events (PR opened, push to PR branch, or marked ready for review), `/review` command, or `ready-for-review` label.
+**Triggered by:** `pull_request_target` events (PR opened, push to PR branch, or marked ready for review), `/fullsend review` command, or `ready-for-review` label.
 
 The review swarm:
 
@@ -149,9 +152,10 @@ Once the PR is merged (by human, merge queue, or automation per org governance),
 
 ### Restarting a stage
 
-- `/triage` — wipes all labels, reopens the issue, runs triage fresh.
-- `/code` — restarts the code agent from the current issue state.
-- `/review` — enqueues a new review round.
+- `/fullsend triage` — wipes all labels, reopens the issue, runs triage fresh.
+- `/fullsend code` — restarts the code agent from the current issue state.
+- `/fullsend review` — enqueues a new review round.
+- `/fullsend fix` — requests the fix agent to address review feedback.
 
 ### Taking over manually
 

--- a/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
@@ -173,8 +173,8 @@ jobs:
           if [[ ! "${TRIGGER_SOURCE}" =~ \[bot\]$ ]]; then
             COMMENT_BODY="$(echo "${EVENT_PAYLOAD}" | jq -r '.comment.body // empty')"
             if [[ -n "${COMMENT_BODY}" ]]; then
-              # Strip the /fix prefix to get the instruction.
-              INSTRUCTION="$(echo "${COMMENT_BODY}" | sed 's|^/fix[[:space:]]*||')"
+              # Strip the /fix or /fullsend fix prefix to get the instruction.
+              INSTRUCTION="$(echo "${COMMENT_BODY}" | sed 's|^/fullsend fix[[:space:]]*||; s|^/fix[[:space:]]*||')"
             fi
             if [[ -z "${INSTRUCTION}" && -n "${INPUT_INSTRUCTION}" ]]; then
               INSTRUCTION="${INPUT_INSTRUCTION}"

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
@@ -42,6 +42,8 @@ jobs:
       github.event_name == 'issue_comment' && (
         github.event.comment.body == '/triage' ||
         startsWith(github.event.comment.body, '/triage ') ||
+        github.event.comment.body == '/fullsend triage' ||
+        startsWith(github.event.comment.body, '/fullsend triage ') ||
         (
           (github.event.comment.author_association != 'NONE' ||
             github.event.comment.user.login == github.event.issue.user.login) &&
@@ -87,7 +89,9 @@ jobs:
         && !github.event.issue.pull_request
         && (
           github.event.comment.body == '/code' ||
-          startsWith(github.event.comment.body, '/code ')
+          startsWith(github.event.comment.body, '/code ') ||
+          github.event.comment.body == '/fullsend code' ||
+          startsWith(github.event.comment.body, '/fullsend code ')
         ))
     steps:
       - name: Build minimal payload
@@ -128,7 +132,9 @@ jobs:
         && github.event.label.name == 'ready-for-review') ||
       (github.event_name == 'issue_comment' && (
         github.event.comment.body == '/review' ||
-        startsWith(github.event.comment.body, '/review ')
+        startsWith(github.event.comment.body, '/review ') ||
+        github.event.comment.body == '/fullsend review' ||
+        startsWith(github.event.comment.body, '/fullsend review ')
       )) ||
       github.event_name == 'pull_request_target'
     steps:
@@ -222,6 +228,8 @@ jobs:
         && (
           github.event.comment.body == '/fix'
           || startsWith(github.event.comment.body, '/fix ')
+          || github.event.comment.body == '/fullsend fix'
+          || startsWith(github.event.comment.body, '/fullsend fix ')
         )
         && (
           github.event.comment.author_association == 'OWNER'


### PR DESCRIPTION
## Summary

- Adds `/fullsend triage`, `/fullsend code`, `/fullsend review`, `/fullsend fix` as namespaced command forms to avoid collisions with other AI tools (e.g., Qodo) that also respond to `/review`
- Bare commands (`/triage`, `/code`, `/review`, `/fix`) remain as aliases — no breaking change
- Updates fix.yml `sed` pattern to strip `/fullsend fix` prefix from human instructions

## Changed files

- `internal/scaffold/fullsend-repo/templates/shim-workflow.yaml` — namespaced patterns in all 4 slash-command jobs
- `.github/workflows/fullsend.yaml` — same (this repo's own shim)
- `internal/scaffold/fullsend-repo/.github/workflows/fix.yml` — instruction prefix stripping
- `docs/guides/user/bugfix-workflow.md` — updated command table and inline references
- `docs/glossary.md` — updated Slash Command definition

## Test plan

- [x] `make lint` passes
- [x] `go test ./internal/scaffold/...` passes
- [x] `make go-test` passes (all packages)
- [ ] Manual: post `/fullsend review` on a PR comment in an enrolled repo, verify dispatch triggers
- [ ] Manual: post `/review` on same repo, verify bare alias still works

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)