### PR TITLE
feat(run): auto-resolve Linux binary for cross-platform security scan

### DIFF
--- a/docs/guides/dev/local-dev.md
+++ b/docs/guides/dev/local-dev.md
@@ -10,7 +10,7 @@ This guide walks through running fullsend agents locally on macOS and Linux. PR 
 | OpenShell | 0.0.37-dev+ (Podman support) | 0.0.37-dev+ |
 | GCP credentials | Service account key (`Vertex AI User` role) | Same |
 | GitHub PAT | `repo` scope for the target org | Same |
-| Go toolchain | For building the CLI from source | Same |
+| Go toolchain | Optional — only needed when building the CLI from source | Same |
 
 > **arm64 note**: Apple Silicon Macs and arm64 Linux hosts must use the `:dev` multi-arch sandbox images. The default `:latest` tag is amd64-only until multi-arch merges to main. See step 3 below.
 
@@ -79,12 +79,47 @@ This switches from the default `:latest` tag (amd64-only) to the `:dev` multi-ar
 
 The `--env-file` flag loads environment variables before the harness is parsed, so variables are available for harness YAML expansion. The flag is repeatable — later files override earlier ones.
 
+## Security scanning and cross-platform binary
+
+The pre-agent security scan runs `fullsend scan context` inside the Linux sandbox to check for prompt injection before the agent starts. This requires a Linux fullsend binary in the sandbox.
+
+On macOS, the host binary is a Mach-O executable that cannot run inside the Linux sandbox. The CLI detects the OS mismatch and automatically obtains a Linux binary — no manual steps needed. The architecture (arm64/amd64) typically matches between the host and the Podman VM, so only the OS differs.
+
+### How the Linux binary is resolved
+
+| Priority | Strategy | When it applies |
+|----------|----------|-----------------|
+| 1 | `--fullsend-binary <path>` | Always used if provided — skips all auto-resolution |
+| 2 | Download from GitHub Release | CLI version matches a release (e.g. `0.4.0`) |
+| 3 | Cross-compile from source | Go toolchain available and run from the module root |
+| 4 | Download latest release | Fallback when cross-compilation fails |
+
+On Linux hosts, the CLI copies its own executable directly — no download or compilation needed.
+
+### Providing an explicit binary
+
+To skip auto-resolution (e.g. testing a dev build), cross-compile a Linux binary and pass it via `--fullsend-binary`:
+
+```bash
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o /tmp/fullsend-linux ./cmd/fullsend/
+./bin/fullsend run review \
+  --fullsend-dir /tmp/fullsend-dot \
+  --target-repo /path/to/repo \
+  --env-file /tmp/fullsend.env \
+  --fullsend-binary /tmp/fullsend-linux
+```
+
+The CLI validates that the provided file is a Linux ELF binary before copying it into the sandbox. Passing a macOS Mach-O binary produces a clear error instead of a cryptic failure inside the sandbox.
+
+> **Note:** if your sandbox image uses a different CPU architecture than the host (e.g. amd64 image on an arm64 Mac via QEMU emulation), set `FULLSEND_SANDBOX_ARCH=amd64` so the CLI downloads or cross-compiles for the correct architecture. This is not needed in the typical setup where the Podman VM matches the host arch.
+
 ## Known issues
 
 ### macOS (Apple Silicon)
 
 - **Podman entrypoint**: the container entrypoint `/bin/bash` may fail with "cannot execute binary file". OpenShell handles this internally, but standalone `podman run` needs `--entrypoint ""` with `/usr/bin/env sh -c`.
 - **Podman machine**: ensure the Podman machine is running (`podman machine start`) before invoking fullsend. The CLI does not start it automatically.
+- **Podman host-gateway**: if sandbox creation fails with `unable to replace "host-gateway"`, set `host_containers_internal_ip = "192.168.127.254"` under `[containers]` in `~/.config/containers/containers.conf` and restart the Podman machine.
 
 ### Linux
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2,8 +2,12 @@ package cli
 
 import (
 	"archive/tar"
+	"bufio"
+	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"debug/elf"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -595,8 +599,11 @@ func bootstrapSandbox(sshConfigPath, sandboxName, repoDir, fullsendBinary string
 			targetArch := sandboxArch()
 			dir, binPath, err := resolveLinuxBinary(targetArch)
 			if err != nil {
+				if h.FailModeClosed() {
+					return fmt.Errorf("could not obtain linux/%s binary for security scan (fail_mode: closed): %w\nUse --fullsend-binary to provide a pre-built Linux binary", targetArch, err)
+				}
 				fmt.Fprintf(os.Stderr, "WARNING: could not obtain linux/%s binary: %v\n", targetArch, err)
-				fmt.Fprintf(os.Stderr, "WARNING: skipping sandbox-side security scan. Use --fullsend-binary to provide a pre-built Linux binary.\n")
+				fmt.Fprintf(os.Stderr, "WARNING: skipping sandbox-side security scan (fail_mode: open). Use --fullsend-binary to provide a pre-built Linux binary.\n")
 				localBinary = ""
 			} else {
 				tmpBinaryDir = dir
@@ -1382,17 +1389,23 @@ func isReleasedVersion(v string) bool {
 	return true
 }
 
-const releaseBaseURL = "https://github.com/fullsend-ai/fullsend/releases/download"
+var releaseBaseURL = "https://github.com/fullsend-ai/fullsend/releases/download"
 
 var httpClient = &http.Client{Timeout: 120 * time.Second}
 
 // downloadReleaseBinary downloads the fullsend binary for linux/{arch} from
-// the GitHub Release matching the given version and writes it to destPath.
+// the GitHub Release matching the given version, verifies its SHA256 checksum
+// against the release checksums.txt, and writes it to destPath.
 func downloadReleaseBinary(ver, arch, destPath string) error {
 	cleanVer := strings.TrimPrefix(ver, "v")
 	assetName := fmt.Sprintf("fullsend_%s_linux_%s.tar.gz", cleanVer, arch)
-	url := fmt.Sprintf("%s/v%s/%s", releaseBaseURL, cleanVer, assetName)
 
+	expectedHash, err := downloadChecksumForAsset(ver, assetName)
+	if err != nil {
+		return fmt.Errorf("fetching checksum for %s: %w", assetName, err)
+	}
+
+	url := fmt.Sprintf("%s/v%s/%s", releaseBaseURL, cleanVer, assetName)
 	resp, err := httpClient.Get(url) //nolint:gosec // URL is constructed from known constants
 	if err != nil {
 		return fmt.Errorf("fetching %s: %w", url, err)
@@ -1404,7 +1417,52 @@ func downloadReleaseBinary(ver, arch, destPath string) error {
 	}
 
 	const maxDownloadSize = 200 * 1024 * 1024 // 200 MB compressed
-	return extractFullsendFromTarGz(io.LimitReader(resp.Body, maxDownloadSize), destPath)
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, io.LimitReader(resp.Body, maxDownloadSize)); err != nil {
+		return fmt.Errorf("reading %s: %w", assetName, err)
+	}
+
+	h := sha256.Sum256(buf.Bytes())
+	actualHash := hex.EncodeToString(h[:])
+	if actualHash != expectedHash {
+		return fmt.Errorf("checksum mismatch for %s: got %s, want %s", assetName, actualHash, expectedHash)
+	}
+
+	return extractFullsendFromTarGz(bytes.NewReader(buf.Bytes()), destPath)
+}
+
+// downloadChecksumForAsset fetches the checksums.txt from the GitHub Release
+// for the given version and returns the SHA256 hash for assetName.
+// GoReleaser format: "<sha256>  <filename>\n"
+func downloadChecksumForAsset(ver, assetName string) (string, error) {
+	cleanVer := strings.TrimPrefix(ver, "v")
+	url := fmt.Sprintf("%s/v%s/fullsend_%s_checksums.txt", releaseBaseURL, cleanVer, cleanVer)
+
+	resp, err := httpClient.Get(url) //nolint:gosec // URL is constructed from known constants
+	if err != nil {
+		return "", fmt.Errorf("fetching checksums: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GET %s returned %d", url, resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(io.LimitReader(resp.Body, 64*1024))
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Fields(line)
+		if len(parts) == 2 && parts[1] == assetName {
+			if len(parts[0]) != 64 {
+				return "", fmt.Errorf("invalid hash length for %s in checksums.txt", assetName)
+			}
+			return parts[0], nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("reading checksums: %w", err)
+	}
+	return "", fmt.Errorf("asset %s not found in checksums.txt", assetName)
 }
 
 // downloadLatestReleaseBinary resolves the latest release tag from the GitHub

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1,11 +1,17 @@
 package cli
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"debug/elf"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -583,20 +589,42 @@ func bootstrapSandbox(sshConfigPath, sandboxName, repoDir, fullsendBinary string
 	// The pre-agent security scan runs inside the sandbox and needs the
 	// fullsend CLI to scan context files.
 	localBinary := fullsendBinary
+	var tmpBinaryDir string
 	if localBinary == "" {
-		var err error
-		localBinary, err = os.Executable()
-		if err != nil {
-			return fmt.Errorf("finding fullsend executable: %w", err)
+		if needsCrossCompilation() {
+			targetArch := sandboxArch()
+			dir, binPath, err := resolveLinuxBinary(targetArch)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: could not obtain linux/%s binary: %v\n", targetArch, err)
+				fmt.Fprintf(os.Stderr, "WARNING: skipping sandbox-side security scan. Use --fullsend-binary to provide a pre-built Linux binary.\n")
+				localBinary = ""
+			} else {
+				tmpBinaryDir = dir
+				localBinary = binPath
+			}
+		} else {
+			var err error
+			localBinary, err = os.Executable()
+			if err != nil {
+				return fmt.Errorf("finding fullsend executable: %w", err)
+			}
 		}
 	}
-	remoteBinary := fmt.Sprintf("%s/bin/fullsend", sandbox.SandboxWorkspace)
-	if err := sandbox.SCP(sshConfigPath, sandboxName, localBinary, remoteBinary); err != nil {
-		return fmt.Errorf("copying fullsend binary to sandbox: %w", err)
+	if tmpBinaryDir != "" {
+		defer os.RemoveAll(tmpBinaryDir)
 	}
-	chmodCmd := fmt.Sprintf("chmod +x %s", remoteBinary)
-	if _, _, _, err := sandbox.SSH(sshConfigPath, sandboxName, chmodCmd, 10*time.Second); err != nil {
-		return fmt.Errorf("chmod fullsend binary: %w", err)
+	if localBinary != "" {
+		if err := validateLinuxBinary(localBinary); err != nil {
+			return fmt.Errorf("fullsend binary %q is not valid for the sandbox: %w", localBinary, err)
+		}
+		remoteBinary := fmt.Sprintf("%s/bin/fullsend", sandbox.SandboxWorkspace)
+		if err := sandbox.SCP(sshConfigPath, sandboxName, localBinary, remoteBinary); err != nil {
+			return fmt.Errorf("copying fullsend binary to sandbox: %w", err)
+		}
+		chmodCmd := fmt.Sprintf("chmod +x %s", remoteBinary)
+		if _, _, _, err := sandbox.SSH(sshConfigPath, sandboxName, chmodCmd, 10*time.Second); err != nil {
+			return fmt.Errorf("chmod fullsend binary: %w", err)
+		}
 	}
 
 	// Host-side scan (Path A): check agent definition and skills for injection
@@ -1241,4 +1269,252 @@ func applySandboxImageOverride(image string) (string, bool) {
 		return override, true
 	}
 	return image, false
+}
+
+// needsCrossCompilation reports whether the host binary cannot run inside the
+// sandbox (Linux). True when running on macOS or any non-Linux OS.
+func needsCrossCompilation() bool {
+	return runtime.GOOS != "linux"
+}
+
+// validateLinuxBinary checks that the file at path is a Linux ELF executable
+// for the expected sandbox architecture. Returns a descriptive error if the
+// file is missing, not ELF, not Linux, or the wrong architecture.
+func validateLinuxBinary(path string) error {
+	f, err := elf.Open(path)
+	if err != nil {
+		return fmt.Errorf("not a valid ELF binary (is this a macOS Mach-O?): %w", err)
+	}
+	defer f.Close()
+
+	if f.OSABI != elf.ELFOSABI_NONE && f.OSABI != elf.ELFOSABI_LINUX {
+		return fmt.Errorf("ELF OS/ABI is %s, expected Linux or NONE", f.OSABI)
+	}
+
+	arch := sandboxArch()
+	archToMachine := map[string]elf.Machine{
+		"amd64": elf.EM_X86_64,
+		"arm64": elf.EM_AARCH64,
+	}
+	if expected, ok := archToMachine[arch]; ok && f.Machine != expected {
+		return fmt.Errorf("ELF machine is %s, expected %s for %s (set FULLSEND_SANDBOX_ARCH to override)", f.Machine, expected, arch)
+	}
+	return nil
+}
+
+var validArchs = map[string]bool{"amd64": true, "arm64": true}
+
+// sandboxArch returns the target architecture for the sandbox binary.
+// Defaults to the host arch (correct when sandbox image matches host, e.g.
+// arm64 Mac → arm64 sandbox image). Override with FULLSEND_SANDBOX_ARCH
+// when the sandbox image uses a different architecture (e.g. amd64 image
+// on an arm64 host via emulation). Only amd64 and arm64 are supported.
+func sandboxArch() string {
+	if arch := os.Getenv("FULLSEND_SANDBOX_ARCH"); arch != "" {
+		if !validArchs[arch] {
+			fmt.Fprintf(os.Stderr, "WARNING: FULLSEND_SANDBOX_ARCH=%q is not a supported architecture (amd64, arm64), using host arch %s\n", arch, runtime.GOARCH)
+			return runtime.GOARCH
+		}
+		return arch
+	}
+	return runtime.GOARCH
+}
+
+// resolveLinuxBinary obtains a Linux fullsend binary for the given arch.
+// Strategy: download from GitHub Release first (fast, no toolchain needed),
+// fall back to cross-compilation if the download fails or version is "dev".
+// Returns the temp directory (caller must clean up), the binary path, and any error.
+func resolveLinuxBinary(arch string) (tmpDir string, binaryPath string, err error) {
+	tmpDir, err = os.MkdirTemp("", "fullsend-linux-*")
+	if err != nil {
+		return "", "", fmt.Errorf("creating temp dir: %w", err)
+	}
+	binaryPath = filepath.Join(tmpDir, "fullsend")
+
+	// 1. Released version → download matching release asset.
+	if isReleasedVersion(version) {
+		fmt.Fprintf(os.Stderr, "Downloading fullsend %s for linux/%s from GitHub Release...\n", version, arch)
+		if dlErr := downloadReleaseBinary(version, arch, binaryPath); dlErr == nil {
+			fmt.Fprintf(os.Stderr, "Downloaded fullsend for linux/%s\n", arch)
+			return tmpDir, binaryPath, nil
+		} else {
+			fmt.Fprintf(os.Stderr, "WARNING: release download failed: %v\n", dlErr)
+		}
+	}
+
+	// 2. Dev build → try cross-compilation (requires Go toolchain + module in CWD).
+	fmt.Fprintf(os.Stderr, "Cross-compiling fullsend for linux/%s...\n", arch)
+	if ccErr := crossCompileFullsend(arch, binaryPath); ccErr == nil {
+		fmt.Fprintf(os.Stderr, "Cross-compiled fullsend for linux/%s\n", arch)
+		return tmpDir, binaryPath, nil
+	} else {
+		fmt.Fprintf(os.Stderr, "WARNING: cross-compilation failed: %v\n", ccErr)
+	}
+
+	// 3. Last resort → download latest release (version won't match exactly,
+	//    but the scan context command interface is stable across patch versions).
+	fmt.Fprintf(os.Stderr, "Downloading latest fullsend release for linux/%s...\n", arch)
+	if dlErr := downloadLatestReleaseBinary(arch, binaryPath); dlErr == nil {
+		fmt.Fprintf(os.Stderr, "Downloaded latest fullsend for linux/%s\n", arch)
+		return tmpDir, binaryPath, nil
+	} else {
+		fmt.Fprintf(os.Stderr, "WARNING: latest release download failed: %v\n", dlErr)
+	}
+
+	os.RemoveAll(tmpDir)
+	return "", "", fmt.Errorf("all strategies failed for linux/%s: provide --fullsend-binary or install Go toolchain", arch)
+}
+
+// isReleasedVersion returns true if version looks like a release tag
+// (e.g. "0.4.0", "v0.4.0") rather than a dev build (e.g. "dev",
+// "0.4.0-3-gabcdef", "0.4.0-vendored").
+func isReleasedVersion(v string) bool {
+	v = strings.TrimPrefix(v, "v")
+	if v == "" || v == "dev" {
+		return false
+	}
+	// A released version is purely digits and dots (e.g. "0.4.0").
+	for _, c := range v {
+		if c != '.' && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+const releaseBaseURL = "https://github.com/fullsend-ai/fullsend/releases/download"
+
+var httpClient = &http.Client{Timeout: 120 * time.Second}
+
+// downloadReleaseBinary downloads the fullsend binary for linux/{arch} from
+// the GitHub Release matching the given version and writes it to destPath.
+func downloadReleaseBinary(ver, arch, destPath string) error {
+	cleanVer := strings.TrimPrefix(ver, "v")
+	assetName := fmt.Sprintf("fullsend_%s_linux_%s.tar.gz", cleanVer, arch)
+	url := fmt.Sprintf("%s/v%s/%s", releaseBaseURL, cleanVer, assetName)
+
+	resp, err := httpClient.Get(url) //nolint:gosec // URL is constructed from known constants
+	if err != nil {
+		return fmt.Errorf("fetching %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s returned %d", url, resp.StatusCode)
+	}
+
+	const maxDownloadSize = 200 * 1024 * 1024 // 200 MB compressed
+	return extractFullsendFromTarGz(io.LimitReader(resp.Body, maxDownloadSize), destPath)
+}
+
+// downloadLatestReleaseBinary resolves the latest release tag from the GitHub
+// API and downloads the Linux binary for the given arch.
+func downloadLatestReleaseBinary(arch, destPath string) error {
+	tag, err := resolveLatestReleaseTag()
+	if err != nil {
+		return err
+	}
+	return downloadReleaseBinary(tag, arch, destPath)
+}
+
+func resolveLatestReleaseTag() (string, error) {
+	resp, err := httpClient.Get("https://api.github.com/repos/fullsend-ai/fullsend/releases/latest") //nolint:gosec
+	if err != nil {
+		return "", fmt.Errorf("fetching latest release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1024*1024)).Decode(&release); err != nil {
+		return "", fmt.Errorf("parsing release JSON: %w", err)
+	}
+	if release.TagName == "" {
+		return "", fmt.Errorf("empty tag_name in latest release")
+	}
+	return release.TagName, nil
+}
+
+const maxBinarySize = 500 * 1024 * 1024 // 500 MB — reasonable upper bound for a Go binary
+
+// extractFullsendFromTarGz reads a tar.gz stream and extracts the "fullsend"
+// binary to destPath.
+func extractFullsendFromTarGz(r io.Reader, destPath string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return fmt.Errorf("fullsend binary not found in archive")
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar: %w", err)
+		}
+		clean := filepath.Clean(hdr.Name)
+		if strings.Contains(clean, "..") || filepath.IsAbs(clean) {
+			continue
+		}
+		if filepath.Base(clean) == "fullsend" && hdr.Typeflag == tar.TypeReg {
+			f, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+			if err != nil {
+				return fmt.Errorf("creating %s: %w", destPath, err)
+			}
+			n, copyErr := io.Copy(f, io.LimitReader(tr, maxBinarySize+1))
+			if copyErr != nil {
+				f.Close()
+				return fmt.Errorf("extracting fullsend: %w", copyErr)
+			}
+			if n > maxBinarySize {
+				f.Close()
+				os.Remove(destPath)
+				return fmt.Errorf("binary exceeds maximum size (%d bytes)", maxBinarySize)
+			}
+			return f.Close()
+		}
+	}
+}
+
+// crossCompileFullsend builds a Linux fullsend binary for the given arch
+// and writes it to destPath. Requires the Go toolchain.
+func crossCompileFullsend(arch, destPath string) error {
+	goPath, lookErr := exec.LookPath("go")
+	if lookErr != nil {
+		return fmt.Errorf("Go toolchain not found — install Go or use a released version of fullsend: %w", lookErr)
+	}
+
+	// Find the module root so `go build ./cmd/fullsend/` resolves correctly
+	// regardless of the caller's working directory.
+	modRootCmd := exec.Command(goPath, "env", "GOMOD")
+	modOutput, err := modRootCmd.Output()
+	if err != nil {
+		return fmt.Errorf("finding module root: %w", err)
+	}
+	modPath := strings.TrimSpace(string(modOutput))
+	if modPath == "" || modPath == os.DevNull {
+		return fmt.Errorf("not in a Go module — run from the fullsend source tree or use a released version")
+	}
+	modRoot := filepath.Dir(modPath)
+
+	buildCmd := exec.Command(goPath, "build",
+		"-ldflags", fmt.Sprintf("-X github.com/fullsend-ai/fullsend/internal/cli.version=%s-crosscompiled", version),
+		"-o", destPath,
+		"./cmd/fullsend/",
+	)
+	buildCmd.Dir = modRoot
+	buildCmd.Env = append(os.Environ(), "GOTOOLCHAIN=auto", "GOOS=linux", "GOARCH="+arch, "CGO_ENABLED=0")
+	buildCmd.Stderr = os.Stderr
+	if err := buildCmd.Run(); err != nil {
+		return fmt.Errorf("cross-compiling for linux/%s: %w", arch, err)
+	}
+	return nil
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1453,10 +1453,14 @@ func downloadChecksumForAsset(ver, assetName string) (string, error) {
 		line := scanner.Text()
 		parts := strings.Fields(line)
 		if len(parts) == 2 && parts[1] == assetName {
-			if len(parts[0]) != 64 {
+			hash := strings.ToLower(parts[0])
+			if len(hash) != 64 {
 				return "", fmt.Errorf("invalid hash length for %s in checksums.txt", assetName)
 			}
-			return parts[0], nil
+			if _, err := hex.DecodeString(hash); err != nil {
+				return "", fmt.Errorf("invalid hex hash for %s in checksums.txt: %w", assetName, err)
+			}
+			return hash, nil
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -4,7 +4,12 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -310,4 +315,129 @@ func TestResolveLinuxBinary_Download(t *testing.T) {
 	// Verify the downloaded artifact is a valid Linux ELF for the requested arch.
 	t.Setenv("FULLSEND_SANDBOX_ARCH", "amd64")
 	assert.NoError(t, validateLinuxBinary(binPath), "downloaded binary should be a valid Linux/amd64 ELF")
+}
+
+func TestDownloadChecksumForAsset_ParsesLine(t *testing.T) {
+	body := "1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014  fullsend_1.0.0_linux_arm64.tar.gz\n" +
+		"60303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c752  fullsend_1.0.0_linux_amd64.tar.gz\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	origBaseURL := releaseBaseURL
+	releaseBaseURL = srv.URL
+	defer func() { releaseBaseURL = origBaseURL }()
+
+	hash, err := downloadChecksumForAsset("1.0.0", "fullsend_1.0.0_linux_amd64.tar.gz")
+	require.NoError(t, err)
+	assert.Equal(t, "60303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c752", hash)
+}
+
+func TestDownloadChecksumForAsset_AssetNotFound(t *testing.T) {
+	body := "1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014  fullsend_1.0.0_linux_amd64.tar.gz\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	origBaseURL := releaseBaseURL
+	releaseBaseURL = srv.URL
+	defer func() { releaseBaseURL = origBaseURL }()
+
+	_, err := downloadChecksumForAsset("1.0.0", "fullsend_1.0.0_linux_arm64.tar.gz")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in checksums.txt")
+}
+
+func TestDownloadReleaseBinary_ChecksumMismatch(t *testing.T) {
+	// Build a valid tar.gz containing a "fullsend" binary.
+	var tarBuf bytes.Buffer
+	gw := gzip.NewWriter(&tarBuf)
+	tw := tar.NewWriter(gw)
+	content := []byte("fake binary")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "fullsend",
+		Size:     int64(len(content)),
+		Mode:     0o755,
+		Typeflag: tar.TypeReg,
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	tarBytes := tarBuf.Bytes()
+
+	// Serve a checksums.txt with a WRONG hash for the asset.
+	wrongHash := "0000000000000000000000000000000000000000000000000000000000000000"
+	checksumBody := fmt.Sprintf("%s  fullsend_1.0.0_linux_amd64.tar.gz\n", wrongHash)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.0.0/fullsend_1.0.0_checksums.txt" {
+			fmt.Fprint(w, checksumBody)
+		} else if r.URL.Path == "/v1.0.0/fullsend_1.0.0_linux_amd64.tar.gz" {
+			w.Write(tarBytes)
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	origBaseURL := releaseBaseURL
+	releaseBaseURL = srv.URL
+	defer func() { releaseBaseURL = origBaseURL }()
+
+	destPath := filepath.Join(t.TempDir(), "fullsend")
+	err = downloadReleaseBinary("1.0.0", "amd64", destPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checksum mismatch")
+}
+
+func TestDownloadReleaseBinary_ChecksumMatch(t *testing.T) {
+	var tarBuf bytes.Buffer
+	gw := gzip.NewWriter(&tarBuf)
+	tw := tar.NewWriter(gw)
+	content := []byte("good binary")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "fullsend",
+		Size:     int64(len(content)),
+		Mode:     0o755,
+		Typeflag: tar.TypeReg,
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	tarBytes := tarBuf.Bytes()
+	h := sha256.Sum256(tarBytes)
+	correctHash := hex.EncodeToString(h[:])
+
+	checksumBody := fmt.Sprintf("%s  fullsend_2.0.0_linux_amd64.tar.gz\n", correctHash)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2.0.0/fullsend_2.0.0_checksums.txt" {
+			fmt.Fprint(w, checksumBody)
+		} else if r.URL.Path == "/v2.0.0/fullsend_2.0.0_linux_amd64.tar.gz" {
+			w.Write(tarBytes)
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	origBaseURL := releaseBaseURL
+	releaseBaseURL = srv.URL
+	defer func() { releaseBaseURL = origBaseURL }()
+
+	destPath := filepath.Join(t.TempDir(), "fullsend")
+	err = downloadReleaseBinary("2.0.0", "amd64", destPath)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, "good binary", string(data))
 }

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -352,6 +352,23 @@ func TestDownloadChecksumForAsset_AssetNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found in checksums.txt")
 }
 
+func TestDownloadChecksumForAsset_InvalidHex(t *testing.T) {
+	body := "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ  fullsend_1.0.0_linux_amd64.tar.gz\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	origBaseURL := releaseBaseURL
+	releaseBaseURL = srv.URL
+	defer func() { releaseBaseURL = origBaseURL }()
+
+	_, err := downloadChecksumForAsset("1.0.0", "fullsend_1.0.0_linux_amd64.tar.gz")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid hex hash")
+}
+
 func TestDownloadReleaseBinary_ChecksumMismatch(t *testing.T) {
 	// Build a valid tar.gz containing a "fullsend" binary.
 	var tarBuf bytes.Buffer

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -151,4 +155,159 @@ func TestEnvToList_Sorted(t *testing.T) {
 	assert.Equal(t, "A_VAR=a", list[0])
 	assert.Equal(t, "M_VAR=m", list[1])
 	assert.Equal(t, "Z_VAR=z", list[2])
+}
+
+func TestNeedsCrossCompilation(t *testing.T) {
+	result := needsCrossCompilation()
+	if runtime.GOOS == "linux" {
+		assert.False(t, result, "should not need cross-compilation on Linux")
+	} else {
+		assert.True(t, result, "should need cross-compilation on %s", runtime.GOOS)
+	}
+}
+
+func TestSandboxArch_Default(t *testing.T) {
+	t.Setenv("FULLSEND_SANDBOX_ARCH", "")
+	assert.Equal(t, runtime.GOARCH, sandboxArch())
+}
+
+func TestSandboxArch_Override(t *testing.T) {
+	t.Setenv("FULLSEND_SANDBOX_ARCH", "amd64")
+	assert.Equal(t, "amd64", sandboxArch())
+}
+
+func TestSandboxArch_InvalidFallsBack(t *testing.T) {
+	t.Setenv("FULLSEND_SANDBOX_ARCH", "../../etc/passwd")
+	assert.Equal(t, runtime.GOARCH, sandboxArch())
+}
+
+func TestValidateLinuxBinary_RejectsNonELF(t *testing.T) {
+	// A plain text file should be rejected.
+	tmp := filepath.Join(t.TempDir(), "not-elf")
+	require.NoError(t, os.WriteFile(tmp, []byte("#!/bin/sh\necho hello"), 0o755))
+	err := validateLinuxBinary(tmp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid ELF binary")
+}
+
+func TestValidateLinuxBinary_RejectsMissing(t *testing.T) {
+	err := validateLinuxBinary("/tmp/nonexistent-fullsend-binary-12345")
+	require.Error(t, err)
+}
+
+func TestValidateLinuxBinary_AcceptsHostBinary(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("host binary is only ELF on Linux")
+	}
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	assert.NoError(t, validateLinuxBinary(exe))
+}
+
+func TestIsReleasedVersion(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected bool
+	}{
+		{"0.4.0", true},
+		{"v0.4.0", true},
+		{"1.0.0", true},
+		{"dev", false},
+		{"", false},
+		{"0.4.0-3-gabcdef", false},
+		{"0.4.0-vendored", false},
+		{"0.4.0-crosscompiled", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isReleasedVersion(tt.version), "version=%q", tt.version)
+		})
+	}
+}
+
+func TestExtractFullsendFromTarGz_PathTraversal(t *testing.T) {
+	// Create a tar.gz with a path-traversal entry named "../../../tmp/fullsend".
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	content := []byte("malicious binary content")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "../../../tmp/fullsend",
+		Size:     int64(len(content)),
+		Mode:     0o755,
+		Typeflag: tar.TypeReg,
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	destPath := filepath.Join(t.TempDir(), "fullsend")
+	err = extractFullsendFromTarGz(&buf, destPath)
+	assert.Error(t, err, "should reject traversal entry and report binary not found")
+	assert.Contains(t, err.Error(), "not found in archive")
+}
+
+func TestExtractFullsendFromTarGz_ValidEntry(t *testing.T) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	content := []byte("valid binary content")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "fullsend_0.4.0_linux_amd64/fullsend",
+		Size:     int64(len(content)),
+		Mode:     0o755,
+		Typeflag: tar.TypeReg,
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	destPath := filepath.Join(t.TempDir(), "fullsend")
+	err = extractFullsendFromTarGz(&buf, destPath)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, "valid binary content", string(data))
+}
+
+func TestCrossCompileFullsend_ProducesBinary(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("cross-compilation test only meaningful on non-Linux hosts")
+	}
+	if testing.Short() {
+		t.Skip("skipping cross-compilation in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	binPath := filepath.Join(tmpDir, "fullsend")
+	err := crossCompileFullsend(runtime.GOARCH, binPath)
+	require.NoError(t, err)
+
+	info, err := os.Stat(binPath)
+	require.NoError(t, err)
+	assert.True(t, info.Size() > 0, "binary should be non-empty")
+}
+
+func TestResolveLinuxBinary_Download(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping download test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	binPath := filepath.Join(tmpDir, "fullsend")
+	err := downloadReleaseBinary("0.4.0", "amd64", binPath)
+	require.NoError(t, err)
+
+	info, err := os.Stat(binPath)
+	require.NoError(t, err)
+	assert.True(t, info.Size() > 0, "downloaded binary should be non-empty")
+
+	// Verify the downloaded artifact is a valid Linux ELF for the requested arch.
+	t.Setenv("FULLSEND_SANDBOX_ARCH", "amd64")
+	assert.NoError(t, validateLinuxBinary(binPath), "downloaded binary should be a valid Linux/amd64 ELF")
 }


### PR DESCRIPTION
## Summary

- When running `fullsend run` on macOS with a Linux sandbox, the pre-agent security scan (`fullsend scan context`) fails because the host Mach-O binary cannot execute inside the Linux container
- Add automatic Linux binary resolution with a 4-priority fallback chain: explicit `--fullsend-binary`, download from matching GitHub Release, cross-compile from source, download latest release
- Harden the download/extraction path: path traversal protection in tar extraction, `io.LimitReader` on compressed stream (200 MB) and extracted binary (500 MB), HTTP client with 120s timeout, ELF validation (OS/ABI + architecture), `FULLSEND_SANDBOX_ARCH` whitelist, `GOMOD=/dev/null` handling
- Update `docs/guides/dev/local-dev.md` with binary resolution docs and `FULLSEND_SANDBOX_ARCH` usage

A companion user-facing guide (`docs/guides/user/running-agents-locally.md`) is split into a separate PR: #663.

## Test plan

- [x] `go test -short ./internal/cli/` — all tests pass
- [x] `go test -short ./...` — full suite passes, no regressions
- [x] `go vet ./internal/cli/` — clean
- [x] `make lint` — clean
- [x] Verified locally: `fullsend run review` on macOS/arm64 with podman Linux sandbox auto-downloads Linux binary and completes security scan
- [x] Verified `--fullsend-binary` with explicit cross-compiled binary
- [x] Verified macOS Mach-O binary is rejected with clear error
- [ ] CI: confirm no behavior change on Linux (uses `os.Executable()` directly)