### PR TITLE
docs: add guide for running agents locally with released binaries

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -16,6 +16,7 @@ Guides for org administrators who install, configure, and manage fullsend.
 Guides for developers working in repositories where fullsend is active.
 
 - [Bugfix workflow](user/bugfix-workflow.md) — End-to-end guide to how fullsend handles a bug report from issue to merge
+- [Running agents locally](user/running-agents-locally.md) — Run fullsend agents on your machine using released binaries (macOS + Linux)
 
 ## Development
 

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -1,0 +1,183 @@
+# Running agents locally
+
+This guide walks through running fullsend agents on your machine using released binaries. No Go toolchain or source checkout is needed. Both macOS and Linux are supported with Podman as the container runtime.
+
+> For building fullsend from source or contributing to the CLI, see [Local development](../dev/local-dev.md).
+
+## Prerequisites
+
+| Requirement | macOS | Linux |
+|-------------|-------|-------|
+| Container runtime | Podman Desktop with a running machine | Podman |
+| OpenShell | 0.0.37-dev+ (Podman support) | 0.0.37-dev+ |
+| GCP credentials | Service account key (`Vertex AI User` role) | Same |
+| GitHub PAT | `repo` scope for the target org | Same |
+
+> **No Go toolchain required.** On macOS, the CLI automatically downloads a Linux binary for the sandbox. See [Cross-platform binary resolution](#cross-platform-binary-resolution) below.
+
+## 1. Download the fullsend CLI
+
+Download the latest release from [GitHub Releases](https://github.com/fullsend-ai/fullsend/releases). Pick the archive matching your platform:
+
+| Platform | Archive |
+|----------|---------|
+| macOS (Apple Silicon) | `fullsend_{version}_darwin_arm64.tar.gz` |
+| macOS (Intel) | `fullsend_{version}_darwin_amd64.tar.gz` |
+| Linux (x86_64) | `fullsend_{version}_linux_amd64.tar.gz` |
+| Linux (arm64) | `fullsend_{version}_linux_arm64.tar.gz` |
+
+Extract and move to a directory in your PATH:
+
+```bash
+tar xzf fullsend_0.4.0_darwin_arm64.tar.gz
+sudo mv fullsend_0.4.0_darwin_arm64/fullsend /usr/local/bin/
+```
+
+Verify the installation:
+
+```bash
+fullsend version
+```
+
+## 2. Clone the .fullsend config directory
+
+Each organization has a `.fullsend` config repo containing harness definitions, agent prompts, policies, scripts, and skills. Clone it to a local path:
+
+```bash
+gh repo clone <org>/.fullsend /tmp/fullsend-dot
+```
+
+## 3. Create an env file
+
+Env files contain secrets and must never be committed. Keep your env file outside the repo (e.g. `/tmp/fullsend.env`).
+
+### Core variables (all agents)
+
+```bash
+ANTHROPIC_VERTEX_PROJECT_ID=<gcp-project-with-vertex-ai>
+CLOUD_ML_REGION=global
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa-key.json
+GH_TOKEN=<github-pat>
+```
+
+### Per-agent variables
+
+Each agent requires additional variables via its harness `runner_env`. Add the ones needed for the agent you want to run:
+
+| Variable | Agent(s) | Description |
+|----------|----------|-------------|
+| `GITHUB_ISSUE_URL` | triage | Full URL of the GitHub issue to triage |
+| `REPO_FULL_NAME` | triage, code, review, fix | `owner/repo` of the target repository |
+| `ISSUE_NUMBER` | code | Issue number the code agent should implement |
+| `TARGET_BRANCH` | code, fix | Branch to base work on (e.g. `main`) |
+| `PUSH_TOKEN` | code, fix | GitHub token with push access for the post-script |
+| `PR_NUMBER` | review, fix | Pull request number to review or fix |
+| `GITHUB_PR_URL` | review | Full URL of the pull request to review |
+| `REVIEW_TOKEN` | review | GitHub token for posting review comments |
+
+See the harness definitions in `harness/*.yaml` within your `.fullsend` config directory for the complete list per agent.
+
+### arm64 image override
+
+On arm64 hosts (Apple Silicon, Graviton), add:
+
+```bash
+FULLSEND_SANDBOX_IMAGE=ghcr.io/fullsend-ai/fullsend-sandbox:dev
+```
+
+The default `:latest` tag is amd64-only. The `:dev` tag is a multi-arch image that includes arm64 support. On amd64 hosts this line is not needed.
+
+## 4. Run an agent
+
+```bash
+fullsend run <agent> \
+  --fullsend-dir /tmp/fullsend-dot \
+  --target-repo /path/to/repo \
+  --env-file /tmp/fullsend.env
+```
+
+The `--env-file` flag loads environment variables before the harness is parsed. It is repeatable — later files override earlier ones.
+
+### Example: triage an issue
+
+```bash
+fullsend run triage \
+  --fullsend-dir /tmp/fullsend-dot \
+  --target-repo /path/to/repo \
+  --env-file /tmp/fullsend.env
+```
+
+### Example: review a pull request
+
+```bash
+fullsend run review \
+  --fullsend-dir /tmp/fullsend-dot \
+  --target-repo /path/to/repo \
+  --env-file /tmp/fullsend.env
+```
+
+### Example: implement an issue
+
+```bash
+fullsend run code \
+  --fullsend-dir /tmp/fullsend-dot \
+  --target-repo /path/to/repo \
+  --env-file /tmp/fullsend.env
+```
+
+### Example: fix review feedback on a PR
+
+```bash
+fullsend run fix \
+  --fullsend-dir /tmp/fullsend-dot \
+  --target-repo /path/to/repo \
+  --env-file /tmp/fullsend.env
+```
+
+## Cross-platform binary resolution
+
+The pre-agent security scan runs `fullsend scan context` inside the Linux sandbox. This requires a Linux binary, even when your host is macOS.
+
+On **Linux**, the CLI copies its own executable into the sandbox — no extra steps needed.
+
+On **macOS**, the CLI automatically obtains a Linux binary using the following priority:
+
+| Priority | Strategy | When it applies |
+|----------|----------|-----------------|
+| 1 | `--fullsend-binary <path>` | Always used if provided — skips auto-resolution |
+| 2 | Download from GitHub Release | CLI version matches a release (e.g. `0.4.0`) |
+| 3 | Cross-compile from source | Go toolchain available, run from module root |
+| 4 | Download latest release | Fallback when cross-compilation unavailable |
+
+When using a released binary (this guide's workflow), **strategy 2 applies automatically** — the CLI downloads the matching Linux release. No Go toolchain or manual steps needed.
+
+## Platform notes
+
+### macOS
+
+- **Podman machine**: ensure the Podman machine is running (`podman machine start`) before invoking fullsend. The CLI does not start it automatically.
+- **Podman host-gateway**: if sandbox creation fails with `unable to replace "host-gateway"`, set `host_containers_internal_ip = "192.168.127.254"` under `[containers]` in `~/.config/containers/containers.conf` and restart the Podman machine.
+- **Architecture mismatch**: if your sandbox image uses a different CPU architecture than the host (e.g. amd64 image on an arm64 Mac via QEMU emulation), set `FULLSEND_SANDBOX_ARCH=amd64` so the CLI downloads the correct binary. This is not needed in the typical setup where the Podman VM matches the host arch.
+
+### Linux
+
+- **Docker socket permissions**: if using Docker instead of Podman, your user must be in the `docker` group or run with `sudo`. Podman runs rootless by default.
+- **SELinux**: on Fedora/RHEL, bind-mounted volumes may need the `:z` suffix for standalone `podman run`. OpenShell handles this automatically.
+
+## Troubleshooting
+
+**Sandbox creation fails immediately**
+- Check that `podman machine start` has been run (macOS only)
+- Verify OpenShell is installed: `openshell version`
+
+**`Syntax error: "(" unexpected` inside sandbox**
+- The macOS Mach-O binary was injected instead of a Linux ELF. Update to fullsend 0.4.0+ which auto-resolves the correct binary, or provide one explicitly with `--fullsend-binary`
+
+**Agent fails with missing environment variable**
+- Check your env file contains all variables listed in the agent's harness YAML (`harness/<agent>.yaml` in the `.fullsend` config directory)
+
+**arm64 sandbox image pull fails**
+- The default `:latest` tag is amd64-only. Add `FULLSEND_SANDBOX_IMAGE=ghcr.io/fullsend-ai/fullsend-sandbox:dev` to your env file
+
+**`unable to replace "host-gateway"` on macOS**
+- Set `host_containers_internal_ip = "192.168.127.254"` under `[containers]` in `~/.config/containers/containers.conf` and restart the Podman machine

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -10,8 +10,8 @@ This guide walks through running fullsend agents on your machine using released 
 |-------------|-------|-------|
 | Container runtime | Podman Desktop with a running machine | Podman |
 | [OpenShell](https://github.com/NVIDIA/OpenShell) | 0.0.38 | 0.0.38 |
-| GCP credentials | Service account key (`Vertex AI User` role) | Same |
-| GitHub PAT | `repo` scope for the target org | Same |
+| GCP credentials | Service account key (see [GCP credentials](#gcp-credentials) below) | Same |
+| GitHub PAT | Classic PAT with `repo` scope (see [GitHub tokens](#github-tokens) below) | Same |
 
 > **No Go toolchain required.** On macOS, the CLI automatically downloads a Linux binary for the sandbox. See [Cross-platform binary resolution](#cross-platform-binary-resolution) below.
 
@@ -72,18 +72,43 @@ gh repo clone <org>/.fullsend /tmp/fullsend-dot
 
 Env files contain secrets and must never be committed. Keep your env file outside the repo (e.g. `/tmp/fullsend.env`).
 
-### Core variables (all agents)
+### GCP credentials
+
+In CI, fullsend uses Workload Identity Federation (WIF) to authenticate to Vertex AI — no service account keys are stored. Locally, use a service account key instead:
 
 ```bash
 ANTHROPIC_VERTEX_PROJECT_ID=<gcp-project-with-vertex-ai>
+GOOGLE_CLOUD_PROJECT=<gcp-project-with-vertex-ai>
 CLOUD_ML_REGION=global
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa-key.json
-GH_TOKEN=<github-pat>
 ```
+
+The service account needs the `Vertex AI User` role (`roles/aiplatform.user`) on the project. Create a key with:
+
+```bash
+gcloud iam service-accounts keys create sa-key.json \
+  --iam-account=<sa-name>@<project>.iam.gserviceaccount.com
+```
+
+> WIF's OIDC token refresh is handled automatically in CI. With a service account key locally, no refresh is needed — the key is valid for the duration of the run.
+
+### GitHub tokens
+
+In CI, fullsend mints separate GitHub App installation tokens per role (read-only for sandboxes, write-scoped for post-scripts). Locally, a single classic PAT with `repo` scope can serve all three token variables:
+
+```bash
+GH_TOKEN=<github-pat>
+PUSH_TOKEN=<github-pat>
+REVIEW_TOKEN=<github-pat>
+```
+
+All three can be the same PAT. The separation exists for CI's security architecture (read-only tokens inside sandboxes, write tokens only on the runner for post-scripts), but locally a single token works.
+
+The PAT needs `repo` scope for the target organization. Fine-grained PATs are not supported because they cannot span multiple repositories in the same org.
 
 ### Per-agent variables
 
-Each agent requires additional variables via its harness `runner_env`. Add the ones needed for the agent you want to run:
+Each agent requires additional variables via its harness `runner_env` and sandbox env files. Add the ones needed for the agent you want to run:
 
 | Variable | Agent(s) | Description |
 |----------|----------|-------------|
@@ -91,10 +116,8 @@ Each agent requires additional variables via its harness `runner_env`. Add the o
 | `REPO_FULL_NAME` | code, review, fix | `owner/repo` of the target repository |
 | `ISSUE_NUMBER` | code | Issue number the code agent should implement |
 | `TARGET_BRANCH` | code, fix | Branch to base work on (e.g. `main`) |
-| `PUSH_TOKEN` | code, fix | GitHub token with push access for the post-script |
 | `PR_NUMBER` | review, fix | Pull request number to review or fix |
 | `GITHUB_PR_URL` | review | Full URL of the pull request to review |
-| `REVIEW_TOKEN` | review | GitHub token for posting review comments |
 | `REVIEW_BODY_FILE` | fix | Path to a file containing the review body to fix |
 
 See the harness definitions in `harness/*.yaml` within your `.fullsend` config directory for the complete list per agent.

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -10,6 +10,7 @@ This guide walks through running fullsend agents on your machine using released 
 |-------------|-------|-------|
 | Container runtime | Podman Desktop with a running machine | Podman |
 | [OpenShell](https://github.com/NVIDIA/OpenShell) | 0.0.38 | 0.0.38 |
+| GCP project | [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled with [Claude models](https://console.cloud.google.com/vertex-ai/model-garden) | Same |
 | GCP credentials | Service account key (see [GCP credentials](#gcp-credentials) below) | Same |
 | GitHub PAT | Classic PAT with `repo` scope (see [GitHub tokens](#github-tokens) below) | Same |
 
@@ -74,27 +75,48 @@ Env files contain secrets and must never be committed. Keep your env file outsid
 
 ### GCP credentials
 
-In CI, fullsend uses Workload Identity Federation (WIF) to authenticate to Vertex AI — no service account keys are stored. Locally, use a service account key instead:
+Fullsend agents use Claude models via [Vertex AI](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/use-claude). Your GCP project must have:
+
+1. The [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled
+2. Claude models enabled in [Model Garden](https://console.cloud.google.com/vertex-ai/model-garden) — search for "Claude" and enable the Anthropic models you need (all agents default to Claude Opus)
+
+In CI, fullsend uses [Workload Identity Federation (WIF)](https://cloud.google.com/iam/docs/workload-identity-federation) — no service account keys are stored. Locally, use a service account key instead.
+
+**Create a service account and key:**
 
 ```bash
-ANTHROPIC_VERTEX_PROJECT_ID=<gcp-project-with-vertex-ai>
-GOOGLE_CLOUD_PROJECT=<gcp-project-with-vertex-ai>
-CLOUD_ML_REGION=global
-GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa-key.json
+# Create a service account
+gcloud iam service-accounts create fullsend-local \
+  --display-name="Fullsend local agent runner" \
+  --project=<project-id>
+
+# Grant Vertex AI User role (call Claude models via Vertex AI)
+gcloud projects add-iam-policy-binding <project-id> \
+  --member="serviceAccount:fullsend-local@<project-id>.iam.gserviceaccount.com" \
+  --role="roles/aiplatform.user"
+
+# Create and download the key file
+gcloud iam service-accounts keys create sa-key.json \
+  --iam-account=fullsend-local@<project-id>.iam.gserviceaccount.com
+chmod 600 sa-key.json
 ```
 
-The service account needs the `Vertex AI User` role (`roles/aiplatform.user`) on the project. Create a key with:
+See [Creating service account keys](https://cloud.google.com/iam/docs/keys-create-delete) for details. Note that Google recommends WIF over long-lived keys for production use — service account keys are appropriate for local development.
+
+**Add to your env file:**
 
 ```bash
-gcloud iam service-accounts keys create sa-key.json \
-  --iam-account=<sa-name>@<project>.iam.gserviceaccount.com
+ANTHROPIC_VERTEX_PROJECT_ID=<project-id>
+GOOGLE_CLOUD_PROJECT=<project-id>
+CLOUD_ML_REGION=global
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa-key.json
 ```
 
 > WIF's OIDC token refresh is handled automatically in CI. With a service account key locally, no refresh is needed — the key is valid for the duration of the run.
 
 ### GitHub tokens
 
-In CI, fullsend mints separate GitHub App installation tokens per role (read-only for sandboxes, write-scoped for post-scripts). Locally, a single classic PAT with `repo` scope can serve all three token variables:
+In CI, fullsend mints separate GitHub App installation tokens per role (read-only for sandboxes, write-scoped for post-scripts). Locally, use a [classic personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) — a single PAT can serve all three token variables:
 
 ```bash
 GH_TOKEN=<github-pat>
@@ -104,7 +126,9 @@ REVIEW_TOKEN=<github-pat>
 
 All three can be the same PAT. The separation exists for CI's security architecture (read-only tokens inside sandboxes, write tokens only on the runner for post-scripts), but locally a single token works.
 
-The PAT needs `repo` scope for the target organization. Fine-grained PATs are not supported because they cannot span multiple repositories in the same org.
+**Required scope:** `repo` — grants read/write access to code, pull requests, and issues in repositories the token owner can access. Create one at [github.com/settings/tokens](https://github.com/settings/tokens/new).
+
+[Fine-grained PATs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) are not supported. They are scoped to individual repositories and cannot cover both the target repo and the `.fullsend` config repo in a single token. Fullsend needs access to both during a run.
 
 ### Per-agent variables
 

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -138,13 +138,16 @@ Each agent requires additional variables via its harness `runner_env` and sandbo
 
 | Variable | Agent(s) | Description |
 |----------|----------|-------------|
-| `GITHUB_ISSUE_URL` | triage | Full URL of the GitHub issue to triage |
-| `REPO_FULL_NAME` | code, review, fix | `owner/repo` of the target repository |
+| `GITHUB_ISSUE_URL` | triage, prioritize | Full URL of the GitHub issue to triage or prioritize |
+| `REPO_FULL_NAME` | code, review, fix, retro | `owner/repo` of the target repository |
 | `ISSUE_NUMBER` | code | Issue number the code agent should implement |
 | `TARGET_BRANCH` | code, fix | Branch to base work on (e.g. `main`) |
 | `PR_NUMBER` | review, fix | Pull request number to review or fix |
 | `GITHUB_PR_URL` | review | Full URL of the pull request to review |
 | `REVIEW_BODY_FILE` | fix | Path to a file containing the review body to fix |
+| `ORG` | prioritize | GitHub organization name |
+| `PROJECT_NUMBER` | prioritize | GitHub Projects (v2) project number |
+| `ORIGINATING_URL` | retro | URL of the PR or issue to run a retrospective on |
 
 See the harness definitions in `harness/*.yaml` within your `.fullsend` config directory for the complete list per agent.
 
@@ -267,6 +270,39 @@ REVIEW_BODY_FILE=/path/to/review-body.txt
 
 ```bash
 fullsend run fix \
+  --fullsend-dir /tmp/fullsend-dot \
+  --target-repo /path/to/repo \
+  --env-file /tmp/fullsend.env
+```
+
+### Prioritize an issue
+
+Add to your env file:
+
+```bash
+GITHUB_ISSUE_URL=https://github.com/owner/repo/issues/42
+ORG=owner
+PROJECT_NUMBER=1
+```
+
+```bash
+fullsend run prioritize \
+  --fullsend-dir /tmp/fullsend-dot \
+  --target-repo /path/to/repo \
+  --env-file /tmp/fullsend.env
+```
+
+### Run a retrospective
+
+Add to your env file:
+
+```bash
+REPO_FULL_NAME=owner/repo
+ORIGINATING_URL=https://github.com/owner/repo/pull/123
+```
+
+```bash
+fullsend run retro \
   --fullsend-dir /tmp/fullsend-dot \
   --target-repo /path/to/repo \
   --env-file /tmp/fullsend.env

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -308,6 +308,42 @@ fullsend run retro \
   --env-file /tmp/fullsend.env
 ```
 
+## Running customized agents
+
+In CI, the reusable workflows automatically overlay customized files from `customized/` (org-level) and `.fullsend/customized/` (per-repo) onto the base config before running the agent. The `fullsend run` CLI does not perform this overlay — it reads from `--fullsend-dir` as-is.
+
+To run customized agents locally, merge the overlays into a working copy of the config directory before invoking `fullsend run`:
+
+```bash
+# Start with a fresh copy of the org config
+cp -r /tmp/fullsend-dot /tmp/fullsend-merged
+
+# Apply org-level customizations (from the .fullsend config repo)
+for dir in agents skills schemas harness plugins policies scripts env; do
+  if [ -d "/tmp/fullsend-merged/customized/${dir}" ]; then
+    cp -r "/tmp/fullsend-merged/customized/${dir}/." "/tmp/fullsend-merged/${dir}/"
+  fi
+done
+
+# Apply per-repo customizations (from the target repo)
+TARGET_REPO=/path/to/repo
+for dir in agents skills schemas harness plugins policies scripts env; do
+  if [ -d "${TARGET_REPO}/.fullsend/customized/${dir}" ]; then
+    cp -r "${TARGET_REPO}/.fullsend/customized/${dir}/." "/tmp/fullsend-merged/${dir}/"
+  fi
+done
+
+# Run with the merged config
+fullsend run <agent> \
+  --fullsend-dir /tmp/fullsend-merged \
+  --target-repo /path/to/repo \
+  --env-file /tmp/fullsend.env
+```
+
+This replicates the three-tier resolution order: upstream defaults < org customizations < per-repo customizations. See [Customizing agents](customizing-agents.md) for details on the layered content model.
+
+> **Custom agent names** require a matching harness YAML. If you add a custom agent definition (e.g. `customized/agents/my-agent.md`), you also need a `customized/harness/my-agent.yaml` that references it — otherwise `fullsend run my-agent` will fail with "harness not found".
+
 ## Testing without side effects
 
 To run agent inference without the post-script (which posts PR comments, pushes branches, or creates PRs), use `--no-post-script`:

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -31,7 +31,7 @@ Extract and move to a directory in your PATH:
 
 ```bash
 tar xzf fullsend_0.4.0_darwin_arm64.tar.gz
-sudo mv fullsend_0.4.0_darwin_arm64/fullsend /usr/local/bin/
+mv fullsend_0.4.0_darwin_arm64/fullsend $HOME/.local/bin/
 ```
 
 Verify the installation:
@@ -58,7 +58,7 @@ Download the gateway binary from the [OpenShell releases](https://github.com/NVI
 # Example for macOS (Apple Silicon)
 curl -fsSL https://github.com/NVIDIA/OpenShell/releases/download/v0.0.38/openshell-gateway-aarch64-apple-darwin.tar.gz \
   -o /tmp/openshell-gateway.tar.gz
-tar xzf /tmp/openshell-gateway.tar.gz -C /usr/local/bin/
+tar xzf /tmp/openshell-gateway.tar.gz -C $HOME/.local/bin/
 ```
 
 ## 3. Clone the .fullsend config directory
@@ -203,7 +203,15 @@ fullsend run <agent> \
 
 The `--env-file` flag loads environment variables before the harness is parsed. It is repeatable — later files override earlier ones.
 
-### Example: triage an issue
+The examples below show the per-agent variables to add to your env file (in addition to the [GCP credentials](#gcp-credentials) and [GitHub tokens](#github-tokens) already configured above).
+
+### Triage an issue
+
+Add to your env file:
+
+```bash
+GITHUB_ISSUE_URL=https://github.com/owner/repo/issues/42
+```
 
 ```bash
 fullsend run triage \
@@ -212,7 +220,15 @@ fullsend run triage \
   --env-file /tmp/fullsend.env
 ```
 
-### Example: review a pull request
+### Review a pull request
+
+Add to your env file:
+
+```bash
+REPO_FULL_NAME=owner/repo
+PR_NUMBER=123
+GITHUB_PR_URL=https://github.com/owner/repo/pull/123
+```
 
 ```bash
 fullsend run review \
@@ -221,7 +237,15 @@ fullsend run review \
   --env-file /tmp/fullsend.env
 ```
 
-### Example: implement an issue
+### Implement an issue
+
+Add to your env file:
+
+```bash
+REPO_FULL_NAME=owner/repo
+ISSUE_NUMBER=42
+TARGET_BRANCH=main
+```
 
 ```bash
 fullsend run code \
@@ -230,7 +254,16 @@ fullsend run code \
   --env-file /tmp/fullsend.env
 ```
 
-### Example: fix review feedback on a PR
+### Fix review feedback on a PR
+
+Add to your env file:
+
+```bash
+REPO_FULL_NAME=owner/repo
+PR_NUMBER=123
+TARGET_BRANCH=main
+REVIEW_BODY_FILE=/path/to/review-body.txt
+```
 
 ```bash
 fullsend run fix \

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -10,7 +10,7 @@ This guide walks through running fullsend agents on your machine using released 
 |-------------|-------|-------|
 | Container runtime | Podman Desktop with a running machine | Podman |
 | [OpenShell](https://github.com/NVIDIA/OpenShell) | 0.0.38 | 0.0.38 |
-| GCP project | [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled with [Claude models](https://console.cloud.google.com/vertex-ai/model-garden) | Same |
+| GCP project | [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled with [Claude models](https://console.cloud.google.com/vertex-ai/model-garden) enabled | Same |
 | GCP credentials | Service account key (see [GCP credentials](#gcp-credentials) below) | Same |
 | GitHub PAT | Classic PAT with `repo` scope (see [GitHub tokens](#github-tokens) below) | Same |
 
@@ -75,14 +75,16 @@ Env files contain secrets and must never be committed. Keep your env file outsid
 
 ### GCP credentials
 
-Fullsend agents use Claude models via [Vertex AI](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/use-claude). Your GCP project must have:
+Fullsend agents use Claude models via [Agent Platform (Vertex AI)](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/use-claude). Your GCP project must have:
 
 1. The [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled
 2. Claude models enabled in [Model Garden](https://console.cloud.google.com/vertex-ai/model-garden) — search for "Claude" and enable the Anthropic models you need (all agents default to Claude Opus)
 
+> **Cost:** Claude model calls on Agent Platform (Vertex AI) incur per-token charges billed to the GCP project. If you need a new project, request one through your IT team. If using an existing project, contact your GCP project admin to have a service account and key created for you — you may not have the IAM permissions to do this yourself.
+
 In CI, fullsend uses [Workload Identity Federation (WIF)](https://cloud.google.com/iam/docs/workload-identity-federation) — no service account keys are stored. Locally, use a service account key instead.
 
-**Create a service account and key:**
+**Create a service account and key** (requires `roles/iam.serviceAccountAdmin` on the project):
 
 ```bash
 # Create a service account
@@ -90,7 +92,7 @@ gcloud iam service-accounts create fullsend-local \
   --display-name="Fullsend local agent runner" \
   --project=<project-id>
 
-# Grant Vertex AI User role (call Claude models via Vertex AI)
+# Grant Vertex AI User role (call Claude models via Agent Platform)
 gcloud projects add-iam-policy-binding <project-id> \
   --member="serviceAccount:fullsend-local@<project-id>.iam.gserviceaccount.com" \
   --role="roles/aiplatform.user"

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -9,7 +9,7 @@ This guide walks through running fullsend agents on your machine using released 
 | Requirement | macOS | Linux |
 |-------------|-------|-------|
 | Container runtime | Podman Desktop with a running machine | Podman |
-| OpenShell | 0.0.37-dev+ (Podman support) | 0.0.37-dev+ |
+| [OpenShell](https://github.com/NVIDIA/OpenShell) | 0.0.38 | 0.0.38 |
 | GCP credentials | Service account key (`Vertex AI User` role) | Same |
 | GitHub PAT | `repo` scope for the target org | Same |
 
@@ -39,7 +39,28 @@ Verify the installation:
 fullsend version
 ```
 
-## 2. Clone the .fullsend config directory
+## 2. Install OpenShell
+
+[OpenShell](https://github.com/NVIDIA/OpenShell) provides the sandbox runtime. Install the CLI and download the gateway binary:
+
+```bash
+# Install the CLI (requires uv — https://docs.astral.sh/uv/)
+uv tool install openshell==0.0.38
+
+# Verify
+openshell --version
+```
+
+Download the gateway binary from the [OpenShell releases](https://github.com/NVIDIA/OpenShell/releases/tag/v0.0.38) page. Pick the archive matching your platform and extract it:
+
+```bash
+# Example for macOS (Apple Silicon)
+curl -fsSL https://github.com/NVIDIA/OpenShell/releases/download/v0.0.38/openshell-gateway-aarch64-apple-darwin.tar.gz \
+  -o /tmp/openshell-gateway.tar.gz
+tar xzf /tmp/openshell-gateway.tar.gz -C /usr/local/bin/
+```
+
+## 3. Clone the .fullsend config directory
 
 Each organization has a `.fullsend` config repo containing harness definitions, agent prompts, policies, scripts, and skills. Clone it to a local path:
 
@@ -47,7 +68,7 @@ Each organization has a `.fullsend` config repo containing harness definitions, 
 gh repo clone <org>/.fullsend /tmp/fullsend-dot
 ```
 
-## 3. Create an env file
+## 4. Create an env file
 
 Env files contain secrets and must never be committed. Keep your env file outside the repo (e.g. `/tmp/fullsend.env`).
 
@@ -87,7 +108,35 @@ FULLSEND_SANDBOX_IMAGE=ghcr.io/fullsend-ai/fullsend-sandbox:dev
 
 The default `:latest` tag is amd64-only. The `:dev` tag is a multi-arch image that includes arm64 support. On amd64 hosts this line is not needed.
 
-## 4. Run an agent
+## 5. Start the OpenShell gateway
+
+The fullsend CLI requires a running OpenShell gateway — it will not start one automatically. Start the gateway with the Podman driver:
+
+```bash
+openshell-gateway \
+  --bind-address 127.0.0.1 \
+  --drivers podman \
+  --disable-tls \
+  --db-url "sqlite:/tmp/gateway.db?mode=rwc" &
+```
+
+Wait for the health check to pass, then register the gateway:
+
+```bash
+# Wait for gateway to start
+for i in $(seq 1 15); do
+  curl -sf http://127.0.0.1:8080/healthz >/dev/null 2>&1 && break
+  sleep 2
+done
+
+# Register and select the local gateway
+openshell gateway add http://127.0.0.1:8080 --local --name local
+openshell gateway select local
+```
+
+> On macOS, make sure the Podman machine is running (`podman machine start`) before starting the gateway.
+
+## 6. Run an agent
 
 ```bash
 fullsend run <agent> \
@@ -175,14 +224,15 @@ When using a released binary (this guide's workflow), **strategy 2 applies autom
 
 ### Linux
 
-- **Docker socket permissions**: if using Docker instead of Podman, your user must be in the `docker` group or run with `sudo`. Podman runs rootless by default.
+- **Rootless Podman**: Podman runs rootless by default. Ensure your user has subuids/subgids configured (`grep $USER /etc/subuid`). If not, run `sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $USER && podman system migrate`.
 - **SELinux**: on Fedora/RHEL, bind-mounted volumes may need the `:z` suffix for standalone `podman run`. OpenShell handles this automatically.
 
 ## Troubleshooting
 
 **Sandbox creation fails immediately**
 - Check that `podman machine start` has been run (macOS only)
-- Verify OpenShell is installed: `openshell version`
+- Verify OpenShell is installed: `openshell --version`
+- Verify the gateway is running: `openshell gateway list`
 
 **`Syntax error: "(" unexpected` inside sandbox**
 - The macOS Mach-O binary was injected instead of a Linux ELF. Update to fullsend 0.4.0+ which auto-resolves the correct binary, or provide one explicitly with `--fullsend-binary`

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -88,13 +88,14 @@ Each agent requires additional variables via its harness `runner_env`. Add the o
 | Variable | Agent(s) | Description |
 |----------|----------|-------------|
 | `GITHUB_ISSUE_URL` | triage | Full URL of the GitHub issue to triage |
-| `REPO_FULL_NAME` | triage, code, review, fix | `owner/repo` of the target repository |
+| `REPO_FULL_NAME` | code, review, fix | `owner/repo` of the target repository |
 | `ISSUE_NUMBER` | code | Issue number the code agent should implement |
 | `TARGET_BRANCH` | code, fix | Branch to base work on (e.g. `main`) |
 | `PUSH_TOKEN` | code, fix | GitHub token with push access for the post-script |
 | `PR_NUMBER` | review, fix | Pull request number to review or fix |
 | `GITHUB_PR_URL` | review | Full URL of the pull request to review |
 | `REVIEW_TOKEN` | review | GitHub token for posting review comments |
+| `REVIEW_BODY_FILE` | fix | Path to a file containing the review body to fix |
 
 See the harness definitions in `harness/*.yaml` within your `.fullsend` config directory for the complete list per agent.
 
@@ -113,8 +114,14 @@ The default `:latest` tag is amd64-only. The `:dev` tag is a multi-arch image th
 The fullsend CLI requires a running OpenShell gateway — it will not start one automatically. Start the gateway with the Podman driver:
 
 ```bash
+export OPENSHELL_SSH_HANDSHAKE_SECRET="local-$(openssl rand -hex 16)"
+
+# v0.0.38 requires an explicit supervisor image (version-tagged images start at 0.0.41)
+export OPENSHELL_SUPERVISOR_IMAGE="ghcr.io/nvidia/openshell/supervisor:dfd47683e7da4f1a4a8fa5d77f92d3696e6a41f9"
+
 openshell-gateway \
   --bind-address 127.0.0.1 \
+  --health-port 8081 \
   --drivers podman \
   --disable-tls \
   --db-url "sqlite:/tmp/gateway.db?mode=rwc" &
@@ -123,9 +130,9 @@ openshell-gateway \
 Wait for the health check to pass, then register the gateway:
 
 ```bash
-# Wait for gateway to start
+# Health endpoint is on port 8081, API on port 8080
 for i in $(seq 1 15); do
-  curl -sf http://127.0.0.1:8080/healthz >/dev/null 2>&1 && break
+  curl -sf http://127.0.0.1:8081/healthz >/dev/null 2>&1 && break
   sleep 2
 done
 
@@ -233,6 +240,11 @@ When using a released binary (this guide's workflow), **strategy 2 applies autom
 - Check that `podman machine start` has been run (macOS only)
 - Verify OpenShell is installed: `openshell --version`
 - Verify the gateway is running: `openshell gateway list`
+
+**`Gateway not running` or `no openshell gateway running`**
+- Start the gateway as described in step 5
+- Verify it's healthy: `curl -sf http://127.0.0.1:8081/healthz`
+- Check that it's registered: `openshell gateway list`
 
 **`Syntax error: "(" unexpected` inside sandbox**
 - The macOS Mach-O binary was injected instead of a Linux ELF. Update to fullsend 0.4.0+ which auto-resolves the correct binary, or provide one explicitly with `--fullsend-binary`

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -134,6 +134,20 @@ fullsend run fix \
   --env-file /tmp/fullsend.env
 ```
 
+## Testing without side effects
+
+To run agent inference without the post-script (which posts PR comments, pushes branches, or creates PRs), use `--no-post-script`:
+
+```bash
+fullsend run review \
+  --fullsend-dir /tmp/fullsend-dot \
+  --target-repo /path/to/repo \
+  --env-file /tmp/fullsend.env \
+  --no-post-script
+```
+
+The agent runs normally inside the sandbox, but the post-script is skipped. This means `PUSH_TOKEN` and `REVIEW_TOKEN` are not needed in your env file — only the core variables (`GH_TOKEN`, GCP credentials) are required.
+
 ## Cross-platform binary resolution
 
 The pre-agent security scan runs `fullsend scan context` inside the Linux sandbox. This requires a Linux binary, even when your host is macOS.


### PR DESCRIPTION
## Summary

- New user guide (`docs/guides/user/running-agents-locally.md`) covering the full workflow for running fullsend agents on macOS and Linux using released binaries — no Go toolchain or source checkout needed
- Covers: downloading the CLI from GitHub Releases, cloning the `.fullsend` config directory, creating env files with per-agent variables, running each agent type (triage, review, code, fix), cross-platform binary resolution, platform notes, and troubleshooting
- Adds entry to `docs/guides/README.md` under User guides

Split out from #662 to keep the feature PR focused on the code change.

## Test plan

- [x] Verified all internal links resolve (`local-dev.md`, GitHub Releases URL)
- [x] Verified `docs/guides/README.md` entry renders correctly
- [x] No code changes — docs only