### PR TITLE
docs: ADR 0031 — reusable workflows for action-installed distribution

### DIFF
--- a/docs/ADRs/0030-reusable-workflows-for-action-installed-distribution.md
+++ b/docs/ADRs/0030-reusable-workflows-for-action-installed-distribution.md
@@ -22,10 +22,11 @@ Proposed
 
 `fullsend admin install` copies ~60 files from the Go binary's embedded scaffold
 (`internal/scaffold/fullsend-repo/`) into each org's `.fullsend` repo. This
-includes agent workflows (78–305 lines each), a composite action, setup
-scripts, and a dispatcher. When a bug is fixed or a security patch lands in the
-scaffold, every org must re-run `fullsend admin install` to pick up the change.
-Workflow drift across orgs is the norm.
+includes agent workflows (78–305 lines each), four composite actions (`fullsend`,
+`mint-token`, `validate-enrollment`, `setup-gcp`), setup scripts, and a
+dispatcher. When a bug is fixed or a security patch lands in the scaffold, every
+org must re-run `fullsend admin install` to pick up the change. Workflow drift
+across orgs is the norm.
 
 The dispatch chain established in
 [ADR 0026](0026-stage-based-dispatch-for-agent-workflow-decoupling.md) —
@@ -39,16 +40,16 @@ workflows themselves change from full copies to thin callers.
 `fullsend admin install` writes full agent workflows into `.fullsend`. Each org
 gets its own copy. Updates require re-running install in every org.
 
-### Option B: Published composite action only
+### Option B: Published composite actions only
 
-Publish the composite action at `fullsend-ai/fullsend@v1`. Agent workflows in
-`.fullsend` replace `uses: ./.github/actions/fullsend` with the published
-reference. Infrastructure logic (checkout, token generation, GCP auth, sandbox
-setup) stays duplicated in each org's workflow files.
+Publish the four composite actions at `fullsend-ai/fullsend@v1`. Agent workflows
+in `.fullsend` replace `uses: ./.github/actions/*` with published references.
+Infrastructure logic (checkout, token minting, GCP auth, sandbox setup) stays
+duplicated in each org's workflow files.
 
-### Option C: Reusable workflows + published composite action
+### Option C: Reusable workflows + published composite actions
 
-Publish reusable workflows (`workflow_call`) and a root composite action from
+Publish reusable workflows (`workflow_call`) and composite actions from
 `fullsend-ai/fullsend`. Agent workflows in `.fullsend` shrink to ~20 line thin
 callers that delegate infrastructure logic upstream via `workflow_call` with
 `secrets: inherit`. Org-specific content (agents, harness, env, policies,
@@ -57,20 +58,26 @@ scripts) stays local.
 ## Decision
 
 Use Option C. Publish reusable workflows
-(`fullsend-ai/fullsend/.github/workflows/reusable-{agent}.yml`) and a root
-composite action (`fullsend-ai/fullsend@v1`).
+(`fullsend-ai/fullsend/.github/workflows/reusable-{agent}.yml`) and composite
+actions (`fullsend-ai/fullsend@v1`, plus `mint-token`, `validate-enrollment`,
+`setup-gcp` under `.github/actions/`).
 
 Thin callers in `.fullsend` use `workflow_call` to invoke upstream reusable
 workflows. Since `workflow_call` runs the callee in the caller's repo context,
 the reusable workflow has access to `.fullsend` secrets and checks out the
 config repo directly. Secrets pass via `secrets: inherit`. Org-specific `vars.*`
-values (client IDs, GCP region, auth mode) are automatically available in the
+values (mint URL, GCP region, auth mode) are automatically available in the
 reusable workflow from the caller's context, but thin callers pass them as
 explicit `inputs.*` to make the interface contract self-documenting, ensure
 missing variables surface visibly with org-appropriate defaults, and provide an
 auditable manifest of configuration flowing across the trust boundary. Each
 reusable workflow also declares agent-specific inputs (e.g., `trigger_source`,
 `pr_number`, `instruction` for the fix workflow) beyond the common set.
+
+Composite actions referenced via `uses: ./` in reusable workflows resolve to the
+upstream repo (`fullsend-ai/fullsend`), not the caller's repo. This is why the
+four composite actions must live upstream. `run:` steps execute in the caller's
+workspace, so scripts in `.fullsend/scripts/` remain accessible.
 
 `dispatch.yml` stays unchanged — thin callers retain `# fullsend-stage:`
 markers, so stage-based dispatch
@@ -88,9 +95,9 @@ shim ──workflow_dispatch──> .fullsend/dispatch.yml
 
 ## Consequences
 
-- Infrastructure patches (checkout, token generation, GCP auth, sandbox setup)
-  ship once upstream and propagate to all orgs on next workflow run — no
-  re-install required.
+- Infrastructure patches (token minting, GCP auth, sandbox setup) ship once
+  upstream and propagate to all orgs on next workflow run — no re-install
+  required.
 - `fullsend-ai/fullsend` must remain public for `workflow_call` and `uses:`
   references to resolve (it already is).
 - Thin callers map `vars.*` to explicit `inputs.*` even though `vars` are
@@ -99,7 +106,8 @@ shim ──workflow_dispatch──> .fullsend/dispatch.yml
   missing variables with explicit defaults instead of silent empty strings,
   and creates a natural review checkpoint when the upstream interface changes.
 - Thin callers pin upstream by tag (`@v1`) or SHA — orgs control when they
-  adopt upstream changes.
+  adopt upstream changes. SHA pinning recommended for production since tags
+  are mutable.
 - Stage-based dispatch ([ADR 0026](0026-stage-based-dispatch-for-agent-workflow-decoupling.md)),
   shim workflows, and org-specific content (agents, harness, policies, scripts)
   are unchanged.

--- a/docs/ADRs/0030-reusable-workflows-for-action-installed-distribution.md
+++ b/docs/ADRs/0030-reusable-workflows-for-action-installed-distribution.md
@@ -123,7 +123,7 @@ shim ──workflow_dispatch──> .fullsend/dispatch.yml
   inline, which partially mitigates this.
 - **GitHub-specific mechanism:** `workflow_call` and `secrets: inherit` are
   GitHub Actions primitives with no direct equivalent in other CI systems.
-  Multi-forge support (ADR 0028, [PR #601](https://github.com/fullsend-ai/fullsend/pull/601)) will need its own
+  Multi-forge support ([ADR 0028](0028-gitlab-support.md)) will need its own
   distribution mechanism (e.g., GitLab CI/CD Components or `include:`)
   independent of this ADR.
 - **Scaffold output changes:** `fullsend admin install` will emit thin callers

--- a/docs/ADRs/0030-reusable-workflows-for-action-installed-distribution.md
+++ b/docs/ADRs/0030-reusable-workflows-for-action-installed-distribution.md
@@ -20,9 +20,9 @@ Proposed
 
 ## Context
 
-`fullsend admin install` copies ~50 files from the Go binary's embedded scaffold
+`fullsend admin install` copies ~60 files from the Go binary's embedded scaffold
 (`internal/scaffold/fullsend-repo/`) into each org's `.fullsend` repo. This
-includes agent workflows (125–354 lines each), a composite action, setup
+includes agent workflows (78–305 lines each), a composite action, setup
 scripts, and a dispatcher. When a bug is fixed or a security patch lands in the
 scaffold, every org must re-run `fullsend admin install` to pick up the change.
 Workflow drift across orgs is the norm.
@@ -127,7 +127,7 @@ shim ──workflow_dispatch──> .fullsend/dispatch.yml
   distribution mechanism (e.g., GitLab CI/CD Components or `include:`)
   independent of this ADR.
 - **Scaffold output changes:** `fullsend admin install` will emit thin callers
-  (~20 lines each) instead of full agent workflows (125–354 lines each). This
+  (~20 lines each) instead of full agent workflows (78–305 lines each). This
   is a user-visible change — orgs running `admin install` after this change
   ships will see substantially different workflow files in `.fullsend`.
 - **Token generation is transitional:** The initial reusable workflows use

--- a/docs/ADRs/0030-reusable-workflows-for-action-installed-distribution.md
+++ b/docs/ADRs/0030-reusable-workflows-for-action-installed-distribution.md
@@ -1,0 +1,97 @@
+---
+title: "0030. Reusable workflows for action-installed distribution"
+status: Proposed
+relates_to:
+  - agent-infrastructure
+topics:
+  - workflows
+  - distribution
+  - reusable-workflows
+  - composite-action
+---
+
+# 0030. Reusable workflows for action-installed distribution
+
+Date: 2026-05-06
+
+## Status
+
+Proposed
+
+## Context
+
+`fullsend admin install` copies ~30 files from the Go binary's embedded scaffold
+(`internal/scaffold/fullsend-repo/`) into each org's `.fullsend` repo. This
+includes full 100–160 line agent workflows, a composite action, setup scripts,
+and a dispatcher. When a bug is fixed or a security patch lands in the scaffold,
+every org must re-run `fullsend admin install` to pick up the change. Workflow
+drift across orgs is the norm.
+
+The dispatch chain established in
+[ADR 0026](0026-stage-based-dispatch-for-agent-workflow-decoupling.md) —
+shim → `dispatch.yml` → agent workflows — is preserved. Only the agent
+workflows themselves change from full copies to thin callers.
+
+## Options
+
+### Option A: Scaffold copies (status quo)
+
+`fullsend admin install` writes full agent workflows into `.fullsend`. Each org
+gets its own copy. Updates require re-running install in every org.
+
+### Option B: Published composite action only
+
+Publish the composite action at `fullsend-ai/fullsend@v1`. Agent workflows in
+`.fullsend` replace `uses: ./.github/actions/fullsend` with the published
+reference. Infrastructure logic (checkout, token generation, GCP auth, sandbox
+setup) stays duplicated in each org's workflow files.
+
+### Option C: Reusable workflows + published composite action
+
+Publish reusable workflows (`workflow_call`) and a root composite action from
+`fullsend-ai/fullsend`. Agent workflows in `.fullsend` shrink to ~20 line thin
+callers that delegate infrastructure logic upstream via `workflow_call` with
+`secrets: inherit`. Org-specific content (agents, harness, env, policies,
+scripts) stays local.
+
+## Decision
+
+Use Option C. Publish reusable workflows
+(`fullsend-ai/fullsend/.github/workflows/reusable-{agent}.yml`) and a root
+composite action (`fullsend-ai/fullsend@v1`).
+
+Thin callers in `.fullsend` use `workflow_call` to invoke upstream reusable
+workflows. Since `workflow_call` runs the callee in the caller's repo context,
+the reusable workflow has access to `.fullsend` secrets and checks out the
+config repo directly. Secrets pass via `secrets: inherit`. Org-specific `vars.*`
+values (client IDs, GCP region, auth mode) pass as explicit `inputs.*` because
+`vars` do not cross the `workflow_call` boundary.
+
+`dispatch.yml` stays unchanged — thin callers retain `# fullsend-stage:`
+markers, so stage-based dispatch
+([ADR 0026](0026-stage-based-dispatch-for-agent-workflow-decoupling.md))
+continues to work without modification.
+
+The dispatch chain uses 1 level of `workflow_call` nesting (limit is 4):
+
+```
+shim ──workflow_dispatch──> .fullsend/dispatch.yml
+        ──workflow_dispatch──> .fullsend/code.yml (thin caller)
+            ──workflow_call──> reusable-code.yml (level 1)
+                ──uses──> fullsend-ai/fullsend@v1 (composite action)
+```
+
+## Consequences
+
+- Infrastructure patches (checkout, token generation, GCP auth, sandbox setup)
+  ship once upstream and propagate to all orgs on next workflow run — no
+  re-install required.
+- `fullsend-ai/fullsend` must remain public for `workflow_call` and `uses:`
+  references to resolve (it already is).
+- Each org must map `vars.*` to explicit `inputs.*` in thin callers, since
+  `vars` do not cross the `workflow_call` boundary.
+- Thin callers pin upstream by tag (`@v1`) or SHA — orgs control when they
+  adopt upstream changes.
+- Stage-based dispatch ([ADR 0026](0026-stage-based-dispatch-for-agent-workflow-decoupling.md)),
+  shim workflows, and org-specific content (agents, harness, policies, scripts)
+  are unchanged.

--- a/docs/ADRs/0030-reusable-workflows-for-action-installed-distribution.md
+++ b/docs/ADRs/0030-reusable-workflows-for-action-installed-distribution.md
@@ -64,15 +64,20 @@ Thin callers in `.fullsend` use `workflow_call` to invoke upstream reusable
 workflows. Since `workflow_call` runs the callee in the caller's repo context,
 the reusable workflow has access to `.fullsend` secrets and checks out the
 config repo directly. Secrets pass via `secrets: inherit`. Org-specific `vars.*`
-values (client IDs, GCP region, auth mode) pass as explicit `inputs.*` because
-`vars` do not cross the `workflow_call` boundary.
+values (client IDs, GCP region, auth mode) are automatically available in the
+reusable workflow from the caller's context, but thin callers pass them as
+explicit `inputs.*` to make the interface contract self-documenting, ensure
+missing variables surface visibly with org-appropriate defaults, and provide an
+auditable manifest of configuration flowing across the trust boundary. Each
+reusable workflow also declares agent-specific inputs (e.g., `trigger_source`,
+`pr_number`, `instruction` for the fix workflow) beyond the common set.
 
 `dispatch.yml` stays unchanged — thin callers retain `# fullsend-stage:`
 markers, so stage-based dispatch
 ([ADR 0026](0026-stage-based-dispatch-for-agent-workflow-decoupling.md))
 continues to work without modification.
 
-The dispatch chain uses 1 level of `workflow_call` nesting (limit is 4):
+The dispatch chain uses 1 level of `workflow_call` nesting (limit is 10):
 
 ```
 shim ──workflow_dispatch──> .fullsend/dispatch.yml
@@ -88,8 +93,11 @@ shim ──workflow_dispatch──> .fullsend/dispatch.yml
   re-install required.
 - `fullsend-ai/fullsend` must remain public for `workflow_call` and `uses:`
   references to resolve (it already is).
-- Each org must map `vars.*` to explicit `inputs.*` in thin callers, since
-  `vars` do not cross the `workflow_call` boundary.
+- Thin callers map `vars.*` to explicit `inputs.*` even though `vars` are
+  automatically available from the caller's context. This makes the reusable
+  workflow's parameter contract visible in the caller's YAML, surfaces
+  missing variables with explicit defaults instead of silent empty strings,
+  and creates a natural review checkpoint when the upstream interface changes.
 - Thin callers pin upstream by tag (`@v1`) or SHA — orgs control when they
   adopt upstream changes.
 - Stage-based dispatch ([ADR 0026](0026-stage-based-dispatch-for-agent-workflow-decoupling.md)),
@@ -118,3 +126,13 @@ shim ──workflow_dispatch──> .fullsend/dispatch.yml
   Multi-forge support (ADR 0028, [PR #601](https://github.com/fullsend-ai/fullsend/pull/601)) will need its own
   distribution mechanism (e.g., GitLab CI/CD Components or `include:`)
   independent of this ADR.
+- **Scaffold output changes:** `fullsend admin install` will emit thin callers
+  (~20 lines each) instead of full agent workflows (125–354 lines each). This
+  is a user-visible change — orgs running `admin install` after this change
+  ships will see substantially different workflow files in `.fullsend`.
+- **Token generation is transitional:** The initial reusable workflows use
+  PEM-based token generation via `actions/create-github-app-token` with
+  secrets passed through `secrets: inherit`. The token mint migration
+  ([PR #655](https://github.com/fullsend-ai/fullsend/pull/655)) will replace
+  this with OIDC-based minting, changing the internal token generation
+  mechanism within the reusable workflows but not the thin caller interface.

--- a/docs/ADRs/0030-reusable-workflows-for-action-installed-distribution.md
+++ b/docs/ADRs/0030-reusable-workflows-for-action-installed-distribution.md
@@ -1,5 +1,5 @@
 ---
-title: "0030. Reusable workflows for action-installed distribution"
+title: "30. Reusable workflows for action-installed distribution"
 status: Proposed
 relates_to:
   - agent-infrastructure
@@ -10,7 +10,7 @@ topics:
   - composite-action
 ---
 
-# 0030. Reusable workflows for action-installed distribution
+# 30. Reusable workflows for action-installed distribution
 
 Date: 2026-05-06
 
@@ -20,12 +20,12 @@ Proposed
 
 ## Context
 
-`fullsend admin install` copies ~30 files from the Go binary's embedded scaffold
+`fullsend admin install` copies ~50 files from the Go binary's embedded scaffold
 (`internal/scaffold/fullsend-repo/`) into each org's `.fullsend` repo. This
-includes full 100–160 line agent workflows, a composite action, setup scripts,
-and a dispatcher. When a bug is fixed or a security patch lands in the scaffold,
-every org must re-run `fullsend admin install` to pick up the change. Workflow
-drift across orgs is the norm.
+includes agent workflows (125–354 lines each), a composite action, setup
+scripts, and a dispatcher. When a bug is fixed or a security patch lands in the
+scaffold, every org must re-run `fullsend admin install` to pick up the change.
+Workflow drift across orgs is the norm.
 
 The dispatch chain established in
 [ADR 0026](0026-stage-based-dispatch-for-agent-workflow-decoupling.md) —
@@ -95,3 +95,26 @@ shim ──workflow_dispatch──> .fullsend/dispatch.yml
 - Stage-based dispatch ([ADR 0026](0026-stage-based-dispatch-for-agent-workflow-decoupling.md)),
   shim workflows, and org-specific content (agents, harness, policies, scripts)
   are unchanged.
+- **Trust boundary shift:** `secrets: inherit` passes all caller secrets to
+  reusable workflow code hosted in `fullsend-ai/fullsend` (a public repo).
+  Under the scaffold-copy model, secrets are consumed by code in the org's
+  own repo. Under the reusable-workflow model, secrets flow to upstream code.
+  SHA pinning (not just tag pinning) gives orgs full control over which
+  upstream code runs with their secrets. This aligns with the project's
+  threat model priority on external injection — a compromised upstream ref
+  could affect all downstream orgs simultaneously, making SHA pinning the
+  recommended default for production installations.
+- **Upstream availability:** `fullsend-ai/fullsend` becomes a runtime
+  dependency for all downstream orgs. If the repo is unavailable or a pinned
+  ref is deleted, downstream workflow runs fail. Scaffold copies are immune
+  to upstream outages after install.
+- **Cross-repo debugging:** When reusable workflows fail, the call stack spans
+  two repositories (the org's `.fullsend` and `fullsend-ai/fullsend`).
+  Developers must inspect both the thin caller and the upstream workflow to
+  diagnose failures. GitHub's workflow run UI shows reusable workflow steps
+  inline, which partially mitigates this.
+- **GitHub-specific mechanism:** `workflow_call` and `secrets: inherit` are
+  GitHub Actions primitives with no direct equivalent in other CI systems.
+  Multi-forge support (ADR 0028, [PR #601](https://github.com/fullsend-ai/fullsend/pull/601)) will need its own
+  distribution mechanism (e.g., GitLab CI/CD Components or `include:`)
+  independent of this ADR.

--- a/docs/ADRs/0031-reusable-workflows-for-action-installed-distribution.md
+++ b/docs/ADRs/0031-reusable-workflows-for-action-installed-distribution.md
@@ -1,5 +1,5 @@
 ---
-title: "30. Reusable workflows for action-installed distribution"
+title: "31. Reusable workflows for action-installed distribution"
 status: Proposed
 relates_to:
   - agent-infrastructure
@@ -10,7 +10,7 @@ topics:
   - composite-action
 ---
 
-# 30. Reusable workflows for action-installed distribution
+# 31. Reusable workflows for action-installed distribution
 
 Date: 2026-05-06
 

--- a/docs/ADRs/0031-reusable-workflows-for-action-installed-distribution.md
+++ b/docs/ADRs/0031-reusable-workflows-for-action-installed-distribution.md
@@ -20,7 +20,7 @@ Proposed
 
 ## Context
 
-`fullsend admin install` copies ~60 files from the Go binary's embedded scaffold
+`fullsend admin install` copies ~80 files from the Go binary's embedded scaffold
 (`internal/scaffold/fullsend-repo/`) into each org's `.fullsend` repo. This
 includes agent workflows (78–305 lines each), four composite actions (`fullsend`,
 `mint-token`, `validate-enrollment`, `setup-gcp`), setup scripts, and a
@@ -50,9 +50,9 @@ duplicated in each org's workflow files.
 ### Option C: Reusable workflows + published composite actions
 
 Publish reusable workflows (`workflow_call`) and composite actions from
-`fullsend-ai/fullsend`. Agent workflows in `.fullsend` shrink to ~20 line thin
+`fullsend-ai/fullsend`. Agent workflows in `.fullsend` shrink to ~40 line thin
 callers that delegate infrastructure logic upstream via `workflow_call` with
-`secrets: inherit`. Org-specific content (agents, harness, env, policies,
+explicit secret passthrough. Org-specific content (agents, harness, env, policies,
 scripts) stays local.
 
 ## Decision
@@ -65,7 +65,9 @@ actions (`fullsend-ai/fullsend@v1`, plus `mint-token`, `validate-enrollment`,
 Thin callers in `.fullsend` use `workflow_call` to invoke upstream reusable
 workflows. Since `workflow_call` runs the callee in the caller's repo context,
 the reusable workflow has access to `.fullsend` secrets and checks out the
-config repo directly. Secrets pass via `secrets: inherit`. Org-specific `vars.*`
+config repo directly. Secrets pass via explicit `secrets:` declarations — each
+thin caller lists only the secrets the reusable workflow needs (GCP credentials),
+following least-privilege over blanket `secrets: inherit`. Org-specific `vars.*`
 values (mint URL, GCP region, auth mode) are automatically available in the
 reusable workflow from the caller's context, but thin callers pass them as
 explicit `inputs.*` to make the interface contract self-documenting, ensure
@@ -84,7 +86,7 @@ markers, so stage-based dispatch
 ([ADR 0026](0026-stage-based-dispatch-for-agent-workflow-decoupling.md))
 continues to work without modification.
 
-The dispatch chain uses 1 level of `workflow_call` nesting (limit is 10):
+The dispatch chain uses 1 level of `workflow_call` nesting (limit is 4):
 
 ```
 shim ──workflow_dispatch──> .fullsend/dispatch.yml
@@ -111,15 +113,17 @@ shim ──workflow_dispatch──> .fullsend/dispatch.yml
 - Stage-based dispatch ([ADR 0026](0026-stage-based-dispatch-for-agent-workflow-decoupling.md)),
   shim workflows, and org-specific content (agents, harness, policies, scripts)
   are unchanged.
-- **Trust boundary shift:** `secrets: inherit` passes all caller secrets to
-  reusable workflow code hosted in `fullsend-ai/fullsend` (a public repo).
-  Under the scaffold-copy model, secrets are consumed by code in the org's
-  own repo. Under the reusable-workflow model, secrets flow to upstream code.
-  SHA pinning (not just tag pinning) gives orgs full control over which
-  upstream code runs with their secrets. This aligns with the project's
-  threat model priority on external injection — a compromised upstream ref
-  could affect all downstream orgs simultaneously, making SHA pinning the
-  recommended default for production installations.
+- **Trust boundary shift:** Thin callers pass GCP credential secrets to
+  reusable workflow code hosted in `fullsend-ai/fullsend` (a public repo)
+  via explicit `secrets:` declarations (not `secrets: inherit`, limiting
+  exposure to only the secrets the reusable workflow declares). Under the
+  scaffold-copy model, secrets are consumed by code in the org's own repo.
+  Under the reusable-workflow model, secrets flow to upstream code. SHA
+  pinning (not just tag pinning) gives orgs full control over which upstream
+  code runs with their secrets. This aligns with the project's threat model
+  priority on external injection — a compromised upstream ref could affect
+  all downstream orgs simultaneously, making SHA pinning the recommended
+  default for production installations.
 - **Upstream availability:** `fullsend-ai/fullsend` becomes a runtime
   dependency for all downstream orgs. If the repo is unavailable or a pinned
   ref is deleted, downstream workflow runs fail. Scaffold copies are immune
@@ -129,18 +133,17 @@ shim ──workflow_dispatch──> .fullsend/dispatch.yml
   Developers must inspect both the thin caller and the upstream workflow to
   diagnose failures. GitHub's workflow run UI shows reusable workflow steps
   inline, which partially mitigates this.
-- **GitHub-specific mechanism:** `workflow_call` and `secrets: inherit` are
+- **GitHub-specific mechanism:** `workflow_call` and `secrets:` passthrough are
   GitHub Actions primitives with no direct equivalent in other CI systems.
   Multi-forge support ([ADR 0028](0028-gitlab-support.md)) will need its own
   distribution mechanism (e.g., GitLab CI/CD Components or `include:`)
   independent of this ADR.
 - **Scaffold output changes:** `fullsend admin install` will emit thin callers
-  (~20 lines each) instead of full agent workflows (78–305 lines each). This
+  (~40 lines each) instead of full agent workflows (78–305 lines each). This
   is a user-visible change — orgs running `admin install` after this change
   ships will see substantially different workflow files in `.fullsend`.
-- **Token generation is transitional:** The initial reusable workflows use
-  PEM-based token generation via `actions/create-github-app-token` with
-  secrets passed through `secrets: inherit`. The token mint migration
-  ([PR #655](https://github.com/fullsend-ai/fullsend/pull/655)) will replace
-  this with OIDC-based minting, changing the internal token generation
-  mechanism within the reusable workflows but not the thin caller interface.
+- **Token generation uses OIDC:** Reusable workflows use the `mint-token`
+  composite action for OIDC-based token minting
+  ([ADR 0029](0029-central-token-mint-secretless-fullsend.md)). Each
+  reusable workflow requests a scoped token for its role (triage, coder,
+  review, fix) — no PEMs or App secrets in the calling repo.


### PR DESCRIPTION
## Summary

- Proposes publishing reusable workflows (`workflow_call`) and a root composite action from `fullsend-ai/fullsend`
- Org `.fullsend` repos shrink from 100-160 line scaffold copies to ~20 line thin callers with `secrets: inherit`
- Eliminates cross-org workflow drift — infrastructure patches ship once upstream
- Preserves ADR 0026 stage-based dispatch, shim workflows, and org-specific content unchanged
- `vars.*` mapped to explicit `inputs.*` since vars don't cross `workflow_call` boundary

## Context

Today `fullsend admin install` copies full agent workflows into each org's `.fullsend` repo. When a bug fix or security patch lands in the scaffold, every org must re-run install to pick up the change. This ADR proposes the distribution model change; implementation follows in subsequent PRs.

## Test plan

- [ ] Team reviews ADR for completeness and feasibility
- [ ] Verify `workflow_call` context semantics match assumptions (callee runs in caller's repo context)
- [ ] Validate `secrets: inherit` passes all required secrets without explicit mapping