### PR TITLE
Simplify install enrollment UX to all-or-none choice

### DIFF
--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -130,6 +130,10 @@ gcloud iam service-accounts keys create sa-key.json \
 
 The installer is interactive. It will open multiple browser windows to create and install a GitHub App for each agent role. Follow the prompts in each window to complete the app setup.
 
+During installation, you'll be prompted to choose repository enrollment:
+- **[a] Enroll all repositories** — immediately enrolls all org repos (excluding `.fullsend`)
+- **[n] Enroll no repositories** — skip enrollment during install; enroll repositories later
+
 Near the end, the installer opens a browser to create a fine-grained personal access token (dispatch token). When creating it, make sure to grant **Actions: Read and write** permission scoped to the `.fullsend` repository — otherwise the verification step will fail with a 404.
 
 If the installer fails partway through, run `fullsend admin uninstall "$ORG_NAME"` to clean up before retrying. The uninstall preflight will prompt you to add the `delete_repo` scope if it is missing.
@@ -137,10 +141,7 @@ If the installer fails partway through, run `fullsend admin uninstall "$ORG_NAME
 **With WIF (recommended):**
 
 ```bash
-export REPO_NAME="<repo-name>"
-
 fullsend admin install "$ORG_NAME" \
-  --repo "$REPO_NAME" \
   --gcp-project "$GCP_PROJECT" \
   --gcp-region global \
   --gcp-wif-provider "$WIF_PROVIDER" \
@@ -150,10 +151,7 @@ fullsend admin install "$ORG_NAME" \
 **With SA key (legacy):**
 
 ```bash
-export REPO_NAME="<repo-name>"
-
 fullsend admin install "$ORG_NAME" \
-  --repo "$REPO_NAME" \
   --gcp-project "$GCP_PROJECT" \
   --gcp-region global \
   --gcp-credentials-file sa-key.json
@@ -168,7 +166,6 @@ If you already have fullsend installed with a service account key:
 2. Re-run the installer with WIF flags (the installer updates secrets in-place):
    ```bash
    fullsend admin install "$ORG_NAME" \
-     --repo "$REPO_NAME" \
      --skip-app-setup \
      --gcp-project "$GCP_PROJECT" \
      --gcp-region global \
@@ -179,11 +176,9 @@ If you already have fullsend installed with a service account key:
 4. Delete the old SA key: `gcloud iam service-accounts keys delete <KEY_ID> --iam-account=...`
 5. Remove the `FULLSEND_GCP_SA_KEY_JSON` secret from the `.fullsend` repo settings
 
-**Note**: the `--repo` flag can be repeated to onboard multiple repositories.
-
 ## 3. Merge enrollment PRs
 
-After install completes, the installer dispatches a workflow that creates an enrollment PR in each repo passed via `--repo`. These PRs add a shim workflow (`.github/workflows/fullsend.yaml`) that wires events to the agent pipeline.
+If you chose to enroll repositories during install, the installer dispatches a workflow that creates an enrollment PR in each enrolled repo. These PRs add a shim workflow (`.github/workflows/fullsend.yaml`) that wires events to the agent pipeline.
 
 Review and merge each enrollment PR to complete enrollment.
 

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -132,7 +132,7 @@ The installer is interactive. It will open multiple browser windows to create an
 
 During installation, you'll be prompted to choose repository enrollment:
 - **[a] Enroll all repositories** — immediately enrolls all org repos (excluding `.fullsend`)
-- **[n] Enroll no repositories** — skip enrollment during install; enroll repositories later
+- **[n] Enroll no repositories** — skip enrollment during install; enroll repositories later using `fullsend admin enable repos`
 
 Near the end, the installer opens a browser to create a fine-grained personal access token (dispatch token). When creating it, make sure to grant **Actions: Read and write** permission scoped to the `.fullsend` repository — otherwise the verification step will fail with a 404.
 

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -90,6 +90,8 @@ func newInstallCmd() *cobra.Command {
 	var dryRun bool
 	var skipAppSetup bool
 	var vendorBinary bool
+	var enrollAllFlag bool
+	var enrollNoneFlag bool
 	var gcpProject string
 	var gcpRegion string
 	var gcpServiceAccount string
@@ -186,10 +188,23 @@ func newInstallCmd() *cobra.Command {
 				inferenceProviderName = loadExistingInferenceProvider(ctx, client, org)
 			}
 
-			// Prompt for enrollment choice: all or none.
-			enrollAll, err := promptEnrollment(printer, os.Stdin)
-			if err != nil {
-				return err
+			// Validate enrollment flags.
+			if enrollAllFlag && enrollNoneFlag {
+				return fmt.Errorf("--enroll-all and --enroll-none are mutually exclusive")
+			}
+
+			// Determine enrollment choice: use flag if set, otherwise prompt.
+			var enrollAll bool
+			if enrollAllFlag {
+				enrollAll = true
+			} else if enrollNoneFlag {
+				enrollAll = false
+			} else {
+				// Prompt for enrollment choice: all or none.
+				enrollAll, err = promptEnrollment(printer, os.Stdin)
+				if err != nil {
+					return err
+				}
 			}
 
 			var repos []string
@@ -209,7 +224,7 @@ func newInstallCmd() *cobra.Command {
 				printer.StepInfo(fmt.Sprintf("Enrolling all %d repositories (excluding %s)", len(repos), forge.ConfigRepoName))
 			} else {
 				printer.StepInfo("No repositories will be enrolled during install")
-				printer.StepInfo(fmt.Sprintf("To enroll repositories later, use:"))
+				printer.StepInfo("To enroll repositories later, use:")
 				printer.StepInfo(fmt.Sprintf("  fullsend admin enable repos %s <repo-name> [repo-name...]", org))
 				printer.StepInfo(fmt.Sprintf("  fullsend admin enable repos %s --all", org))
 			}
@@ -240,6 +255,8 @@ func newInstallCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview changes without making them")
 	cmd.Flags().BoolVar(&skipAppSetup, "skip-app-setup", false, "skip GitHub App creation/setup")
 	cmd.Flags().BoolVar(&vendorBinary, "vendor-fullsend-binary", false, "cross-compile and upload the fullsend binary into .fullsend/bin/ for development iteration")
+	cmd.Flags().BoolVar(&enrollAllFlag, "enroll-all", false, "enroll all repositories without prompting")
+	cmd.Flags().BoolVar(&enrollNoneFlag, "enroll-none", false, "skip repository enrollment without prompting")
 	cmd.Flags().StringVar(&gcpProject, "gcp-project", "", "GCP project ID for Vertex AI inference")
 	cmd.Flags().StringVar(&gcpRegion, "gcp-region", "", "GCP region for Vertex AI (e.g. global, required with --gcp-project)")
 	cmd.Flags().StringVar(&gcpServiceAccount, "gcp-service-account", "", "existing GCP service account name (optional, used with --gcp-project)")
@@ -508,7 +525,7 @@ func ensureConfigRepoExists(ctx context.Context, client forge.Client, printer *u
 // validateEnabledRepos checks that every enabled repository exists in the
 // discovered (eligible) repo list. Repos filtered out by ListOrgRepos
 // (forks, archived) will not appear in discoveredNames, so this catches
-// the case where a user targets a fork or archived repo.
+// the case where an enabled repo is a fork or archived.
 //
 // This validation exists because fullsend's trust model is org-centric:
 // forks may live outside the org's permission boundary or lack the same

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -224,7 +224,7 @@ func newInstallCmd() *cobra.Command {
 				printer.StepInfo(fmt.Sprintf("Enrolling all %d repositories (excluding %s)", len(repos), forge.ConfigRepoName))
 			} else {
 				printer.StepInfo("No repositories will be enrolled during install")
-				printer.StepInfo(fmt.Sprintf("To enroll repositories later, use: fullsend admin repos enable %s <repo-name> or --all", org))
+				printer.StepInfo(fmt.Sprintf("To enroll repositories later, use: fullsend admin enable repos %s <repo-name> or --all", org))
 			}
 			printer.Blank()
 
@@ -922,7 +922,7 @@ func promptEnrollment(printer *ui.Printer, in io.Reader) (bool, error) {
 	printer.Blank()
 	printer.StepInfo("Choose repository enrollment:")
 	printer.StepInfo("  [a] Enroll all repositories (excluding .fullsend)")
-	printer.StepInfo("  [n] Enroll no repositories (configure later with 'fullsend admin repos enable')")
+	printer.StepInfo("  [n] Enroll no repositories (configure later with 'fullsend admin enable repos')")
 	printer.Blank()
 
 	reader := bufio.NewReader(in)

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -224,7 +224,7 @@ func newInstallCmd() *cobra.Command {
 				printer.StepInfo(fmt.Sprintf("Enrolling all %d repositories (excluding %s)", len(repos), forge.ConfigRepoName))
 			} else {
 				printer.StepInfo("No repositories will be enrolled during install")
-				printer.StepInfo(fmt.Sprintf("To enroll repositories later, use: fullsend admin enable repos %s <repo-name> or --all", org))
+				printer.StepInfo(fmt.Sprintf("To enroll repositories later, use: fullsend admin repos enable %s <repo-name> or --all", org))
 			}
 			printer.Blank()
 
@@ -491,7 +491,7 @@ func ensureConfigRepoExists(ctx context.Context, client forge.Client, printer *u
 	return nil
 }
 
-// validateEnabledRepos checks that every --repo value exists in the
+// validateEnabledRepos checks that every enabled repository exists in the
 // discovered (eligible) repo list. Repos filtered out by ListOrgRepos
 // (forks, archived) will not appear in discoveredNames, so this catches
 // the case where a user targets a fork or archived repo.
@@ -536,7 +536,7 @@ func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, o
 	printer.StepDone(fmt.Sprintf("Found %d repositories", len(allRepos)))
 	printer.Blank()
 
-	// Validate that every --repo value matches a discovered repo.
+	// Validate that every enabled repository matches a discovered repo.
 	if err := validateEnabledRepos(enabledRepos, repoNames); err != nil {
 		return err
 	}

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -85,7 +85,6 @@ func validateOrgName(org string) error {
 }
 
 func newInstallCmd() *cobra.Command {
-	var repos []string
 	var agents string
 	var dryRun bool
 	var skipAppSetup bool
@@ -186,10 +185,6 @@ func newInstallCmd() *cobra.Command {
 				inferenceProviderName = loadExistingInferenceProvider(ctx, client, org)
 			}
 
-			if dryRun {
-				return runDryRun(ctx, client, printer, org, repos, roles, inferenceProvider, inferenceProviderName)
-			}
-
 			// Collect agent credentials via app setup.
 			var agentCreds []layers.AgentCredentials
 			if !skipAppSetup {
@@ -203,11 +198,36 @@ func newInstallCmd() *cobra.Command {
 				agentCreds = creds
 			}
 
+			// Prompt for enrollment choice: all or none.
+			var repos []string
+			if !dryRun {
+				enrollAll, err := promptEnrollment(printer)
+				if err != nil {
+					return err
+				}
+				if enrollAll {
+					// Discover repos and filter out .fullsend.
+					allRepos, err := client.ListOrgRepos(ctx, org)
+					if err != nil {
+						return fmt.Errorf("listing org repos: %w", err)
+					}
+					for _, r := range allRepos {
+						if r.Name != forge.ConfigRepoName {
+							repos = append(repos, r.Name)
+						}
+					}
+					printer.StepInfo(fmt.Sprintf("Enrolling all %d repositories (excluding %s)", len(repos), forge.ConfigRepoName))
+				} else {
+					printer.StepInfo("No repositories will be enrolled during install")
+					printer.StepInfo(fmt.Sprintf("To enroll repositories later, use: fullsend admin repos enable %s <repo-name> or --all", org))
+				}
+				printer.Blank()
+			}
+
 			return runInstall(ctx, client, printer, org, repos, roles, agentCreds, inferenceProvider, inferenceProviderName, vendorBinary)
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&repos, "repo", nil, "repositories to enable (repeatable)")
 	cmd.Flags().StringVar(&agents, "agents", "fullsend,triage,coder,review", "comma-separated agent roles")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview changes without making them")
 	cmd.Flags().BoolVar(&skipAppSetup, "skip-app-setup", false, "skip GitHub App creation/setup")
@@ -888,6 +908,34 @@ func collectEnrolledRepoIDs(allRepos []forge.Repository, enabledRepos []string) 
 		}
 	}
 	return ids
+}
+
+// promptEnrollment asks the user whether to enroll all repositories or none.
+// Returns true if the user chooses to enroll all, false if none.
+func promptEnrollment(printer *ui.Printer) (bool, error) {
+	printer.Header("Repository Enrollment")
+	printer.Blank()
+	printer.StepInfo("Choose repository enrollment:")
+	printer.StepInfo("  [a] Enroll all repositories (excluding .fullsend)")
+	printer.StepInfo("  [n] Enroll no repositories (configure later with 'fullsend admin repos enable')")
+	printer.Blank()
+	fmt.Print("Enter choice (a/n): ")
+
+	reader := bufio.NewReader(os.Stdin)
+	choice, err := reader.ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("reading enrollment choice: %w", err)
+	}
+	choice = strings.TrimSpace(strings.ToLower(choice))
+
+	switch choice {
+	case "a", "all":
+		return true, nil
+	case "n", "none":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid choice: %q (expected 'a' or 'n')", choice)
+	}
 }
 
 // promptDispatchToken checks whether the dispatch token org secret already

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -207,15 +207,15 @@ func newInstallCmd() *cobra.Command {
 				}
 			}
 
+			// Discover all org repos upfront to avoid redundant API calls in runDryRun/runInstall.
+			allRepos, err := client.ListOrgRepos(ctx, org)
+			if err != nil {
+				return fmt.Errorf("listing org repos: %w", err)
+			}
+
 			var repos []string
-			var allRepos []forge.Repository
 			if enrollAll {
-				// Discover repos and filter out .fullsend.
-				discovered, err := client.ListOrgRepos(ctx, org)
-				if err != nil {
-					return fmt.Errorf("listing org repos: %w", err)
-				}
-				allRepos = discovered
+				// Filter out .fullsend from enrollment.
 				for _, r := range allRepos {
 					if r.Name != forge.ConfigRepoName {
 						repos = append(repos, r.Name)

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"os/exec"
@@ -185,6 +186,10 @@ func newInstallCmd() *cobra.Command {
 				inferenceProviderName = loadExistingInferenceProvider(ctx, client, org)
 			}
 
+			if dryRun {
+				return runDryRun(ctx, client, printer, org, nil, roles, inferenceProvider, inferenceProviderName)
+			}
+
 			// Collect agent credentials via app setup.
 			var agentCreds []layers.AgentCredentials
 			if !skipAppSetup {
@@ -199,30 +204,29 @@ func newInstallCmd() *cobra.Command {
 			}
 
 			// Prompt for enrollment choice: all or none.
-			var repos []string
-			if !dryRun {
-				enrollAll, err := promptEnrollment(printer)
-				if err != nil {
-					return err
-				}
-				if enrollAll {
-					// Discover repos and filter out .fullsend.
-					allRepos, err := client.ListOrgRepos(ctx, org)
-					if err != nil {
-						return fmt.Errorf("listing org repos: %w", err)
-					}
-					for _, r := range allRepos {
-						if r.Name != forge.ConfigRepoName {
-							repos = append(repos, r.Name)
-						}
-					}
-					printer.StepInfo(fmt.Sprintf("Enrolling all %d repositories (excluding %s)", len(repos), forge.ConfigRepoName))
-				} else {
-					printer.StepInfo("No repositories will be enrolled during install")
-					printer.StepInfo(fmt.Sprintf("To enroll repositories later, use: fullsend admin repos enable %s <repo-name> or --all", org))
-				}
-				printer.Blank()
+			enrollAll, err := promptEnrollment(printer, os.Stdin)
+			if err != nil {
+				return err
 			}
+
+			var repos []string
+			if enrollAll {
+				// Discover repos and filter out .fullsend.
+				allRepos, err := client.ListOrgRepos(ctx, org)
+				if err != nil {
+					return fmt.Errorf("listing org repos: %w", err)
+				}
+				for _, r := range allRepos {
+					if r.Name != forge.ConfigRepoName {
+						repos = append(repos, r.Name)
+					}
+				}
+				printer.StepInfo(fmt.Sprintf("Enrolling all %d repositories (excluding %s)", len(repos), forge.ConfigRepoName))
+			} else {
+				printer.StepInfo("No repositories will be enrolled during install")
+				printer.StepInfo(fmt.Sprintf("To enroll repositories later, use: fullsend admin repos enable %s <repo-name> or --all", org))
+			}
+			printer.Blank()
 
 			return runInstall(ctx, client, printer, org, repos, roles, agentCreds, inferenceProvider, inferenceProviderName, vendorBinary)
 		},
@@ -912,29 +916,32 @@ func collectEnrolledRepoIDs(allRepos []forge.Repository, enabledRepos []string) 
 
 // promptEnrollment asks the user whether to enroll all repositories or none.
 // Returns true if the user chooses to enroll all, false if none.
-func promptEnrollment(printer *ui.Printer) (bool, error) {
+// Accepts an io.Reader to enable testing without os.Stdin.
+func promptEnrollment(printer *ui.Printer, in io.Reader) (bool, error) {
 	printer.Header("Repository Enrollment")
 	printer.Blank()
 	printer.StepInfo("Choose repository enrollment:")
 	printer.StepInfo("  [a] Enroll all repositories (excluding .fullsend)")
 	printer.StepInfo("  [n] Enroll no repositories (configure later with 'fullsend admin repos enable')")
 	printer.Blank()
-	fmt.Print("Enter choice (a/n): ")
 
-	reader := bufio.NewReader(os.Stdin)
-	choice, err := reader.ReadString('\n')
-	if err != nil {
-		return false, fmt.Errorf("reading enrollment choice: %w", err)
-	}
-	choice = strings.TrimSpace(strings.ToLower(choice))
+	reader := bufio.NewReader(in)
+	for {
+		printer.StepInfo("Enter choice (a/n): ")
+		choice, err := reader.ReadString('\n')
+		if err != nil {
+			return false, fmt.Errorf("reading enrollment choice: %w", err)
+		}
+		choice = strings.TrimSpace(strings.ToLower(choice))
 
-	switch choice {
-	case "a", "all":
-		return true, nil
-	case "n", "none":
-		return false, nil
-	default:
-		return false, fmt.Errorf("invalid choice: %q (expected 'a' or 'n')", choice)
+		switch choice {
+		case "a", "all":
+			return true, nil
+		case "n", "none":
+			return false, nil
+		default:
+			printer.StepWarn(fmt.Sprintf("Invalid choice: %q (expected 'a' or 'n')", choice))
+		}
 	}
 }
 

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -186,8 +186,35 @@ func newInstallCmd() *cobra.Command {
 				inferenceProviderName = loadExistingInferenceProvider(ctx, client, org)
 			}
 
+			// Prompt for enrollment choice: all or none.
+			enrollAll, err := promptEnrollment(printer, os.Stdin)
+			if err != nil {
+				return err
+			}
+
+			var repos []string
+			var allRepos []forge.Repository
+			if enrollAll {
+				// Discover repos and filter out .fullsend.
+				discovered, err := client.ListOrgRepos(ctx, org)
+				if err != nil {
+					return fmt.Errorf("listing org repos: %w", err)
+				}
+				allRepos = discovered
+				for _, r := range allRepos {
+					if r.Name != forge.ConfigRepoName {
+						repos = append(repos, r.Name)
+					}
+				}
+				printer.StepInfo(fmt.Sprintf("Enrolling all %d repositories (excluding %s)", len(repos), forge.ConfigRepoName))
+			} else {
+				printer.StepInfo("No repositories will be enrolled during install")
+				printer.StepInfo(fmt.Sprintf("To enroll repositories later, use: fullsend admin enable repos %s <repo-name> or --all", org))
+			}
+			printer.Blank()
+
 			if dryRun {
-				return runDryRun(ctx, client, printer, org, nil, roles, inferenceProvider, inferenceProviderName)
+				return runDryRun(ctx, client, printer, org, repos, roles, inferenceProvider, inferenceProviderName)
 			}
 
 			// Collect agent credentials via app setup.
@@ -203,32 +230,7 @@ func newInstallCmd() *cobra.Command {
 				agentCreds = creds
 			}
 
-			// Prompt for enrollment choice: all or none.
-			enrollAll, err := promptEnrollment(printer, os.Stdin)
-			if err != nil {
-				return err
-			}
-
-			var repos []string
-			if enrollAll {
-				// Discover repos and filter out .fullsend.
-				allRepos, err := client.ListOrgRepos(ctx, org)
-				if err != nil {
-					return fmt.Errorf("listing org repos: %w", err)
-				}
-				for _, r := range allRepos {
-					if r.Name != forge.ConfigRepoName {
-						repos = append(repos, r.Name)
-					}
-				}
-				printer.StepInfo(fmt.Sprintf("Enrolling all %d repositories (excluding %s)", len(repos), forge.ConfigRepoName))
-			} else {
-				printer.StepInfo("No repositories will be enrolled during install")
-				printer.StepInfo(fmt.Sprintf("To enroll repositories later, use: fullsend admin enable repos %s <repo-name> or --all", org))
-			}
-			printer.Blank()
-
-			return runInstall(ctx, client, printer, org, repos, roles, agentCreds, inferenceProvider, inferenceProviderName, vendorBinary)
+			return runInstall(ctx, client, printer, org, repos, roles, agentCreds, inferenceProvider, inferenceProviderName, vendorBinary, allRepos)
 		},
 	}
 
@@ -522,18 +524,26 @@ func validateEnabledRepos(enabledRepos, discoveredNames []string) error {
 }
 
 // runInstall performs the full installation.
-func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, org string, enabledRepos, roles []string, agentCreds []layers.AgentCredentials, inferenceProvider inference.Provider, inferenceProviderName string, vendorBinary bool) error {
-	printer.Header("Discovering repositories")
+// If discoveredRepos is non-nil, it will be used instead of calling ListOrgRepos.
+func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, org string, enabledRepos, roles []string, agentCreds []layers.AgentCredentials, inferenceProvider inference.Provider, inferenceProviderName string, vendorBinary bool, discoveredRepos []forge.Repository) error {
+	var allRepos []forge.Repository
+	var err error
 
-	allRepos, err := client.ListOrgRepos(ctx, org)
-	if err != nil {
-		return fmt.Errorf("listing org repos: %w", err)
+	if discoveredRepos != nil {
+		allRepos = discoveredRepos
+		printer.Header("Using discovered repositories")
+		printer.StepDone(fmt.Sprintf("Found %d repositories", len(allRepos)))
+	} else {
+		printer.Header("Discovering repositories")
+		allRepos, err = client.ListOrgRepos(ctx, org)
+		if err != nil {
+			return fmt.Errorf("listing org repos: %w", err)
+		}
+		printer.StepDone(fmt.Sprintf("Found %d repositories", len(allRepos)))
 	}
 
 	repoNames := repoNameList(allRepos)
 	hasPrivate := hasPrivateRepos(allRepos)
-
-	printer.StepDone(fmt.Sprintf("Found %d repositories", len(allRepos)))
 	printer.Blank()
 
 	// Validate that every enabled repository matches a discovered repo.

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -209,7 +209,9 @@ func newInstallCmd() *cobra.Command {
 				printer.StepInfo(fmt.Sprintf("Enrolling all %d repositories (excluding %s)", len(repos), forge.ConfigRepoName))
 			} else {
 				printer.StepInfo("No repositories will be enrolled during install")
-				printer.StepInfo(fmt.Sprintf("To enroll repositories later, use: fullsend admin enable repos %s <repo-name> or --all", org))
+				printer.StepInfo(fmt.Sprintf("To enroll repositories later, use:"))
+				printer.StepInfo(fmt.Sprintf("  fullsend admin enable repos %s <repo-name> [repo-name...]", org))
+				printer.StepInfo(fmt.Sprintf("  fullsend admin enable repos %s --all", org))
 			}
 			printer.Blank()
 
@@ -394,7 +396,7 @@ func runDryRun(ctx context.Context, client forge.Client, printer *ui.Printer, or
 	repoNames := repoNameList(allRepos)
 	hasPrivate := hasPrivateRepos(allRepos)
 
-	// Validate that every --repo value matches a discovered repo.
+	// Validate that every enabled repository matches a discovered repo.
 	if err := validateEnabledRepos(enabledRepos, repoNames); err != nil {
 		return err
 	}

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -214,7 +214,7 @@ func newInstallCmd() *cobra.Command {
 			printer.Blank()
 
 			if dryRun {
-				return runDryRun(ctx, client, printer, org, repos, roles, inferenceProvider, inferenceProviderName)
+				return runDryRun(ctx, client, printer, org, repos, roles, inferenceProvider, inferenceProviderName, allRepos)
 			}
 
 			// Collect agent credentials via app setup.
@@ -372,13 +372,23 @@ func newAnalyzeCmd() *cobra.Command {
 }
 
 // runDryRun builds a layer stack with empty credentials and analyzes.
-func runDryRun(ctx context.Context, client forge.Client, printer *ui.Printer, org string, enabledRepos, roles []string, inferenceProvider inference.Provider, inferenceProviderName string) error {
+// If discoveredRepos is non-nil, it will be used instead of calling ListOrgRepos.
+func runDryRun(ctx context.Context, client forge.Client, printer *ui.Printer, org string, enabledRepos, roles []string, inferenceProvider inference.Provider, inferenceProviderName string, discoveredRepos []forge.Repository) error {
 	printer.Header("Dry run - analyzing what install would do")
 	printer.Blank()
 
-	allRepos, err := client.ListOrgRepos(ctx, org)
-	if err != nil {
-		return fmt.Errorf("listing org repos: %w", err)
+	var allRepos []forge.Repository
+	var err error
+
+	if discoveredRepos != nil {
+		allRepos = discoveredRepos
+		printer.StepDone(fmt.Sprintf("Using %d discovered repositories", len(allRepos)))
+	} else {
+		allRepos, err = client.ListOrgRepos(ctx, org)
+		if err != nil {
+			return fmt.Errorf("listing org repos: %w", err)
+		}
+		printer.StepDone(fmt.Sprintf("Found %d repositories", len(allRepos)))
 	}
 
 	repoNames := repoNameList(allRepos)

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -224,7 +224,7 @@ func newInstallCmd() *cobra.Command {
 				printer.StepInfo(fmt.Sprintf("Enrolling all %d repositories (excluding %s)", len(repos), forge.ConfigRepoName))
 			} else {
 				printer.StepInfo("No repositories will be enrolled during install")
-				printer.StepInfo(fmt.Sprintf("To enroll repositories later, use: fullsend admin repos enable %s <repo-name> or --all", org))
+				printer.StepInfo(fmt.Sprintf("To enroll repositories later, use: fullsend admin enable repos %s <repo-name> or --all", org))
 			}
 			printer.Blank()
 

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -627,4 +628,99 @@ func TestRunDisableRepos_CommitMessageFormat(t *testing.T) {
 
 	require.Len(t, client.CreatedFiles, 1)
 	assert.Contains(t, client.CreatedFiles[0].Message, "chore: disable 2 repositories")
+}
+
+func TestPromptEnrollment_ChooseAll(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"lowercase a", "a\n"},
+		{"uppercase A", "A\n"},
+		{"word all", "all\n"},
+		{"word ALL", "ALL\n"},
+		{"with spaces", "  a  \n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input := strings.NewReader(tc.input)
+			printer := ui.New(&discardWriter{})
+
+			enrollAll, err := promptEnrollment(printer, input)
+			require.NoError(t, err)
+			assert.True(t, enrollAll)
+		})
+	}
+}
+
+func TestPromptEnrollment_ChooseNone(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"lowercase n", "n\n"},
+		{"uppercase N", "N\n"},
+		{"word none", "none\n"},
+		{"word NONE", "NONE\n"},
+		{"with spaces", "  n  \n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input := strings.NewReader(tc.input)
+			printer := ui.New(&discardWriter{})
+
+			enrollAll, err := promptEnrollment(printer, input)
+			require.NoError(t, err)
+			assert.False(t, enrollAll)
+		})
+	}
+}
+
+func TestPromptEnrollment_RetryOnInvalidInput(t *testing.T) {
+	// First input is invalid, second is valid.
+	input := strings.NewReader("invalid\na\n")
+	printer := ui.New(&discardWriter{})
+
+	enrollAll, err := promptEnrollment(printer, input)
+	require.NoError(t, err)
+	assert.True(t, enrollAll)
+}
+
+func TestPromptEnrollment_MultipleRetriesBeforeValid(t *testing.T) {
+	// Multiple invalid inputs before valid one.
+	input := strings.NewReader("y\nyes\nmaybe\nn\n")
+	printer := ui.New(&discardWriter{})
+
+	enrollAll, err := promptEnrollment(printer, input)
+	require.NoError(t, err)
+	assert.False(t, enrollAll)
+}
+
+func TestPromptEnrollment_ErrorOnEOF(t *testing.T) {
+	// EOF without any valid input.
+	input := strings.NewReader("")
+	printer := ui.New(&discardWriter{})
+
+	_, err := promptEnrollment(printer, input)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading enrollment choice")
+}
+
+func TestPromptEnrollment_ErrorOnReadFailure(t *testing.T) {
+	// errorReader always returns an error.
+	input := &errorReader{}
+	printer := ui.New(&discardWriter{})
+
+	_, err := promptEnrollment(printer, input)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading enrollment choice")
+}
+
+// errorReader is a test helper that always returns an error on Read.
+type errorReader struct{}
+
+func (e *errorReader) Read(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("simulated read error")
 }

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -38,9 +38,6 @@ func TestInstallCmd_RequiresOrg(t *testing.T) {
 func TestInstallCmd_Flags(t *testing.T) {
 	cmd := newInstallCmd()
 
-	repoFlag := cmd.Flags().Lookup("repo")
-	require.NotNil(t, repoFlag, "expected --repo flag")
-
 	agentsFlag := cmd.Flags().Lookup("agents")
 	require.NotNil(t, agentsFlag, "expected --agents flag")
 	assert.Equal(t, "fullsend,triage,coder,review", agentsFlag.DefValue)
@@ -60,6 +57,10 @@ func TestInstallCmd_Flags(t *testing.T) {
 
 	wifSAEmailFlag := cmd.Flags().Lookup("gcp-wif-sa-email")
 	require.NotNil(t, wifSAEmailFlag, "expected --gcp-wif-sa-email flag")
+
+	// --repo flag should not exist (issue #495)
+	repoFlag := cmd.Flags().Lookup("repo")
+	assert.Nil(t, repoFlag, "--repo flag should have been removed")
 }
 
 func TestUninstallCmd_RequiresOrg(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements #495 by removing the `--repo` flag from `fullsend admin install` and replacing it with an interactive prompt that gives users a simple choice: enroll all repositories or none.

## Changes

- **Removed `--repo` flag**: No longer need to specify repos upfront during installation
- **Interactive enrollment prompt**: Users choose between:
  - `[a]` Enroll all repositories (excluding `.fullsend`)
  - `[n]` Enroll no repositories (configure later)
- **Automatic `.fullsend` exclusion**: Config repo is never enrolled, even with "all" option
- **Helpful guidance**: Users who choose "none" are shown how to enable repos later via `fullsend admin repos enable`
- **Updated tests**: Verify --repo flag removal and proper command structure

## Benefits

- **Simpler onboarding**: No need to enumerate repositories during install
- **Better UX for large orgs**: Organizations with many repos no longer face unwieldy command lines
- **Clear default paths**: All-or-none choice is straightforward, with easy post-install adjustment via the enable/disable commands

## Test plan

- [x] Unit tests verify --repo flag no longer exists
- [x] All existing CLI tests pass
- [x] Code compiles successfully
- [x] Enrollment prompt function handles user input correctly

## Related

Closes #495
Depends on #697 (enable/disable commands for post-install configuration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)