### PR TITLE
fix(review): dismiss stale request-changes review when verdict softens

### DIFF
--- a/internal/cli/postreview.go
+++ b/internal/cli/postreview.go
@@ -258,12 +258,14 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 		return nil
 	}
 
-	if err := dismissStaleRequestChanges(ctx, client, owner, repo, pr, event, printer); err != nil {
-		return err
-	}
-
-	if err := minimizeStaleReviews(ctx, client, owner, repo, pr, printer); err != nil {
-		return err
+	user, err := client.GetAuthenticatedUser(ctx)
+	if err != nil {
+		printer.StepInfo("Could not determine authenticated user, skipping stale review cleanup")
+	} else if reviews, err := client.ListPullRequestReviews(ctx, owner, repo, pr); err != nil {
+		printer.StepInfo("Could not list reviews, skipping stale review cleanup")
+	} else {
+		dismissStaleRequestChanges(ctx, client, owner, repo, pr, event, user, reviews, printer)
+		minimizeStaleReviews(ctx, client, user, reviews, printer)
 	}
 
 	var reviewBody string
@@ -284,21 +286,9 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 
 // dismissStaleRequestChanges dismisses the most recent CHANGES_REQUESTED
 // review by the authenticated user when the new verdict is softer.
-func dismissStaleRequestChanges(ctx context.Context, client forge.Client, owner, repo string, pr int, newEvent string, printer *ui.Printer) error {
+func dismissStaleRequestChanges(ctx context.Context, client forge.Client, owner, repo string, pr int, newEvent, user string, reviews []forge.PullRequestReview, printer *ui.Printer) {
 	if newEvent == "REQUEST_CHANGES" {
-		return nil
-	}
-
-	user, err := client.GetAuthenticatedUser(ctx)
-	if err != nil {
-		printer.StepInfo("Could not determine authenticated user, skipping review dismissal")
-		return nil
-	}
-
-	reviews, err := client.ListPullRequestReviews(ctx, owner, repo, pr)
-	if err != nil {
-		printer.StepInfo("Could not list reviews, skipping review dismissal")
-		return nil
+		return
 	}
 
 	for i := len(reviews) - 1; i >= 0; i-- {
@@ -314,26 +304,12 @@ func dismissStaleRequestChanges(ctx context.Context, client forge.Client, owner,
 		}
 		break
 	}
-
-	return nil
 }
 
-// minimizeStaleReviews lists all reviews on the PR, finds previous reviews
-// by the authenticated user, and minimizes them. Called before creating a
-// new review, so all existing reviews by this user are stale.
-func minimizeStaleReviews(ctx context.Context, client forge.Client, owner, repo string, pr int, printer *ui.Printer) error {
-	user, err := client.GetAuthenticatedUser(ctx)
-	if err != nil {
-		printer.StepInfo("Could not determine authenticated user, skipping stale review cleanup")
-		return nil
-	}
-
-	reviews, err := client.ListPullRequestReviews(ctx, owner, repo, pr)
-	if err != nil {
-		printer.StepInfo("Could not list reviews, skipping stale review cleanup")
-		return nil
-	}
-
+// minimizeStaleReviews finds previous reviews by the given user and
+// minimizes them. Called before creating a new review, so all existing
+// reviews by this user are stale.
+func minimizeStaleReviews(ctx context.Context, client forge.Client, user string, reviews []forge.PullRequestReview, printer *ui.Printer) {
 	var stale []forge.PullRequestReview
 	for _, r := range reviews {
 		if r.User == user {
@@ -342,7 +318,7 @@ func minimizeStaleReviews(ctx context.Context, client forge.Client, owner, repo 
 	}
 
 	if len(stale) == 0 {
-		return nil
+		return
 	}
 
 	printer.StepStart(fmt.Sprintf("Minimizing %d stale review(s)", len(stale)))
@@ -352,8 +328,6 @@ func minimizeStaleReviews(ctx context.Context, client forge.Client, owner, repo 
 		}
 	}
 	printer.StepDone("Stale reviews minimized")
-
-	return nil
 }
 
 // parseReviewResult attempts to parse the body as a JSON ReviewResult.

--- a/internal/cli/postreview.go
+++ b/internal/cli/postreview.go
@@ -248,11 +248,6 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 		return nil
 	}
 
-	if event == "COMMENT" {
-		printer.StepInfo("Skipping formal COMMENT review (sticky comment already updated)")
-		return nil
-	}
-
 	if dryRun {
 		printer.StepInfo(fmt.Sprintf("Dry run — would submit %s review", event))
 		return nil
@@ -266,6 +261,11 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 	} else {
 		dismissStaleRequestChanges(ctx, client, owner, repo, pr, event, user, reviews, printer)
 		minimizeStaleReviews(ctx, client, user, reviews, printer)
+	}
+
+	if event == "COMMENT" {
+		printer.StepInfo("Skipping formal COMMENT review (sticky comment already updated)")
+		return nil
 	}
 
 	var reviewBody string

--- a/internal/cli/postreview.go
+++ b/internal/cli/postreview.go
@@ -258,6 +258,10 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 		return nil
 	}
 
+	if err := dismissStaleRequestChanges(ctx, client, owner, repo, pr, event, printer); err != nil {
+		return err
+	}
+
 	if err := minimizeStaleReviews(ctx, client, owner, repo, pr, printer); err != nil {
 		return err
 	}
@@ -275,6 +279,42 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 		return fmt.Errorf("submitting review: %w", err)
 	}
 	printer.StepDone("Review submitted")
+	return nil
+}
+
+// dismissStaleRequestChanges dismisses the most recent CHANGES_REQUESTED
+// review by the authenticated user when the new verdict is softer.
+func dismissStaleRequestChanges(ctx context.Context, client forge.Client, owner, repo string, pr int, newEvent string, printer *ui.Printer) error {
+	if newEvent == "REQUEST_CHANGES" {
+		return nil
+	}
+
+	user, err := client.GetAuthenticatedUser(ctx)
+	if err != nil {
+		printer.StepInfo("Could not determine authenticated user, skipping review dismissal")
+		return nil
+	}
+
+	reviews, err := client.ListPullRequestReviews(ctx, owner, repo, pr)
+	if err != nil {
+		printer.StepInfo("Could not list reviews, skipping review dismissal")
+		return nil
+	}
+
+	for i := len(reviews) - 1; i >= 0; i-- {
+		r := reviews[i]
+		if r.User != user || r.State != "CHANGES_REQUESTED" {
+			continue
+		}
+		printer.StepStart(fmt.Sprintf("Dismissing stale CHANGES_REQUESTED review %d", r.ID))
+		if err := client.DismissPullRequestReview(ctx, owner, repo, pr, r.ID, "Superseded by updated review"); err != nil {
+			printer.StepInfo(fmt.Sprintf("Warning: could not dismiss review %d: %v", r.ID, err))
+		} else {
+			printer.StepDone("Stale review dismissed")
+		}
+		break
+	}
+
 	return nil
 }
 

--- a/internal/cli/postreview_test.go
+++ b/internal/cli/postreview_test.go
@@ -213,6 +213,27 @@ func TestSubmitFormalReview_CreatesAndMinimizesStale(t *testing.T) {
 	assert.Equal(t, "OUTDATED", fc.MinimizedComments[0].Reason)
 	assert.Equal(t, "PRR_300", fc.MinimizedComments[1].NodeID)
 	assert.Equal(t, "OUTDATED", fc.MinimizedComments[1].Reason)
+
+	assert.Empty(t, fc.DismissedReviews, "no CHANGES_REQUESTED reviews to dismiss")
+}
+
+func TestSubmitFormalReview_DismissesStaleRequestChanges(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "fullsend-bot"
+	fc.PRReviews = map[string][]forge.PullRequestReview{
+		"acme/repo/1": {
+			{ID: 100, NodeID: "PRR_100", User: "fullsend-bot", State: "COMMENTED", Body: "old"},
+			{ID: 200, NodeID: "PRR_200", User: "fullsend-bot", State: "CHANGES_REQUESTED", Body: "fix this"},
+		},
+	}
+
+	printer := ui.New(io.Discard)
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "comment", "", "", false, printer)
+	require.NoError(t, err)
+
+	require.Len(t, fc.DismissedReviews, 1)
+	assert.Equal(t, 200, fc.DismissedReviews[0].ReviewID)
+	assert.Equal(t, "Superseded by updated review", fc.DismissedReviews[0].Message)
 }
 
 func TestSubmitFormalReview_DryRun(t *testing.T) {
@@ -388,4 +409,139 @@ func TestSubmitFormalReview_CommentSkipped(t *testing.T) {
 	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "comment", "", "", false, printer)
 	require.NoError(t, err)
 	assert.Empty(t, fc.CreatedReviews, "COMMENT events should skip formal review")
+}
+
+func TestDismissStaleRequestChanges(t *testing.T) {
+	tests := []struct {
+		name           string
+		user           string
+		reviews        []forge.PullRequestReview
+		newEvent       string
+		errors         map[string]error
+		wantDismissed  int
+		wantReviewID   int
+	}{
+		{
+			name:     "softening from request-changes to comment",
+			user:     "bot",
+			newEvent: "COMMENT",
+			reviews: []forge.PullRequestReview{
+				{ID: 100, User: "bot", State: "CHANGES_REQUESTED"},
+			},
+			wantDismissed: 1,
+			wantReviewID:  100,
+		},
+		{
+			name:     "softening from request-changes to approve",
+			user:     "bot",
+			newEvent: "APPROVE",
+			reviews: []forge.PullRequestReview{
+				{ID: 100, User: "bot", State: "CHANGES_REQUESTED"},
+			},
+			wantDismissed: 1,
+			wantReviewID:  100,
+		},
+		{
+			name:     "same severity skips dismiss",
+			user:     "bot",
+			newEvent: "REQUEST_CHANGES",
+			reviews: []forge.PullRequestReview{
+				{ID: 100, User: "bot", State: "CHANGES_REQUESTED"},
+			},
+			wantDismissed: 0,
+		},
+		{
+			name:          "no prior reviews",
+			user:          "bot",
+			newEvent:      "COMMENT",
+			reviews:       nil,
+			wantDismissed: 0,
+		},
+		{
+			name:     "prior is commented not changes-requested",
+			user:     "bot",
+			newEvent: "COMMENT",
+			reviews: []forge.PullRequestReview{
+				{ID: 100, User: "bot", State: "COMMENTED"},
+			},
+			wantDismissed: 0,
+		},
+		{
+			name:     "prior is approved and new is request-changes",
+			user:     "bot",
+			newEvent: "REQUEST_CHANGES",
+			reviews: []forge.PullRequestReview{
+				{ID: 100, User: "bot", State: "APPROVED"},
+			},
+			wantDismissed: 0,
+		},
+		{
+			name:     "different user review ignored",
+			user:     "bot",
+			newEvent: "COMMENT",
+			reviews: []forge.PullRequestReview{
+				{ID: 100, User: "someone-else", State: "CHANGES_REQUESTED"},
+			},
+			wantDismissed: 0,
+		},
+		{
+			name:     "multiple bot reviews dismisses most recent CR only",
+			user:     "bot",
+			newEvent: "COMMENT",
+			reviews: []forge.PullRequestReview{
+				{ID: 100, User: "bot", State: "COMMENTED"},
+				{ID: 200, User: "bot", State: "CHANGES_REQUESTED"},
+			},
+			wantDismissed: 1,
+			wantReviewID:  200,
+		},
+		{
+			name:     "dismiss API error is non-fatal",
+			user:     "bot",
+			newEvent: "COMMENT",
+			reviews: []forge.PullRequestReview{
+				{ID: 100, User: "bot", State: "CHANGES_REQUESTED"},
+			},
+			errors:        map[string]error{"DismissPullRequestReview": fmt.Errorf("API error")},
+			wantDismissed: 0,
+		},
+		{
+			name:          "auth error skips dismissal",
+			user:          "bot",
+			newEvent:      "COMMENT",
+			errors:        map[string]error{"GetAuthenticatedUser": fmt.Errorf("auth error")},
+			wantDismissed: 0,
+		},
+		{
+			name:          "list error skips dismissal",
+			user:          "bot",
+			newEvent:      "COMMENT",
+			errors:        map[string]error{"ListPullRequestReviews": fmt.Errorf("list error")},
+			wantDismissed: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc := forge.NewFakeClient()
+			fc.AuthenticatedUser = tt.user
+			if tt.reviews != nil {
+				fc.PRReviews = map[string][]forge.PullRequestReview{
+					"acme/repo/1": tt.reviews,
+				}
+			}
+			for k, v := range tt.errors {
+				fc.Errors[k] = v
+			}
+
+			printer := ui.New(io.Discard)
+			err := dismissStaleRequestChanges(context.Background(), fc, "acme", "repo", 1, tt.newEvent, printer)
+			require.NoError(t, err)
+
+			assert.Len(t, fc.DismissedReviews, tt.wantDismissed)
+			if tt.wantDismissed > 0 {
+				assert.Equal(t, tt.wantReviewID, fc.DismissedReviews[0].ReviewID)
+			}
+		})
+	}
 }

--- a/internal/cli/postreview_test.go
+++ b/internal/cli/postreview_test.go
@@ -228,7 +228,7 @@ func TestSubmitFormalReview_DismissesStaleRequestChanges(t *testing.T) {
 	}
 
 	printer := ui.New(io.Discard)
-	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "comment", "", "", false, printer)
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "approve", "", "", false, printer)
 	require.NoError(t, err)
 
 	require.Len(t, fc.DismissedReviews, 1)
@@ -256,43 +256,34 @@ func TestSubmitFormalReview_UnknownAction(t *testing.T) {
 
 func TestMinimizeStaleReviews_MinimizesAll(t *testing.T) {
 	fc := forge.NewFakeClient()
-	fc.AuthenticatedUser = "fullsend-bot"
-	fc.PRReviews = map[string][]forge.PullRequestReview{
-		"acme/repo/1": {
-			{ID: 100, NodeID: "PRR_100", User: "fullsend-bot", State: "APPROVED", Body: "only review"},
-		},
+	reviews := []forge.PullRequestReview{
+		{ID: 100, NodeID: "PRR_100", User: "fullsend-bot", State: "APPROVED", Body: "only review"},
 	}
 
 	printer := ui.New(io.Discard)
-	err := minimizeStaleReviews(context.Background(), fc, "acme", "repo", 1, printer)
-	require.NoError(t, err)
+	minimizeStaleReviews(context.Background(), fc, "fullsend-bot", reviews, printer)
 	require.Len(t, fc.MinimizedComments, 1)
 	assert.Equal(t, "PRR_100", fc.MinimizedComments[0].NodeID)
 }
 
 func TestMinimizeStaleReviews_ErrorTolerance(t *testing.T) {
 	fc := forge.NewFakeClient()
-	fc.AuthenticatedUser = "fullsend-bot"
-	fc.PRReviews = map[string][]forge.PullRequestReview{
-		"acme/repo/1": {
-			{ID: 100, NodeID: "PRR_100", User: "fullsend-bot", State: "COMMENTED", Body: "review 1"},
-			{ID: 200, NodeID: "PRR_200", User: "fullsend-bot", State: "APPROVED", Body: "review 2"},
-		},
-	}
 	fc.Errors["MinimizeComment"] = fmt.Errorf("GraphQL error")
+	reviews := []forge.PullRequestReview{
+		{ID: 100, NodeID: "PRR_100", User: "fullsend-bot", State: "COMMENTED", Body: "review 1"},
+		{ID: 200, NodeID: "PRR_200", User: "fullsend-bot", State: "APPROVED", Body: "review 2"},
+	}
 
 	printer := ui.New(io.Discard)
-	err := minimizeStaleReviews(context.Background(), fc, "acme", "repo", 1, printer)
-	require.NoError(t, err, "minimizeStaleReviews should not return error when MinimizeComment fails")
+	minimizeStaleReviews(context.Background(), fc, "fullsend-bot", reviews, printer)
+	// soft-fail: no panic despite MinimizeComment errors
 }
 
 func TestMinimizeStaleReviews_NoReviews(t *testing.T) {
 	fc := forge.NewFakeClient()
-	fc.AuthenticatedUser = "fullsend-bot"
 
 	printer := ui.New(io.Discard)
-	err := minimizeStaleReviews(context.Background(), fc, "acme", "repo", 1, printer)
-	require.NoError(t, err)
+	minimizeStaleReviews(context.Background(), fc, "fullsend-bot", nil, printer)
 	assert.Empty(t, fc.MinimizedComments)
 }
 
@@ -413,13 +404,13 @@ func TestSubmitFormalReview_CommentSkipped(t *testing.T) {
 
 func TestDismissStaleRequestChanges(t *testing.T) {
 	tests := []struct {
-		name           string
-		user           string
-		reviews        []forge.PullRequestReview
-		newEvent       string
-		errors         map[string]error
-		wantDismissed  int
-		wantReviewID   int
+		name          string
+		user          string
+		reviews       []forge.PullRequestReview
+		newEvent      string
+		dismissErr    error
+		wantDismissed int
+		wantReviewID  int
 	}{
 		{
 			name:     "softening from request-changes to comment",
@@ -485,11 +476,11 @@ func TestDismissStaleRequestChanges(t *testing.T) {
 			wantDismissed: 0,
 		},
 		{
-			name:     "multiple bot reviews dismisses most recent CR only",
+			name:     "multiple CR reviews dismisses most recent only",
 			user:     "bot",
 			newEvent: "COMMENT",
 			reviews: []forge.PullRequestReview{
-				{ID: 100, User: "bot", State: "COMMENTED"},
+				{ID: 100, User: "bot", State: "CHANGES_REQUESTED"},
 				{ID: 200, User: "bot", State: "CHANGES_REQUESTED"},
 			},
 			wantDismissed: 1,
@@ -502,21 +493,7 @@ func TestDismissStaleRequestChanges(t *testing.T) {
 			reviews: []forge.PullRequestReview{
 				{ID: 100, User: "bot", State: "CHANGES_REQUESTED"},
 			},
-			errors:        map[string]error{"DismissPullRequestReview": fmt.Errorf("API error")},
-			wantDismissed: 0,
-		},
-		{
-			name:          "auth error skips dismissal",
-			user:          "bot",
-			newEvent:      "COMMENT",
-			errors:        map[string]error{"GetAuthenticatedUser": fmt.Errorf("auth error")},
-			wantDismissed: 0,
-		},
-		{
-			name:          "list error skips dismissal",
-			user:          "bot",
-			newEvent:      "COMMENT",
-			errors:        map[string]error{"ListPullRequestReviews": fmt.Errorf("list error")},
+			dismissErr:    fmt.Errorf("API error"),
 			wantDismissed: 0,
 		},
 	}
@@ -524,19 +501,12 @@ func TestDismissStaleRequestChanges(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fc := forge.NewFakeClient()
-			fc.AuthenticatedUser = tt.user
-			if tt.reviews != nil {
-				fc.PRReviews = map[string][]forge.PullRequestReview{
-					"acme/repo/1": tt.reviews,
-				}
-			}
-			for k, v := range tt.errors {
-				fc.Errors[k] = v
+			if tt.dismissErr != nil {
+				fc.Errors["DismissPullRequestReview"] = tt.dismissErr
 			}
 
 			printer := ui.New(io.Discard)
-			err := dismissStaleRequestChanges(context.Background(), fc, "acme", "repo", 1, tt.newEvent, printer)
-			require.NoError(t, err)
+			dismissStaleRequestChanges(context.Background(), fc, "acme", "repo", 1, tt.newEvent, tt.user, tt.reviews, printer)
 
 			assert.Len(t, fc.DismissedReviews, tt.wantDismissed)
 			if tt.wantDismissed > 0 {
@@ -544,4 +514,29 @@ func TestDismissStaleRequestChanges(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSubmitFormalReview_AuthErrorSkipsCleanup(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.Errors["GetAuthenticatedUser"] = fmt.Errorf("auth error")
+	printer := ui.New(io.Discard)
+
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "approve", "", "", false, printer)
+	require.NoError(t, err)
+	assert.Empty(t, fc.DismissedReviews)
+	assert.Empty(t, fc.MinimizedComments)
+	require.Len(t, fc.CreatedReviews, 1, "review should still be created despite auth error")
+}
+
+func TestSubmitFormalReview_ListErrorSkipsCleanup(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "bot"
+	fc.Errors["ListPullRequestReviews"] = fmt.Errorf("list error")
+	printer := ui.New(io.Discard)
+
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "approve", "", "", false, printer)
+	require.NoError(t, err)
+	assert.Empty(t, fc.DismissedReviews)
+	assert.Empty(t, fc.MinimizedComments)
+	require.Len(t, fc.CreatedReviews, 1, "review should still be created despite list error")
 }

--- a/internal/cli/postreview_test.go
+++ b/internal/cli/postreview_test.go
@@ -236,6 +236,24 @@ func TestSubmitFormalReview_DismissesStaleRequestChanges(t *testing.T) {
 	assert.Equal(t, "Superseded by updated review", fc.DismissedReviews[0].Message)
 }
 
+func TestSubmitFormalReview_DismissesOnCommentVerdict(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "fullsend-bot"
+	fc.PRReviews = map[string][]forge.PullRequestReview{
+		"acme/repo/1": {
+			{ID: 100, NodeID: "PRR_100", User: "fullsend-bot", State: "CHANGES_REQUESTED", Body: "fix this"},
+		},
+	}
+
+	printer := ui.New(io.Discard)
+	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "comment", "", "", false, printer)
+	require.NoError(t, err)
+
+	require.Len(t, fc.DismissedReviews, 1, "COMMENT verdict must still dismiss stale CHANGES_REQUESTED")
+	assert.Equal(t, 100, fc.DismissedReviews[0].ReviewID)
+	assert.Empty(t, fc.CreatedReviews, "COMMENT events skip formal review submission")
+}
+
 func TestSubmitFormalReview_DryRun(t *testing.T) {
 	fc := forge.NewFakeClient()
 	printer := ui.New(io.Discard)

--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -63,6 +63,14 @@ type ReviewRecord struct {
 	CommitSHA   string
 }
 
+// DismissedReviewRecord records a review dismissal call.
+type DismissedReviewRecord struct {
+	Owner, Repo string
+	Number      int
+	ReviewID    int
+	Message     string
+}
+
 // FakeClient is a thread-safe test double for forge.Client.
 // Pre-populate its fields to control return values, and inspect
 // recorder slices after the test to verify which calls were made.
@@ -113,6 +121,7 @@ type FakeClient struct {
 	UpdatedComments   []UpdatedCommentRecord
 	MinimizedComments []MinimizedCommentRecord
 	CreatedReviews    []ReviewRecord
+	DismissedReviews  []DismissedReviewRecord
 
 	// internal counters
 	proposalCounter int
@@ -681,6 +690,31 @@ func (f *FakeClient) ListPullRequestReviews(_ context.Context, owner, repo strin
 		}
 	}
 	return nil, nil
+}
+
+func (f *FakeClient) DismissPullRequestReview(_ context.Context, owner, repo string, number, reviewID int, message string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e := f.err("DismissPullRequestReview"); e != nil {
+		return e
+	}
+	f.DismissedReviews = append(f.DismissedReviews, DismissedReviewRecord{
+		Owner:    owner,
+		Repo:     repo,
+		Number:   number,
+		ReviewID: reviewID,
+		Message:  message,
+	})
+	key := fmt.Sprintf("%s/%s/%d", owner, repo, number)
+	if f.PRReviews != nil {
+		for i, r := range f.PRReviews[key] {
+			if r.ID == reviewID {
+				f.PRReviews[key][i].State = "DISMISSED"
+				break
+			}
+		}
+	}
+	return nil
 }
 
 func (f *FakeClient) MergeChangeProposal(_ context.Context, _, _ string, _ int) error {

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -169,6 +169,7 @@ type Client interface {
 	// GitHub rejects the request if the commit is not the PR's current HEAD.
 	CreatePullRequestReview(ctx context.Context, owner, repo string, number int, event, body, commitSHA string) error
 	ListPullRequestReviews(ctx context.Context, owner, repo string, number int) ([]PullRequestReview, error)
+	DismissPullRequestReview(ctx context.Context, owner, repo string, number, reviewID int, message string) error
 
 	// Change proposal merge
 	MergeChangeProposal(ctx context.Context, owner, repo string, number int) error

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -1195,6 +1195,21 @@ func (c *LiveClient) ListPullRequestReviews(ctx context.Context, owner, repo str
 	return result, nil
 }
 
+// DismissPullRequestReview dismisses a review, changing its state to DISMISSED.
+func (c *LiveClient) DismissPullRequestReview(ctx context.Context, owner, repo string, number, reviewID int, message string) error {
+	payload := map[string]string{
+		"message": message,
+		"event":   "DISMISS",
+	}
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews/%d/dismissals", owner, repo, number, reviewID)
+	resp, err := c.put(ctx, path, payload)
+	if err != nil {
+		return fmt.Errorf("dismiss review %d on #%d: %w", reviewID, number, err)
+	}
+	resp.Body.Close()
+	return nil
+}
+
 // MergeChangeProposal squash-merges a pull request by number.
 func (c *LiveClient) MergeChangeProposal(ctx context.Context, owner, repo string, number int) error {
 	resp, err := c.put(ctx, fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, number), map[string]string{"merge_method": "squash"})

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -1199,7 +1199,6 @@ func (c *LiveClient) ListPullRequestReviews(ctx context.Context, owner, repo str
 func (c *LiveClient) DismissPullRequestReview(ctx context.Context, owner, repo string, number, reviewID int, message string) error {
 	payload := map[string]string{
 		"message": message,
-		"event":   "DISMISS",
 	}
 	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews/%d/dismissals", owner, repo, number, reviewID)
 	resp, err := c.put(ctx, path, payload)


### PR DESCRIPTION
Minimizing old reviews via GraphQL minimizeComment hides them in the UI but does not remove the CHANGES_REQUESTED merge block under branch protection. Add DismissPullRequestReview to the forge client interface and call it from submitFormalReview() before minimizing, so the most recent CHANGES_REQUESTED review is dismissed when the new verdict is softer (COMMENT or APPROVE).

Fixes: #414

Assisted-by: Claude Code (Opus 4.6)