### PR TITLE
fix: correct checksums.txt URL in release binary download

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1446,7 +1446,7 @@ func downloadReleaseBinary(ver, arch, destPath string) error {
 // GoReleaser format: "<sha256>  <filename>\n"
 func downloadChecksumForAsset(ver, assetName string) (string, error) {
 	cleanVer := strings.TrimPrefix(ver, "v")
-	url := fmt.Sprintf("%s/v%s/fullsend_%s_checksums.txt", releaseBaseURL, cleanVer, cleanVer)
+	url := fmt.Sprintf("%s/v%s/checksums.txt", releaseBaseURL, cleanVer)
 
 	resp, err := httpClient.Get(url) //nolint:gosec // URL is constructed from known constants
 	if err != nil {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -400,7 +400,7 @@ func TestDownloadReleaseBinary_ChecksumMismatch(t *testing.T) {
 	checksumBody := fmt.Sprintf("%s  fullsend_1.0.0_linux_amd64.tar.gz\n", wrongHash)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v1.0.0/fullsend_1.0.0_checksums.txt" {
+		if r.URL.Path == "/v1.0.0/checksums.txt" {
 			fmt.Fprint(w, checksumBody)
 		} else if r.URL.Path == "/v1.0.0/fullsend_1.0.0_linux_amd64.tar.gz" {
 			w.Write(tarBytes)
@@ -443,7 +443,7 @@ func TestDownloadReleaseBinary_ChecksumMatch(t *testing.T) {
 	checksumBody := fmt.Sprintf("%s  fullsend_2.0.0_linux_amd64.tar.gz\n", correctHash)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v2.0.0/fullsend_2.0.0_checksums.txt" {
+		if r.URL.Path == "/v2.0.0/checksums.txt" {
 			fmt.Fprint(w, checksumBody)
 		} else if r.URL.Path == "/v2.0.0/fullsend_2.0.0_linux_amd64.tar.gz" {
 			w.Write(tarBytes)


### PR DESCRIPTION
## Summary
- The `downloadChecksumForAsset` function constructed the checksums URL as `fullsend_<ver>_checksums.txt`, but GoReleaser publishes the asset as just `checksums.txt`, causing a 404 when downloading release binaries
- Fixed the URL template and updated two mock test handlers to match

## Test plan
- [x] `TestResolveLinuxBinary_Download` passes (downloads real v0.4.0 release)
- [x] `TestDownloadChecksumForAsset_ParsesLine` passes
- [x] `TestDownloadChecksumForAsset_AssetNotFound` passes
- [x] `TestDownloadChecksumForAsset_InvalidHex` passes
- [x] `TestDownloadReleaseBinary_ChecksumMismatch` passes
- [x] `TestDownloadReleaseBinary_ChecksumMatch` passes