### PR TITLE
fix(ci): run wrangler preCommands as one shell line

### DIFF
--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -126,6 +126,8 @@ jobs:
       # before `deploy` when `secrets:` is set. Use `wrangler versions secret bulk` in preCommands
       # instead (cloudflare/wrangler-action#374).
       # preCommands run under `/bin/sh` (dash on Ubuntu): no `pipefail` (bash-only).
+      # Each newline in preCommands is a separate shell invocation — no line continuations or
+      # multi-line printf; keep the secret bulk prep on one line so mktemp and the file path match.
       - name: Deploy to production (Workers + static assets)
         id: cf-prod
         if: github.event.workflow_run.event == 'push'
@@ -135,16 +137,7 @@ jobs:
           workingDirectory: cloudflare_site
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          preCommands: |
-            set -eu
-            secrets_file="$(mktemp)"
-            printf '%s\n' \
-              "GITHUB_APP_CLIENT_SECRET=${GITHUB_APP_CLIENT_SECRET}" \
-              "TURNSTILE_SECRET_KEY=${TURNSTILE_SECRET_KEY}" \
-              >"$secrets_file"
-            npx wrangler@4.36.0 versions secret bulk "$secrets_file" \
-              --message "Production secrets (workflow-run ${{ github.event.workflow_run.id }})"
-            rm -f "$secrets_file"
+          preCommands: set -eu; secrets_file="$(mktemp)"; printf '%s\n' "GITHUB_APP_CLIENT_SECRET=${GITHUB_APP_CLIENT_SECRET}" "TURNSTILE_SECRET_KEY=${TURNSTILE_SECRET_KEY}" >"$secrets_file"; npx wrangler@4.36.0 versions secret bulk "$secrets_file" --message "Production secrets (workflow-run ${{ github.event.workflow_run.id }})"; rm -f "$secrets_file"
           command: deploy --name="${{ vars.CLOUDFLARE_PROJECT_NAME }}"
           vars: |
             GITHUB_APP_CLIENT_ID
@@ -160,6 +153,7 @@ jobs:
       # with `wrangler versions secret bulk` in preCommands instead (cloudflare/wrangler-action#374).
       # Plain `vars` are only auto-injected for deploy/publish, so pass `--var` on `versions upload`.
       # preCommands run under `/bin/sh` (dash on Ubuntu): no `pipefail` (bash-only).
+      # Each newline in preCommands is a separate shell invocation — keep secret bulk prep on one line.
       - name: Upload preview version (Workers + static assets)
         id: cf-preview
         if: github.event.workflow_run.event == 'pull_request'
@@ -169,16 +163,7 @@ jobs:
           workingDirectory: cloudflare_site
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          preCommands: |
-            set -eu
-            secrets_file="$(mktemp)"
-            printf '%s\n' \
-              "GITHUB_APP_CLIENT_SECRET=${GITHUB_APP_CLIENT_SECRET}" \
-              "TURNSTILE_SECRET_KEY=${TURNSTILE_SECRET_KEY}" \
-              >"$secrets_file"
-            npx wrangler@4.36.0 versions secret bulk "$secrets_file" \
-              --message "PR preview secrets (workflow-run ${{ github.event.workflow_run.id }})"
-            rm -f "$secrets_file"
+          preCommands: set -eu; secrets_file="$(mktemp)"; printf '%s\n' "GITHUB_APP_CLIENT_SECRET=${GITHUB_APP_CLIENT_SECRET}" "TURNSTILE_SECRET_KEY=${TURNSTILE_SECRET_KEY}" >"$secrets_file"; npx wrangler@4.36.0 versions secret bulk "$secrets_file" --message "PR preview secrets (workflow-run ${{ github.event.workflow_run.id }})"; rm -f "$secrets_file"
           command: >-
             versions upload
             --name="${{ vars.CLOUDFLARE_PROJECT_NAME }}"


### PR DESCRIPTION
## Summary

Deploy Site was failing on `preCommands` because `cloudflare/wrangler-action` runs **each line** of `preCommands` as a separate `/bin/sh` invocation. Multi-line `printf` with backslash continuations split across invocations, so secret lines were executed as commands (exit 127: `not found`).

## Change

Collapse production and preview `versions secret bulk` prep into **single-line** scripts (semicolon-separated) so `mktemp`, `printf`, and `wrangler` run in one shell.

## Verification

- Fork `main` push: Build Site + Deploy Site (production) succeeded.
- Fork PR: Build Site + Deploy Site (preview `versions upload`) succeeded.

Made with [Cursor](https://cursor.com)