### PR TITLE
fix: remove leading zeros from ADR titles and add linter

### DIFF
--- a/docs/ADRs/0017-credential-isolation-for-sandboxed-agents.md
+++ b/docs/ADRs/0017-credential-isolation-for-sandboxed-agents.md
@@ -1,5 +1,5 @@
 ---
-title: "0017. Credential Isolation for Sandboxed Agents"
+title: "17. Credential Isolation for Sandboxed Agents"
 status: Accepted
 relates_to:
   - security-threat-model
@@ -10,7 +10,7 @@ topics:
   - security
 ---
 
-# 0017. Credential Isolation for Sandboxed Agents
+# 17. Credential Isolation for Sandboxed Agents
 
 Date: 2026-04-01
 

--- a/docs/ADRs/0019-web-source-and-cloudflare-site-layout.md
+++ b/docs/ADRs/0019-web-source-and-cloudflare-site-layout.md
@@ -1,5 +1,5 @@
 ---
-title: "0019. Web source under web/ and Cloudflare project under cloudflare_site/"
+title: "19. Web source under web/ and Cloudflare project under cloudflare_site/"
 status: Accepted
 relates_to:
   - contributor-guidance
@@ -9,7 +9,7 @@ topics:
   - cloudflare
 ---
 
-# 0019. Web source under `web/` and Cloudflare project under `cloudflare_site/`
+# 19. Web source under `web/` and Cloudflare project under `cloudflare_site/`
 
 Date: 2026-04-15
 

--- a/docs/ADRs/0025-provider-credential-delivery-for-sandboxed-agents.md
+++ b/docs/ADRs/0025-provider-credential-delivery-for-sandboxed-agents.md
@@ -1,5 +1,5 @@
 ---
-title: "0025. Provider-based credential delivery for sandboxed agents"
+title: "25. Provider-based credential delivery for sandboxed agents"
 status: Accepted
 relates_to:
   - agent-architecture
@@ -12,7 +12,7 @@ topics:
   - providers
 ---
 
-# 0025. Provider-based credential delivery for sandboxed agents
+# 25. Provider-based credential delivery for sandboxed agents
 
 Date: 2026-04-23
 

--- a/docs/ADRs/0027-allowed-and-disallowed-tools-for-agents.md
+++ b/docs/ADRs/0027-allowed-and-disallowed-tools-for-agents.md
@@ -1,5 +1,5 @@
 ---
-title: "0027. Allowed and Disallowed Tools for Agents"
+title: "27. Allowed and Disallowed Tools for Agents"
 status: Proposed
 relates_to:
   - agent-architecture
@@ -10,7 +10,7 @@ topics:
   - sandbox
 ---
 
-# 0027. Allowed and Disallowed Tools for Agents
+# 27. Allowed and Disallowed Tools for Agents
 
 Date: 2026-04-21
 

--- a/hack/lint-adr-numbers
+++ b/hack/lint-adr-numbers
@@ -41,15 +41,44 @@ done
 
 duplicates=$(printf '%s\n' "${numbers[@]}" | sort | uniq -d)
 
+has_errors=0
+
 if [[ -n "$duplicates" ]]; then
     for dup in $duplicates; do
         error "Duplicate ADR number $dup found"
     done
-    echo "======================================"
-    error "Duplicate ADR numbers found. Each ADR must have a unique numeric identifier."
+    has_errors=1
+fi
+
+echo ""
+echo "Checking for leading zeros in titles..."
+echo "======================================"
+
+for file in "${adr_files[@]}"; do
+    filename=$(basename "$file")
+    if [[ $filename =~ ^([0-9]{4})- ]]; then
+        file_number=${BASH_REMATCH[1]}
+        expected_number=$((10#$file_number))
+
+        title_line=$(grep '^title:' "$file" || true)
+        if [[ $title_line =~ ^title:\ *\"0[0-9]+\. ]]; then
+            error "$filename: title has leading zeros (found: $title_line). Use \"$expected_number. ...\" instead."
+            has_errors=1
+        fi
+
+        heading_line=$(grep '^# 0[0-9]\+\. ' "$file" || true)
+        if [[ -n "$heading_line" ]]; then
+            error "$filename: H1 heading has leading zeros (found: $heading_line). Use \"# $expected_number. ...\" instead."
+            has_errors=1
+        fi
+    fi
+done
+
+echo "======================================"
+if [[ $has_errors -ne 0 ]]; then
+    error "ADR number issues found. See errors above."
     exit 1
 else
-    echo "======================================"
-    success "All ${#adr_files[@]} ADR files have unique numeric identifiers"
+    success "All ${#adr_files[@]} ADR files have unique numeric identifiers and no leading zeros in titles"
     exit 0
 fi

--- a/skills/writing-adrs/SKILL.md
+++ b/skills/writing-adrs/SKILL.md
@@ -120,7 +120,10 @@ Follow these steps in order:
 3. **Fill in frontmatter.** `relates_to` must reference existing filenames
    (without `.md`) from `docs/problems/`. Use `"*"` only for ADRs that truly
    apply to all problem areas. The `status` in frontmatter must match the
-   `## Status` heading in the body (the linter enforces this).
+   `## Status` heading in the body (the linter enforces this). The number in
+   the `title` field and the `# heading` must have **no leading zeros**
+   (e.g., `"1. Use ADRs"`, not `"0001. Use ADRs"`). The four-digit
+   zero-padded format is only for filenames.
 4. **Choose the right status.** Use **Proposed** for a draft awaiting
    discussion. Use **Undecided** when the problem is identified but no choice
    has been made. Use **Accepted** when the decision is made. Include an
@@ -205,3 +208,4 @@ If the ADR partially answers a question, add a parenthetical:
 | Wrong ADR number | Check existing files in `docs/ADRs/` first |
 | Editing an accepted ADR's content | Write a new ADR that supersedes it |
 | Forgetting to update architecture.md | It must always reflect current decisions |
+| Leading zeros in title number | Use `"1. Title"` not `"0001. Title"` — zero-padded numbers are only for filenames |


### PR DESCRIPTION
## Summary
- Updates the `writing-adrs` skill to document that ADR title numbers must not have leading zeros (zero-padded format is only for filenames)
- Fixes 4 existing ADRs (17, 19, 25, 27) that had zero-padded numbers in their `title:` frontmatter and `# heading`
- Extends `hack/lint-adr-numbers` to catch leading zeros in titles and headings going forward

## Test plan
- [x] `make lint` passes
- [x] Linter correctly catches leading zeros (verified by temporarily reverting ADR 17)
- [x] Linter passes on all fixed ADR files

🤖 Generated with [Claude Code](https://claude.com/claude-code)