### PR TITLE
fix(#721): add pull-requests: write to post-run-link scaffold

### DIFF
--- a/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
@@ -435,6 +435,7 @@ jobs:
   post-run-link:
     permissions:
       issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: always() && !cancelled()
     needs:


### PR DESCRIPTION
## Summary

- Add `pull-requests: write` permission to `post-run-link` job in the scaffold shim workflow template
- The job uses `gh issue comment` to post on both issues and PRs, but commenting on PRs requires `pull-requests: write` — without it GitHub returns `Resource not accessible by integration (addComment)`

## Test plan

- [ ] Verify `make lint` passes
- [ ] Trigger a dispatch workflow on a PR and confirm the post-run-link comment is posted successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)