### PR TITLE
fix: add pull-requests: write to post-run-link job

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -435,6 +435,7 @@ jobs:
   post-run-link:
     permissions:
       issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: always() && !cancelled()
     needs:


### PR DESCRIPTION
## Summary

- The `post-run-link` job only had `issues: write` permission, which is insufficient for commenting on pull requests
- PR-triggered events (via `pull_request_target`) caused `GraphQL: Resource not accessible by integration (addComment)` errors
- Adds `pull-requests: write` to match what `dispatch-stop-fix` already does correctly

Fixes the failure seen on #697.

## Test plan

- [ ] Verify `post-run-link` succeeds on next PR event (e.g. re-trigger on #697)

🤖 Generated with [Claude Code](https://claude.com/claude-code)