### PR TITLE
chore: add local binary install step to cutting-releases skill

### DIFF
--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use when the user wants to tag a release, cut a release candidate, or ship a
   new version. Also use when asking about release process, versioning, or how
   GoReleaser is configured.
-allowed-tools: Read, Grep, Glob, Bash(git tag:*), Bash(git log:*), Bash(git diff:*), Bash(gh release:*), Bash(git checkout:*), Bash(bash scripts/install-binary.sh:*)
+allowed-tools: Read, Grep, Glob, AskUserQuestion, Bash(git tag:*), Bash(git log:*), Bash(git diff:*), Bash(git pull:*), Bash(git push:*), Bash(gh release:*), Bash(gh run:*), Bash(git checkout:*), Bash(bash scripts/install-binary.sh:*)
 ---
 
 # Cutting Releases

--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -113,6 +113,28 @@ gh release view <tag>
 
 Check that the title, changelog, and binary assets look correct.
 
+### 9. Install the binary locally
+
+Download the release binary for the current platform, unpack it, and install
+it to `~/bin/` with a versioned name:
+
+```bash
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+cd /tmp
+gh release download <tag> --pattern "fullsend_*_${OS}_${ARCH}.tar.gz" --clobber
+tar xzf fullsend_*_${OS}_${ARCH}.tar.gz fullsend
+mkdir -p ~/bin
+mv fullsend ~/bin/fullsend-<tag>
+chmod +x ~/bin/fullsend-<tag>
+```
+
+Verify it works and print the installed path:
+
+```
+~/bin/fullsend-<tag> --version
+```
+
 ## Notes
 
 - **Pre-releases:** Tags with `-rc.N`, `-alpha.N`, or `-beta.N` suffixes are

--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Use when the user wants to tag a release, cut a release candidate, or ship a
   new version. Also use when asking about release process, versioning, or how
   GoReleaser is configured.
+allowed-tools: Read, Grep, Glob
 ---
 
 # Cutting Releases
@@ -115,25 +116,16 @@ Check that the title, changelog, and binary assets look correct.
 
 ### 9. Install the binary locally
 
-Download the release binary for the current platform, unpack it, and install
-it to `~/bin/` with a versioned name:
+Ask the user where to install (default: `~/.local/bin/`), then run
+[scripts/install-binary.sh](scripts/install-binary.sh):
 
 ```bash
-ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-cd /tmp
-gh release download <tag> --pattern "fullsend_*_${OS}_${ARCH}.tar.gz" --clobber
-tar xzf fullsend_*_${OS}_${ARCH}.tar.gz fullsend
-mkdir -p ~/bin
-mv fullsend ~/bin/fullsend-<tag>
-chmod +x ~/bin/fullsend-<tag>
+bash scripts/install-binary.sh <tag> [install-dir]
 ```
 
-Verify it works and print the installed path:
-
-```
-~/bin/fullsend-<tag> --version
-```
+The script downloads the release archive, verifies its SHA-256 checksum
+against the release's `checksums.txt`, and installs the binary as
+`fullsend-<tag>` so multiple versions can coexist.
 
 ## Notes
 

--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use when the user wants to tag a release, cut a release candidate, or ship a
   new version. Also use when asking about release process, versioning, or how
   GoReleaser is configured.
-allowed-tools: Read, Grep, Glob
+allowed-tools: Read, Grep, Glob, Bash(git tag:*), Bash(git log:*), Bash(git diff:*), Bash(gh release:*), Bash(bash scripts/install-binary.sh:*)
 ---
 
 # Cutting Releases

--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use when the user wants to tag a release, cut a release candidate, or ship a
   new version. Also use when asking about release process, versioning, or how
   GoReleaser is configured.
-allowed-tools: Read, Grep, Glob, Bash(git tag:*), Bash(git log:*), Bash(git diff:*), Bash(gh release:*), Bash(bash scripts/install-binary.sh:*)
+allowed-tools: Read, Grep, Glob, Bash(git tag:*), Bash(git log:*), Bash(git diff:*), Bash(gh release:*), Bash(git checkout:*), Bash(bash scripts/install-binary.sh:*)
 ---
 
 # Cutting Releases

--- a/skills/cutting-releases/scripts/install-binary.sh
+++ b/skills/cutting-releases/scripts/install-binary.sh
@@ -13,9 +13,12 @@ set -euo pipefail
 TAG="${1:?Usage: install-binary.sh <tag> [install-dir]}"
 INSTALL_DIR="${2:-$HOME/.local/bin}"
 
+# macOS returns arm64 natively; Linux returns aarch64 which we map to arm64.
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCHIVE="fullsend_*_${OS}_${ARCH}.tar.gz"
+# GoReleaser's name_template uses .Version (no v prefix).
+VERSION="${TAG#v}"
+ARCHIVE="fullsend_${VERSION}_${OS}_${ARCH}.tar.gz"
 
 WORKDIR=$(mktemp -d)
 trap 'rm -rf "$WORKDIR"' EXIT
@@ -29,10 +32,17 @@ gh release download "$TAG" \
   --clobber
 
 echo "Verifying checksum..."
-grep "${OS}_${ARCH}.tar.gz" checksums.txt | sha256sum -c
+if command -v sha256sum >/dev/null 2>&1; then
+  grep -F "${ARCHIVE}" checksums.txt | sha256sum -c
+elif command -v shasum >/dev/null 2>&1; then
+  grep -F "${ARCHIVE}" checksums.txt | shasum -a 256 -c
+else
+  echo "ERROR: No sha256sum or shasum found" >&2
+  exit 1
+fi
 
 echo "Extracting..."
-tar xzf ${ARCHIVE} fullsend
+tar xzf "${ARCHIVE}" fullsend
 
 mkdir -p "${INSTALL_DIR}"
 mv fullsend "${INSTALL_DIR}/fullsend-${TAG}"

--- a/skills/cutting-releases/scripts/install-binary.sh
+++ b/skills/cutting-releases/scripts/install-binary.sh
@@ -11,6 +11,10 @@
 set -euo pipefail
 
 TAG="${1:?Usage: install-binary.sh <tag> [install-dir]}"
+if [[ ! "$TAG" =~ ^v[0-9] ]]; then
+  echo "ERROR: Tag must start with 'v' followed by a digit (e.g. v0.5.0)" >&2
+  exit 1
+fi
 INSTALL_DIR="${2:-$HOME/.local/bin}"
 
 # macOS returns arm64 natively; Linux returns aarch64 which we map to arm64.

--- a/skills/cutting-releases/scripts/install-binary.sh
+++ b/skills/cutting-releases/scripts/install-binary.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Install a fullsend release binary locally after verifying its checksum.
+#
+# Usage: install-binary.sh <tag> [install-dir]
+#
+# Arguments:
+#   tag          Release tag (e.g. v0.5.0)
+#   install-dir  Where to place the binary (default: ~/.local/bin)
+#
+# The binary is installed as fullsend-<tag> so multiple versions can coexist.
+set -euo pipefail
+
+TAG="${1:?Usage: install-binary.sh <tag> [install-dir]}"
+INSTALL_DIR="${2:-$HOME/.local/bin}"
+
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCHIVE="fullsend_*_${OS}_${ARCH}.tar.gz"
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+cd "$WORKDIR"
+
+echo "Downloading ${TAG} for ${OS}/${ARCH}..."
+gh release download "$TAG" \
+  --repo fullsend-ai/fullsend \
+  --pattern "${ARCHIVE}" \
+  --pattern "checksums.txt" \
+  --clobber
+
+echo "Verifying checksum..."
+grep "${OS}_${ARCH}.tar.gz" checksums.txt | sha256sum -c
+
+echo "Extracting..."
+tar xzf ${ARCHIVE} fullsend
+
+mkdir -p "${INSTALL_DIR}"
+mv fullsend "${INSTALL_DIR}/fullsend-${TAG}"
+chmod +x "${INSTALL_DIR}/fullsend-${TAG}"
+
+echo "Installed: ${INSTALL_DIR}/fullsend-${TAG}"
+"${INSTALL_DIR}/fullsend-${TAG}" --version


### PR DESCRIPTION
After verifying a release, download the binary for the current platform and install it to ~/bin/fullsend-v<tag>.