### PR TITLE
fix(#731): clear blocked on sufficient triage

### DIFF
--- a/internal/scaffold/fullsend-repo/scripts/post-triage.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-triage.sh
@@ -145,6 +145,8 @@ case "${ACTION}" in
     echo "Posting triage summary..."
     printf '%s' "${COMMENT}" | fullsend post-comment --repo "${REPO}" --number "${ISSUE_NUMBER}" --marker "<!-- fullsend:triage-agent -->" --token "${GH_TOKEN}" --result -
 
+    remove_label "blocked"
+
     # Only bugs get the ready-to-code label (which triggers the code agent).
     # Non-bug sufficient results (enhancement, performance, documentation, etc.)
     # receive the triaged label instead and wait for human prioritization.


### PR DESCRIPTION
## Summary

- Clear stale `blocked` labels when `post-triage.sh` handles a `sufficient` result.
- Keeps `blocked` mutually exclusive with the next triage state (`ready-to-code` for bugs, `triaged` for non-bugs).

Fixes #731.

## Validation

- `bash -n internal/scaffold/fullsend-repo/scripts/post-triage.sh`
- `bash internal/scaffold/fullsend-repo/scripts/post-triage-test.sh`
- `git diff --check`
- `make script-test`