### PR TITLE
fix(#701): update enrollment branch atomically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help:
 	@echo "  go-fmt               - Format Go code"
 	@echo "  go-vet               - Run go vet"
 	@echo "  go-tidy              - Run go mod tidy"
-	@echo "  script-test          - Run shell script tests (post-triage, post-code, validate-output-schema)"
+	@echo "  script-test          - Run shell script tests (post-triage, post-code, reconcile-repos, validate-output-schema)"
 	@echo "  test                 - Run all checks: lint, go-vet, go-test, script-test"
 	@echo "  e2e-test             - Run admin e2e tests (requires E2E_GITHUB_SESSION_FILE or E2E_GITHUB_USERNAME + E2E_GITHUB_PASSWORD)"
 	@echo "  e2e-export-session   - Login to GitHub and export a Playwright session file"
@@ -100,6 +100,7 @@ go-tidy:
 script-test:
 	bash internal/scaffold/fullsend-repo/scripts/post-triage-test.sh
 	bash internal/scaffold/fullsend-repo/scripts/post-code-test.sh
+	bash internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh
 	bash internal/scaffold/fullsend-repo/scripts/validate-output-schema-test.sh
 	python3 internal/scaffold/fullsend-repo/scripts/process-fix-result-test.py
 

--- a/docs/normative/admin-install/v1/adr-0012-fullsend-repo-files/SPEC.md
+++ b/docs/normative/admin-install/v1/adr-0012-fullsend-repo-files/SPEC.md
@@ -99,7 +99,8 @@ filesystem walk order, then `CODEOWNERS` last (CODEOWNERS failure is non-fatal).
 ### 3.14 `scripts/reconcile-repos.sh`
 
 - Shell script that reconciles enrollment shims in target repos. Called by
-  `repo-maintenance.yml`. Uses `gh` CLI and `yq` to read `config.yaml`.
+  `repo-maintenance.yml`. Uses `gh` CLI, `yq` to read `config.yaml`, and
+  `jq` to construct Git API request bodies.
   For enabled repos: creates branches, writes shim workflows, and opens
   enrollment PRs. For disabled repos: creates branches, deletes shim
   workflows (via GitHub Contents API DELETE with blob SHA), and opens

--- a/docs/normative/admin-install/v1/adr-0013-enrollment/SPEC.md
+++ b/docs/normative/admin-install/v1/adr-0013-enrollment/SPEC.md
@@ -152,6 +152,8 @@ The workflow uses a GitHub App token (generated via `actions/create-github-app-t
 1. Reads enabled repos from `config.yaml` using `yq`
 2. For each repo, checks if the shim already exists on the default branch
 3. If an enrollment PR already exists, updates the shim content on the branch
+   without temporarily resetting the branch to a zero-diff state against the
+   default branch
 4. Otherwise, creates a branch from the default branch tip, writes the shim, and opens a PR titled `chore: connect to fullsend agent pipeline`
 5. Closes any stale unenrollment PR (`fullsend/offboard` branch) for the repo
 

--- a/internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# reconcile-repos-test.sh - Regression tests for reconcile-repos.sh.
+#
+# Uses mocked gh/yq/base64 commands so tests do not hit GitHub.
+# Run from the repo root: bash internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RECONCILE_SCRIPT="${SCRIPT_DIR}/reconcile-repos.sh"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+CONFIG_DIR="${TMPDIR}/config"
+MOCK_BIN="${TMPDIR}/bin"
+GH_LOG="${TMPDIR}/gh-calls.log"
+mkdir -p "${CONFIG_DIR}/templates" "${MOCK_BIN}"
+
+cat > "${CONFIG_DIR}/config.yaml" <<'EOF'
+version: 1
+repos:
+  test-repo:
+    enabled: true
+EOF
+
+cat > "${CONFIG_DIR}/templates/shim-workflow.yaml" <<'EOF'
+fresh shim template
+EOF
+
+cat > "${MOCK_BIN}/base64" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-w0" ]]; then
+  shift
+fi
+/usr/bin/base64 "$@" | tr -d '\r\n'
+EOF
+chmod +x "${MOCK_BIN}/base64"
+
+cat > "${MOCK_BIN}/yq" <<'EOF'
+#!/usr/bin/env bash
+query="${1:-}"
+if [[ "$query" == *"enabled == true"* ]]; then
+  echo "test-repo"
+elif [[ "$query" == *"enabled == false"* ]]; then
+  :
+else
+  echo "unexpected yq query: $*" >&2
+  exit 1
+fi
+EOF
+chmod +x "${MOCK_BIN}/yq"
+
+cat > "${MOCK_BIN}/gh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'gh' >> "${GH_LOG}"
+for arg in "\$@"; do
+  printf ' %q' "\$arg" >> "${GH_LOG}"
+done
+printf '\n' >> "${GH_LOG}"
+
+if [[ "\$1" == "pr" && "\$2" == "list" ]]; then
+  for arg in "\$@"; do
+    if [[ "\$arg" == "fullsend/onboard" ]]; then
+      echo "https://github.com/test-org/test-repo/pull/18"
+    fi
+  done
+  exit 0
+fi
+
+if [[ "\$1" != "api" ]]; then
+  echo "unexpected gh command: \$*" >&2
+  exit 1
+fi
+
+endpoint="\$2"
+case "\$endpoint" in
+  repos/test-org/test-repo/contents/.github/workflows/fullsend.yaml)
+    echo "c3RhbGUgc2hpbSB0ZW1wbGF0ZQo="
+    ;;
+  repos/test-org/test-repo)
+    echo "main"
+    ;;
+  repos/test-org/test-repo/git/ref/heads/main)
+    echo "base-sha"
+    ;;
+  repos/test-org/test-repo/git/commits/base-sha)
+    echo "base-tree-sha"
+    ;;
+  repos/test-org/test-repo/git/blobs)
+    echo "blob-sha"
+    ;;
+  repos/test-org/test-repo/git/trees)
+    echo "tree-sha"
+    ;;
+  repos/test-org/test-repo/git/commits)
+    echo "desired-commit-sha"
+    ;;
+  repos/test-org/test-repo/git/refs)
+    exit 1
+    ;;
+  repos/test-org/test-repo/git/refs/heads/fullsend/onboard)
+    exit 0
+    ;;
+  repos/test-org/test-repo/git/refs/heads/fullsend/offboard)
+    exit 0
+    ;;
+  *)
+    echo "unexpected gh api endpoint: \$endpoint" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${MOCK_BIN}/gh"
+
+export PATH="${MOCK_BIN}:${PATH}"
+export GITHUB_REPOSITORY_OWNER="test-org"
+export GITHUB_SHA="test-sha"
+export GH_TOKEN="fake-token"
+
+bash "${RECONCILE_SCRIPT}" "${CONFIG_DIR}" > "${TMPDIR}/stdout.log" 2>&1
+
+if grep -q "refs/heads/fullsend/onboard.*sha=base-sha" "${GH_LOG}"; then
+  echo "FAIL: fullsend/onboard was reset to the default branch SHA"
+  cat "${GH_LOG}"
+  exit 1
+fi
+
+if ! grep -q "refs/heads/fullsend/onboard.*sha=desired-commit-sha" "${GH_LOG}"; then
+  echo "FAIL: fullsend/onboard was not moved directly to the desired shim commit"
+  cat "${GH_LOG}"
+  exit 1
+fi
+
+if grep -q "contents/.github/workflows/fullsend.yaml.*--method PUT" "${GH_LOG}"; then
+  echo "FAIL: shim update used Contents API after resetting branch state"
+  cat "${GH_LOG}"
+  exit 1
+fi
+
+echo "PASS: stale shim branch update is atomic"

--- a/internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh
+++ b/internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh
@@ -85,6 +85,9 @@ close_pr_on_branch() {
   fi
 }
 
+# load_default_branch fetches the default branch name and current SHA for a
+# given repo. Sets DEFAULT_BRANCH and DEFAULT_BRANCH_SHA as side effects.
+# Returns 0 on success, 1 on failure (with error logged).
 load_default_branch() {
   local repo="$1"
 
@@ -102,7 +105,7 @@ load_default_branch() {
 }
 
 # ensure_branch creates or resets a branch to the default branch tip.
-# Sets DEFAULT_BRANCH as a side effect (callers need it for PR creation).
+# Sets DEFAULT_BRANCH and DEFAULT_BRANCH_SHA as side effects.
 # Returns 0 on success, 1 on failure (with error logged).
 ensure_branch() {
   local repo="$1"

--- a/internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh
+++ b/internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh
@@ -6,6 +6,7 @@
 # Requires:
 #   GH_TOKEN  — GitHub token with contents:write and pull-requests:write on target repos
 #   yq        — for YAML parsing (pre-installed on GitHub Actions ubuntu runners)
+#   jq        — for constructing Git API request bodies
 #
 # Usage: ./scripts/reconcile-repos.sh [config-dir]
 #   config-dir: directory containing config.yaml and templates/ (default: current directory)
@@ -84,12 +85,8 @@ close_pr_on_branch() {
   fi
 }
 
-# ensure_branch creates or resets a branch to the default branch tip.
-# Sets DEFAULT_BRANCH as a side effect (callers need it for PR creation).
-# Returns 0 on success, 1 on failure (with error logged).
-ensure_branch() {
+load_default_branch() {
   local repo="$1"
-  local branch="$2"
 
   DEFAULT_BRANCH=$(gh api "repos/$ORG/$repo" --jq .default_branch 2>/dev/null || true)
   if [ -z "$DEFAULT_BRANCH" ]; then
@@ -97,23 +94,34 @@ ensure_branch() {
     return 1
   fi
 
-  local default_sha
-  default_sha=$(gh api "repos/$ORG/$repo/git/ref/heads/$DEFAULT_BRANCH" --jq .object.sha 2>/dev/null || true)
-  if [ -z "$default_sha" ]; then
+  DEFAULT_BRANCH_SHA=$(gh api "repos/$ORG/$repo/git/ref/heads/$DEFAULT_BRANCH" --jq .object.sha 2>/dev/null || true)
+  if [ -z "$DEFAULT_BRANCH_SHA" ]; then
     echo "::error::Could not get default branch SHA for $repo"
+    return 1
+  fi
+}
+
+# ensure_branch creates or resets a branch to the default branch tip.
+# Sets DEFAULT_BRANCH as a side effect (callers need it for PR creation).
+# Returns 0 on success, 1 on failure (with error logged).
+ensure_branch() {
+  local repo="$1"
+  local branch="$2"
+
+  if ! load_default_branch "$repo"; then
     return 1
   fi
 
   if ! gh api "repos/$ORG/$repo/git/refs" \
     --method POST \
     --field "ref=refs/heads/$branch" \
-    --field "sha=$default_sha" \
+    --field "sha=$DEFAULT_BRANCH_SHA" \
     --silent 2>/dev/null; then
     # Branch exists — force it to the current default branch tip to avoid
     # operating on a stale or attacker-controlled branch.
     if ! gh api "repos/$ORG/$repo/git/refs/heads/$branch" \
       --method PATCH \
-      --field "sha=$default_sha" \
+      --field "sha=$DEFAULT_BRANCH_SHA" \
       --field "force=true" \
       --silent; then
       echo "::error::Failed to create or update branch $branch on $repo"
@@ -122,25 +130,84 @@ ensure_branch() {
   fi
 }
 
-# write_shim_to_branch writes the shim template to a file on a branch.
+# write_shim_to_branch_from_default writes the shim template to a branch whose
+# tree is based on the current default branch. The branch ref moves directly to
+# the desired commit, avoiding a transient zero-diff state that can auto-close
+# an existing GitHub PR on the branch.
 # Returns 0 on success, 1 on failure (with error logged).
-write_shim_to_branch() {
+write_shim_to_branch_from_default() {
   local repo="$1"
   local branch="$2"
   local content_b64="$3"
   local commit_msg="$4"
 
-  local existing_sha
-  existing_sha=$(gh api "repos/$ORG/$repo/contents/$SHIM_PATH?ref=$branch" --jq .sha 2>/dev/null || true)
-
-  local args=(--method PUT --field "message=$commit_msg" --field "branch=$branch" --field "content=$content_b64")
-  if [ -n "$existing_sha" ]; then
-    args+=(--field "sha=$existing_sha")
+  if ! load_default_branch "$repo"; then
+    return 1
   fi
 
-  if ! gh api "repos/$ORG/$repo/contents/$SHIM_PATH" "${args[@]}" --silent; then
-    echo "::error::Failed to write shim to $repo (path=$SHIM_PATH, branch=$branch)"
+  local default_tree_sha
+  default_tree_sha=$(gh api "repos/$ORG/$repo/git/commits/$DEFAULT_BRANCH_SHA" --jq .tree.sha 2>/dev/null || true)
+  if [ -z "$default_tree_sha" ]; then
+    echo "::error::Could not get default branch tree for $repo"
     return 1
+  fi
+
+  local blob_sha
+  if ! blob_sha=$(jq -n \
+    --arg content "$content_b64" \
+    '{content: $content, encoding: "base64"}' |
+    gh api "repos/$ORG/$repo/git/blobs" --method POST --input - --jq .sha); then
+    echo "::error::Failed to create shim blob for $repo"
+    return 1
+  fi
+  if [ -z "$blob_sha" ]; then
+    echo "::error::Created empty shim blob SHA for $repo"
+    return 1
+  fi
+
+  local tree_sha
+  if ! tree_sha=$(jq -n \
+    --arg base_tree "$default_tree_sha" \
+    --arg path "$SHIM_PATH" \
+    --arg sha "$blob_sha" \
+    '{base_tree: $base_tree, tree: [{path: $path, mode: "100644", type: "blob", sha: $sha}]}' |
+    gh api "repos/$ORG/$repo/git/trees" --method POST --input - --jq .sha); then
+    echo "::error::Failed to create shim tree for $repo"
+    return 1
+  fi
+  if [ -z "$tree_sha" ]; then
+    echo "::error::Created empty shim tree SHA for $repo"
+    return 1
+  fi
+
+  local commit_sha
+  if ! commit_sha=$(jq -n \
+    --arg message "$commit_msg" \
+    --arg tree "$tree_sha" \
+    --arg parent "$DEFAULT_BRANCH_SHA" \
+    '{message: $message, tree: $tree, parents: [$parent]}' |
+    gh api "repos/$ORG/$repo/git/commits" --method POST --input - --jq .sha); then
+    echo "::error::Failed to create shim commit for $repo"
+    return 1
+  fi
+  if [ -z "$commit_sha" ]; then
+    echo "::error::Created empty shim commit SHA for $repo"
+    return 1
+  fi
+
+  if ! gh api "repos/$ORG/$repo/git/refs" \
+    --method POST \
+    --field "ref=refs/heads/$branch" \
+    --field "sha=$commit_sha" \
+    --silent 2>/dev/null; then
+    if ! gh api "repos/$ORG/$repo/git/refs/heads/$branch" \
+      --method PATCH \
+      --field "sha=$commit_sha" \
+      --field "force=true" \
+      --silent; then
+      echo "::error::Failed to create or update branch $branch on $repo"
+      return 1
+    fi
   fi
 }
 
@@ -180,12 +247,7 @@ if [ -n "$ENABLED_REPOS" ]; then
       # Shim is stale — update via PR to respect branch protection.
       echo "⟳ $REPO enrolled but shim is stale — creating update PR"
 
-      if ! ensure_branch "$REPO" "$ENROLL_BRANCH"; then
-        FAILED=$((FAILED + 1))
-        continue
-      fi
-
-      if ! write_shim_to_branch "$REPO" "$ENROLL_BRANCH" "$EXPECTED_B64" "chore: update fullsend shim workflow"; then
+      if ! write_shim_to_branch_from_default "$REPO" "$ENROLL_BRANCH" "$EXPECTED_B64" "chore: update fullsend shim workflow"; then
         FAILED=$((FAILED + 1))
         continue
       fi
@@ -217,7 +279,7 @@ if [ -n "$ENABLED_REPOS" ]; then
     if [ -n "$EXISTING_PR" ]; then
       echo "✓ $REPO has existing enrollment PR: $EXISTING_PR"
       # Update the shim on the existing branch to reflect the latest content.
-      if ! write_shim_to_branch "$REPO" "$ENROLL_BRANCH" "$(base64 -w0 < "$SHIM_TEMPLATE")" "chore: update fullsend shim workflow"; then
+      if ! write_shim_to_branch_from_default "$REPO" "$ENROLL_BRANCH" "$(base64 -w0 < "$SHIM_TEMPLATE")" "chore: update fullsend shim workflow"; then
         FAILED=$((FAILED + 1))
       else
         ENROLLED=$((ENROLLED + 1))
@@ -227,11 +289,6 @@ if [ -n "$ENABLED_REPOS" ]; then
 
     echo "Enrolling $REPO..."
 
-    if ! ensure_branch "$REPO" "$ENROLL_BRANCH"; then
-      FAILED=$((FAILED + 1))
-      continue
-    fi
-
     # Encode shim template content.
     SHIM_CONTENT=$(base64 -w0 < "$SHIM_TEMPLATE")
     if [ -z "$SHIM_CONTENT" ]; then
@@ -240,7 +297,7 @@ if [ -n "$ENABLED_REPOS" ]; then
       continue
     fi
 
-    if ! write_shim_to_branch "$REPO" "$ENROLL_BRANCH" "$SHIM_CONTENT" "chore: add fullsend shim workflow"; then
+    if ! write_shim_to_branch_from_default "$REPO" "$ENROLL_BRANCH" "$SHIM_CONTENT" "chore: add fullsend shim workflow"; then
       FAILED=$((FAILED + 1))
       continue
     fi


### PR DESCRIPTION
## Summary

- Update `reconcile-repos.sh` so enrollment/update branches move directly to the desired shim commit.
- Avoid temporarily resetting `fullsend/onboard` to the default branch SHA, which can create a zero-diff state and auto-close an existing enrollment PR.
- Add a mocked regression test for stale shim branch updates and wire it into `make script-test`.
- Document the new `jq` usage and the no-zero-diff branch update behavior.

Fixes #701.

## Root Cause

`ensure_branch()` reset `fullsend/onboard` to the target repo’s default branch tip before writing the shim content. If an enrollment PR already existed, GitHub could observe that intermediate zero-diff state and automatically close the PR before the script wrote the desired shim commit.

This PR fixes the root cause by building the desired shim commit first, then creating or force-updating `refs/heads/fullsend/onboard` directly to that commit in one ref move.

## Why This Approach

This keeps the #348/#413 update-via-PR behavior intact. The script still updates `fullsend/onboard` and opens or updates a PR rather than writing directly to the default branch. The difference is that it builds the desired shim commit first, parented by the current default branch, and only then moves the branch ref.

That preserves the controlled PR-based update flow while avoiding the transient zero-diff state described in #701.

### Why add `jq`?

This change uses `jq` to construct JSON request bodies for the lower-level Git API calls: create blob, create tree, and create commit. These payloads include nested objects and arrays, which are awkward and more error-prone to build with repeated `gh api --field` arguments.

Using `jq -n --arg ...` keeps the JSON construction structured and safely escaped for commit messages, base64 content, paths, tree entries, and parent SHAs. `jq` is also available on GitHub Actions Ubuntu runners, which is the script’s intended runtime environment.

### Why use the Git API instead of the Contents API?

The old flow reset `fullsend/onboard` to the default branch SHA and then used the Contents API to write the shim file. That intermediate branch state is the bug: the branch can briefly have zero diff from `main`, causing GitHub to auto-close the existing PR.

The Git API lets the script build the final desired commit before moving the branch ref:

```text
default tree + shim blob -> new tree -> new commit -> update fullsend/onboard ref
```

That means `fullsend/onboard` moves directly from its previous state to the desired shim commit. It never temporarily points at the default branch SHA.

### Does this reopen already auto-closed PRs?

No. This prevents future auto-closures by removing the zero-diff intermediate state.

It does not try to reopen already-auto-closed historical PRs. That is intentional: reopening is a recovery strategy, while this PR fixes the root cause. #701 listed atomic update as an acceptable solution, and this implementation chooses that path.

## Validation

- `bash -n internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh`
- `git diff --check origin/main..HEAD`
- `bash internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh` passed repeatedly
- `GOCACHE=/private/tmp/fullsend-go-build-cache GOMODCACHE=/private/tmp/fullsend-go-mod-cache go test ./internal/scaffold`
- `PRE_COMMIT_HOME=/private/tmp/fullsend-pre-commit-cache pre-commit run --files Makefile docs/normative/admin-install/v1/adr-0012-fullsend-repo-files/SPEC.md docs/normative/admin-install/v1/adr-0013-enrollment/SPEC.md internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh`

## Note

This PR intentionally does not include the unrelated `post-triage.sh` cleanup, keeping #701 scoped to enrollment branch handling. The existing `post-triage` script-test failure is tracked separately in #731.
