### PR TITLE
feat(#461): use /fs- prefix for slash commands

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -48,9 +48,9 @@ jobs:
       (github.event_name == 'issues'
         && (github.event.action == 'opened' || github.event.action == 'edited')) ||
       (github.event_name == 'issue_comment' && (
-        github.event.comment.body == '/triage' ||
-        startsWith(github.event.comment.body, '/triage ') ||
-        startsWith(github.event.comment.body, format('{0}{1}', '/triage', fromJSON('"\n"'))) ||
+        github.event.comment.body == '/fs-triage' ||
+        startsWith(github.event.comment.body, '/fs-triage ') ||
+        startsWith(github.event.comment.body, format('{0}{1}', '/fs-triage', fromJSON('"\n"'))) ||
         (
           (github.event.comment.author_association != 'NONE' ||
             github.event.comment.user.login == github.event.issue.user.login) &&
@@ -100,9 +100,9 @@ jobs:
       (github.event_name == 'issue_comment'
         && !github.event.issue.pull_request
         && (
-          github.event.comment.body == '/code' ||
-          startsWith(github.event.comment.body, '/code ') ||
-          startsWith(github.event.comment.body, format('{0}{1}', '/code', fromJSON('"\n"')))
+          github.event.comment.body == '/fs-code' ||
+          startsWith(github.event.comment.body, '/fs-code ') ||
+          startsWith(github.event.comment.body, format('{0}{1}', '/fs-code', fromJSON('"\n"')))
         ))
     steps:
       - name: Build minimal payload
@@ -147,9 +147,9 @@ jobs:
       (github.event_name == 'issues' && github.event.action == 'labeled'
         && github.event.label.name == 'ready-for-review') ||
       (github.event_name == 'issue_comment' && (
-        github.event.comment.body == '/review' ||
-        startsWith(github.event.comment.body, '/review ') ||
-        startsWith(github.event.comment.body, format('{0}{1}', '/review', fromJSON('"\n"')))
+        github.event.comment.body == '/fs-review' ||
+        startsWith(github.event.comment.body, '/fs-review ') ||
+        startsWith(github.event.comment.body, format('{0}{1}', '/fs-review', fromJSON('"\n"')))
       )) ||
       (github.event_name == 'pull_request_target'
         && github.event.action != 'closed')
@@ -253,9 +253,9 @@ jobs:
         && github.event.issue.pull_request
         && github.event.comment.user.type != 'Bot'
         && (
-          github.event.comment.body == '/fix'
-          || startsWith(github.event.comment.body, '/fix ')
-          || startsWith(github.event.comment.body, format('{0}{1}', '/fix', fromJSON('"\n"')))
+          github.event.comment.body == '/fs-fix'
+          || startsWith(github.event.comment.body, '/fs-fix ')
+          || startsWith(github.event.comment.body, format('{0}{1}', '/fs-fix', fromJSON('"\n"')))
         )
         && (
           github.event.comment.author_association == 'OWNER'
@@ -353,12 +353,9 @@ jobs:
       github.event_name == 'issue_comment'
         && github.event.comment.user.type != 'Bot'
         && (
-          github.event.comment.body == '/retro'
-          || startsWith(github.event.comment.body, '/retro ')
-          || startsWith(github.event.comment.body, format('{0}{1}', '/retro', fromJSON('"\n"')))
-          || github.event.comment.body == '/fullsend retro'
-          || startsWith(github.event.comment.body, '/fullsend retro ')
-          || startsWith(github.event.comment.body, format('{0}{1}', '/fullsend retro', fromJSON('"\n"')))
+          github.event.comment.body == '/fs-retro'
+          || startsWith(github.event.comment.body, '/fs-retro ')
+          || startsWith(github.event.comment.body, format('{0}{1}', '/fs-retro', fromJSON('"\n"')))
         )
         && (
           github.event.comment.author_association == 'OWNER'
@@ -499,7 +496,7 @@ jobs:
       github.event_name == 'issue_comment'
         && github.event.issue.pull_request
         && github.event.comment.user.type != 'Bot'
-        && github.event.comment.body == '/stop-fix'
+        && github.event.comment.body == '/fs-stop-fix'
         && (
           github.event.comment.author_association == 'OWNER'
           || github.event.comment.author_association == 'MEMBER'
@@ -524,7 +521,7 @@ jobs:
           gh pr edit "$PR_NUMBER" --repo "$REPO" \
             --add-label "fullsend-no-fix"
           gh pr comment "$PR_NUMBER" --repo "$REPO" \
-            --body "Fix agent disabled for this PR. Remove the \`fullsend-no-fix\` label or use \`/fix\` to re-engage."
+            --body "Fix agent disabled for this PR. Remove the \`fullsend-no-fix\` label or use \`/fs-fix\` to re-engage."
 
   post-run-link:
     permissions:

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -28,7 +28,7 @@ permissions:
 
 on:
   issues:
-    types: [labeled, opened, edited]
+    types: [labeled, opened]
   issue_comment:
     types: [created]
   pull_request_target:
@@ -45,12 +45,10 @@ jobs:
       group: triage-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: true
     if: >-
-      (github.event_name == 'issues'
-        && (github.event.action == 'opened' || github.event.action == 'edited')) ||
-      (github.event_name == 'issue_comment' && (
-        github.event.comment.body == '/fs-triage' ||
-        startsWith(github.event.comment.body, '/fs-triage ') ||
-        startsWith(github.event.comment.body, format('{0}{1}', '/fs-triage', fromJSON('"\n"'))) ||
+      github.event_name == 'issue_comment' && (
+        github.event.comment.body == '/triage' ||
+        startsWith(github.event.comment.body, '/triage ') ||
+        startsWith(github.event.comment.body, format('{0}{1}', '/triage', fromJSON('"\n"'))) ||
         (
           (github.event.comment.author_association != 'NONE' ||
             github.event.comment.user.login == github.event.issue.user.login) &&
@@ -58,7 +56,7 @@ jobs:
           contains(toJSON(github.event.issue.labels.*.name), 'needs-info') &&
           !contains(toJSON(github.event.issue.labels.*.name), 'type/feature')
         )
-      ))
+      )
     steps:
       - name: Build minimal payload
         id: payload
@@ -100,9 +98,9 @@ jobs:
       (github.event_name == 'issue_comment'
         && !github.event.issue.pull_request
         && (
-          github.event.comment.body == '/fs-code' ||
-          startsWith(github.event.comment.body, '/fs-code ') ||
-          startsWith(github.event.comment.body, format('{0}{1}', '/fs-code', fromJSON('"\n"')))
+          github.event.comment.body == '/code' ||
+          startsWith(github.event.comment.body, '/code ') ||
+          startsWith(github.event.comment.body, format('{0}{1}', '/code', fromJSON('"\n"')))
         ))
     steps:
       - name: Build minimal payload
@@ -147,9 +145,9 @@ jobs:
       (github.event_name == 'issues' && github.event.action == 'labeled'
         && github.event.label.name == 'ready-for-review') ||
       (github.event_name == 'issue_comment' && (
-        github.event.comment.body == '/fs-review' ||
-        startsWith(github.event.comment.body, '/fs-review ') ||
-        startsWith(github.event.comment.body, format('{0}{1}', '/fs-review', fromJSON('"\n"')))
+        github.event.comment.body == '/review' ||
+        startsWith(github.event.comment.body, '/review ') ||
+        startsWith(github.event.comment.body, format('{0}{1}', '/review', fromJSON('"\n"')))
       )) ||
       (github.event_name == 'pull_request_target'
         && github.event.action != 'closed')
@@ -253,9 +251,9 @@ jobs:
         && github.event.issue.pull_request
         && github.event.comment.user.type != 'Bot'
         && (
-          github.event.comment.body == '/fs-fix'
-          || startsWith(github.event.comment.body, '/fs-fix ')
-          || startsWith(github.event.comment.body, format('{0}{1}', '/fs-fix', fromJSON('"\n"')))
+          github.event.comment.body == '/fix'
+          || startsWith(github.event.comment.body, '/fix ')
+          || startsWith(github.event.comment.body, format('{0}{1}', '/fix', fromJSON('"\n"')))
         )
         && (
           github.event.comment.author_association == 'OWNER'
@@ -353,9 +351,12 @@ jobs:
       github.event_name == 'issue_comment'
         && github.event.comment.user.type != 'Bot'
         && (
-          github.event.comment.body == '/fs-retro'
-          || startsWith(github.event.comment.body, '/fs-retro ')
-          || startsWith(github.event.comment.body, format('{0}{1}', '/fs-retro', fromJSON('"\n"')))
+          github.event.comment.body == '/retro'
+          || startsWith(github.event.comment.body, '/retro ')
+          || startsWith(github.event.comment.body, format('{0}{1}', '/retro', fromJSON('"\n"')))
+          || github.event.comment.body == '/fullsend retro'
+          || startsWith(github.event.comment.body, '/fullsend retro ')
+          || startsWith(github.event.comment.body, format('{0}{1}', '/fullsend retro', fromJSON('"\n"')))
         )
         && (
           github.event.comment.author_association == 'OWNER'
@@ -397,61 +398,6 @@ jobs:
             -f event_type="$EVENT_TYPE" \
             -f source_repo="$SOURCE_REPO" \
             -f event_payload="$EVENT_PAYLOAD"
-
-  dispatch-prioritize:
-    runs-on: ubuntu-latest
-    outputs:
-      agent: ${{ steps.dispatch.outputs.agent }}
-    concurrency:
-      group: prioritize-${{ github.event.issue.number }}
-      cancel-in-progress: true
-    if: >-
-      github.event_name == 'issue_comment'
-        && !github.event.issue.pull_request
-        && github.event.comment.user.type != 'Bot'
-        && (
-          github.event.comment.body == '/prioritize'
-          || startsWith(github.event.comment.body, '/prioritize ')
-          || startsWith(github.event.comment.body, format('{0}{1}', '/prioritize', fromJSON('"\n"')))
-        )
-        && (
-          github.event.comment.author_association == 'OWNER'
-          || github.event.comment.author_association == 'MEMBER'
-          || github.event.comment.author_association == 'COLLABORATOR'
-        )
-    steps:
-      - name: Build minimal payload
-        id: payload
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_HTML_URL: ${{ github.event.issue.html_url }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-        run: |
-          set -euo pipefail
-          PAYLOAD=$(jq -cn \
-            --arg in "${ISSUE_NUMBER}" \
-            --arg iu "${ISSUE_HTML_URL}" \
-            --arg cb "${COMMENT_BODY:-}" \
-            '{issue: {number: ($in | tonumber), html_url: $iu},
-              comment: {body: $cb}}')
-          echo "json=$PAYLOAD" >> "$GITHUB_OUTPUT"
-      - name: Dispatch prioritize stage
-        id: dispatch
-        env:
-          GH_TOKEN: ${{ secrets.FULLSEND_DISPATCH_TOKEN }}
-          EVENT_PAYLOAD: ${{ steps.payload.outputs.json }}
-          EVENT_TYPE: ${{ github.event_name }}
-          SOURCE_REPO: ${{ github.repository }}
-          DISPATCH_REPO: ${{ github.repository_owner }}/.fullsend
-        run: |
-          DISPATCH_URL=$(gh workflow run dispatch.yml \
-            --repo "$DISPATCH_REPO" \
-            -f stage=prioritize \
-            -f event_type="$EVENT_TYPE" \
-            -f source_repo="$SOURCE_REPO" \
-            -f event_payload="$EVENT_PAYLOAD")
-          echo "::notice::Dispatched prioritize → ${DISPATCH_URL}"
-          echo "agent=prioritize" >> "$GITHUB_OUTPUT"
 
   dispatch-gh-classify:
     runs-on: ubuntu-latest
@@ -496,7 +442,7 @@ jobs:
       github.event_name == 'issue_comment'
         && github.event.issue.pull_request
         && github.event.comment.user.type != 'Bot'
-        && github.event.comment.body == '/fs-stop-fix'
+        && github.event.comment.body == '/stop-fix'
         && (
           github.event.comment.author_association == 'OWNER'
           || github.event.comment.author_association == 'MEMBER'
@@ -521,7 +467,7 @@ jobs:
           gh pr edit "$PR_NUMBER" --repo "$REPO" \
             --add-label "fullsend-no-fix"
           gh pr comment "$PR_NUMBER" --repo "$REPO" \
-            --body "Fix agent disabled for this PR. Remove the \`fullsend-no-fix\` label or use \`/fs-fix\` to re-engage."
+            --body "Fix agent disabled for this PR. Remove the \`fullsend-no-fix\` label or use \`/fix\` to re-engage."
 
   post-run-link:
     permissions:
@@ -536,7 +482,6 @@ jobs:
         dispatch-review,
         dispatch-fix-bot,
         dispatch-fix-human,
-        dispatch-prioritize,
       ]
     env:
       GH_TOKEN: ${{ github.token }}
@@ -548,8 +493,7 @@ jobs:
              || needs.dispatch-code.outputs.agent
              || needs.dispatch-review.outputs.agent
              || needs.dispatch-fix-bot.outputs.agent
-             || needs.dispatch-fix-human.outputs.agent
-             || needs.dispatch-prioritize.outputs.agent }}
+             || needs.dispatch-fix-human.outputs.agent }}
           SHIM_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -208,7 +208,7 @@ ADR 0002: [Building block 1](ADRs/0002-initial-fullsend-design.md#1-webhook--dis
 
 ### 2. Slash-command parser + ACL
 
-Parses `/triage`, `/code`, `/review`, and related commands and enforces who is allowed to invoke each.
+Parses `/fs-triage`, `/fs-code`, `/fs-review`, and related commands and enforces who is allowed to invoke each.
 ADR 0002: [Building block 2](ADRs/0002-initial-fullsend-design.md#2-slash-command-parser--acl).
 
 ### 3. Label state machine guard
@@ -273,7 +273,7 @@ ADR 0002: [Building block 13](ADRs/0002-initial-fullsend-design.md#13-observabil
 
 ### 14. retro agent runtime
 
-Retrospective analyst — examines completed or in-progress agent workflows, identifies improvement opportunities, and files proposals as GitHub issues. Runs automatically on PR close (merged or rejected) and on-demand via `/retro` command. Analyzes the full workflow graph (triage, code, review, fix agent interactions and human interventions) and posts a summary comment on the originating PR/issue linking to all filed proposals.
+Retrospective analyst — examines completed or in-progress agent workflows, identifies improvement opportunities, and files proposals as GitHub issues. Runs automatically on PR close (merged or rejected) and on-demand via `/fs-retro` command. Analyzes the full workflow graph (triage, code, review, fix agent interactions and human interventions) and posts a summary comment on the originating PR/issue linking to all filed proposals.
 
 ## Configuration layering
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -152,7 +152,7 @@ See [ADR 0002](ADRs/0002-initial-fullsend-design.md).
 
 ### Slash Command
 
-A GitHub comment in the form `/triage`, `/code`, `/review`, etc., that manually triggers an agent workflow. Slash commands are parsed by the entry point and gated by an ACL — not every user can invoke every command. They provide an explicit human-initiated trigger alongside the automatic label-based triggers.
+A GitHub comment in the form `/fs-triage`, `/fs-code`, `/fs-review`, `/fs-fix`, etc., that manually triggers an agent workflow. The `/fs-` prefix avoids collisions with other AI tools that respond to generic command names like `/review`, and the hyphen separator (rather than a space) prevents ambiguity when appending instructions (e.g., `/fs-fix add error handling`). Slash commands are parsed by the entry point and gated by an ACL — not every user can invoke every command. They provide an explicit human-initiated trigger alongside the automatic label-based triggers.
 See [ADR 0002](ADRs/0002-initial-fullsend-design.md) building block 2.
 
 ## T

--- a/docs/guides/user/bugfix-workflow.md
+++ b/docs/guides/user/bugfix-workflow.md
@@ -63,6 +63,7 @@ You can control the pipeline from issue or PR comments:
 | `/fs-review` | PR comment | Enqueues a new review round for the current PR head |
 | `/fs-fix` | PR comment | Requests the fix agent to address review feedback (OWNER/MEMBER/COLLABORATOR only) |
 | `/fs-retro` | Issue or PR comment | Triggers a retrospective analysis of the workflow |
+| `/fs-stop-fix` | PR comment | Disables bot-triggered fix agent runs on this PR |
 
 ### What to expect from agent PRs
 

--- a/docs/guides/user/bugfix-workflow.md
+++ b/docs/guides/user/bugfix-workflow.md
@@ -33,7 +33,7 @@ The triage agent reads the issue title, body, comments, and GitHub-native attach
 - Put key information in the issue body — expected behavior, actual behavior, steps to reproduce, version/environment.
 - Use GitHub's native file attachments for logs, screenshots, or reproduction scripts.
 - You can add details via comments — the triage agent reads those too. Other users can also comment with additional context (e.g., confirming the bug on a different platform).
-- Editing the issue title or body triggers triage automatically. You can also use `/triage` to force a fresh run.
+- Editing the issue title or body triggers triage automatically. You can also use `/fs-triage` to force a fresh run.
 
 ### Labels are the state machine
 
@@ -58,10 +58,11 @@ You can control the pipeline from issue or PR comments:
 
 | Command | Where | Effect |
 |---------|-------|--------|
-| `/triage` | Issue comment | Re-runs triage from scratch (clears all labels, reopens if closed) |
-| `/code` | Issue comment | Hands off to the code agent (expects `ready-to-code` or forces with human ack) |
-| `/review` | PR comment | Enqueues a new review round for the current PR head |
-| `/retro` | Issue or PR comment | Triggers a retrospective analysis of the workflow |
+| `/fs-triage` | Issue comment | Re-runs triage from scratch (clears all labels, reopens if closed) |
+| `/fs-code` | Issue comment | Hands off to the code agent (expects `ready-to-code` or forces with human ack) |
+| `/fs-review` | PR comment | Enqueues a new review round for the current PR head |
+| `/fs-fix` | PR comment | Requests the fix agent to address review feedback (OWNER/MEMBER/COLLABORATOR only) |
+| `/fs-retro` | Issue or PR comment | Triggers a retrospective analysis of the workflow |
 
 ### What to expect from agent PRs
 
@@ -97,7 +98,7 @@ Every push to a PR in the review stage triggers a new review round. This means `
 
 ### Stage 1: Triage
 
-**Triggered by:** issue creation, issue title/body edit, or `/triage` command.
+**Triggered by:** issue creation, issue title/body edit, or `/fs-triage` command.
 
 The triage agent:
 
@@ -108,11 +109,11 @@ The triage agent:
 5. **Produces a test artifact.** When possible, writes a failing test case aligned with the repo's test framework.
 6. **Hands off.** Labels `ready-to-code` with a summary comment.
 
-**If triage gets it wrong:** Add a comment with the missing information, or edit the issue body. Edits to the title or body trigger triage automatically. You can also use `/triage` to force a fresh run — this clears all previous labels and starts from scratch.
+**If triage gets it wrong:** Add a comment with the missing information, or edit the issue body. Edits to the title or body trigger triage automatically. You can also use `/fs-triage` to force a fresh run — this clears all previous labels and starts from scratch.
 
 ### Stage 2: Code
 
-**Triggered by:** `ready-to-code` label or `/code` command.
+**Triggered by:** `ready-to-code` label or `/fs-code` command.
 
 The code agent:
 
@@ -125,7 +126,7 @@ The code agent:
 
 ### Stage 3: Review
 
-**Triggered by:** `pull_request_target` events (PR opened, push to PR branch, or marked ready for review), `/review` command, or `ready-for-review` label.
+**Triggered by:** `pull_request_target` events (PR opened, push to PR branch, or marked ready for review), `/fs-review` command, or `ready-for-review` label.
 
 The review swarm:
 
@@ -139,20 +140,21 @@ Re-review happens automatically on every push to the PR. The `ready-for-merge` l
 
 Once the PR is merged (by human, merge queue, or automation per org governance), the automated pipeline for this issue is complete.
 
-The **retro agent** ([#131](https://github.com/fullsend-ai/fullsend/issues/131)) runs automatically when a PR is closed (merged or rejected) and can also be triggered on-demand via `/retro` on any issue or PR comment. It analyzes the full workflow graph — triage, code, review, and fix agent interactions plus any human interventions — to identify improvement opportunities. Proposals are filed as GitHub issues in the appropriate repo, and a summary comment is posted on the originating PR/issue linking to all proposals.
+The **retro agent** ([#131](https://github.com/fullsend-ai/fullsend/issues/131)) runs automatically when a PR is closed (merged or rejected) and can also be triggered on-demand via `/fs-retro` on any issue or PR comment. It analyzes the full workflow graph — triage, code, review, and fix agent interactions plus any human interventions — to identify improvement opportunities. Proposals are filed as GitHub issues in the appropriate repo, and a summary comment is posted on the originating PR/issue linking to all proposals.
 
 ## Intervening in the pipeline
 
 ### Stopping automation
 
 - Remove the triggering label (`ready-to-code`) to prevent the next stage from starting. Note: review is triggered automatically by PR events (`pull_request_target`), so closing the PR is the way to stop review dispatch.
-- Close the issue. Agents don't act on closed issues (except `/triage` which explicitly reopens).
+- Close the issue. Agents don't act on closed issues (except `/fs-triage` which explicitly reopens).
 
 ### Restarting a stage
 
-- `/triage` — wipes all labels, reopens the issue, runs triage fresh.
-- `/code` — restarts the code agent from the current issue state.
-- `/review` — enqueues a new review round.
+- `/fs-triage` — wipes all labels, reopens the issue, runs triage fresh.
+- `/fs-code` — restarts the code agent from the current issue state.
+- `/fs-review` — enqueues a new review round.
+- `/fs-fix` — requests the fix agent to address review feedback.
 
 ### Taking over manually
 

--- a/docs/normative/admin-install/v1/adr-0013-enrollment/SPEC.md
+++ b/docs/normative/admin-install/v1/adr-0013-enrollment/SPEC.md
@@ -55,7 +55,7 @@ The shim file MUST match the content embedded in `internal/scaffold/fullsend-rep
 
 1. **Event payload via environment variables** — All GitHub Actions context values (`toJSON(github.event)`, `github.event_name`, `github.repository`, `github.repository_owner`) are assigned to environment variables (`EVENT_PAYLOAD`, `EVENT_TYPE`, `SOURCE_REPO`, `DISPATCH_REPO`) and referenced as `"$VAR"` in the `run:` script. This prevents script injection from attacker-controlled fields (issue titles, comment bodies, PR descriptions).
 
-2. **Slash-command matching** — Uses a three-condition pattern per command: (1) exact equality for bare commands (`github.event.comment.body == '/triage'`), (2) `startsWith` with a trailing space for same-line arguments (`startsWith(github.event.comment.body, '/triage ')`), and (3) `startsWith` with a trailing newline for multi-line bodies (`startsWith(github.event.comment.body, format('{0}{1}', '/triage', fromJSON('"\n"')))`). The `fromJSON('"\n"')` expression produces a literal newline character, which GitHub Actions expression strings cannot represent directly. This avoids false positives from partial matches like `/triagefoo` while supporting both inline arguments and newline-separated bodies.
+2. **Slash-command matching** — Uses a three-condition pattern per command: (1) exact equality for bare commands (`github.event.comment.body == '/fs-triage'`), (2) `startsWith` with a trailing space for same-line arguments (`startsWith(github.event.comment.body, '/fs-triage ')`), and (3) `startsWith` with a trailing newline for multi-line bodies (`startsWith(github.event.comment.body, format('{0}{1}', '/fs-triage', fromJSON('"\n"')))`). The `fromJSON('"\n"')` expression produces a literal newline character, which GitHub Actions expression strings cannot represent directly. This avoids false positives from partial matches like `/fs-triagefoo` while supporting both inline arguments and newline-separated bodies.
 
 3. **Label matching** — Uses `github.event.action == 'labeled' && github.event.label.name == 'ready-to-code'` (exact match on the triggering label) rather than `contains(github.event.issue.labels.*.name, ...)` (which scans all labels). This ensures dispatch fires only on the labeling action that matters, not on unrelated label additions to an issue that already has the label.
 
@@ -83,9 +83,9 @@ jobs:
     if: >-
       github.event_name == 'issues' ||
       (github.event_name == 'issue_comment' && (
-        github.event.comment.body == '/triage' ||
-        startsWith(github.event.comment.body, '/triage ') ||
-        startsWith(github.event.comment.body, format('{0}{1}', '/triage', fromJSON('"\n"')))
+        github.event.comment.body == '/fs-triage' ||
+        startsWith(github.event.comment.body, '/fs-triage ') ||
+        startsWith(github.event.comment.body, format('{0}{1}', '/fs-triage', fromJSON('"\n"')))
       ))
     steps:
       - name: Dispatch triage

--- a/docs/problems/security-threat-model.md
+++ b/docs/problems/security-threat-model.md
@@ -347,7 +347,7 @@ An attacker triggers excessive consumption of compute, API tokens, or event-proc
 
 **Event flooding:**
 - Rapidly filing issues, posting comments, toggling labels, or creating PRs to trigger agent invocations at scale
-- Abusing slash commands (`/triage`, `/code`) to queue expensive operations
+- Abusing slash commands (`/fs-triage`, `/fs-code`) to queue expensive operations
 - Creating issues in bulk across multiple repos in an organization to saturate shared infrastructure
 
 **Cost amplification:**

--- a/docs/superpowers/plans/2026-05-04-retro-agent.md
+++ b/docs/superpowers/plans/2026-05-04-retro-agent.md
@@ -226,7 +226,7 @@ Minimal — validates inputs and writes trigger context. Follows the same `set -
 #   GH_TOKEN        — GitHub token with read scope
 #
 # Optional env vars:
-#   RETRO_COMMENT   — The /retro comment text (empty for automatic triggers)
+#   RETRO_COMMENT   — The /fs-retro comment text (empty for automatic triggers)
 
 set -euo pipefail
 

--- a/docs/superpowers/plans/2026-05-04-retro-agent.md
+++ b/docs/superpowers/plans/2026-05-04-retro-agent.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a retrospective agent that analyzes completed or in-progress agent workflows and proposes improvements by filing GitHub issues.
 
-**Architecture:** The retro agent follows the same harness/sandbox/runtime/post-script pattern as all other agents (ADR 0024). It is triggered by PR close events (automatic) and `/retro` commands (on-demand). The agent explores workflow history at runtime using `gh` CLI and the `finding-agent-runs` skill, then writes structured proposal files that the post-script converts into GitHub issues and summary comments.
+**Architecture:** The retro agent follows the same harness/sandbox/runtime/post-script pattern as all other agents (ADR 0024). It is triggered by PR close events (automatic) and `/fs-retro` commands (on-demand). The agent explores workflow history at runtime using `gh` CLI and the `finding-agent-runs` skill, then writes structured proposal files that the post-script converts into GitHub issues and summary comments.
 
 **Tech Stack:** Bash (pre/post scripts), YAML (harness config, workflow, policy), JSON Schema (output validation), Markdown (agent definition), GitHub Actions (dispatch workflow)
 
@@ -183,7 +183,7 @@ git commit -m "feat(retro): add sandbox policy for retro agent"
 **Files:**
 - Create: `internal/scaffold/fullsend-repo/env/retro.env`
 
-The retro agent needs the originating URL, comment text (if `/retro`), the repo name, and a GH_TOKEN for API access inside the sandbox.
+The retro agent needs the originating URL, comment text (if `/fs-retro`), the repo name, and a GH_TOKEN for API access inside the sandbox.
 
 - [ ] **Step 1: Create the env file**
 
@@ -420,7 +420,7 @@ DISPATCH_REPO="${ORG}/.fullsend"
 
 ### From an issue
 
-1. Find triage dispatches (triggered by `/triage` or `needs-info` comments):
+1. Find triage dispatches (triggered by `/fs-triage` or `needs-info` comments):
 
 ```bash
 gh run list --repo "$REPO_FULL_NAME" --workflow=fullsend.yaml \
@@ -576,7 +576,7 @@ You are a retrospective analyst. You examine agent workflows — completed, reje
 ## Inputs
 
 - `ORIGINATING_URL` — HTML URL of the PR or issue that triggered this retro.
-- `RETRO_COMMENT` — (optional) The human's `/retro` comment, if this was triggered on-demand. This is high-signal context: the human is telling you what to focus on. Read it carefully.
+- `RETRO_COMMENT` — (optional) The human's `/fs-retro` comment, if this was triggered on-demand. This is high-signal context: the human is telling you what to focus on. Read it carefully.
 - `REPO_FULL_NAME` — The source repository (owner/repo).
 
 ## Your role
@@ -882,7 +882,7 @@ git commit -m "feat(retro): add dispatch target workflow for retro stage"
 **Files:**
 - Modify: `internal/scaffold/fullsend-repo/templates/shim-workflow.yaml`
 
-Add two new dispatch jobs: `dispatch-retro` (automatic on PR close) and `dispatch-retro-command` (on-demand via `/retro`).
+Add two new dispatch jobs: `dispatch-retro` (automatic on PR close) and `dispatch-retro-command` (on-demand via `/fs-retro`).
 
 - [ ] **Step 1: Read the current shim**
 
@@ -1089,7 +1089,7 @@ Find the retro agent placeholder text.
 
 - [ ] **Step 2: Update the retro agent section**
 
-Replace the "Planned" placeholder with a description of what the retro agent does: runs automatically on PR close and on-demand via `/retro`, analyzes the workflow graph, and files improvement proposals as GitHub issues.
+Replace the "Planned" placeholder with a description of what the retro agent does: runs automatically on PR close and on-demand via `/fs-retro`, analyzes the workflow graph, and files improvement proposals as GitHub issues.
 
 - [ ] **Step 3: Commit**
 

--- a/docs/superpowers/plans/2026-05-04-retro-agent.md
+++ b/docs/superpowers/plans/2026-05-04-retro-agent.md
@@ -953,8 +953,8 @@ Append after the `dispatch-fix-human` job:
     if: >-
       github.event_name == 'issue_comment'
         && (
-          github.event.comment.body == '/retro'
-          || startsWith(github.event.comment.body, '/retro ')
+          github.event.comment.body == '/fs-retro'
+          || startsWith(github.event.comment.body, '/fs-retro ')
         )
         && (
           github.event.comment.author_association == 'OWNER'

--- a/docs/superpowers/specs/2026-04-17-installer-agent-content-design.md
+++ b/docs/superpowers/specs/2026-04-17-installer-agent-content-design.md
@@ -164,8 +164,8 @@ jobs:
     if: >-
       github.event_name == 'issues' ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body || '', '/triage') ||
-        github.event.comment.body == '/triage'
+        startsWith(github.event.comment.body || '', '/fs-triage') ||
+        github.event.comment.body == '/fs-triage'
       ))
     steps:
       - name: Dispatch triage
@@ -184,8 +184,8 @@ jobs:
       (github.event_name == 'issues' && github.event.action == 'labeled'
         && github.event.label.name == 'ready-to-code') ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body || '', '/code') ||
-        github.event.comment.body == '/code'
+        startsWith(github.event.comment.body || '', '/fs-code') ||
+        github.event.comment.body == '/fs-code'
       ))
     steps:
       - name: Dispatch code
@@ -204,8 +204,8 @@ jobs:
       (github.event_name == 'issues' && github.event.action == 'labeled'
         && github.event.label.name == 'ready-for-review') ||
       (github.event_name == 'issue_comment' && (
-        startsWith(github.event.comment.body || '', '/review') ||
-        github.event.comment.body == '/review'
+        startsWith(github.event.comment.body || '', '/fs-review') ||
+        github.event.comment.body == '/fs-review'
       )) ||
       github.event_name == 'pull_request_target' ||
       github.event_name == 'pull_request_review'

--- a/docs/superpowers/specs/2026-05-04-retro-agent-design.md
+++ b/docs/superpowers/specs/2026-05-04-retro-agent-design.md
@@ -170,7 +170,7 @@ dispatch-retro:
 **`/fs-retro` command:**
 ```yaml
 dispatch-retro:
-  if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/retro')
+  if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/fs-retro')
   # dispatch to .fullsend repo's retro.yml with comment text
 ```
 

--- a/docs/superpowers/specs/2026-05-04-retro-agent-design.md
+++ b/docs/superpowers/specs/2026-05-04-retro-agent-design.md
@@ -15,13 +15,13 @@ The retro agent is an analyst, not a fixer. It produces well-contextualized prop
 
 When a PR is closed (merged or rejected), the dispatch shim (`fullsend.yaml`) triggers a `dispatch-retro` job via the `pull_request_target` event with `closed` action. This dispatches to the `.fullsend` repo's `retro.yml` workflow, passing the PR URL as input.
 
-### On-demand: `/retro` command
+### On-demand: `/fs-retro` command
 
-A human posts `/retro` as a comment on an issue or PR, optionally with additional context explaining what they think is wrong and why. The shim handles this as an `issue_comment` event and dispatches to `retro.yml`, passing the originating URL and the full comment text.
+A human posts `/fs-retro` as a comment on an issue or PR, optionally with additional context explaining what they think is wrong and why. The shim handles this as an `issue_comment` event and dispatches to `retro.yml`, passing the originating URL and the full comment text.
 
 The human's comment is high-signal context. For example:
 
-> `/retro` this triage output is wrong — I would never prioritize a cosmetic label change over a broken test. Go figure out why and propose a fix.
+> `/fs-retro` this triage output is wrong — I would never prioritize a cosmetic label change over a broken test. Go figure out why and propose a fix.
 
 The retro agent treats this as a starting point for its investigation.
 
@@ -59,7 +59,7 @@ Write credentials are held only by the post-script, outside the sandbox, consist
 The pre-script collects only the trigger context and writes it to the `agent_input` directory:
 
 - **Originating URL:** The PR or issue that triggered the retro
-- **Comment text:** The `/retro` comment, if on-demand (empty for automatic triggers)
+- **Comment text:** The `/fs-retro` comment, if on-demand (empty for automatic triggers)
 - **Repo metadata:** Org name, repo name, `.fullsend` repo location
 
 The pre-script does not attempt to gather logs, traces, or workflow history. That is the agent's job.
@@ -97,7 +97,7 @@ These goals are the lens through which the agent evaluates what it finds. Custom
 - Start from the originating PR/issue
 - Use `finding-agent-runs` skill to trace the workflow graph
 - Dispatch subagents for all read-heavy operations to protect the main context window
-- If triggered by `/retro` with a human comment, treat that comment as the primary signal — the human is telling you where to look
+- If triggered by `/fs-retro` with a human comment, treat that comment as the primary signal — the human is telling you where to look
 - Go deep: follow threads, check related PRs, look for recurring patterns
 
 **Analysis instructions:**
@@ -167,7 +167,7 @@ dispatch-retro:
   # dispatch to .fullsend repo's retro.yml
 ```
 
-**`/retro` command:**
+**`/fs-retro` command:**
 ```yaml
 dispatch-retro:
   if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '/retro')
@@ -183,7 +183,7 @@ A standard dispatch workflow that runs `fullsend run retro` with the provided in
 - **Read-only sandbox:** The retro agent cannot modify code, push branches, or alter harness configs. It only proposes changes via issues.
 - **Credential isolation (ADR 0017):** Write credentials (`gh` token with issue-create and comment permissions) are held only by the post-script, outside the sandbox.
 - **Unidirectional control flow (ADR 0016):** The retro agent proposes changes via issues. Changes go through standard review (CODEOWNERS, human approval) and take effect in future invocations, never the current one.
-- **Adversarial feedback risk:** A malicious reviewer could post `/retro` with misleading context to bias the retro agent's proposals. The mitigation is the same human approval gate on the resulting issues — a proposal only takes effect if a maintainer approves and merges the change.
+- **Adversarial feedback risk:** A malicious reviewer could post `/fs-retro` with misleading context to bias the retro agent's proposals. The mitigation is the same human approval gate on the resulting issues — a proposal only takes effect if a maintainer approves and merges the change.
 - **Per-role GitHub App (ADR 0007):** The retro agent gets its own GitHub App with scoped permissions: read access to repos, issues, PRs, workflow runs, and artifacts; write access limited to creating issues and posting comments.
 
 ## Architectural Constraints

--- a/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
@@ -27,7 +27,7 @@ on:
         type: string
         description: "Human instruction (workflow_dispatch manual fallback)"
 
-# Single concurrency group per PR. A human /fix cancels any running fix
+# Single concurrency group per PR. A human /fs-fix cancels any running fix
 # (bot or human) so the human's instruction takes immediate effect.
 # Bot-triggered runs also cancel previous bot runs on the same PR.
 concurrency:
@@ -123,7 +123,7 @@ jobs:
           echo "pr_number=${PR_NUM}" >> "${GITHUB_OUTPUT}"
 
           # Resolve the PR head branch. For pull_request_review events the
-          # payload has .pull_request.head.ref. For /fix comment events
+          # payload has .pull_request.head.ref. For /fs-fix comment events
           # (issue_comment) it does not — query the GitHub API instead.
           HEAD_REF="$(echo "${EVENT_PAYLOAD}" | jq -r '.pull_request.head.ref // empty')"
           BASE_REF="$(echo "${EVENT_PAYLOAD}" | jq -r '.pull_request.base.ref // empty')"
@@ -141,7 +141,7 @@ jobs:
           echo "base_ref=${BASE_REF}" >> "${GITHUB_OUTPUT}"
           echo "PR #${PR_NUM}: ${HEAD_REF} → ${BASE_REF}"
 
-          # Extract human instruction (from /fix comment or workflow_dispatch).
+          # Extract human instruction (from /fs-fix comment or workflow_dispatch).
           # Default to "none" so the env var is always non-empty (the fullsend
           # binary rejects empty runner_env values). The agent checks
           # TRIGGER_SOURCE before reading this value.
@@ -159,7 +159,7 @@ jobs:
               INSTRUCTION="none"
             fi
           fi
-          # Use a random heredoc delimiter so a /fix comment containing
+          # Use a random heredoc delimiter so a /fs-fix comment containing
           # the literal delimiter string cannot inject GITHUB_OUTPUT values.
           DELIM="INSTRUCTION_$(openssl rand -hex 8)"
           {

--- a/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
@@ -149,8 +149,8 @@ jobs:
           if [[ ! "${TRIGGER_SOURCE}" =~ \[bot\]$ ]]; then
             COMMENT_BODY="$(echo "${EVENT_PAYLOAD}" | jq -r '.comment.body // empty')"
             if [[ -n "${COMMENT_BODY}" ]]; then
-              # Strip the /fix prefix to get the instruction.
-              INSTRUCTION="$(echo "${COMMENT_BODY}" | sed 's|^/fix[[:space:]]*||')"
+              # Strip the /fs-fix prefix to get the instruction.
+              INSTRUCTION="$(echo "${COMMENT_BODY}" | sed 's|^/fs-fix[[:space:]]*||')"
             fi
             if [[ -z "${INSTRUCTION}" && -n "${INPUT_INSTRUCTION}" ]]; then
               INSTRUCTION="${INPUT_INSTRUCTION}"

--- a/internal/scaffold/fullsend-repo/agents/fix.md
+++ b/internal/scaffold/fullsend-repo/agents/fix.md
@@ -80,7 +80,7 @@ code before acting on it. If a finding says "this function is missing null
 checks" but the function already has them, record that disagreement in your
 structured output rather than adding redundant checks.
 
-When a human provides a `/fix` instruction, treat it with higher trust than
+When a human provides a `/fs-fix` instruction, treat it with higher trust than
 bot feedback — but still verify against the code. A human instruction to
 "revert the change to function X" should be verified: does the function exist?
 Was it actually changed?
@@ -141,7 +141,7 @@ fix strategy.
 Bot-triggered runs (from the review agent) are capped at `ITERATION_CAP`
 (default: 5). When the iteration count approaches this cap, the `needs-human`
 label is added and the autonomous loop stops on the next attempt. A human can
-then direct the agent with `/fix` commands up to `ITERATION_CAP_HUMAN`
+then direct the agent with `/fs-fix` commands up to `ITERATION_CAP_HUMAN`
 (default: 10) total iterations (bot + human combined). This ensures humans
 are never locked out of the agent after a bot loop exhausts its budget.
 

--- a/internal/scaffold/fullsend-repo/agents/fix.md
+++ b/internal/scaffold/fullsend-repo/agents/fix.md
@@ -4,7 +4,7 @@ description: >-
   Review-feedback specialist for open PRs. Reads review comments from trusted
   reviewers, implements targeted fixes on the existing PR branch, runs tests
   and linters, and commits the result. Use when the review agent requests
-  changes or a human issues a /fix command on a PR.
+  changes or a human issues a /fs-fix command on a PR.
 disallowedTools: >-
   Bash(sed *), Bash(sed),
   Bash(awk *), Bash(awk),

--- a/internal/scaffold/fullsend-repo/agents/retro.md
+++ b/internal/scaffold/fullsend-repo/agents/retro.md
@@ -19,7 +19,7 @@ You are a retrospective analyst. You examine agent workflows — completed, reje
 ## Inputs
 
 - `ORIGINATING_URL` — HTML URL of the PR or issue that triggered this retro.
-- `RETRO_COMMENT` — (optional) The human's `/retro` comment, if this was triggered on-demand. This is high-signal context: the human is telling you what to focus on. Read it carefully.
+- `RETRO_COMMENT` — (optional) The human's `/fs-retro` comment, if this was triggered on-demand. This is high-signal context: the human is telling you what to focus on. Read it carefully.
 - `REPO_FULL_NAME` — The source repository (owner/repo).
 - `FULLSEND_OUTPUT_DIR` — Directory where you must write output files.
 

--- a/internal/scaffold/fullsend-repo/skills/finding-agent-runs/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/finding-agent-runs/SKILL.md
@@ -25,7 +25,7 @@ dispatches to `${DISPATCH_REPO}` which runs the agent workflows
 
 ### Triage dispatch
 
-Triage dispatches from `issue_comment` events (the `/triage` command):
+Triage dispatches from `issue_comment` events (the `/fs-triage` command):
 
 ```bash
 gh run list --workflow=fullsend.yaml \
@@ -33,7 +33,7 @@ gh run list --workflow=fullsend.yaml \
   -q '.[] | select(.event == "issue_comment")'
 ```
 
-Match by timestamp against the `/triage` comment (`gh issue view <N> --json comments`), then confirm `dispatch-triage` succeeded:
+Match by timestamp against the `/fs-triage` comment (`gh issue view <N> --json comments`), then confirm `dispatch-triage` succeeded:
 
 ```bash
 gh run view <RUN_ID> --json jobs \
@@ -91,7 +91,7 @@ gh run list --repo "${DISPATCH_REPO}" --workflow=review.yml --limit 5 \
 ### Retro dispatch
 
 Retro dispatches from `pull_request_target` (on PR close) and from
-`issue_comment` events (the `/retro` command):
+`issue_comment` events (the `/fs-retro` command):
 
 ```bash
 gh run list --workflow=fullsend.yaml \

--- a/internal/scaffold/fullsend-repo/skills/fix-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/fix-review/SKILL.md
@@ -170,7 +170,7 @@ summaries from previous iterations and have already been addressed.
 
 **Important:** The fix agent does not read or respond to inline PR comments.
 Inline comments are not part of the review agent's output. If humans need to
-direct the fix agent, they use the `/fix` command.
+direct the fix agent, they use the `/fs-fix` command.
 
 **If TRIGGER_SOURCE doesn't end in `[bot]` (human-triggered):**
 

--- a/internal/scaffold/fullsend-repo/skills/retro-analysis/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/retro-analysis/SKILL.md
@@ -21,7 +21,7 @@ DISPATCH_REPO="${ORG}/.fullsend"
 
 ### From an issue
 
-1. Find triage dispatches (triggered by `/triage` command or `needs-info` label responses):
+1. Find triage dispatches (triggered by `/fs-triage` command or `needs-info` label responses):
 
 ```bash
 gh run list --repo "$REPO_FULL_NAME" --workflow=fullsend.yaml \

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow-call.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow-call.yaml
@@ -41,9 +41,9 @@ jobs:
       (github.event_name == 'issues'
         && (github.event.action == 'opened' || github.event.action == 'edited')) ||
       (github.event_name == 'issue_comment' && (
-        github.event.comment.body == '/triage' ||
-        startsWith(github.event.comment.body, '/triage ') ||
-        startsWith(github.event.comment.body, format('{0}{1}', '/triage', fromJSON('"\n"'))) ||
+        github.event.comment.body == '/fs-triage' ||
+        startsWith(github.event.comment.body, '/fs-triage ') ||
+        startsWith(github.event.comment.body, format('{0}{1}', '/fs-triage', fromJSON('"\n"'))) ||
         (
           (github.event.comment.author_association != 'NONE' ||
             github.event.comment.user.login == github.event.issue.user.login) &&
@@ -67,9 +67,9 @@ jobs:
       (github.event_name == 'issue_comment'
         && !github.event.issue.pull_request
         && (
-          github.event.comment.body == '/code' ||
-          startsWith(github.event.comment.body, '/code ') ||
-          startsWith(github.event.comment.body, format('{0}{1}', '/code', fromJSON('"\n"')))
+          github.event.comment.body == '/fs-code' ||
+          startsWith(github.event.comment.body, '/fs-code ') ||
+          startsWith(github.event.comment.body, format('{0}{1}', '/fs-code', fromJSON('"\n"')))
         ))
     uses: __ORG__/.fullsend/.github/workflows/dispatch.yml@main
     with:
@@ -88,9 +88,9 @@ jobs:
       (github.event_name == 'issues' && github.event.action == 'labeled'
         && github.event.label.name == 'ready-for-review') ||
       (github.event_name == 'issue_comment' && (
-        github.event.comment.body == '/review' ||
-        startsWith(github.event.comment.body, '/review ') ||
-        startsWith(github.event.comment.body, format('{0}{1}', '/review', fromJSON('"\n"')))
+        github.event.comment.body == '/fs-review' ||
+        startsWith(github.event.comment.body, '/fs-review ') ||
+        startsWith(github.event.comment.body, format('{0}{1}', '/fs-review', fromJSON('"\n"')))
       )) ||
       (github.event_name == 'pull_request_target'
         && github.event.action != 'closed')
@@ -126,9 +126,9 @@ jobs:
         && github.event.issue.pull_request
         && github.event.comment.user.type != 'Bot'
         && (
-          github.event.comment.body == '/fix'
-          || startsWith(github.event.comment.body, '/fix ')
-          || startsWith(github.event.comment.body, format('{0}{1}', '/fix', fromJSON('"\n"')))
+          github.event.comment.body == '/fs-fix'
+          || startsWith(github.event.comment.body, '/fs-fix ')
+          || startsWith(github.event.comment.body, format('{0}{1}', '/fs-fix', fromJSON('"\n"')))
         )
         && (
           github.event.comment.author_association == 'OWNER'
@@ -161,9 +161,9 @@ jobs:
       github.event_name == 'issue_comment'
         && github.event.comment.user.type != 'Bot'
         && (
-          github.event.comment.body == '/retro'
-          || startsWith(github.event.comment.body, '/retro ')
-          || startsWith(github.event.comment.body, format('{0}{1}', '/retro', fromJSON('"\n"')))
+          github.event.comment.body == '/fs-retro'
+          || startsWith(github.event.comment.body, '/fs-retro ')
+          || startsWith(github.event.comment.body, format('{0}{1}', '/fs-retro', fromJSON('"\n"')))
           || github.event.comment.body == '/fullsend retro'
           || startsWith(github.event.comment.body, '/fullsend retro ')
           || startsWith(github.event.comment.body, format('{0}{1}', '/fullsend retro', fromJSON('"\n"')))
@@ -187,9 +187,9 @@ jobs:
         && !github.event.issue.pull_request
         && github.event.comment.user.type != 'Bot'
         && (
-          github.event.comment.body == '/prioritize'
-          || startsWith(github.event.comment.body, '/prioritize ')
-          || startsWith(github.event.comment.body, format('{0}{1}', '/prioritize', fromJSON('"\n"')))
+          github.event.comment.body == '/fs-prioritize'
+          || startsWith(github.event.comment.body, '/fs-prioritize ')
+          || startsWith(github.event.comment.body, format('{0}{1}', '/fs-prioritize', fromJSON('"\n"')))
         )
         && (
           github.event.comment.author_association == 'OWNER'
@@ -206,7 +206,7 @@ jobs:
       github.event_name == 'issue_comment'
         && github.event.issue.pull_request
         && github.event.comment.user.type != 'Bot'
-        && github.event.comment.body == '/stop-fix'
+        && github.event.comment.body == '/fs-stop-fix'
         && (
           github.event.comment.author_association == 'OWNER'
           || github.event.comment.author_association == 'MEMBER'
@@ -232,4 +232,4 @@ jobs:
           gh pr edit "$PR_NUMBER" --repo "$REPO" \
             --add-label "fullsend-no-fix"
           gh pr comment "$PR_NUMBER" --repo "$REPO" \
-            --body "Fix agent disabled for this PR. Remove the \`fullsend-no-fix\` label or use \`/fix\` to re-engage."
+            --body "Fix agent disabled for this PR. Remove the \`fullsend-no-fix\` label or use \`/fs-fix\` to re-engage."


### PR DESCRIPTION
## Summary

- Replace bare `/triage`, `/code`, `/review`, `/fix`, `/retro` with `/fs-triage`, `/fs-code`, `/fs-review`, `/fs-fix`, `/fs-retro`
- Hyphen separator avoids ambiguity with prompt args (e.g. `/fs-fix add error handling`)
- Short `/fs-` prefix per review feedback on #660 — `/fullsend` was too long (8 chars)
- Preserves `fromJSON` newline matching for multi-line comment bodies
- Updates shim workflow template, this repo's shim, fix.yml prefix stripping, agent/skill docs, and user-facing guides

Supersedes #660 with a clean, focused change.

Closes #461

## Test plan

- [x] `make lint` passes
- [x] `go test ./internal/scaffold/...` passes (pre-existing `TestFileModeMatchesFilesystem` failure unrelated)
- [ ] Manual: post `/fs-review` on a PR comment in an enrolled repo, verify dispatch triggers
- [ ] Manual: verify old bare `/review` no longer triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)