### PR TITLE
fix: remove --force from gh label create in stop-fix workflow

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -463,7 +463,7 @@ jobs:
         run: |
           gh label create "fullsend-no-fix" --repo "$REPO" \
             --description "Skip bot-triggered fix agent runs" --color "FBCA04" \
-            --force 2>/dev/null || true
+            2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" \
             --add-label "fullsend-no-fix"
           gh pr comment "$PR_NUMBER" --repo "$REPO" \

--- a/internal/scaffold/fullsend-repo/scripts/post-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-fix.sh
@@ -260,7 +260,7 @@ if [ "${ITERATION}" -ge "${WARN_THRESHOLD}" ] && is_bot_user "${TRIGGER_SOURCE}"
   echo "::warning::Fix iteration ${ITERATION} is approaching bot cap of ${BOT_CAP}"
   gh label create "needs-human" --repo "${REPO_FULL_NAME}" \
     --description "Agent loop needs human intervention" --color "D93F0B" \
-    --force 2>/dev/null || true
+    2>/dev/null || true
   gh pr edit "${PR_NUMBER}" --repo "${REPO_FULL_NAME}" \
     --add-label "needs-human" 2>/dev/null || true
 fi

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
@@ -426,7 +426,7 @@ jobs:
         run: |
           gh label create "fullsend-no-fix" --repo "$REPO" \
             --description "Skip bot-triggered fix agent runs" --color "FBCA04" \
-            --force 2>/dev/null || true
+            2>/dev/null || true
           gh pr edit "$PR_NUMBER" --repo "$REPO" \
             --add-label "fullsend-no-fix"
           gh pr comment "$PR_NUMBER" --repo "$REPO" \


### PR DESCRIPTION
## Summary

- `gh label create --force` fails with `'fullsend-no-fix' not found` when the label doesn't exist yet
- The `--force` flag changes behavior from "create new" to "update existing", so it never creates the label on first use
- The `|| true` swallows the error, leaving the label uncreated, and the subsequent `gh pr edit --add-label` fails with exit code 1
- Dropping `--force` makes `gh label create` work correctly: creates when missing, `|| true` handles "already exists" on repeat runs

## Failing run

https://github.com/fullsend-ai/fullsend/actions/runs/25556545077/job/75016905497

## Test plan

- [x] `go vet ./...` — clean
- [x] Unit tests pass (pre-existing failure in `TestFileModeMatchesFilesystem` unrelated to this change)
- [ ] Review squad verification