### PR TITLE
Document Forge landscape analysis

### DIFF
--- a/docs/landscape.md
+++ b/docs/landscape.md
@@ -106,6 +106,68 @@ Launched November 2025. The closest thing in the industry to autonomous merging.
 
 While the tools above focus on code review, a separate category of systems addresses end-to-end agent orchestration — from task intake through coding and merge. These are closer to the fullsend vision than review-only tools.
 
+### Forge-sdlc/forge
+
+[GitHub](https://github.com/forge-sdlc/forge) | [README](https://github.com/forge-sdlc/forge/blob/main/README.md) | [Container sandbox](https://github.com/forge-sdlc/forge/blob/main/containers/README.md) | [Skills](https://github.com/forge-sdlc/forge/blob/main/skills/README.md) | [implement_review proposal](https://github.com/forge-sdlc/forge/blob/main/proposals/007-implement-review-node.md)
+
+Forge is an open-source SDLC orchestrator that connects Jira, GitHub, and Claude/Gemini-backed agents. It takes Jira features or bugs through planning artifacts, implementation, pull requests, CI repair, AI review, and human review.
+
+**Bottom line:** Forge is worth studying, not adopting wholesale.
+
+It validates several fullsend assumptions: issue-to-PR automation needs event-driven execution, sandboxed code agents, pre-PR review, CI repair loops, human-visible state, and layered agent instructions. Its strongest ideas are staged intent artifacts, Q&A at approval gates, resumable webhook workflows, project-specific skills, and audited manual overrides.
+
+The mismatch is the authority model. Forge centralizes workflow truth in a FastAPI/Redis/LangGraph worker and treats Jira labels/comments as approval signals. Fullsend is trying to keep authority in repository-visible mechanisms: CODEOWNERS, branch protection, required checks, per-role forge identity, and auditable PR/issue state.
+
+**Workflow:** Forge's feature path is:
+
+`Jira Feature -> PRD -> approval/Q&A -> spec -> approval/Q&A -> epics -> approval/Q&A -> tasks -> approval/Q&A -> implementation -> local review -> PR -> CI/fix loop -> AI review -> human review`
+
+The bug path is shorter:
+
+`Jira Bug -> RCA -> approval/Q&A -> implementation -> PR -> CI/fix loop -> review`
+
+**Architecture:** FastAPI receives Jira and GitHub webhooks, Redis Streams queue events for workers, and LangGraph checkpoints workflow state so later webhooks can resume the graph. A host orchestrator handles planning and Jira/GitHub interaction. Ephemeral Podman containers run implementation agents. Markdown skills resolve from `skills/default` plus per-Jira-project overrides. Prometheus and Langfuse provide metrics and tracing.
+
+**Comparison to fullsend:**
+
+| Area | Forge | Fullsend direction |
+|---|---|---|
+| Coordination | Central checkpointed workflow | Repository as coordinator |
+| Authority | Jira labels/comments, GitHub reviews | CODEOWNERS, branch protection, required checks |
+| Intent | Jira elaborated into PRD/spec/tasks | Tiered intent with stronger strategic authorization |
+| Review | Local review, AI review, human gate | Independent zero-trust review sub-agents |
+| Sandbox | Productive Podman runner | Stricter credential isolation and egress policy |
+| Portability | GitHub/Jira-centric | Forge-neutral `forge.Client` abstraction |
+
+**Feature delta:** Forge has several shipped or proposed product features fullsend does not yet have in comparable form:
+
+- PRD/spec/epic/task generation from a single feature ticket.
+- Q&A mode at planning approval gates.
+- LangGraph checkpointing for long-lived workflow state.
+- Per-Jira-project skill overrides.
+- A first-class `/forge skip-gate` command for audited CI bypasses.
+- An implemented `implement_review` node for addressing or contesting PR feedback.
+
+Fullsend has design commitments that Forge does not appear to cover:
+
+- Repo-as-coordinator semantics for agent interaction.
+- Zero-trust review decomposition across independent review sub-agents.
+- Per-role forge identity and permission boundaries.
+- Credential isolation and egress policy as first-class architecture concerns.
+- Harness-level output schema enforcement.
+- Multi-forge portability through `forge.Client`.
+
+**Ideas to borrow:**
+
+- *Staged intent artifacts.* Forge's PRD -> spec -> epics -> tasks sequence is a useful model for Tier 2+ work. Fullsend should borrow the artifact progression, not the Jira-label authority.
+- *Q&A without approval.* Humans can ask questions at a gate without approving or rejecting. This fits fullsend's ambiguous-intent and dual-interpretation escalation problems.
+- *Checkpointed pause/resume.* Forge waits for humans through durable workflow state, not idle implementation containers. Fullsend should keep this operational pattern while keeping authoritative state repo-visible.
+- *Skill override resolution.* `skills/default` plus `skills/{project}` is a simple precedent for fullsend's harness layering.
+- *Review feedback as a task type.* Forge's `implement_review` flow classifies review comments as actionable or contested before acting. That is relevant to fullsend's review loop and salvage/rewrite questions.
+- *Audited CI gate skips.* `/forge skip-gate` is dangerous unless governed, but the UX is useful: constrained command, named check, PR confirmation, audit comment, and re-evaluation.
+
+**Cautions:** Jira label approval is too weak for high-tier intent. A workflow engine can dispatch work, but should not become merge authority. Forge's Podman runner is a productivity sandbox, not a full zero-trust boundary. A single AI review stage is not enough for autonomous merge confidence. CI skip mechanisms need permission checks, policy, and auditability from day one.
+
 ### Stripe Minions
 
 [Architecture blog post](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents) | [Part 2](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents-part-2)

--- a/docs/problems/agent-architecture.md
+++ b/docs/problems/agent-architecture.md
@@ -165,6 +165,8 @@ The "coordination logic" is the repository's branch protection configuration —
 
 This principle aligns with what Yegge's Gas City project calls "Zero Framework Cognition" (ZFC): the orchestration layer should handle mechanics only, while all judgment is deferred to the LLM via prompts. Gas City enforces this with a testable invariant — "does any line of Go contain a judgment call? If yes, it's a violation" — and extends it with the Bitter Lesson test: anything a smarter model would handle better from the prompt doesn't belong in the framework. (See [landscape.md](../landscape.md#gas-town--gas-city).) Fullsend's repo-as-coordinator model naturally satisfies ZFC: branch protection rules, CODEOWNERS, and status checks are deterministic infrastructure. The judgment happens in the review and implementation agents, mediated through GitHub's existing mechanisms. Note the architectural distinction: Gas City *does* have a controller process (reconciliation, health patrol), but enforces that it contain zero cognition. Fullsend's model goes further by eliminating the controller entirely and using the forge's native mechanisms instead.
 
+[Forge-sdlc/forge](../landscape.md#forge-sdlcforge) is the useful contrast case. It uses an event-driven FastAPI/Redis/LangGraph worker and durable checkpoints to move work forward, which is operationally sensible, but it also centralizes workflow truth and treats Jira labels/comments as approval signals. Fullsend can borrow the event-driven resume mechanics without moving merge authority or intent authorization out of repository-visible controls.
+
 ### How agents communicate
 
 Agents interact through GitHub's existing mechanisms:

--- a/docs/problems/agent-infrastructure.md
+++ b/docs/problems/agent-infrastructure.md
@@ -73,6 +73,8 @@ Agents are often discussed as if they run on a developer workstation: fast local
 
 - **Compute held open for human latency** — A long-lived pod that **blocks on PR approval, architecture sign-off, or escalation** consumes cluster quota and cost while idle. That misaligns with typical “always-on service” defaults. Better fits include **event-driven** scheduling (wake on comment or approval), aggressive scale-to-zero, or separating **planning** from **execution** so capacity is not reserved across human response times; see [human-factors.md](human-factors.md) and [autonomy-spectrum.md](autonomy-spectrum.md).
 
+[Forge-sdlc/forge](../landscape.md#forge-sdlcforge) demonstrates one practical pause/resume pattern: LangGraph checkpoints workflow state, then later Jira or GitHub webhooks resume the graph while implementation work happens in ephemeral Podman containers. That separation is directionally useful for fullsend, even though Forge's sandbox is a productivity boundary rather than the stricter credential and egress isolation boundary fullsend needs.
+
 ## Ambient Code Platform (ACP)
 
 [Ambient Code Platform](https://github.com/ambient-code/platform) is a Kubernetes-native stack (API, operator, runner pods) for agentic sessions—aligned in spirit with “ambient,” CR-driven agent workloads on a cluster.
@@ -92,6 +94,7 @@ ACP may still be useful for **narrow experiments** where those constraints are a
 - **Thin orchestration layer** — We build a small layer that triggers agents, gathers results, and posts status checks; the actual compute is 3rd party or internal. This keeps coordination logic in our control while deferring platform choice.
 - **Phase by phase** — Start with a 3rd party or internal option for early experiments (e.g. review agents only); decide later whether to replace or extend with custom infrastructure as autonomy expands.
 - **By agent type** — Triage and review agents might run on one platform (e.g. event-driven, short-lived); code agents that need more tooling and longer runs might need a different environment.
+- **Layered skill resolution** — Forge's `skills/default` plus `skills/{project}` fallback is a simple precedent for repo or project-specific harness instructions without duplicating every default. Fullsend's version would need clearer ownership, provenance, and policy controls, but the resolver shape is worth borrowing.
 
 ## Kubernetes SIG Agent Sandbox
 

--- a/docs/problems/code-review.md
+++ b/docs/problems/code-review.md
@@ -170,6 +170,8 @@ The human sees coherent framings and can pick the one that matches their underst
 
 This pattern is most valuable at escalation boundaries — where the system has already decided it can't resolve something autonomously. It doesn't replace confidence scores or explicit uncertainty signals; it complements them by making the *nature* of the uncertainty actionable. It applies wherever agents interact with humans: tier classification (see [intent-representation.md](intent-representation.md#the-tier-escalation-problem)), the exploration phase for proposed features (see [intent-representation.md](intent-representation.md#the-try-it-phase)), and deadlock resolution between review sub-agents (see [agent-architecture.md](agent-architecture.md#how-deadlocks-are-resolved)).
 
+[Forge-sdlc/forge](../landscape.md#forge-sdlcforge) has a concrete version of this idea in its `implement_review` flow: review comments are treated as their own task type, classified as actionable or contested before the agent acts, and contested comments trigger a structured response rather than silent compliance. That is a useful precedent for fullsend's review loops, especially when an agent should push back on incorrect feedback while still respecting the reviewer's blocking authority.
+
 ## Review as salvage
 
 The sub-agent model above assumes a binary outcome: approve or reject. But when reviewing external contributions (especially AI-generated ones), a third outcome becomes important: *salvage* — extracting the valuable idea from a poor implementation and having a project agent rewrite it properly.

--- a/docs/problems/governance.md
+++ b/docs/problems/governance.md
@@ -15,6 +15,7 @@ The decisions that shape how the agentic system behaves across the org:
 - **Agent permissions** — what authority each agent role has (merge, approve, comment, label). What are the boundaries, and who draws them?
 - **Org-wide guardrails** — minimum standards that apply to all repos regardless of individual repo policy. Examples: all repos must have CODEOWNERS, all security-sensitive paths require human approval, all agent config changes require human approval.
 - **Model and tool egress policy** — which model providers and tool protocols (e.g. MCP servers) agent runtimes may use, how spend and quotas are enforced, and who may approve changes to those allowlists. Central **protocol gateways** are one enforcement point; they should fall under the same change-control rigor as other agent infrastructure (see [landscape.md](../landscape.md#agent-gateway)).
+- **Manual bypass policy** — whether and how humans can temporarily bypass failed agent or CI gates. [Forge-sdlc/forge](../landscape.md#forge-sdlcforge) exposes `/forge skip-gate` for infrastructure-related CI failures, with PR confirmation and Jira audit comments. Fullsend needs the same UX category only if it is governed from day one: named checks, permission checks, expiry or revalidation, and immutable audit trails.
 
 ### 2. Configuration security
 

--- a/docs/problems/intent-representation.md
+++ b/docs/problems/intent-representation.md
@@ -216,6 +216,8 @@ Kubernetes has KEPs (enhancement proposals). Rust has RFCs. Fedora has Changes. 
 
 The difference for us: the process needs to be machine-readable enough for agents to evaluate, and fast enough that it doesn't bottleneck agent-speed development for lower tiers.
 
+[Forge-sdlc/forge](../landscape.md#forge-sdlcforge) is useful prior art for the *shape* of high-tier intent artifacts: a feature ticket is progressively elaborated into PRD, spec, epics, and tasks, with humans able to ask questions at each gate without approving or rejecting. The part to avoid is treating Jira labels/comments as the authority mechanism. For fullsend, the artifact progression is interesting; the authorization still needs to come from repo-visible mechanisms with stronger ownership and approval semantics.
+
 ## Adversarial analysis
 
 Any intent system needs to survive attack:


### PR DESCRIPTION
## Summary

- Add Forge-sdlc/forge to `docs/landscape.md` as an end-to-end SDLC orchestrator comparison.
- Document Forge’s workflow, architecture, feature delta, ideas to borrow, and cautions.
- Cross-reference Forge lessons in the intent, infrastructure, architecture, code review, and governance problem docs.

## Notes

This incorporates the Forge analysis from #686 into the main landscape document and threads the especially relevant takeaways into existing problem docs.

Key takeaways:
- Borrow Forge’s staged intent artifacts and Q&A gates, not its Jira-label authority model.
- Treat checkpointed pause/resume as useful operational prior art.
- Study `implement_review` as a precedent for review-feedback tasks.
- Govern any CI gate skip mechanism from day one.

Closes #686