### PR TITLE
fix: restore automatic triage on issue open/edit

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -28,7 +28,7 @@ permissions:
 
 on:
   issues:
-    types: [labeled, opened]
+    types: [labeled, opened, edited]
   issue_comment:
     types: [created]
   pull_request_target:
@@ -45,7 +45,9 @@ jobs:
       group: triage-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: true
     if: >-
-      github.event_name == 'issue_comment' && (
+      (github.event_name == 'issues'
+        && (github.event.action == 'opened' || github.event.action == 'edited')) ||
+      (github.event_name == 'issue_comment' && (
         github.event.comment.body == '/triage' ||
         startsWith(github.event.comment.body, '/triage ') ||
         startsWith(github.event.comment.body, format('{0}{1}', '/triage', fromJSON('"\n"'))) ||
@@ -56,7 +58,7 @@ jobs:
           contains(toJSON(github.event.issue.labels.*.name), 'needs-info') &&
           !contains(toJSON(github.event.issue.labels.*.name), 'type/feature')
         )
-      )
+      ))
     steps:
       - name: Build minimal payload
         id: payload

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow.yaml
@@ -28,7 +28,7 @@ permissions:
 
 on:
   issues:
-    types: [labeled]
+    types: [labeled, opened, edited]
   issue_comment:
     types: [created]
   pull_request_target:
@@ -45,7 +45,9 @@ jobs:
       group: triage-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: true
     if: >-
-      github.event_name == 'issue_comment' && (
+      (github.event_name == 'issues'
+        && (github.event.action == 'opened' || github.event.action == 'edited')) ||
+      (github.event_name == 'issue_comment' && (
         github.event.comment.body == '/triage' ||
         startsWith(github.event.comment.body, '/triage ') ||
         startsWith(github.event.comment.body, format('{0}{1}', '/triage', fromJSON('"\n"'))) ||
@@ -56,7 +58,7 @@ jobs:
           contains(toJSON(github.event.issue.labels.*.name), 'needs-info') &&
           !contains(toJSON(github.event.issue.labels.*.name), 'type/feature')
         )
-      )
+      ))
     steps:
       - name: Build minimal payload
         id: payload


### PR DESCRIPTION
## Summary

- Re-enables `issues.opened` and `issues.edited` triggers for the `dispatch-triage` job in both the repo shim workflow and the scaffold template
- Adds `opened` and `edited` to the `on.issues.types` array so the workflow receives these events
- Adds an `issues.opened || issues.edited` condition to the `dispatch-triage` `if` expression alongside the existing `issue_comment` triggers

This was disabled in #394 as a temporary measure pending better downstream guardrails. Those guardrails now exist:
- **#557** gated `ready-to-code` to bugs only
- **#561** refined gating: auto-promotes only low-risk categories (`bug`, `documentation`, `performance`) while requiring human review for `feature` issues

Closes #563

## Test plan

- [ ] Verify `make lint` passes
- [ ] Verify scaffold tests pass (`go test ./internal/scaffold/`)
- [ ] Open a test issue in an enrolled repo and confirm triage dispatches automatically
- [ ] Edit an existing issue and confirm triage re-dispatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)