### PR TITLE
fix: prevent dev build versions from being pinned in action.yml

### DIFF
--- a/internal/layers/workflows.go
+++ b/internal/layers/workflows.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/fullsend-ai/fullsend/internal/forge"
 	"github.com/fullsend-ai/fullsend/internal/scaffold"
@@ -173,13 +174,19 @@ func (l *WorkflowsLayer) Analyze(ctx context.Context) (*LayerReport, error) {
 	return report, nil
 }
 
+// releaseVersionPattern matches a clean release tag: v1.2.3 or 1.2.3.
+// Dev builds from git describe (e.g. v0.7.0-58-g4273effb, v0.7.0-dirty)
+// will NOT match and are treated as non-release.
+var releaseVersionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+
 // pinVersionInAction replaces the "default: latest" line in the action.yml
-// version input with the concrete CLI version. If the version is "dev"
-// (local build), it falls back to "latest" and logs a warning.
+// version input with the concrete CLI version. Non-release versions (dev
+// builds, git-describe output like v0.7.0-58-gXXXXXXX) fall back to
+// "latest" so that workflows don't try to download a nonexistent release.
 func (l *WorkflowsLayer) pinVersionInAction(content []byte) []byte {
-	if l.cliVersion == "" || l.cliVersion == "dev" {
-		if l.cliVersion == "dev" {
-			l.ui.StepWarn("CLI version is \"dev\"; action.yml will use \"latest\" (unpinned)")
+	if !releaseVersionPattern.MatchString(l.cliVersion) {
+		if l.cliVersion != "" {
+			l.ui.StepWarn(fmt.Sprintf("CLI version %q is not a release; action.yml will use \"latest\" (unpinned)", l.cliVersion))
 		}
 		return content
 	}

--- a/internal/layers/workflows_test.go
+++ b/internal/layers/workflows_test.go
@@ -192,6 +192,39 @@ func TestWorkflowsLayer_Install_ReinstallUpdatesVersion(t *testing.T) {
 		"re-install should update pinned version")
 }
 
+func TestWorkflowsLayer_Install_GitDescribeVersionFallsBackToLatest(t *testing.T) {
+	devVersions := []string{
+		"v0.7.0-58-g4273effb",
+		"v0.7.0-dirty",
+		"v0.7.0-3-g1234567-dirty",
+		"4273effb",
+	}
+	for _, ver := range devVersions {
+		t.Run(ver, func(t *testing.T) {
+			client := forge.NewFakeClient()
+			var buf bytes.Buffer
+			printer := ui.New(&buf)
+			layer := NewWorkflowsLayer("test-org", client, printer, "admin-user", ver)
+
+			err := layer.Install(context.Background())
+			require.NoError(t, err)
+
+			var actionContent string
+			for _, f := range client.CommittedFiles[0].Files {
+				if f.Path == actionYMLPath {
+					actionContent = string(f.Content)
+					break
+				}
+			}
+			require.NotEmpty(t, actionContent, "action.yml should have been written")
+			assert.Contains(t, actionContent, "default: latest",
+				"non-release version %q should fall back to latest", ver)
+			assert.Contains(t, buf.String(), "not a release",
+				"should warn about non-release version")
+		})
+	}
+}
+
 func TestWorkflowsLayer_Install_Error(t *testing.T) {
 	client := &forge.FakeClient{
 		Errors: map[string]error{

--- a/internal/layers/workflows_test.go
+++ b/internal/layers/workflows_test.go
@@ -198,6 +198,8 @@ func TestWorkflowsLayer_Install_GitDescribeVersionFallsBackToLatest(t *testing.T
 		"v0.7.0-dirty",
 		"v0.7.0-3-g1234567-dirty",
 		"4273effb",
+		"dev",
+		"v1.0.0-rc.1",
 	}
 	for _, ver := range devVersions {
 		t.Run(ver, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Local builds produce git-describe versions like `v0.7.0-58-g4273effb` that get pinned into the scaffolded `action.yml` version input default. When workflows run in GitHub Actions, they try to download this nonexistent release from `github.com/fullsend-ai/fullsend/releases` and fail.
- Replace the exact `"dev"` string check in `pinVersionInAction` with a regex that only pins clean semver release tags (`v1.2.3` or `1.2.3`). All other versions — `dev`, git-describe output, dirty builds, bare commit hashes — fall back to `"latest"` with a warning.

## Test plan

- [x] Existing tests pass: `PinsCliVersion` (clean `v0.2.0`), `DevVersionFallsBackToLatest`, `EmptyVersionKeepsLatest`, `ReinstallUpdatesVersion`
- [x] New test `GitDescribeVersionFallsBackToLatest` covers: `v0.7.0-58-g4273effb`, `v0.7.0-dirty`, `v0.7.0-3-g1234567-dirty`, `4273effb`
- [x] `go vet ./...` clean