### PR TITLE
fix(#810): use OPENSHELL_VERSION env var for OpenShell install

### DIFF
--- a/internal/scaffold/fullsend-repo/.github/actions/fullsend/action.yml
+++ b/internal/scaffold/fullsend-repo/.github/actions/fullsend/action.yml
@@ -124,7 +124,7 @@ runs:
         attempt=1
         delay=5
         while true; do
-          if curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/v0.0.36/install.sh | sh; then
+          if curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | OPENSHELL_VERSION=v0.0.36 sh; then
             break
           fi
           if (( attempt >= max_attempts )); then

--- a/internal/scaffold/fullsend-repo/.github/actions/fullsend/action.yml
+++ b/internal/scaffold/fullsend-repo/.github/actions/fullsend/action.yml
@@ -124,7 +124,7 @@ runs:
         attempt=1
         delay=5
         while true; do
-          if curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | OPENSHELL_VERSION=v0.0.36 sh; then
+          if curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/v0.0.36/install.sh | OPENSHELL_VERSION=v0.0.36 sh; then
             break
           fi
           if (( attempt >= max_attempts )); then


### PR DESCRIPTION
## Summary

- Switch OpenShell install in scaffold action from hardcoded version in URL path to `main` branch script with `OPENSHELL_VERSION` env var
- The install script installs latest regardless of which tag it was fetched from — the URL tag only controls which version of the *script* is fetched, not which binary is installed
- This broke konflux-ci when a new OpenShell release landed unexpectedly

Mirrors [konflux-ci/.fullsend#12](https://github.com/konflux-ci/.fullsend/pull/12).

Closes #810

## Test plan

- [ ] Verify `openshell --version` output matches `v0.0.36` after install step runs
- [ ] Confirm scaffold action installs correctly in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)