### PR TITLE
chore: add merge-queue skill

### DIFF
--- a/skills/merge-queue/SKILL.md
+++ b/skills/merge-queue/SKILL.md
@@ -1,12 +1,25 @@
 ---
 name: merge-queue
-description: >
+description: >-
   Use when you need to add a PR to a GitHub merge queue. The gh CLI has no
   built-in merge-queue command, so this skill provides a script that uses the
   GraphQL API.
 allowed-tools: Bash(bash skills/merge-queue/scripts/enqueue-pr.sh:*)
 ---
 
-Run `bash skills/merge-queue/scripts/enqueue-pr.sh [PR_NUMBER_OR_URL]` to enqueue a PR.
+# Merge Queue
 
+Run `bash skills/merge-queue/scripts/enqueue-pr.sh [PR_NUMBER_OR_URL]` to enqueue a PR.
 Omit the argument to enqueue the current branch's PR.
+
+## Prerequisites
+
+- `gh` CLI authenticated with write access to the target repository
+- `jq` installed
+- The target repository must have merge queues enabled in its branch protection rules
+
+## Common errors
+
+- **"Pull request is already in the merge queue"** — the PR was previously enqueued; no action needed.
+- **"Pull request is not mergeable"** — the PR may need approvals, passing checks, or conflict resolution before it can be enqueued.
+- **"Resource not accessible by integration"** — the `gh` token lacks sufficient permissions.

--- a/skills/merge-queue/SKILL.md
+++ b/skills/merge-queue/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: merge-queue
+description: >
+  Use when you need to add a PR to a GitHub merge queue. The gh CLI has no
+  built-in merge-queue command, so this skill provides a script that uses the
+  GraphQL API.
+allowed-tools: Bash(bash skills/merge-queue/scripts/enqueue-pr.sh:*)
+---
+
+Run `bash skills/merge-queue/scripts/enqueue-pr.sh [PR_NUMBER_OR_URL]` to enqueue a PR.
+
+Omit the argument to enqueue the current branch's PR.

--- a/skills/merge-queue/scripts/enqueue-pr.sh
+++ b/skills/merge-queue/scripts/enqueue-pr.sh
@@ -3,25 +3,25 @@
 # Usage: enqueue-pr.sh [PR_NUMBER_OR_URL]
 #
 # If no argument is given, uses the current branch's PR.
-# Requires: gh CLI authenticated with sufficient permissions.
+# Requires: gh CLI authenticated with sufficient permissions, and jq.
 
 set -euo pipefail
 
 pr="${1:-}"
 
-# Resolve PR number/URL to the full PR URL and extract owner/repo/number
+# Resolve PR to its URL and node ID in a single API call
 if [[ -z "$pr" ]]; then
-  pr_url="$(gh pr view --json url -q .url)"
+  pr_json="$(gh pr view --json url,id)"
 elif [[ "$pr" =~ ^[0-9]+$ ]]; then
-  pr_url="$(gh pr view "$pr" --json url -q .url)"
+  pr_json="$(gh pr view "$pr" --json url,id)"
 else
-  pr_url="$pr"
+  pr_json="$(gh pr view "$pr" --json url,id)"
 fi
 
-echo "Enqueuing: $pr_url"
+pr_url="$(echo "$pr_json" | jq -r .url)"
+pr_node_id="$(echo "$pr_json" | jq -r .id)"
 
-# Get the PR's node ID (required by the GraphQL mutation)
-pr_node_id="$(gh pr view "$pr_url" --json id -q .id)"
+echo "Enqueuing: $pr_url"
 
 # Enqueue the PR
 result="$(gh api graphql -f query='
@@ -35,10 +35,10 @@ result="$(gh api graphql -f query='
   }
 ' -f prId="$pr_node_id")"
 
-errors="$(echo "$result" | jq -r '.errors // empty')"
-if [[ -n "$errors" ]]; then
+# Check for GraphQL errors
+if echo "$result" | jq -e '.errors' >/dev/null 2>&1; then
   echo "GraphQL errors:" >&2
-  echo "$errors" | jq . >&2
+  echo "$result" | jq '.errors' >&2
   exit 1
 fi
 

--- a/skills/merge-queue/scripts/enqueue-pr.sh
+++ b/skills/merge-queue/scripts/enqueue-pr.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Adds a pull request to a GitHub merge queue using the GraphQL API.
+# Usage: enqueue-pr.sh [PR_NUMBER_OR_URL]
+#
+# If no argument is given, uses the current branch's PR.
+# Requires: gh CLI authenticated with sufficient permissions.
+
+set -euo pipefail
+
+pr="${1:-}"
+
+# Resolve PR number/URL to the full PR URL and extract owner/repo/number
+if [[ -z "$pr" ]]; then
+  pr_url="$(gh pr view --json url -q .url)"
+elif [[ "$pr" =~ ^[0-9]+$ ]]; then
+  pr_url="$(gh pr view "$pr" --json url -q .url)"
+else
+  pr_url="$pr"
+fi
+
+echo "Enqueuing: $pr_url"
+
+# Get the PR's node ID (required by the GraphQL mutation)
+pr_node_id="$(gh pr view "$pr_url" --json id -q .id)"
+
+# Enqueue the PR
+result="$(gh api graphql -f query='
+  mutation($prId: ID!) {
+    enqueuePullRequest(input: {pullRequestId: $prId}) {
+      mergeQueueEntry {
+        position
+        estimatedTimeToMerge
+      }
+    }
+  }
+' -f prId="$pr_node_id")"
+
+errors="$(echo "$result" | jq -r '.errors // empty')"
+if [[ -n "$errors" ]]; then
+  echo "GraphQL errors:" >&2
+  echo "$errors" | jq . >&2
+  exit 1
+fi
+
+position="$(echo "$result" | jq -r '.data.enqueuePullRequest.mergeQueueEntry.position')"
+eta="$(echo "$result" | jq -r '.data.enqueuePullRequest.mergeQueueEntry.estimatedTimeToMerge // "unknown"')"
+
+echo "PR added to merge queue at position $position (ETA: $eta)"


### PR DESCRIPTION
## Summary

- Adds a `merge-queue` skill with a script that enqueues PRs via the GitHub GraphQL `enqueuePullRequest` mutation
- The `gh` CLI has no built-in merge-queue command, so this fills the gap
- Usage: `bash skills/merge-queue/scripts/enqueue-pr.sh [PR_NUMBER_OR_URL]`

## Test plan

- [ ] Run script against a PR on a merge-queue-enabled repo and confirm it enqueues

🤖 Generated with [Claude Code](https://claude.com/claude-code)