### PR TITLE
feat(appsetup): add retro agent app configuration

### DIFF
--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -135,6 +135,17 @@ func AgentAppConfig(org, role string) AppConfig {
 		// No webhook events — this agent runs on a cron schedule, not events.
 		base.Events = []string{}
 
+	case "retro":
+		base.Description = fmt.Sprintf("Fullsend retro agent for %s", org)
+		base.Permissions = AppPermissions{
+			Actions:      "read",
+			Contents:     "read",
+			PullRequests: "read",
+			Issues:       "write",
+		}
+		// No webhook events — triggered via workflow_dispatch from other agents.
+		base.Events = []string{}
+
 	default:
 		base.Description = fmt.Sprintf("Fullsend %s agent for %s", role, org)
 		base.Permissions = AppPermissions{

--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -60,7 +60,7 @@ func AgentAppConfig(org, role string) AppConfig {
 
 	base.Name = fmt.Sprintf("fullsend-%s", role)
 
-	switch role {
+	switch role{
 	case "fullsend":
 		base.Description = fmt.Sprintf("Fullsend orchestrator for %s", org)
 		base.Permissions = AppPermissions{
@@ -112,15 +112,6 @@ func AgentAppConfig(org, role string) AppConfig {
 			Issues:       "write",
 		}
 		base.Events = []string{"issues", "issue_comment", "pull_request"}
-
-	case "retro":
-		base.Description = fmt.Sprintf("Fullsend retro agent for %s", org)
-		base.Permissions = AppPermissions{
-			Contents:     "read",
-			PullRequests: "read",
-			Issues:       "write",
-		}
-		base.Events = []string{"issues", "pull_request"}
 
 	case "prioritize":
 		base.Description = fmt.Sprintf("Fullsend prioritize agent for %s", org)

--- a/internal/forge/github/types_test.go
+++ b/internal/forge/github/types_test.go
@@ -90,7 +90,7 @@ func TestAgentAppConfig_Prioritize(t *testing.T) {
 func TestAgentAppConfig_Retro(t *testing.T) {
 	cfg := AgentAppConfig("myorg", "retro")
 
-	assert.Equal(t, "myorg-retro", cfg.Name)
+	assert.Equal(t, "fullsend-retro", cfg.Name)
 	assert.Equal(t, "read", cfg.Permissions.Actions)
 	assert.Equal(t, "read", cfg.Permissions.Contents)
 	assert.Equal(t, "read", cfg.Permissions.PullRequests)

--- a/internal/forge/github/types_test.go
+++ b/internal/forge/github/types_test.go
@@ -87,6 +87,20 @@ func TestAgentAppConfig_Prioritize(t *testing.T) {
 	assert.Empty(t, cfg.Events)
 }
 
+func TestAgentAppConfig_Retro(t *testing.T) {
+	cfg := AgentAppConfig("myorg", "retro")
+
+	assert.Equal(t, "myorg-retro", cfg.Name)
+	assert.Equal(t, "read", cfg.Permissions.Actions)
+	assert.Equal(t, "read", cfg.Permissions.Contents)
+	assert.Equal(t, "read", cfg.Permissions.PullRequests)
+	assert.Equal(t, "write", cfg.Permissions.Issues)
+	assert.Empty(t, cfg.Permissions.OrganizationProjects)
+
+	// Retro is triggered via workflow_dispatch, no webhook events.
+	assert.Empty(t, cfg.Events)
+}
+
 func TestAgentAppConfig_UnknownRole(t *testing.T) {
 	cfg := AgentAppConfig("myorg", "custom-bot")
 


### PR DESCRIPTION
## Summary
- Adds retro agent app configuration with Actions/Contents/PRs read and Issues write permissions
- Retro agent is triggered via workflow_dispatch (no webhook events)
- Includes test coverage for the new configuration

## Test Plan
- [x] Unit tests pass (`make go-test`)
- [x] Test verifies retro agent permissions and event configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)