### PR TITLE
fix: install lychee in post-code and post-fix scripts

### DIFF
--- a/internal/scaffold/fullsend-repo/scripts/post-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-code.sh
@@ -35,6 +35,8 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 GITLEAKS_VERSION="8.30.1"
 GITLEAKS_SHA256="551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+LYCHEE_VERSION="0.24.2"
+LYCHEE_SHA256="1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
 
 # ---------------------------------------------------------------------------
 # Setup
@@ -116,7 +118,22 @@ gitleaks detect --source . --log-opts="${SCAN_RANGE}" --redact
 echo "Secret scan passed — no leaks in agent's commit(s)"
 
 # ---------------------------------------------------------------------------
-# 4. Authoritative pre-commit check
+# 4. Install lychee (for pre-commit markdown link checking)
+# ---------------------------------------------------------------------------
+if ! command -v lychee >/dev/null 2>&1; then
+  echo "Installing lychee v${LYCHEE_VERSION}..."
+  mkdir -p "${HOME}/.local/bin"
+  curl -fsSL \
+    "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
+    -o /tmp/lychee.tar.gz \
+    && echo "${LYCHEE_SHA256}  /tmp/lychee.tar.gz" | sha256sum -c - \
+    && tar xzf /tmp/lychee.tar.gz -C "${HOME}/.local/bin" lychee \
+    && rm /tmp/lychee.tar.gz
+  export PATH="${HOME}/.local/bin:${PATH}"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Authoritative pre-commit check
 # ---------------------------------------------------------------------------
 if [ -f .pre-commit-config.yaml ]; then
   echo "Running authoritative pre-commit on agent's changed files..."
@@ -148,7 +165,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 5. Push branch
+# 6. Push branch
 # ---------------------------------------------------------------------------
 git remote set-url origin \
   "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO_FULL_NAME}.git"
@@ -157,7 +174,7 @@ echo "Pushing branch ${BRANCH}..."
 git push --force-with-lease -u origin -- "${BRANCH}" 2>&1
 
 # ---------------------------------------------------------------------------
-# 6. Create PR
+# 7. Create PR
 # ---------------------------------------------------------------------------
 export GH_TOKEN="${PUSH_TOKEN}"
 

--- a/internal/scaffold/fullsend-repo/scripts/post-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-fix.sh
@@ -58,6 +58,8 @@ PROTECTED_PATHS=(
 
 GITLEAKS_VERSION="8.30.1"
 GITLEAKS_SHA256="551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+LYCHEE_VERSION="0.24.2"
+LYCHEE_SHA256="1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
 
 # ---------------------------------------------------------------------------
 # Setup
@@ -153,7 +155,22 @@ if [ "${NO_PUSH}" = "false" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 3. Authoritative pre-commit check (only if pushing)
+# 3. Install lychee (for pre-commit markdown link checking)
+# ---------------------------------------------------------------------------
+if ! command -v lychee >/dev/null 2>&1; then
+  echo "Installing lychee v${LYCHEE_VERSION}..."
+  mkdir -p "${HOME}/.local/bin"
+  curl -fsSL \
+    "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
+    -o /tmp/lychee.tar.gz \
+    && echo "${LYCHEE_SHA256}  /tmp/lychee.tar.gz" | sha256sum -c - \
+    && tar xzf /tmp/lychee.tar.gz -C "${HOME}/.local/bin" lychee \
+    && rm /tmp/lychee.tar.gz
+  export PATH="${HOME}/.local/bin:${PATH}"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Authoritative pre-commit check (only if pushing)
 # ---------------------------------------------------------------------------
 if [ "${NO_PUSH}" = "false" ] && [ -f .pre-commit-config.yaml ]; then
   echo "Running authoritative pre-commit on agent's changed files..."
@@ -179,7 +196,7 @@ if [ "${NO_PUSH}" = "false" ] && [ -f .pre-commit-config.yaml ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 4. Push branch (only if we have commits)
+# 5. Push branch (only if we have commits)
 # ---------------------------------------------------------------------------
 if [ "${NO_PUSH}" = "false" ]; then
   git remote set-url origin \
@@ -195,7 +212,7 @@ if [ "${NO_PUSH}" = "false" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 5. Process structured output (fix-result.json)
+# 6. Process structured output (fix-result.json)
 # ---------------------------------------------------------------------------
 export GH_TOKEN="${PUSH_TOKEN}"
 
@@ -247,7 +264,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 6. Iteration-cap warning label
+# 7. Iteration-cap warning label
 # ---------------------------------------------------------------------------
 ITERATION="${FIX_ITERATION:-1}"
 BOT_CAP="${ITERATION_CAP:-5}"
@@ -266,7 +283,7 @@ if [ "${ITERATION}" -ge "${WARN_THRESHOLD}" ] && is_bot_user "${TRIGGER_SOURCE}"
 fi
 
 # ---------------------------------------------------------------------------
-# 7. Summary
+# 8. Summary
 # ---------------------------------------------------------------------------
 echo ""
 echo "Fix post-script complete:"


### PR DESCRIPTION
## Summary

Agent runs were failing when pre-commit hooks tried to run lychee for markdown link checking. The lychee binary wasn't available on GitHub Actions runners, causing the authoritative pre-commit check to fail.

## Changes

- Add lychee v0.24.2 installation to `post-code.sh` and `post-fix.sh`
- Download and verify lychee binary before running pre-commit hooks
- Follow same pattern as existing gitleaks installation
- Extract to `${HOME}/.local/bin` and add to PATH

This ensures the `lint-md-links` pre-commit hook can execute successfully.

## Test plan

- [ ] Verify post-code.sh and post-fix.sh syntax is valid (✅ already verified)
- [ ] Trigger a code agent run and verify pre-commit hooks pass
- [ ] Trigger a fix agent run and verify pre-commit hooks pass

## Related

- #830 - Documents broader security issue with pre-commit hooks running outside sandbox (this is a tactical fix while we work on the strategic solution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)