### PR TITLE
fix: add actions:read permission to retro role

### DIFF
--- a/internal/mint/main.go
+++ b/internal/mint/main.go
@@ -684,7 +684,7 @@ var rolePermissions = map[string]map[string]string{
 	"coder":    {"contents": "write", "pull_requests": "write", "issues": "write", "checks": "read", "metadata": "read"},
 	"review":   {"contents": "read", "pull_requests": "write", "issues": "write", "checks": "read", "metadata": "read"},
 	"fix":      {"contents": "write", "pull_requests": "write", "issues": "write", "metadata": "read"},
-	"retro":       {"contents": "read", "pull_requests": "read", "issues": "write", "metadata": "read"},
+	"retro":       {"actions": "read", "contents": "read", "pull_requests": "read", "issues": "write", "metadata": "read"},
 	"prioritize":  {"contents": "read", "issues": "write", "organization_projects": "write", "metadata": "read"},
 	"fullsend":    {"actions": "write", "contents": "write", "pull_requests": "write", "workflows": "write", "metadata": "read"},
 }


### PR DESCRIPTION
## Summary

- Adds `actions: read` permission to the retro role's installation token
- Fixes 403 Forbidden errors when retro agent tries to access workflow run logs and artifacts
- Aligns implementation with design spec that explicitly requires read access to workflow runs and artifacts

## Problem

The retro agent was getting 403 Forbidden errors when attempting to:
- Read workflow run logs via `gh run view --log`
- Download workflow run artifacts

This prevented the agent from performing root cause analysis on agent runs, forcing it to hedge with statements like "cannot confirm definitively without log access (403 Forbidden)".

Evidence from [run 25748112694](https://github.com/fullsend-ai/.fullsend/actions/runs/25748112694):
- "**Logs inaccessible**: All run logs return `Forbidden`, preventing verification of what `fullsend post-review` actually did"
- "**Artifacts inaccessible**: Cannot download the `fullsend-review` artifacts to inspect `agent-result.json`"

## Solution

The token mint service (`internal/mint/main.go`) defines a `rolePermissions` map that specifies which GitHub API permissions each agent role receives. The `retro` role was missing `"actions": "read"`, which is required to access workflow runs and their artifacts.

The design spec (`docs/superpowers/specs/2026-05-04-retro-agent-design.md:187`) explicitly states:
> The retro agent gets its own GitHub App with scoped permissions: read access to repos, issues, PRs, **workflow runs, and artifacts**

This one-line change adds the missing permission.

## Deployment

After merge, the token mint Cloud Function needs to be redeployed with the updated `rolePermissions` map. Future retro agent runs will then receive tokens with `actions: read` permission.

## Test plan

- [x] Verified the change compiles
- [x] Ran `make lint` (passes)
- [x] Reviewed design spec to confirm this aligns with intended permissions
- [ ] After deployment: verify retro agent can access workflow logs in a test run

Fixes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)