### PR TITLE
fix: install uvx in post-code and post-fix scripts

### DIFF
--- a/internal/scaffold/fullsend-repo/scripts/post-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-code.sh
@@ -37,6 +37,8 @@ GITLEAKS_VERSION="8.30.1"
 GITLEAKS_SHA256="551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
 LYCHEE_VERSION="0.24.2"
 LYCHEE_SHA256="1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
+UV_VERSION="0.11.14"
+UV_SHA256="f3b623eb0e6141a7053d571d59a0bdc341e0f238ea8f5f0b4815ddbec9a2a296"
 
 # ---------------------------------------------------------------------------
 # Setup
@@ -133,7 +135,24 @@ if ! command -v lychee >/dev/null 2>&1; then
 fi
 
 # ---------------------------------------------------------------------------
-# 5. Authoritative pre-commit check
+# 5. Install uv and uvx (for pre-commit Python tooling)
+# ---------------------------------------------------------------------------
+if ! command -v uvx >/dev/null 2>&1; then
+  echo "Installing uv v${UV_VERSION} (includes uvx)..."
+  mkdir -p "${HOME}/.local/bin"
+  curl -fsSL \
+    "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" \
+    -o /tmp/uv.tar.gz \
+    && echo "${UV_SHA256}  /tmp/uv.tar.gz" | sha256sum -c - \
+    && tar xzf /tmp/uv.tar.gz -C /tmp \
+    && mv /tmp/uv-x86_64-unknown-linux-gnu/uv "${HOME}/.local/bin/" \
+    && mv /tmp/uv-x86_64-unknown-linux-gnu/uvx "${HOME}/.local/bin/" \
+    && rm -rf /tmp/uv.tar.gz /tmp/uv-x86_64-unknown-linux-gnu
+  export PATH="${HOME}/.local/bin:${PATH}"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Authoritative pre-commit check
 # ---------------------------------------------------------------------------
 if [ -f .pre-commit-config.yaml ]; then
   echo "Running authoritative pre-commit on agent's changed files..."
@@ -165,7 +184,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 6. Push branch
+# 7. Push branch
 # ---------------------------------------------------------------------------
 git remote set-url origin \
   "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO_FULL_NAME}.git"
@@ -174,7 +193,7 @@ echo "Pushing branch ${BRANCH}..."
 git push --force-with-lease -u origin -- "${BRANCH}" 2>&1
 
 # ---------------------------------------------------------------------------
-# 7. Create PR
+# 8. Create PR
 # ---------------------------------------------------------------------------
 export GH_TOKEN="${PUSH_TOKEN}"
 

--- a/internal/scaffold/fullsend-repo/scripts/post-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-fix.sh
@@ -60,6 +60,8 @@ GITLEAKS_VERSION="8.30.1"
 GITLEAKS_SHA256="551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
 LYCHEE_VERSION="0.24.2"
 LYCHEE_SHA256="1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
+UV_VERSION="0.11.14"
+UV_SHA256="f3b623eb0e6141a7053d571d59a0bdc341e0f238ea8f5f0b4815ddbec9a2a296"
 
 # ---------------------------------------------------------------------------
 # Setup
@@ -170,7 +172,24 @@ if ! command -v lychee >/dev/null 2>&1; then
 fi
 
 # ---------------------------------------------------------------------------
-# 4. Authoritative pre-commit check (only if pushing)
+# 4. Install uv and uvx (for pre-commit Python tooling)
+# ---------------------------------------------------------------------------
+if ! command -v uvx >/dev/null 2>&1; then
+  echo "Installing uv v${UV_VERSION} (includes uvx)..."
+  mkdir -p "${HOME}/.local/bin"
+  curl -fsSL \
+    "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" \
+    -o /tmp/uv.tar.gz \
+    && echo "${UV_SHA256}  /tmp/uv.tar.gz" | sha256sum -c - \
+    && tar xzf /tmp/uv.tar.gz -C /tmp \
+    && mv /tmp/uv-x86_64-unknown-linux-gnu/uv "${HOME}/.local/bin/" \
+    && mv /tmp/uv-x86_64-unknown-linux-gnu/uvx "${HOME}/.local/bin/" \
+    && rm -rf /tmp/uv.tar.gz /tmp/uv-x86_64-unknown-linux-gnu
+  export PATH="${HOME}/.local/bin:${PATH}"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Authoritative pre-commit check (only if pushing)
 # ---------------------------------------------------------------------------
 if [ "${NO_PUSH}" = "false" ] && [ -f .pre-commit-config.yaml ]; then
   echo "Running authoritative pre-commit on agent's changed files..."
@@ -196,7 +215,7 @@ if [ "${NO_PUSH}" = "false" ] && [ -f .pre-commit-config.yaml ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 5. Push branch (only if we have commits)
+# 6. Push branch (only if we have commits)
 # ---------------------------------------------------------------------------
 if [ "${NO_PUSH}" = "false" ]; then
   git remote set-url origin \
@@ -212,7 +231,7 @@ if [ "${NO_PUSH}" = "false" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 6. Process structured output (fix-result.json)
+# 7. Process structured output (fix-result.json)
 # ---------------------------------------------------------------------------
 export GH_TOKEN="${PUSH_TOKEN}"
 


### PR DESCRIPTION
## Summary

Completes the pre-commit tooling setup by adding `uvx` installation to scaffold post-scripts. Agent runs were failing when the `ty` pre-commit hook tried to run Python type checking because uvx wasn't available on GitHub Actions runners.

**Note:** This fix has already been manually applied to the `.fullsend` repo in https://github.com/fullsend-ai/.fullsend/pull/29. This PR updates the scaffold templates so future enrolled repos get the complete tooling setup.

**Root cause:** PR #831 added lychee but didn't address uvx, which is also required by pre-commit hooks (specifically the `ty` hook that runs via `uvx ty check`).

**Changes:**
- ✅ Install uv/uvx v0.11.14 before running pre-commit hooks
- ✅ Add SHA256 verification following gitleaks/lychee pattern
- ✅ Extract both `uv` and `uvx` binaries to `~/.local/bin`
- ✅ Update section numbering in both scripts
- ✅ Applied to both `post-code.sh` and `post-fix.sh` in scaffold templates

**Impact:** This prevents agent run failures where the ty pre-commit hook fails with:
```
Executable 'uvx' not found
```

**Background:** This builds on the tooling setup started in #831 (lychee) and #783 (markdown link linter). Together, these ensure all pre-commit hooks have their required tools available.

## Test plan

- [x] Verify SHA256 hash matches official uv 0.11.14 release
- [x] Check installation logic follows gitleaks/lychee pattern
- [x] Confirm both uv and uvx are extracted from tarball
- [x] Same fix already deployed to .fullsend repo (https://github.com/fullsend-ai/.fullsend/pull/29)
- [ ] Test that new repo enrollments work with ty hook enabled

## Related work

- Closes #100 (by ensuring uvx is available for ty hook)
- Related to #830 (pre-commit security considerations)
- Builds on #831 (lychee installation)
- Builds on #783 (markdown link linter addition)
- Deployed to .fullsend: https://github.com/fullsend-ai/.fullsend/pull/29

🤖 Generated with [Claude Code](https://claude.com/claude-code)