### PR TITLE
docs: clarify accepted input formats for merge-queue skill

### DIFF
--- a/skills/merge-queue/SKILL.md
+++ b/skills/merge-queue/SKILL.md
@@ -12,6 +12,14 @@ allowed-tools: Bash(bash skills/merge-queue/scripts/enqueue-pr.sh:*)
 Run `bash skills/merge-queue/scripts/enqueue-pr.sh [PR_NUMBER_OR_URL]` to enqueue a PR.
 Omit the argument to enqueue the current branch's PR.
 
+## Accepted input formats
+
+- **PR number:** `652` (uses the current repo context from `gh`)
+- **PR URL:** `https://github.com/owner/repo/pull/652`
+- **Omitted:** uses the current branch's PR
+
+The `owner/repo#number` format is **not supported** — use a URL or number instead.
+
 ## Prerequisites
 
 - `gh` CLI authenticated with write access to the target repository


### PR DESCRIPTION
## Summary

- Documents the accepted argument formats for the merge-queue skill (`PR_NUMBER`, `PR_URL`, or omitted)
- Explicitly notes that `owner/repo#number` format is not supported

This prevents failed invocations when an LLM passes the wrong format to the enqueue script.

## Test plan

- [ ] Verify the skill doc renders correctly
- [ ] Invoke the merge-queue skill and confirm the agent passes a supported format

🤖 Generated with [Claude Code](https://claude.com/claude-code)