### PR TITLE
fix: scope sandbox-images tag trigger to semver, exclude bare v0/v1

### DIFF
--- a/.github/workflows/sandbox-images.yml
+++ b/.github/workflows/sandbox-images.yml
@@ -3,7 +3,7 @@ name: Sandbox Images
 on:
   push:
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+*"
     branches:
       - main
     paths:
@@ -16,8 +16,8 @@ on:
   workflow_dispatch:
 
 # NOTE: GitHub Actions ignores `paths` filters on tag pushes, so every
-# v* tag triggers a build.  This is intentional — the sandbox image is
-# published alongside the CLI so consumers can pin both to the same
+# semver tag triggers a build.  This is intentional — the sandbox image
+# is published alongside the CLI so consumers can pin both to the same
 # version.  Branch pushes and PRs still respect the paths filter.
 
 jobs:


### PR DESCRIPTION
## Summary

- Narrow `sandbox-images.yml` tag filter from `v*` to `v[0-9]+.[0-9]+*` so bare floating tags like `v0`, `v1` don't trigger sandbox image builds
- `release.yml` keeps its original `v[0-9]+.[0-9]+.[0-9]+*` pattern (GoReleaser requires three-component semver)

Excluding bare major tags (`v0`, `v1`, etc.) supports tagging reusable workflow refs (e.g. `fullsend-ai/fullsend@v0`) without triggering the sandbox-images pipeline.

## Test plan

- [ ] Verify `v0` tag does not trigger sandbox-images workflow
- [ ] Verify `v0.1.0` tag would still match both workflow patterns