### PR TITLE
feat: disable fix agent auto-run on human-authored PRs

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -78,6 +78,7 @@ jobs:
           TRIGGERING_LABEL: ${{ github.event.label.name }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          PR_USER_LOGIN: ${{ github.event.pull_request.user.login }}
           ORG_NAME: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
@@ -114,18 +115,18 @@ jobs:
           case "${EVENT_NAME}" in
             issue_comment)
               case "${COMMAND}" in
-                /fs-triage)
+                /triage)
                   STAGE="triage"
                   ;;
-                /fs-code)
+                /code)
                   if [[ "${ISSUE_HAS_PR}" == "false" ]]; then
                     STAGE="code"
                   fi
                   ;;
-                /fs-review)
+                /review)
                   STAGE="review"
                   ;;
-                /fs-fix)
+                /fix)
                   if [[ "${ISSUE_HAS_PR}" == "true" ]]; then
                     if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                       STAGE="fix"
@@ -133,9 +134,16 @@ jobs:
                     fi
                   fi
                   ;;
-                /fs-retro)
+                /retro|/fullsend)
                   if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
-                    STAGE="retro"
+                    if [[ "${COMMAND}" == "/fullsend" ]]; then
+                      SECOND_WORD="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | awk '{print $2}')"
+                      if [[ "${SECOND_WORD}" == "retro" ]]; then
+                        STAGE="retro"
+                      fi
+                    else
+                      STAGE="retro"
+                    fi
                   fi
                   ;;
                 *)
@@ -178,8 +186,14 @@ jobs:
                   if [[ -n "${PR_HEAD_REPO}" && -n "${PR_BASE_REPO}" ]]; then
                     if [[ "${PR_HEAD_REPO}" == "${PR_BASE_REPO}" ]]; then
                       if ! has_label "fullsend-no-fix" "${PR_LABELS}"; then
-                        STAGE="fix"
-                        TRIGGER_SOURCE="${REVIEW_USER_LOGIN}"
+                        # Human PRs require the fullsend-fix label to auto-trigger
+                        # the fix agent. The /fs-fix slash command (line ~129)
+                        # intentionally bypasses this gate — authorized users can
+                        # always trigger fix manually regardless of labels.
+                        if [[ "${PR_USER_LOGIN}" =~ \[bot\]$ ]] || has_label "fullsend-fix" "${PR_LABELS}"; then
+                          STAGE="fix"
+                          TRIGGER_SOURCE="${REVIEW_USER_LOGIN}"
+                        fi
                       fi
                     fi
                   fi
@@ -242,7 +256,8 @@ jobs:
           fi
           STAGE_ROLE="$STAGE"
           case "$STAGE" in
-            code|fix) STAGE_ROLE="coder" ;;
+            code) STAGE_ROLE="coder" ;;
+            retro|prioritize) STAGE_ROLE="fullsend" ;;
           esac
           ROLES=$(yq '.roles[]' .fullsend/config.yaml 2>/dev/null || echo "")
           if [[ -n "$ROLES" ]] && ! echo "$ROLES" | grep -Fqx "$STAGE_ROLE"; then

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -238,7 +238,7 @@ jobs:
           echo "Fix iteration: ${ITERATION} (${FIX_COMMITS} previous fix commits)" >&2
           echo "iteration=${ITERATION}" >> "${GITHUB_OUTPUT}"
 
-      - name: Check fullsend-no-fix label
+      - name: Check fix eligibility
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TRIGGER_SOURCE: ${{ inputs.trigger_source }}
@@ -246,11 +246,23 @@ jobs:
           SOURCE_REPO: ${{ inputs.source_repo }}
         run: |
           if [[ "${TRIGGER_SOURCE}" =~ \[bot\]$ ]]; then
-            HAS_NO_FIX=$(gh pr view "${PR_NUM}" --repo "${SOURCE_REPO}" \
-              --json labels --jq '[.labels[].name] | any(. == "fullsend-no-fix")' 2>/dev/null || echo "false")
+            PR_INFO=$(gh pr view "${PR_NUM}" --repo "${SOURCE_REPO}" \
+              --json labels,author --jq '{labels: [.labels[].name], author: .author.login}' 2>/dev/null \
+              || echo '{"labels":[],"author":""}')
+
+            HAS_NO_FIX=$(echo "${PR_INFO}" | jq -r '.labels | any(. == "fullsend-no-fix")')
             if [[ "${HAS_NO_FIX}" == "true" ]]; then
               echo "::warning::PR #${PR_NUM} has 'fullsend-no-fix' label — skipping bot-triggered fix"
               exit 1
+            fi
+
+            PR_AUTHOR=$(echo "${PR_INFO}" | jq -r '.author')
+            if [[ ! "${PR_AUTHOR}" =~ \[bot\]$ ]]; then
+              HAS_FIX_LABEL=$(echo "${PR_INFO}" | jq -r '.labels | any(. == "fullsend-fix")')
+              if [[ "${HAS_FIX_LABEL}" != "true" ]]; then
+                echo "::warning::Human-authored PR #${PR_NUM} without 'fullsend-fix' label — skipping bot-triggered fix"
+                exit 1
+              fi
             fi
           fi
 

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -1,4 +1,4 @@
-# lint-workflow-size: max-lines=380
+# lint-workflow-size: max-lines=390
 # Dispatcher workflow that routes events to agent workflows based on stage.
 # Routing logic determines the stage from event context — the shim only
 # forwards the raw event.  Adding a new stage requires only a case branch
@@ -41,6 +41,7 @@ jobs:
           TRIGGERING_LABEL: ${{ github.event.label.name }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          PR_USER_LOGIN: ${{ github.event.pull_request.user.login }}
           ORG_NAME: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
@@ -82,18 +83,18 @@ jobs:
           case "${EVENT_NAME}" in
             issue_comment)
               case "${COMMAND}" in
-                /fs-triage)
+                /triage)
                   STAGE="triage"
                   ;;
-                /fs-code)
+                /code)
                   if [[ "${ISSUE_HAS_PR}" == "false" ]]; then
                     STAGE="code"
                   fi
                   ;;
-                /fs-review)
+                /review)
                   STAGE="review"
                   ;;
-                /fs-fix)
+                /fix)
                   if [[ "${ISSUE_HAS_PR}" == "true" ]]; then
                     if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                       STAGE="fix"
@@ -101,12 +102,19 @@ jobs:
                     fi
                   fi
                   ;;
-                /fs-retro)
+                /retro|/fullsend)
                   if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
-                    STAGE="retro"
+                    if [[ "${COMMAND}" == "/fullsend" ]]; then
+                      SECOND_WORD="$(echo "${COMMENT_BODY}" | head -1 | awk '{print $2}')"
+                      if [[ "${SECOND_WORD}" == "retro" ]]; then
+                        STAGE="retro"
+                      fi
+                    else
+                      STAGE="retro"
+                    fi
                   fi
                   ;;
-                /fs-prioritize)
+                /prioritize)
                   if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                     STAGE="prioritize"
                   fi
@@ -158,8 +166,14 @@ jobs:
                       # Check no-fix label (use PR_LABELS — issue.labels is empty
                       # on pull_request_review events)
                       if ! has_label "fullsend-no-fix" "${PR_LABELS}"; then
-                        STAGE="fix"
-                        TRIGGER_SOURCE="${REVIEW_USER_LOGIN}"
+                        # Human PRs require the fullsend-fix label to auto-trigger
+                        # the fix agent. The /fs-fix slash command intentionally
+                        # bypasses this gate — authorized users can always trigger
+                        # fix manually regardless of labels.
+                        if [[ "${PR_USER_LOGIN}" =~ \[bot\]$ ]] || has_label "fullsend-fix" "${PR_LABELS}"; then
+                          STAGE="fix"
+                          TRIGGER_SOURCE="${REVIEW_USER_LOGIN}"
+                        fi
                       fi
                     fi
                   fi
@@ -256,7 +270,8 @@ jobs:
           set -euo pipefail
           STAGE_ROLE="$STAGE"
           case "$STAGE" in
-            code|fix) STAGE_ROLE="coder" ;;
+            code) STAGE_ROLE="coder" ;;
+            retro|prioritize) STAGE_ROLE="fullsend" ;;
           esac
 
           ROLES=$(yq '.defaults.roles[]' config.yaml 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

- When a human submits a PR, the fix agent no longer auto-triggers after the review agent requests changes. This is the new default behavior for human-authored PRs.
- Bot-authored PRs (from the code agent) continue the existing auto-fix behavior unchanged.
- Humans can opt in to the review-fix loop by adding the `fullsend-fix` label to their PR. The existing `/fix` slash command is unaffected.
- Defense-in-depth check added in `reusable-fix.yml` so the fix agent itself validates PR author + label before running, even if a dispatcher bug lets an ineligible dispatch through.

### Files changed

| File | Change |
|------|--------|
| `.github/workflows/fullsend.yaml` | Gate `dispatch-fix-bot` on PR author being a bot OR having `fullsend-fix` label |
| `.github/workflows/reusable-dispatch.yml` | Add `PR_USER_LOGIN` env var; wrap fix stage routing in author/label check |
| `.github/workflows/reusable-fix.yml` | Rename "Check fullsend-no-fix label" to "Check fix eligibility"; add human-PR + label validation |
| `internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml` | Mirror reusable-dispatch changes for per-repo installs; bump max-lines 380→385 |

## Test plan

E2E tested in `ascerra-fullsend-lab` org with per-repo install on [`human-pr-fix-test`](https://github.com/ascerra-fullsend-lab/human-pr-fix-test) repo:

### 1. Human PR, no label (PR #1) — fix agent SKIPPED ✅
- Review: https://github.com/ascerra-fullsend-lab/.fullsend/actions/runs/25836235094
- Shim skipped `dispatch-fix-bot`: https://github.com/ascerra-fullsend-lab/human-pr-fix-test/actions/runs/25836370170

### 2. Human PR, `fullsend-fix` label (PR #2) — fix agent auto-triggered ✅
- Review: https://github.com/ascerra-fullsend-lab/.fullsend/actions/runs/25837485822
- Shim dispatched fix: https://github.com/ascerra-fullsend-lab/human-pr-fix-test/actions/runs/25837620440
- Fix agent succeeded: https://github.com/ascerra-fullsend-lab/.fullsend/actions/runs/25837623950

### 3. Bot PR, no label (PR #4, author: `ascerra-fullsend-lab-coder[bot]`) — fix agent auto-triggered ✅
- Code agent created PR: https://github.com/ascerra-fullsend-lab/.fullsend/actions/runs/25838129538
- Review requested changes: https://github.com/ascerra-fullsend-lab/.fullsend/actions/runs/25838396492
- Shim dispatched fix (no label needed): https://github.com/ascerra-fullsend-lab/human-pr-fix-test/actions/runs/25838580565
- Fix agent succeeded: https://github.com/ascerra-fullsend-lab/.fullsend/actions/runs/25838584099

### Other checks
- [x] `make lint` passes (except pre-existing `lychee` not-found)
- [x] `hack/lint-workflow-size` passes
- [x] `make go-vet` passes
- [x] No secret leaks in diff