### PR TITLE
docs(skills): add spec-refine and spec-refine-github

### DIFF
--- a/skills/spec-refine-github/SKILL.md
+++ b/skills/spec-refine-github/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: spec-refine-github
+description: >-
+  Use when a GitHub spec PR needs review and PR comments ingested into spec.md
+  and qna.md: prepare comments.md from GitHub (with edit detection and qna.md
+  placement rules), run spec-refine phases, commit spec.md and qna.md only (never
+  comments.md), then push and reply on threads—or defer those writes to harness
+  post-automation. Pair with spec-refine and spec-start for formats.
+# Cursor Agent Skills: prefer explicit @-style invocation; other tooling may ignore.
+disable-model-invocation: true
+---
+
+# spec-refine-github (PR comments into spec and Q&A, push updates)
+
+Use this skill **together with `spec-refine`** (and **`spec-start`** for `qna.md` / `spec.md` grammar). This document adds **GitHub + git + PR** mechanics only. **Do not** duplicate the Phase 1–3 procedure in [`spec-refine/SKILL.md`](../spec-refine/SKILL.md)—after you prepare `comments.md` / `qna.md` from GitHub data, run that file’s phases **in order** on the resolved topic directory.
+
+When a session only needs local planning files without GitHub, use **`spec-refine`** alone.
+
+## Relationship to `spec-refine` and `spec-start-github`
+
+1. **Eligibility and ingest** (this skill) — checkout PR head, confirm **exactly one** touched `docs/plans/YYYY-MM-DD-<topic>/` tree, pull comments from GitHub, write **`comments.md`** and/or append **`###`** answers to **`qna.md`** per the rules below.
+2. **Refine pass** — follow **`spec-refine`** through Phase 1 → Phase 2 → Phase 3 (including deleting empty `comments.md` when that skill says to).
+3. **Publish** — `git add` only publishable paths, `git commit`; then **`git push`** and **review-thread replies** only when **local mode** (see **Harness vs local**). This skill **overrides** `spec-refine`’s default “documentation only / commit only if asked” for **GitHub-bound runs**: committing the topic’s `spec.md` / `qna.md` after a successful refine is **in scope** when this skill is invoked for a PR refresh.
+
+If **`spec-start-github`** exists in the repo, treat its **branch naming** (`agent/*-spec-*`) and **harness vs local** language as **hints** for the same automation family—not as the only way to qualify a PR.
+
+## Harness vs local (mirror `spec-start-github`)
+
+**Primary signal:** session or wrapper instructions.
+
+| Mode | When | Agent must |
+|------|------|------------|
+| **Harness** | Session or wrapper says **post-automation owns** `git push` and/or **GitHub API writes** (thread replies) | After **`git commit`**, **do not** `git push`. **Do not** post review-thread replies via `gh api`. Emit a **handoff**: branch name, remote, `git push` suggestion, and copy-pastable `gh api` examples for thread replies (REST URLs, JSON bodies, thread / comment IDs). |
+| **Local** | No such restriction | May **`git push`** the PR head branch. May post **optional** short replies on review threads (Step F). |
+
+Harness authors may set an env var such as **`SPEC_REFINE_GITHUB_POST_SCRIPT_PUSHES=1`** (or equivalent session wording) so ownership of pushes is explicit—**session text still wins** when it conflicts.
+
+## Inputs
+
+- **`PR_NUMBER`** or **PR URL** — required unless inferred from `gh pr status` / current branch’s tracking PR.
+- **`gh`** CLI authenticated to **read** the PR always; **write** (push, create replies) only in **local mode**.
+
+## Step 1 — Resolve PR and checkout
+
+```bash
+gh pr view "${PR_NUMBER}" --json number,url,baseRefName,headRefName,headRepositoryOwner,files
+```
+
+Check out the PR head (typical pattern):
+
+```bash
+gh pr checkout "${PR_NUMBER}"
+```
+
+Confirm the working tree matches the PR you intend to update.
+
+## Step 2 — Eligibility guard (one modified topic directory)
+
+Many directories under **`docs/plans/`** may exist on the default branch; that is normal. The guard uses **paths changed by this PR**, not repo-wide counts.
+
+1. List paths touched by the PR vs its base, for example:
+
+   ```bash
+   gh pr diff "${PR_NUMBER}" --name-only
+   ```
+
+   Alternatively use `gh pr view "${PR_NUMBER}" --json files` and derive paths from the `files` entries (use `path` / `path` + `previousPath` if renames matter).
+
+2. From that set, keep only paths under **`docs/plans/YYYY-MM-DD-<topic>/`** (topic slug convention matches **`spec-start`**: dated folder with kebab-case slug).
+
+3. **Exactly one** distinct topic directory prefix must appear among changed paths. If **zero** or **two or more** such prefixes appear, **stop** with a clear error—do **not** guess.
+
+4. At PR **head**, that directory must contain both **`spec.md`** and **`qna.md`** (required for **`spec-refine`**). If either is missing, **stop**.
+
+Optional: if the head branch matches **`agent/*-spec-*`**, note alignment with **`spec-start-github`**; do **not** require that pattern for eligibility.
+
+## Step 3 — Fetch GitHub comments
+
+Pull enough metadata to support **edit detection** and **threading**:
+
+- **Pull request review comments** (inline on diffs): REST `GET /repos/{owner}/{repo}/pulls/{pull_number}/comments` via `gh api`, or GraphQL equivalent. Capture at least: `id`, `body`, `path`, `line` / `original_line`, `side`, `diff_hunk`, `in_reply_to_id`, `created_at`, `updated_at`, `html_url`, `commit_id` (or current head) as needed for mapping.
+
+- **Issue comments on the PR** (conversation tab): `GET /repos/{owner}/{repo}/issues/{pull_number}/comments` (the PR number is the issue number). Capture `id`, `body`, `updated_at`, `html_url`.
+
+Use `owner` / `repo` from `gh repo view --json nameWithOwner -q .nameWithOwner` or from the PR JSON.
+
+## Step 4 — Ingest into `comments.md` and `qna.md`
+
+### Ingest markers and edited comments
+
+Use **one** stable marker convention everywhere you mirror GitHub text into committed files, for example:
+
+`<!-- gh-rc:COMMENT_ID ts:UPDATED_AT_ISO -->`
+
+placed on the line **immediately after** the `###` heading (or at the start of an inline insert inside an answer body) so reruns can find prior ingests.
+
+- **First time** you ingest comment `COMMENT_ID`: write the marker with the GitHub **`updated_at`** (or body hash) you observed, then the prose.
+- **Later runs:** if GitHub’s **`updated_at`** or **body** changed since the marker’s `ts` / recorded snapshot, **update** the previously ingested material (replace or revise)—do **not** skip forever.
+- If the comment is **unchanged** and already fully reflected next to its marker, **skip** re-adding duplicate prose.
+
+For **issue** (conversation) comments, you may use a parallel prefix, e.g. `<!-- gh-ic:COMMENT_ID ts:... -->`, in `comments.md` only (still **not** committed if only in scratch—see routing).
+
+### Routing
+
+- **Inline review on `spec.md`** (path matches topic `spec.md`): append a new section to **`comments.md`** following the shape in **`spec-refine`** (e.g. **## For file spec.md lines N** with the reviewer text and permalink). Do **not** commit `comments.md`.
+
+- **Non-inline** PR feedback (issue comments, review summaries without a single line): append to **`comments.md`** as general **`## …`** blocks with attribution when useful.
+
+- **Inline review on `qna.md`** — **placement preserves intent** (map the commented line to the **current** file after checkout):
+
+  1. Resolve which **`## Q-NN — …`** block contains the line (and whether the line is **before the first `###`**, **after the last `###`** for that question, or **inside a `### Answer …` body**, including nested `####`).
+
+  2. **Comment on the question stem** (under `## Q-NN` bullets, before any `###`, or clearly addressing the question row): treat as a **new answer** — append **`### Answer — …`** under that `## Q-NN` per **`spec-start`** (`qna.md` format): unique slug, permalink line under heading when long, then marker + body.
+
+  3. **Comment after all answers** for that `## Q-NN` (below the final `###` of that block): treat as a **new answer** — append another **`### Answer — …`** at the end of that question.
+
+  4. **Comment inside an existing `### Answer …` body**: treat as **discussion on that answer** — prefer **in-place** edits inside that answer (extra paragraph, blockquote, or a child **`#### Thread`** subsection). Avoid silently moving the text to an unrelated top-level `###`. If in-place merge is unsafe, add a **new `###`** that **cites** the target answer heading and states the correction or dispute explicitly.
+
+When multiple GitHub threads map to the same `## Q-NN`, preserve **thread order** where sensible; later activity may supersede earlier per **`spec-refine`** “later overrides earlier” guidance.
+
+## Step 5 — Run `spec-refine`
+
+Execute **Phase 1 → Phase 2 → Phase 3** from [`spec-refine/SKILL.md`](../spec-refine/SKILL.md) on the single topic directory you locked in Step 2.
+
+## Step 6 — Commit (never `comments.md`)
+
+1. **`git add`** with **explicit paths only** — at minimum:
+
+   - `docs/plans/YYYY-MM-DD-<topic>/spec.md`
+   - `docs/plans/YYYY-MM-DD-<topic>/qna.md`
+   - plus any **tracked** optional assets under that same directory that **`spec-refine`** legitimately changed.
+
+2. **Never** stage **`comments.md`**. If it appears staged, run `git restore --staged -- docs/plans/.../comments.md` (and verify it is not in the commit).
+
+3. Commit with a message consistent with repo conventions, e.g. **“Address PR review feedback”** and reference the driving issue with **`Refs #N`** when known (the PR itself is not an issue number—link the PR URL in the body if helpful).
+
+## Step 7 — Push (local mode only)
+
+In **local mode**, **`git push`** to update the existing PR branch (use the remote tracking branch for the PR head).
+
+In **harness mode**, **do not push**; include exact suggested commands in the final reply.
+
+## Step 8 — Review-thread replies (local mode, optional)
+
+Posting replies is a **GitHub write**, same class as **`git push`**.
+
+- **Harness mode:** **Do not** call reply APIs; output suggested `gh api` / GraphQL mutations and thread / comment IDs.
+- **Local mode:** **Best-effort** only—when new or updated answer material clearly corresponds to an open **review thread** on `qna.md`, post a short reply (for example `gh api -X POST repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies -f body='…'` per [GitHub “Create a reply for a review comment”](https://docs.github.com/rest/pulls/comments#create-a-reply-for-a-review-comment); `comment_id` must be a **top-level** thread root, not a reply). If mapping is uncertain, skip rather than spam the wrong thread.
+
+Retain **thread id** next to ingested material (e.g. `<!-- gh-thread:THREAD_ROOT_ID -->` near the marker) when it helps a harness or a later run. Document that **force-pushes**, **line shifts**, and **resolved threads** can break mapping.
+
+## Aftercare (message to user)
+
+- Topic directory path, PR URL, and **local vs harness** outcome.
+- List files changed in the commit; confirm **`comments.md`** was **not** committed.
+- Top remaining **`## Q-NN`** items that still need humans.
+- If harness: paste **push** and **thread-reply** handoff blocks.

--- a/skills/spec-refine/SKILL.md
+++ b/skills/spec-refine/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: spec-refine
+description: >-
+  Use when an existing docs/plans topic from spec-start needs review feedback
+  folded back in: optional comments.md into qna.md ### answers, resolved threads
+  into spec.md, and the same self-review bar as spec-start. Documentation only
+  inside the topic directory; requires spec.md and qna.md already present. Pair
+  with spec-refine-github for PR round-trips.
+# Cursor Agent Skills: prefer explicit @-style invocation; other tooling may ignore.
+disable-model-invocation: true
+---
+
+# spec-refine (fold comments and Q&A back into the spec)
+
+Take an **existing** topic directory under `docs/plans/`—the layout produced by **`spec-start`**—and bring it up to date: absorb `comments.md`, reconcile `qna.md`, refresh `spec.md`, then self-review. This is **documentation only** inside that directory (plus an optional git commit only if the caller explicitly asked to commit).
+
+Do **not** write production code, scaffold projects, or invoke implementation skills.
+
+## Delegation and subagents
+
+Long `spec.md` bodies, broad repo research, or many `comments.md` sections can consume main-agent context quickly. **Parallel reasoning is fine; parallel writers on the same file are not.**
+
+- **Orchestrator (main agent):** Resolves the **topic directory**, applies **all** edits to `spec.md`, `qna.md`, and `comments.md`, runs **Phase 3 self-review**, and owns the final message to the user.
+- **Subagents (optional):** Use for **narrow** work units—one independent `comments.md` section (or one **thread** of sections that explicitly reference each other), or one `## Q-NN` whose integration needs deep repo search. Each subagent returns a **short summary** and **proposed edits** (what to append or remove, with exact text where possible). The orchestrator **merges** those proposals; subagents do **not** patch the same Markdown file concurrently.
+- **Bounded reads:** Prefer headings, line ranges cited in comments, and targeted search over pasting entire large files repeatedly.
+
+For **`qna.md` grammar** and **self-review depth**, stay aligned with **`spec-start`** (flat `## Q-NN`, `###` answers, chronology).
+
+## Resolve the topic directory
+
+Paths are **relative to the topic directory** once resolved.
+
+1. Infer the directory from the user message and repo context. Convention: `docs/plans/YYYY-MM-DD-<topic>/` (same as **`spec-start`**).
+2. If **multiple** candidates match or none is identifiable, **stop** and report an error—do **not** guess.
+
+The directory **must** already contain `spec.md` and `qna.md`. Optional: `comments.md`.
+
+## Process overview
+
+```mermaid
+flowchart TD
+  resolveDir[Resolve topic directory]
+  phase1[Phase 1: comments.md to qna]
+  phase2[Phase 2: qna into spec]
+  phase3[Phase 3: self review]
+  resolveDir --> phase1
+  phase1 --> phase2
+  phase2 --> phase3
+```
+
+## Phase 1 — `comments.md` (optional)
+
+Skip this phase if `comments.md` is **missing**.
+
+### Comment file shape
+
+Reviewers may structure `comments.md` as **multiple** top-level sections. Typical patterns (examples—not an exhaustive grammar):
+
+- Optional `#` title (for example `# Comments`).
+- **`## …`** for each comment block. A title line may include optional attribution, for example **## General note — @handle**.
+- **## For question Q-03** — text targets question **Q-03** in `qna.md`.
+- **## For file spec.md lines 30** — text targets a location in `spec.md` (line numbers are hints; reconcile with current file content).
+
+### Merge into `qna.md` first when applicable
+
+1. For sections that clearly map to **`## Q-NN`** in `qna.md`, append new **`### Answer — …`** children under that question using the same rules as **`spec-start`**: **unique slug text** in each `###` heading; **oldest answer first, newest last** under the same `## Q-NN`; permalink on the line under the heading when long.
+2. **Consume** comment text as you fold it in: remove passages from `comments.md` once their substance lives under the right `###` (or is clearly obsolete). Remove a whole **`## …`** section when nothing usable remains in it.
+3. **Later vs earlier:** When two comments conflict, treat **later** sections in file order as **overriding** earlier ones unless the earlier text is still needed for traceability—then capture the tension in a new **`### Answer — …`** noting the override.
+
+### Remaining general comments
+
+For text that does **not** map cleanly to an existing `## Q-NN`:
+
+- Apply edits to **`spec.md`** when the comment is design-level, or
+- Add new **`## Q-NN`** rows to **`qna.md`** when clarification is still needed. Assign the next IDs after the current maximum (`Q-01` … two-digit style; continue with `Q-10`, `Q-11`, … as needed).
+
+### Parallelization
+
+For independent sections, you **may** **dispatch a subagent** per section (or per thread of mutually referring sections) to draft summaries and proposed `qna.md` / `spec.md` edits. The orchestrator applies merges **in document order** within `comments.md` when order matters for overrides.
+
+## Phase 2 — `qna.md` → `spec.md`
+
+For each **`## Q-NN`** in order:
+
+1. Read the question bullets and **all** `###` answers.
+2. If the thread **fully resolves** the question, update **`spec.md`** so the canonical design matches the decision. Remove or rewrite **overruled** implementation options so the spec does not read like a menu of dead paths—capture discarded options briefly in `qna.md` if historical trace matters (**new `###`** or **Kind**-appropriate update).
+3. If the thread is **only partially** resolved, still fold **confirmed** facts into `spec.md`. When it helps reviewers, append a **`### Answer — …`** (synthesis) that states what remains open, who might decide it, and risks—**without** blocking the run on live Q&A with the user.
+4. For heavy integration (large codebase, cross-cutting research), **dispatch a subagent** per `## Q-NN` if useful; the orchestrator applies the summarized proposal to `spec.md` and any new `###` / `## Q-NN` entries.
+
+Keep **`spec.md`** as the **canonical** design surface; keep debate and attribution in **`qna.md`** where it belongs.
+
+## Phase 3 — Spec self-review
+
+Re-run the same quality bar as **`spec-start`** (“Spec self-review”):
+
+1. **Placeholder scan:** Any "TBD", "TODO", vague requirements? Fix in `spec.md` or track in `qna.md` as `## Q-NN` with explicit uncertainty.
+2. **Internal consistency:** Sections agree; architecture matches behavior; `spec.md` and `qna.md` agree. Mermaid and links still parse; paths resolve.
+3. **Scope check:** Single coherent implementation plan or explicit decomposition in `qna.md`.
+4. **Ambiguity check:** No requirement readable two ways without a recorded call in `spec.md` or `qna.md`.
+5. **`qna.md` shape:** Stable **`Q-NN`** IDs in order; real answers use unique `###` slugs; chronology preserved.
+
+Fix issues inline. One pass is enough unless edits reintroduce problems.
+
+## `comments.md` lifecycle after Phase 1
+
+When **no** pending comment text remains, **delete `comments.md`** so the topic directory does not carry empty review scratch space. If your tooling or team policy forbids deletion, leave a single-line file stating there are no pending comments—prefer deletion when allowed.
+
+## Commit
+
+Commit only if the user or automation **explicitly** asked to commit. Otherwise leave changes in the working tree and report paths.
+
+For **GitHub PR round-trips** (ingest PR review comments, commit `spec.md` / `qna.md` to the PR branch, optional push and thread replies), use **`spec-refine-github`** instead of relying on this skill alone—it owns `gh`, PR-scoped eligibility, and harness vs local writes.
+
+## Aftercare (message to user)
+
+In the final reply, list the **topic directory path**, summarize **what changed** in `spec.md`, `qna.md`, and `comments.md` (including deletion), and surface the **top** remaining `## Q-NN` items that still need human decisions (**Kind:** `open`, or high blast-radius assumptions).
+
+If the work was driven from a **spec PR** and you need push/thread-reply automation, point the user at **`spec-refine-github`** for the next step.

--- a/skills/spec-start-github/SKILL.md
+++ b/skills/spec-start-github/SKILL.md
@@ -75,6 +75,8 @@ Run **`scan-secrets`** on changed paths if available; run **pre-commit** on thos
 
 Some runner scripts append **`Closes #N`** to PR bodies automatically. Harness authors should prefer **`Refs`** for spec-only PRs when they control templates.
 
+After the PR is open, do **not** auto-invoke **`spec-refine-github`** unless the session asks for a refine pass. When reviewers leave PR or issue comments (or request changes), use **`spec-refine-github`** to ingest that feedback and update `spec.md` / `qna.md` on the same branch (see that skill for harness vs local push rules).
+
 ## Aftercare
 
-Mirror `spec-start`: list topic path, summarize the recommended approach, surface top open questions. If harness mode, also paste the suggested PR title and body.
+Mirror `spec-start`: list topic path, summarize the recommended approach, surface top open questions. If harness mode, also paste the suggested PR title and body. After review on the PR, **`spec-refine-github`** is the follow-up skill that merges feedback back into `spec.md` / `qna.md`.

--- a/skills/spec-start/SKILL.md
+++ b/skills/spec-start/SKILL.md
@@ -42,7 +42,7 @@ You **must** complete these in order. Treat them as a single uninterrupted pass�
 5. **Write the design** — in sections scaled to complexity (see **Presenting the design** below), **directly into** `spec.md` (no separate "chat" design pass).
 6. **Write Q&A** — `qna.md` as a flat list of `## Q-NN` entries (see **`qna.md` format**). Include **example `###` answer headings only under `Q-01`**; other questions stay bullet-only until real discussion adds answers.
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see **Spec self-review** below). Fix issues inline before finishing.
-8. **Stop** — do not auto-invoke planning or implementation skills. Optionally note that a follow-up session may produce an implementation plan once reviewers have read `qna.md` (and any review artifacts other skills add later, such as `comments.md`).
+8. **Stop** — do not auto-invoke planning or implementation skills. Optionally note that a follow-up session may produce an implementation plan once reviewers have read `qna.md` (and any review artifacts other skills add later, such as `comments.md`). When reviewers add `comments.md`, use **`spec-refine`** to fold that feedback into `spec.md` and `qna.md`.
 
 ## Process flow (headless)
 
@@ -123,7 +123,7 @@ Within it, for this skill’s initial pass, you **must** create these files (eac
 
 You **may** add **optional** files in the same directory when visualization helps (for example `architecture.svg`, `state-machine.png`, or other assets). Reference them from `spec.md` or `qna.md` with paths that work in a GitHub-style file view (repo-relative paths from the repo root, or paths relative to the topic directory—pick one convention per topic and use it consistently).
 
-**Do not** create, edit, or seed `comments.md`. That avoids accidental commits of review scratch space before another workflow defines it. A **separate skill** may later add and process `comments.md` (and define its format) in the same topic directory.
+**Do not** create, edit, or seed `comments.md`. That avoids accidental commits of review scratch space before another workflow defines it. **`spec-refine`** processes an optional `comments.md` reviewers add in the same topic directory (see that skill for format and workflow).
 
 Other future artifacts for the same topic (appendices, `plan.md`, exports, `comments.md` once owned elsewhere) should live **in the same directory** so one topic stays in one place.
 
@@ -234,4 +234,4 @@ Commit only if the user or automation **explicitly** asked to commit. Otherwise 
 
 ## Aftercare (message to user)
 
-In the final reply, list the **topic directory path**, summarize the **recommended approach** in one paragraph, and surface the **top three** `## Q-NN` items from `qna.md` that most need reviewer attention (for example **Kind:** `open`, or high blast-radius assumptions). If you added optional diagram or image files, list them too so reviewers know what to open.
+In the final reply, list the **topic directory path**, summarize the **recommended approach** in one paragraph, and surface the **top three** `## Q-NN` items from `qna.md` that most need reviewer attention (for example **Kind:** `open`, or high blast-radius assumptions). If you added optional diagram or image files, list them too so reviewers know what to open. After `comments.md` exists, **`spec-refine`** is the skill that merges review feedback back into `spec.md` / `qna.md`.


### PR DESCRIPTION
## Summary

Adds **`spec-refine`** (`skills/spec-refine/SKILL.md`) to fold optional `comments.md` and answered threads into `spec.md` / `qna.md` after `spec-start`, plus **`spec-refine-github`** (`skills/spec-refine-github/SKILL.md`) to run that flow from a **GitHub spec PR** (ingest comments, commit only publishable files, push/thread replies per local vs harness). `spec-start` gains pointers to `spec-refine`; `spec-refine` notes `spec-refine-github` for PR round-trips.

## Related issues

- https://github.com/fullsend-ai/fullsend/issues/802
- https://github.com/fullsend-ai/fullsend/issues/804