### PR TITLE
fix(e2e): queue concurrent runs instead of cancelling

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,7 @@ on:
 concurrency:
   group: e2e-halfsend
   cancel-in-progress: false
+  queue: max
 
 jobs:
   e2e:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,7 @@ repos:
     rev: v1.7.11
     hooks:
       - id: actionlint
+        args: ["-ignore", "unexpected key \"queue\" for \"concurrency\""]
 
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary

- Add `queue: max` to e2e workflow concurrency group so pending runs wait in FIFO order instead of being cancelled when a 3rd run arrives
- Add actionlint `-ignore` for the `queue` key (not yet recognized by actionlint v1.7.11)

The static concurrency group (`e2e-halfsend`) is preserved — tests still serialize against the shared org. Previously, GitHub's default `queue: single` behavior meant only 1 pending run was allowed; a 3rd trigger would cancel the pending run, wasting ~15 min of e2e work.

Closes #866

## Test plan

- [ ] Trigger 3+ e2e runs in quick succession and verify none are cancelled
- [ ] Verify runs execute in FIFO order

🤖 Generated with [Claude Code](https://claude.com/claude-code)