### PR TITLE
refactor: unify mint provisioning and harden URL validation

### DIFF
--- a/docs/ADRs/0033-per-repo-installation-mode.md
+++ b/docs/ADRs/0033-per-repo-installation-mode.md
@@ -264,7 +264,7 @@ Per-org-only flags (`--vendor-fullsend-binary`, `--enroll-all`, `--enroll-none`)
 3. If no mint exists: deploys the token mint Cloud Function (same provisioner path as per-org).
 4. If a mint already exists: validates PEMs, registers the org, and sets up per-repo WIF.
 5. Auto-provisions inference WIF pool/provider if `--inference-wif-provider` is omitted.
-6. Generates scaffold files (`.github/workflows/fullsend.yml`, `.fullsend/config.yaml`, `.fullsend/customized/` directories).
+6. Generates scaffold files (`.github/workflows/fullsend.yaml`, `.fullsend/config.yaml`, `.fullsend/customized/` directories).
 7. Commits all scaffold files to the target repo via the GitHub API.
 8. Sets repository variables (`FULLSEND_MINT_URL`, `FULLSEND_GCP_REGION`, `FULLSEND_PER_REPO_INSTALL`).
 9. Sets repository secrets (`FULLSEND_GCP_PROJECT_ID`, WIF credentials).

--- a/docs/ADRs/0033-per-repo-installation-mode.md
+++ b/docs/ADRs/0033-per-repo-installation-mode.md
@@ -255,19 +255,19 @@ Shared flags (valid for both per-org and per-repo):
 - `--mint-project` — GCP project containing the mint function (defaults to `--inference-project` in per-repo)
 - `--mint-region` — cloud region for the mint function (default: `us-central1`)
 
-Per-org-only flags (`--vendor-fullsend-binary`, `--enroll-all`, `--enroll-none`) are rejected when an `owner/repo` argument is given. Other flags (`--public`, `--skip-app-setup`, `--mint-provider`, `--mint-source-dir`, `--skip-mint-deploy`) are shared between per-org and per-repo modes — per-repo can create GitHub Apps and deploy a mint when existing infrastructure is not found.
+Per-org-only flags (`--vendor-fullsend-binary`, `--enroll-all`, `--enroll-none`) are rejected when an `owner/repo` argument is given. All other flags are shared between per-org and per-repo modes — per-repo can create GitHub Apps, deploy a mint, and manage public apps when existing infrastructure is not found.
 
 **Per-repo install steps**:
 
-1. Discovers existing infrastructure: auto-discovers mint URL from `--mint-project`/`--mint-region`, resolves app IDs from the mint's env vars.
+1. Discovers existing infrastructure: auto-discovers mint URL and app IDs from `--mint-project`/`--mint-region` in a single API call.
 2. If apps are missing and `--skip-app-setup` is not set: creates GitHub Apps via the browser-based manifest flow (same as per-org). PEMs are stored in Secret Manager.
 3. If no mint exists: deploys the token mint Cloud Function (same provisioner path as per-org).
 4. If a mint already exists: validates PEMs, registers the org, and sets up per-repo WIF.
-5. Generates scaffold files (`.github/workflows/fullsend.yml`, `.fullsend/config.yaml`, `.fullsend/customized/` directories).
-6. Commits all scaffold files to the target repo via the GitHub API.
-7. Sets repository variables (`FULLSEND_MINT_URL`, `FULLSEND_GCP_REGION`, `FULLSEND_PER_REPO_INSTALL`).
-8. Sets repository secrets (`FULLSEND_GCP_PROJECT_ID`, WIF credentials).
-9. Auto-provisions WIF pool/provider if `--inference-wif-provider` is omitted.
+5. Auto-provisions inference WIF pool/provider if `--inference-wif-provider` is omitted.
+6. Generates scaffold files (`.github/workflows/fullsend.yml`, `.fullsend/config.yaml`, `.fullsend/customized/` directories).
+7. Commits all scaffold files to the target repo via the GitHub API.
+8. Sets repository variables (`FULLSEND_MINT_URL`, `FULLSEND_GCP_REGION`, `FULLSEND_PER_REPO_INSTALL`).
+9. Sets repository secrets (`FULLSEND_GCP_PROJECT_ID`, WIF credentials).
 
 Per-repo install requires only `repo` and `workflow` OAuth scopes when reusing existing infrastructure. When creating apps, scope escalation to `admin:org` is required (same as per-org).
 

--- a/docs/ADRs/0033-per-repo-installation-mode.md
+++ b/docs/ADRs/0033-per-repo-installation-mode.md
@@ -255,19 +255,21 @@ Shared flags (valid for both per-org and per-repo):
 - `--mint-project` — GCP project containing the mint function (defaults to `--inference-project` in per-repo)
 - `--mint-region` — cloud region for the mint function (default: `us-central1`)
 
-Per-org-only flags (`--public`, `--enroll-all`, `--enroll-none`, `--skip-app-setup`, `--vendor-fullsend-binary`, `--skip-mint-deploy`, `--mint-provider`, `--mint-source-dir`) are rejected when an `owner/repo` argument is given.
+Per-org-only flags (`--vendor-fullsend-binary`, `--enroll-all`, `--enroll-none`) are rejected when an `owner/repo` argument is given. Other flags (`--public`, `--skip-app-setup`, `--mint-provider`, `--mint-source-dir`, `--skip-mint-deploy`) are shared between per-org and per-repo modes — per-repo can create GitHub Apps and deploy a mint when existing infrastructure is not found.
 
 **Per-repo install steps**:
 
-1. Generates `.github/workflows/fullsend.yml` from the per-repo shim template.
-2. Generates `.fullsend/config.yaml` with agent roles and kill switch.
-3. Creates `.fullsend/customized/` directory structure (agents, skills, schemas, harness, policies, scripts, env).
-4. Commits all scaffold files to the target repo via the GitHub API.
-5. Sets repository variables (`FULLSEND_MINT_URL`, `FULLSEND_GCP_REGION`, `FULLSEND_PER_REPO_INSTALL`).
-6. Sets repository secrets (`FULLSEND_GCP_PROJECT_ID`, WIF credentials).
-7. Auto-provisions WIF pool/provider if `--inference-wif-provider` is omitted.
+1. Discovers existing infrastructure: auto-discovers mint URL from `--mint-project`/`--mint-region`, resolves app IDs from the mint's env vars.
+2. If apps are missing and `--skip-app-setup` is not set: creates GitHub Apps via the browser-based manifest flow (same as per-org). PEMs are stored in Secret Manager.
+3. If no mint exists: deploys the token mint Cloud Function (same provisioner path as per-org).
+4. If a mint already exists: validates PEMs, registers the org, and sets up per-repo WIF.
+5. Generates scaffold files (`.github/workflows/fullsend.yml`, `.fullsend/config.yaml`, `.fullsend/customized/` directories).
+6. Commits all scaffold files to the target repo via the GitHub API.
+7. Sets repository variables (`FULLSEND_MINT_URL`, `FULLSEND_GCP_REGION`, `FULLSEND_PER_REPO_INSTALL`).
+8. Sets repository secrets (`FULLSEND_GCP_PROJECT_ID`, WIF credentials).
+9. Auto-provisions WIF pool/provider if `--inference-wif-provider` is omitted.
 
-Per-repo install requires only `repo` and `workflow` OAuth scopes (no `admin:org`).
+Per-repo install requires only `repo` and `workflow` OAuth scopes when reusing existing infrastructure. When creating apps, scope escalation to `admin:org` is required (same as per-org).
 
 ### 8. Coexistence
 

--- a/docs/ADRs/0033-per-repo-installation-mode.md
+++ b/docs/ADRs/0033-per-repo-installation-mode.md
@@ -255,7 +255,7 @@ Shared flags (valid for both per-org and per-repo):
 - `--mint-project` — GCP project containing the mint function (defaults to `--inference-project` in per-repo)
 - `--mint-region` — cloud region for the mint function (default: `us-central1`)
 
-Per-org-only flags (`--public`, `--enroll-all`, `--enroll-none`, `--skip-app-setup`, `--vendor-fullsend-binary`, `--skip-mint-deploy`, etc.) are rejected when an `owner/repo` argument is given.
+Per-org-only flags (`--public`, `--enroll-all`, `--enroll-none`, `--skip-app-setup`, `--vendor-fullsend-binary`, `--skip-mint-deploy`, `--mint-provider`, `--mint-source-dir`) are rejected when an `owner/repo` argument is given.
 
 **Per-repo install steps**:
 

--- a/docs/ADRs/0033-per-repo-installation-mode.md
+++ b/docs/ADRs/0033-per-repo-installation-mode.md
@@ -245,20 +245,23 @@ fullsend admin install <org>            # per-org installation
 fullsend admin install <owner/repo>     # per-repo installation
 ```
 
-Per-repo flags (only valid with `owner/repo` argument):
-- `--mint-url` — token mint URL for OIDC token exchange (required)
+Per-repo flags:
 - `--inference-project` — GCP project for Vertex AI inference (required)
 - `--inference-region` — GCP region for Vertex AI inference (default: `global`)
 - `--inference-wif-provider` — pre-existing WIF provider (auto-provisioned if omitted)
-- `--scaffold-customized` — create `.fullsend/customized/` directory structure
 
-Per-org-only flags (`--mint-region`, `--public`, `--enroll-all`, `--enroll-none`, `--skip-app-setup`, `--vendor-fullsend-binary`, etc.) are rejected when an `owner/repo` argument is given. `--mint-project` is accepted in both modes (defaults to `--inference-project` in per-repo).
+Shared flags (valid for both per-org and per-repo):
+- `--mint-url` — token mint URL for OIDC token exchange (optional; auto-discovered from `--mint-project`/`--mint-region` if omitted)
+- `--mint-project` — GCP project containing the mint function (defaults to `--inference-project` in per-repo)
+- `--mint-region` — cloud region for the mint function (default: `us-central1`)
+
+Per-org-only flags (`--public`, `--enroll-all`, `--enroll-none`, `--skip-app-setup`, `--vendor-fullsend-binary`, `--skip-mint-deploy`, etc.) are rejected when an `owner/repo` argument is given.
 
 **Per-repo install steps**:
 
 1. Generates `.github/workflows/fullsend.yml` from the per-repo shim template.
 2. Generates `.fullsend/config.yaml` with agent roles and kill switch.
-3. Optionally creates `.fullsend/customized/` directory structure (`--scaffold-customized`).
+3. Creates `.fullsend/customized/` directory structure (agents, skills, schemas, harness, policies, scripts, env).
 4. Commits all scaffold files to the target repo via the GitHub API.
 5. Sets repository variables (`FULLSEND_MINT_URL`, `FULLSEND_GCP_REGION`, `FULLSEND_PER_REPO_INSTALL`).
 6. Sets repository secrets (`FULLSEND_GCP_PROJECT_ID`, WIF credentials).

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -160,6 +160,49 @@ Once a repo is enrolled (enrollment PR merged):
 
 ---
 
+## Per-repo installation
+
+Per-repo mode installs fullsend for a single repository without requiring an org-wide `.fullsend` config repo. It's fully self-contained — creating GitHub Apps, deploying a token mint, and configuring WIF as needed.
+
+### First-time install (no prior infrastructure)
+
+```bash
+fullsend admin install "$ORG_NAME/$REPO_NAME" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-project "$GCP_PROJECT"
+```
+
+This discovers existing infrastructure and creates what's missing:
+- If no GitHub Apps exist, opens browser windows to create them (same manifest flow as per-org)
+- If no token mint exists, deploys a Cloud Function
+- If both exist from a prior per-org install, reuses them
+
+Creating apps requires `admin:org` OAuth scope (the installer prompts for it). Reusing existing apps only requires `repo` and `workflow` scopes.
+
+### Reusing existing infrastructure
+
+When a per-org install already exists, per-repo reuses the apps and mint:
+
+```bash
+fullsend admin install "$ORG_NAME/$REPO_NAME" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-url "$MINT_URL"
+```
+
+Or let it auto-discover the mint from the GCP project:
+
+```bash
+fullsend admin install "$ORG_NAME/$REPO_NAME" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-project "$GCP_PROJECT"
+```
+
+### Per-repo flags
+
+Per-repo accepts all flags except `--vendor-fullsend-binary`, `--enroll-all`, and `--enroll-none` (which only apply to org-wide enrollment).
+
+---
+
 ## Advanced: pre-configure WIF
 
 The installer auto-provisions WIF infrastructure, but you can create it manually if you need custom pool names, attribute conditions, or want to share a provider across tools.

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -63,6 +63,7 @@ Additional mint flags:
 | `--mint-region` | `us-central1` | Cloud region for the token mint function |
 | `--mint-url` | | Use an existing mint at this URL instead of deploying one |
 | `--public` | `false` | Create public unlisted GitHub Apps (for multi-org) |
+| `--skip-app-setup` | `false` | Skip GitHub App creation (reuse existing apps) |
 | `--skip-mint-deploy` | `false` | Skip Cloud Function deployment, reuse existing mint URL |
 
 The installer automatically detects when the deployed mint function is up-to-date (same source hash) and skips code redeployment, only updating WIF infrastructure, org registration, and PEM secrets. Use `--skip-mint-deploy` when running from a machine without the function source code.
@@ -200,6 +201,8 @@ fullsend admin install "$ORG_NAME/$REPO_NAME" \
 ### Per-repo flags
 
 Per-repo accepts all flags except `--vendor-fullsend-binary`, `--enroll-all`, and `--enroll-none` (which only apply to org-wide enrollment).
+
+> **`--mint-region` note:** Per-repo uses the same `--mint-region` default (`us-central1`) as per-org. When reusing a mint deployed to a non-default region, pass `--mint-region` explicitly so auto-discovery finds the correct function.
 
 ---
 

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -65,7 +65,7 @@ Additional mint flags:
 | `--public` | `false` | Create public unlisted GitHub Apps (for multi-org) |
 | `--skip-mint-deploy` | `false` | Skip Cloud Function deployment, reuse existing mint URL |
 
-The installer automatically detects when the deployed mint function is up-to-date (same source hash) and skips redeployment, only updating org registration and PEM secrets. Use `--skip-mint-deploy` when running from a machine without the function source code.
+The installer automatically detects when the deployed mint function is up-to-date (same source hash) and skips code redeployment, only updating WIF infrastructure, org registration, and PEM secrets. Use `--skip-mint-deploy` when running from a machine without the function source code.
 
 > **Mint URL stability:** The mint URL is stable across redeploys within the same project and region — updating the Cloud Function does not change its URL. Adding a new org to an existing mint only updates env vars (`ROLE_APP_IDS`, `ALLOWED_ORGS`) without redeploying the function. Existing enrolled repos continue working with no changes. However, deploying to a **different region** (e.g., changing `--mint-region` from `us-central1` to `us-east5`) creates a new Cloud Run service with a different URL. All enrolled repos store the mint URL in a repo variable (`FULLSEND_MINT_URL`) or org variable, so changing the region requires updating every enrolled repo's variable to the new URL. Avoid changing `--mint-region` after initial deployment unless you plan to update all consumers.
 
@@ -92,7 +92,7 @@ fullsend admin install "$ADDITIONAL_ORG" \
   --mint-project "$GCP_PROJECT"
 ```
 
-The installer auto-detects the existing mint function and skips infrastructure deployment, only registering the new org and storing its PEM secrets. You can also pass `--mint-url "$MINT_URL"` explicitly to skip the auto-discovery step. PEMs use org-scoped naming (`fullsend-{org}--{role}-app-pem`), so each org's secrets are stored independently. For public apps (shared across orgs), the provisioner stores the same PEM under each org's scoped key.
+The installer auto-detects the existing mint function and skips code redeployment. WIF infrastructure is always updated (adding the new org to the WIF provider's attribute condition and granting Vertex AI IAM access), and the new org is registered in the mint's env vars. You can also pass `--mint-url "$MINT_URL"` explicitly to skip the auto-discovery step. PEMs use org-scoped naming (`fullsend-{org}--{role}-app-pem`), so each org's secrets are stored independently. For public apps (shared across orgs), the provisioner stores the same PEM under each org's scoped key.
 
 > **Note:** Multi-org with `--public` requires all orgs to share the same GitHub Apps. Private apps (the default) are single-org only.
 

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -64,11 +64,10 @@ Additional mint flags:
 | `--mint-url` | | Use an existing mint at this URL instead of deploying one |
 | `--public` | `false` | Create public unlisted GitHub Apps (for multi-org) |
 | `--skip-mint-deploy` | `false` | Skip Cloud Function deployment, reuse existing mint URL |
-| `--force-mint-deploy` | `false` | Force Cloud Function redeployment even if unchanged |
 
-`--skip-mint-deploy` and `--force-mint-deploy` are mutually exclusive.
+The installer automatically detects when the deployed mint function is up-to-date (same source hash) and skips redeployment, only updating org registration and PEM secrets. Use `--skip-mint-deploy` when running from a machine without the function source code.
 
-> **Mint URL stability:** The mint URL is stable across redeploys within the same project and region — updating the Cloud Function does not change its URL. Adding a new org or per-repo enrollment triggers a redeploy (to update env vars like `ROLE_APP_IDS` and `ALLOWED_ORGS`), but this is an in-place update that preserves the URL. Existing enrolled repos continue working with no changes. However, deploying to a **different region** (e.g., changing `--mint-region` from `us-central1` to `us-east5`) creates a new Cloud Run service with a different URL. All enrolled repos store the mint URL in a repo variable (`FULLSEND_MINT_URL`) or org variable, so changing the region requires updating every enrolled repo's variable to the new URL. Avoid changing `--mint-region` after initial deployment unless you plan to update all consumers.
+> **Mint URL stability:** The mint URL is stable across redeploys within the same project and region — updating the Cloud Function does not change its URL. Adding a new org to an existing mint only updates env vars (`ROLE_APP_IDS`, `ALLOWED_ORGS`) without redeploying the function. Existing enrolled repos continue working with no changes. However, deploying to a **different region** (e.g., changing `--mint-region` from `us-central1` to `us-east5`) creates a new Cloud Run service with a different URL. All enrolled repos store the mint URL in a repo variable (`FULLSEND_MINT_URL`) or org variable, so changing the region requires updating every enrolled repo's variable to the new URL. Avoid changing `--mint-region` after initial deployment unless you plan to update all consumers.
 
 ### Multi-org setup
 
@@ -90,10 +89,10 @@ The `--public` flag creates GitHub Apps as public unlisted — they won't appear
 ```bash
 fullsend admin install "$ADDITIONAL_ORG" \
   --inference-project "$GCP_PROJECT" \
-  --mint-url "$MINT_URL"
+  --mint-project "$GCP_PROJECT"
 ```
 
-`--mint-url` skips Cloud Function deployment and stores PEMs in the existing mint's GCP project. PEMs use org-scoped naming (`fullsend-{org}--{role}-app-pem`), so each org's secrets are stored independently. For public apps (shared across orgs), the provisioner stores the same PEM under each org's scoped key.
+The installer auto-detects the existing mint function and skips infrastructure deployment, only registering the new org and storing its PEM secrets. You can also pass `--mint-url "$MINT_URL"` explicitly to skip the auto-discovery step. PEMs use org-scoped naming (`fullsend-{org}--{role}-app-pem`), so each org's secrets are stored independently. For public apps (shared across orgs), the provisioner stores the same PEM under each org's scoped key.
 
 > **Note:** Multi-org with `--public` requires all orgs to share the same GitHub Apps. Private apps (the default) are single-org only.
 

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/url"
 	"os"
 	"os/exec"
@@ -132,6 +131,10 @@ func validateMintURL(raw string) error {
 			scheme = parsed.Scheme
 		}
 		return fmt.Errorf("--mint-url must be a valid HTTPS URL (got scheme=%q)", scheme)
+	}
+	if !strings.HasSuffix(parsed.Host, ".run.app") &&
+		!strings.HasSuffix(parsed.Host, ".cloudfunctions.net") {
+		return fmt.Errorf("--mint-url must be a Cloud Run URL (.run.app or .cloudfunctions.net), got host %q", parsed.Host)
 	}
 	return nil
 }
@@ -569,7 +572,8 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 	if mintURL != "" {
 		mintFound = true
 		// Mint URL provided — still discover role IDs from the function
-		// to resolve existing apps (skip in dry-run since no changes are made).
+		// to resolve existing apps. Skipped in dry-run to avoid requiring
+		// GCP credentials for preview-only invocations.
 		if mintProject != "" && !dryRun {
 			printer.StepStart("Resolving app IDs from mint")
 			discovery, discoverErr := discoverer.DiscoverMint(ctx)
@@ -578,8 +582,10 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 					printer.StepFail("Failed to read mint state")
 					return fmt.Errorf("reading mint state: %w", discoverErr)
 				}
+				printer.StepDone("Mint function not found in project — will discover apps from setup")
 			} else {
 				existingIDs = discovery.RoleAppIDs
+				printer.StepDone("Resolved app IDs from mint")
 			}
 		}
 	} else if mintProject != "" {
@@ -603,7 +609,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 	if mintFound && existingIDs != nil {
 		roleAppIDs, resolveErr := resolveSharedRoleAppIDs(ctx, client, existingIDs, owner, roles)
 		if resolveErr != nil {
-			log.Printf("resolveSharedRoleAppIDs: %v (will attempt app creation)", resolveErr)
+			printer.StepWarn(fmt.Sprintf("Could not resolve shared app IDs: %v (will attempt app creation)", resolveErr))
 		} else {
 			agentAppIDs = make(map[string]string, len(roles))
 			appsFound = true

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -102,9 +102,7 @@ var rolePattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
 
 // perOrgOnlyFlags are flags that only apply to per-org mode.
 var perOrgOnlyFlags = []string{
-	"skip-app-setup", "vendor-fullsend-binary", "enroll-all", "enroll-none",
-	"mint-provider", "mint-source-dir",
-	"skip-mint-deploy", "public",
+	"vendor-fullsend-binary", "enroll-all", "enroll-none",
 }
 
 // parseAgentRoles splits a comma-separated agents string into a validated role list.
@@ -171,7 +169,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 				}
 				return runPerRepoInstall(cmd.Context(), arg, perRepoAgents, mintURL, inferenceRegion,
 					inferenceProject, inferenceWIFProvider, perRepoMintProject, mintRegion,
-					dryRun)
+					dryRun, skipAppSetup, publicApps, mintProvider, mintSourceDir, mintSkipDeploy)
 			}
 
 			org := arg
@@ -405,7 +403,8 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 
 func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, inferenceRegion,
 	inferenceProject, inferenceWIFProvider, mintProject, mintRegion string,
-	dryRun bool) error {
+	dryRun, skipAppSetup, publicApps bool,
+	mintProvider, mintSourceDir string, mintSkipDeploy bool) error {
 	if strings.Contains(repoFullName, "://") || strings.HasPrefix(repoFullName, "www.") {
 		return fmt.Errorf("expected owner/repo format, got a URL — use just the owner/repo portion (e.g. acme/widget)")
 	}
@@ -430,8 +429,9 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 			}
 			return fmt.Errorf("--mint-url must be a valid HTTPS URL (got scheme=%q)", scheme)
 		}
-	} else if mintProject == "" {
-		return fmt.Errorf("--mint-url or --mint-project (or --inference-project) is required for per-repo installation")
+	}
+	if mintProject == "" && mintURL == "" {
+		return fmt.Errorf("--mint-project (or --inference-project) is required for per-repo installation")
 	}
 	if inferenceProject == "" {
 		return fmt.Errorf("--inference-project is required for per-repo installation")
@@ -513,6 +513,17 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		}
 		printer.StepInfo("Dry run — no changes will be made")
 		printer.Blank()
+		if !skipAppSetup {
+			printer.StepInfo(fmt.Sprintf("Would create GitHub Apps (if missing) for roles: %s", strings.Join(roles, ", ")))
+			if publicApps {
+				printer.StepInfo("  Apps would be public (unlisted)")
+			}
+			printer.Blank()
+		}
+		if mintURL == "" {
+			printer.StepInfo(fmt.Sprintf("Would deploy token mint (if missing) to project %s, region %s", mintProject, mintRegion))
+			printer.Blank()
+		}
 		printer.StepInfo("Would validate mint infrastructure:")
 		printer.StepInfo(fmt.Sprintf("  Mint URL: %s", mintDisplay))
 		printer.StepInfo(fmt.Sprintf("  Mint project: %s, region: %s", mintProject, mintRegion))
@@ -548,73 +559,165 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		return nil
 	}
 
-	if err := checkPerRepoScopes(ctx, client, printer); err != nil {
-		return err
-	}
+	// Phase 1: Discover existing infrastructure.
+	var mintFound bool
+	var appsFound bool
+	var agentAppIDs map[string]string
+	var agentPEMs map[string][]byte
 
-	// Auto-discover mint URL if not provided.
 	discoverer := gcf.NewProvisioner(gcf.Config{
 		ProjectID:  mintProject,
 		Region:     mintRegion,
 		GitHubOrgs: []string{owner},
 	}, gcf.NewLiveGCFClient())
 
-	if mintURL == "" {
+	if mintURL != "" {
+		mintFound = true
+	} else if mintProject != "" {
 		printer.StepStart("Discovering mint URL")
 		discovered, discoverErr := discoverer.GetFunctionURL(ctx)
 		if discoverErr != nil {
-			printer.StepFail("Mint discovery failed")
-			if strings.Contains(discoverErr.Error(), "not found") {
-				return fmt.Errorf("no mint function found in project %s region %s — provide --mint-url or run per-org install first",
-					mintProject, mintRegion)
+			if !strings.Contains(discoverErr.Error(), "not found") {
+				printer.StepFail("Mint discovery failed")
+				return fmt.Errorf("failed to discover mint URL in project %s region %s: %w",
+					mintProject, mintRegion, discoverErr)
 			}
-			return fmt.Errorf("failed to discover mint URL in project %s region %s: %w",
-				mintProject, mintRegion, discoverErr)
+			printer.StepDone("No existing mint found — will deploy")
+		} else {
+			mintURL = discovered
+			mintFound = true
+			printer.StepDone(fmt.Sprintf("Found mint at %s", mintURL))
 		}
-		mintURL = discovered
-		printer.StepDone(fmt.Sprintf("Found mint at %s", mintURL))
 	}
 
-	// Resolve shared app IDs from the existing mint.
-	printer.StepStart("Validating mint infrastructure")
-	existingIDs, err := discoverer.GetExistingRoleAppIDs(ctx)
-	if err != nil {
-		printer.StepFail("Failed to read mint state")
-		return fmt.Errorf("reading existing role app IDs: %w", err)
-	}
-
-	roleAppIDs, err := resolveSharedRoleAppIDs(ctx, client, existingIDs, owner, roles)
-	if err != nil {
-		printer.StepFail("Failed to resolve shared app IDs")
-		return fmt.Errorf("resolving shared role app IDs: %w", err)
-	}
-
-	// Convert org-scoped app IDs (owner/role → appID) to role-only (role → appID).
-	agentAppIDs := make(map[string]string, len(roles))
-	for _, role := range roles {
-		appID, ok := roleAppIDs[owner+"/"+role]
-		if !ok {
-			printer.StepFail(fmt.Sprintf("Role %q not registered", role))
-			return fmt.Errorf("role %q is not registered for org %q in the mint — run per-org install first", role, owner)
+	if mintFound {
+		printer.StepStart("Resolving app IDs from mint")
+		existingIDs, idErr := discoverer.GetExistingRoleAppIDs(ctx)
+		if idErr != nil {
+			printer.StepFail("Failed to read mint state")
+			return fmt.Errorf("reading existing role app IDs: %w", idErr)
 		}
-		agentAppIDs[role] = appID
+
+		roleAppIDs, resolveErr := resolveSharedRoleAppIDs(ctx, client, existingIDs, owner, roles)
+		if resolveErr == nil {
+			agentAppIDs = make(map[string]string, len(roles))
+			appsFound = true
+			for _, role := range roles {
+				appID, ok := roleAppIDs[owner+"/"+role]
+				if !ok {
+					appsFound = false
+					break
+				}
+				agentAppIDs[role] = appID
+			}
+		}
+		if appsFound {
+			printer.StepDone("Resolved all app IDs")
+		} else {
+			printer.StepDone("Some app IDs missing — will create apps")
+		}
 	}
 
-	// Provision: PEM validation + auto-copy + EnsureOrgInMint + RegisterPerRepoWIF.
-	mintProvisioner := gcf.NewProvisioner(gcf.Config{
-		ProjectID:   mintProject,
-		Region:      mintRegion,
-		GitHubOrgs:  []string{owner},
-		AgentAppIDs: agentAppIDs,
-		MintURL:     mintURL,
-		Repo:        owner + "/" + repo,
-	}, gcf.NewLiveGCFClient())
+	needAppSetup := !appsFound && !skipAppSetup
+	needMintDeploy := !mintFound
 
-	if _, err := mintProvisioner.Provision(ctx); err != nil {
-		printer.StepFail("Mint provisioning failed")
-		return fmt.Errorf("provisioning mint: %w", err)
+	if skipAppSetup && !appsFound {
+		if !mintFound {
+			return fmt.Errorf("no mint function found in project %s region %s and --skip-app-setup prevents creating one", mintProject, mintRegion)
+		}
+		return fmt.Errorf("could not resolve app IDs for %s from the mint and --skip-app-setup prevents creating them", owner)
 	}
-	printer.StepDone("Mint validated and org registered")
+
+	// Scope escalation: app creation requires admin:org.
+	if needAppSetup {
+		if err := checkInstallScopes(ctx, client, printer); err != nil {
+			return err
+		}
+	} else {
+		if err := checkPerRepoScopes(ctx, client, printer); err != nil {
+			return err
+		}
+	}
+
+	// Phase 2: App creation + mint provisioning based on discovered state.
+	if needAppSetup {
+		var sharedSlugs map[string]string
+		if mintProject != "" {
+			slugs, slugErr := copySharedAppPEMs(ctx, client, printer, owner, roles, mintProject, mintRegion)
+			if slugErr != nil {
+				return slugErr
+			}
+			sharedSlugs = slugs
+		}
+
+		creds, credErr := runAppSetup(ctx, client, printer, owner, roles, mintProject, publicApps, sharedSlugs)
+		if credErr != nil {
+			return credErr
+		}
+
+		agentAppIDs = make(map[string]string, len(roles))
+		agentPEMs = make(map[string][]byte)
+		for _, ac := range creds {
+			if ac.AppID != 0 {
+				agentAppIDs[ac.Role] = strconv.Itoa(ac.AppID)
+				if ac.PEM != "" {
+					agentPEMs[ac.Role] = []byte(ac.PEM)
+				}
+			}
+		}
+	}
+
+	if needMintDeploy {
+		if mintProvider != "gcf" {
+			return fmt.Errorf("--mint-provider must be 'gcf' for mint deployment")
+		}
+		if mintSourceDir == "" {
+			mintSourceDir = gcf.DefaultFunctionSourceDir()
+		}
+		deployMode := gcf.DeployAuto
+		if mintSkipDeploy {
+			deployMode = gcf.DeploySkip
+		}
+
+		printer.StepStart("Deploying token mint")
+		mintProvisioner := gcf.NewProvisioner(gcf.Config{
+			ProjectID:         mintProject,
+			Region:            mintRegion,
+			GitHubOrgs:        []string{owner},
+			AgentPEMs:         agentPEMs,
+			AgentAppIDs:       agentAppIDs,
+			FunctionSourceDir: mintSourceDir,
+			DeployMode:        deployMode,
+			Repo:              owner + "/" + repo,
+		}, gcf.NewLiveGCFClient())
+
+		provResult, provErr := mintProvisioner.Provision(ctx)
+		if provErr != nil {
+			printer.StepFail("Mint deployment failed")
+			return fmt.Errorf("provisioning mint: %w", provErr)
+		}
+		if url, ok := provResult["FULLSEND_MINT_URL"]; ok {
+			mintURL = url
+		}
+		printer.StepDone(fmt.Sprintf("Mint deployed at %s", mintURL))
+	} else {
+		printer.StepStart("Validating mint infrastructure")
+		mintProvisioner := gcf.NewProvisioner(gcf.Config{
+			ProjectID:   mintProject,
+			Region:      mintRegion,
+			GitHubOrgs:  []string{owner},
+			AgentAppIDs: agentAppIDs,
+			AgentPEMs:   agentPEMs,
+			MintURL:     mintURL,
+			Repo:        owner + "/" + repo,
+		}, gcf.NewLiveGCFClient())
+
+		if _, err := mintProvisioner.Provision(ctx); err != nil {
+			printer.StepFail("Mint provisioning failed")
+			return fmt.Errorf("provisioning mint: %w", err)
+		}
+		printer.StepDone("Mint validated and org registered")
+	}
 
 	if needsWIFProvision {
 		printer.StepStart("Provisioning WIF infrastructure")

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -3,8 +3,10 @@ package cli
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/url"
 	"os"
 	"os/exec"
@@ -105,6 +107,35 @@ var perOrgOnlyFlags = []string{
 	"vendor-fullsend-binary", "enroll-all", "enroll-none",
 }
 
+type perRepoInstallConfig struct {
+	RepoFullName        string
+	Agents              string
+	MintURL             string
+	InferenceRegion     string
+	InferenceProject    string
+	InferenceWIFProvider string
+	MintProject         string
+	MintRegion          string
+	DryRun              bool
+	SkipAppSetup        bool
+	PublicApps          bool
+	MintProvider        string
+	MintSourceDir       string
+	MintSkipDeploy      bool
+}
+
+func validateMintURL(raw string) error {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		scheme := ""
+		if parsed != nil {
+			scheme = parsed.Scheme
+		}
+		return fmt.Errorf("--mint-url must be a valid HTTPS URL (got scheme=%q)", scheme)
+	}
+	return nil
+}
+
 // parseAgentRoles splits a comma-separated agents string into a validated role list.
 func parseAgentRoles(agents string) ([]string, error) {
 	var roles []string
@@ -167,9 +198,22 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 				if perRepoMintProject == "" {
 					perRepoMintProject = inferenceProject
 				}
-				return runPerRepoInstall(cmd.Context(), arg, perRepoAgents, mintURL, inferenceRegion,
-					inferenceProject, inferenceWIFProvider, perRepoMintProject, mintRegion,
-					dryRun, skipAppSetup, publicApps, mintProvider, mintSourceDir, mintSkipDeploy)
+				return runPerRepoInstall(cmd.Context(), perRepoInstallConfig{
+					RepoFullName:        arg,
+					Agents:              perRepoAgents,
+					MintURL:             mintURL,
+					InferenceRegion:     inferenceRegion,
+					InferenceProject:    inferenceProject,
+					InferenceWIFProvider: inferenceWIFProvider,
+					MintProject:         perRepoMintProject,
+					MintRegion:          mintRegion,
+					DryRun:              dryRun,
+					SkipAppSetup:        skipAppSetup,
+					PublicApps:          publicApps,
+					MintProvider:        mintProvider,
+					MintSourceDir:       mintSourceDir,
+					MintSkipDeploy:      mintSkipDeploy,
+				})
 			}
 
 			org := arg
@@ -208,13 +252,8 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 
 			// Validate --mint-url early (before app setup which is irreversible).
 			if mintURL != "" {
-				parsedMintURL, err := url.Parse(mintURL)
-				if err != nil || parsedMintURL.Scheme != "https" || parsedMintURL.Host == "" {
-					scheme := ""
-					if parsedMintURL != nil {
-						scheme = parsedMintURL.Scheme
-					}
-					return fmt.Errorf("--mint-url must be a valid HTTPS URL (got scheme=%q)", scheme)
+				if err := validateMintURL(mintURL); err != nil {
+					return err
 				}
 			}
 
@@ -401,10 +440,22 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 	return cmd
 }
 
-func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, inferenceRegion,
-	inferenceProject, inferenceWIFProvider, mintProject, mintRegion string,
-	dryRun, skipAppSetup, publicApps bool,
-	mintProvider, mintSourceDir string, mintSkipDeploy bool) error {
+func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
+	repoFullName := c.RepoFullName
+	agents := c.Agents
+	mintURL := c.MintURL
+	inferenceRegion := c.InferenceRegion
+	inferenceProject := c.InferenceProject
+	inferenceWIFProvider := c.InferenceWIFProvider
+	mintProject := c.MintProject
+	mintRegion := c.MintRegion
+	dryRun := c.DryRun
+	skipAppSetup := c.SkipAppSetup
+	publicApps := c.PublicApps
+	mintProvider := c.MintProvider
+	mintSourceDir := c.MintSourceDir
+	mintSkipDeploy := c.MintSkipDeploy
+
 	if strings.Contains(repoFullName, "://") || strings.HasPrefix(repoFullName, "www.") {
 		return fmt.Errorf("expected owner/repo format, got a URL — use just the owner/repo portion (e.g. acme/widget)")
 	}
@@ -421,13 +472,8 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 	}
 
 	if mintURL != "" {
-		parsedMintURL, err := url.Parse(mintURL)
-		if err != nil || parsedMintURL.Scheme != "https" || parsedMintURL.Host == "" {
-			scheme := ""
-			if parsedMintURL != nil {
-				scheme = parsedMintURL.Scheme
-			}
-			return fmt.Errorf("--mint-url must be a valid HTTPS URL (got scheme=%q)", scheme)
+		if err := validateMintURL(mintURL); err != nil {
+			return err
 		}
 	}
 	if mintProject == "" && mintURL == "" {
@@ -506,29 +552,102 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		printer.StepInfo(fmt.Sprintf("Setting up new per-repo installation for %s/%s", owner, repo))
 	}
 
+	// Phase 1: Discover existing infrastructure (read-only, safe for dry-run).
+	var mintFound bool
+	var appsFound bool
+	var agentAppIDs map[string]string
+	var agentPEMs map[string][]byte
+
+	discoverer := gcf.NewProvisioner(gcf.Config{
+		ProjectID:  mintProject,
+		Region:     mintRegion,
+		GitHubOrgs: []string{owner},
+	}, gcf.NewLiveGCFClient())
+
+	var existingIDs map[string]string
+
+	if mintURL != "" {
+		mintFound = true
+		// Mint URL provided — still discover role IDs from the function
+		// to resolve existing apps (skip in dry-run since no changes are made).
+		if mintProject != "" && !dryRun {
+			printer.StepStart("Resolving app IDs from mint")
+			discovery, discoverErr := discoverer.DiscoverMint(ctx)
+			if discoverErr != nil {
+				if !errors.Is(discoverErr, gcf.ErrFunctionNotFound) {
+					printer.StepFail("Failed to read mint state")
+					return fmt.Errorf("reading mint state: %w", discoverErr)
+				}
+			} else {
+				existingIDs = discovery.RoleAppIDs
+			}
+		}
+	} else if mintProject != "" {
+		printer.StepStart("Discovering mint infrastructure")
+		discovery, discoverErr := discoverer.DiscoverMint(ctx)
+		if discoverErr != nil {
+			if !errors.Is(discoverErr, gcf.ErrFunctionNotFound) {
+				printer.StepFail("Mint discovery failed")
+				return fmt.Errorf("failed to discover mint in project %s region %s: %w",
+					mintProject, mintRegion, discoverErr)
+			}
+			printer.StepDone("No existing mint found — will deploy")
+		} else {
+			mintURL = discovery.URL
+			mintFound = true
+			existingIDs = discovery.RoleAppIDs
+			printer.StepDone(fmt.Sprintf("Found mint at %s", mintURL))
+		}
+	}
+
+	if mintFound && existingIDs != nil {
+		roleAppIDs, resolveErr := resolveSharedRoleAppIDs(ctx, client, existingIDs, owner, roles)
+		if resolveErr != nil {
+			log.Printf("resolveSharedRoleAppIDs: %v (will attempt app creation)", resolveErr)
+		} else {
+			agentAppIDs = make(map[string]string, len(roles))
+			appsFound = true
+			for _, role := range roles {
+				appID, ok := roleAppIDs[owner+"/"+role]
+				if !ok {
+					appsFound = false
+					break
+				}
+				agentAppIDs[role] = appID
+			}
+		}
+		if appsFound {
+			printer.StepDone("Resolved all app IDs")
+		} else {
+			printer.StepDone("Some app IDs missing — will create apps")
+		}
+	}
+
 	if dryRun {
 		mintDisplay := mintURL
 		if mintDisplay == "" {
-			mintDisplay = fmt.Sprintf("(auto-discover from project %s, region %s)", mintProject, mintRegion)
+			mintDisplay = fmt.Sprintf("(will deploy to project %s, region %s)", mintProject, mintRegion)
 		}
 		printer.StepInfo("Dry run — no changes will be made")
 		printer.Blank()
-		if !skipAppSetup {
-			printer.StepInfo(fmt.Sprintf("Would create GitHub Apps (if missing) for roles: %s", strings.Join(roles, ", ")))
+		if !appsFound && !skipAppSetup {
+			printer.StepInfo(fmt.Sprintf("Would create GitHub Apps for roles: %s", strings.Join(roles, ", ")))
 			if publicApps {
 				printer.StepInfo("  Apps would be public (unlisted)")
 			}
 			printer.Blank()
 		}
-		if mintURL == "" {
-			printer.StepInfo(fmt.Sprintf("Would deploy token mint (if missing) to project %s, region %s", mintProject, mintRegion))
+		if !mintFound {
+			printer.StepInfo(fmt.Sprintf("Would deploy token mint to project %s, region %s", mintProject, mintRegion))
 			printer.Blank()
 		}
-		printer.StepInfo("Would validate mint infrastructure:")
+		printer.StepInfo("Mint infrastructure:")
 		printer.StepInfo(fmt.Sprintf("  Mint URL: %s", mintDisplay))
 		printer.StepInfo(fmt.Sprintf("  Mint project: %s, region: %s", mintProject, mintRegion))
-		printer.StepInfo(fmt.Sprintf("  Check: function exists, URL matches, %s in ALLOWED_ORGS", owner))
-		printer.StepInfo(fmt.Sprintf("  Check: ROLE_APP_IDS has entries for %s/{%s}", owner, strings.Join(roles, ",")))
+		if mintFound {
+			printer.StepInfo(fmt.Sprintf("  Would register %s in ALLOWED_ORGS", owner))
+			printer.StepInfo(fmt.Sprintf("  Would set ROLE_APP_IDS entries for %s/{%s}", owner, strings.Join(roles, ",")))
+		}
 		printer.Blank()
 		if needsWIFProvision {
 			printer.StepInfo("Would provision WIF infrastructure in GCP project " + inferenceProject)
@@ -559,63 +678,10 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		return nil
 	}
 
-	// Phase 1: Discover existing infrastructure.
-	var mintFound bool
-	var appsFound bool
-	var agentAppIDs map[string]string
-	var agentPEMs map[string][]byte
-
-	discoverer := gcf.NewProvisioner(gcf.Config{
-		ProjectID:  mintProject,
-		Region:     mintRegion,
-		GitHubOrgs: []string{owner},
-	}, gcf.NewLiveGCFClient())
-
-	if mintURL != "" {
-		mintFound = true
-	} else if mintProject != "" {
-		printer.StepStart("Discovering mint URL")
-		discovered, discoverErr := discoverer.GetFunctionURL(ctx)
-		if discoverErr != nil {
-			if !strings.Contains(discoverErr.Error(), "not found") {
-				printer.StepFail("Mint discovery failed")
-				return fmt.Errorf("failed to discover mint URL in project %s region %s: %w",
-					mintProject, mintRegion, discoverErr)
-			}
-			printer.StepDone("No existing mint found — will deploy")
-		} else {
-			mintURL = discovered
-			mintFound = true
-			printer.StepDone(fmt.Sprintf("Found mint at %s", mintURL))
-		}
-	}
-
-	if mintFound {
-		printer.StepStart("Resolving app IDs from mint")
-		existingIDs, idErr := discoverer.GetExistingRoleAppIDs(ctx)
-		if idErr != nil {
-			printer.StepFail("Failed to read mint state")
-			return fmt.Errorf("reading existing role app IDs: %w", idErr)
-		}
-
-		roleAppIDs, resolveErr := resolveSharedRoleAppIDs(ctx, client, existingIDs, owner, roles)
-		if resolveErr == nil {
-			agentAppIDs = make(map[string]string, len(roles))
-			appsFound = true
-			for _, role := range roles {
-				appID, ok := roleAppIDs[owner+"/"+role]
-				if !ok {
-					appsFound = false
-					break
-				}
-				agentAppIDs[role] = appID
-			}
-		}
-		if appsFound {
-			printer.StepDone("Resolved all app IDs")
-		} else {
-			printer.StepDone("Some app IDs missing — will create apps")
-		}
+	// Early scope check — at minimum we need repo+workflow. If app creation
+	// turns out to be needed, checkInstallScopes escalates below.
+	if err := checkPerRepoScopes(ctx, client, printer); err != nil {
+		return err
 	}
 
 	needAppSetup := !appsFound && !skipAppSetup
@@ -628,13 +694,10 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		return fmt.Errorf("could not resolve app IDs for %s from the mint and --skip-app-setup prevents creating them", owner)
 	}
 
-	// Scope escalation: app creation requires admin:org.
+	// Scope escalation: app creation requires admin:org beyond the
+	// repo+workflow scopes already verified above.
 	if needAppSetup {
 		if err := checkInstallScopes(ctx, client, printer); err != nil {
-			return err
-		}
-	} else {
-		if err := checkPerRepoScopes(ctx, client, printer); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -108,9 +108,7 @@ var perOrgOnlyFlags = []string{
 }
 
 // perRepoOnlyFlags are flags that only apply to per-repo mode.
-var perRepoOnlyFlags = []string{
-	"scaffold-customized",
-}
+var perRepoOnlyFlags []string
 
 // parseAgentRoles splits a comma-separated agents string into a validated role list.
 func parseAgentRoles(agents string) ([]string, error) {
@@ -399,7 +397,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 	cmd.Flags().BoolVar(&publicApps, "public", false, "create public (unlisted) GitHub Apps installable by other orgs")
 	// Per-repo flags.
 	cmd.Flags().StringVar(&mintURL, "mint-url", "", "token mint URL for OIDC token exchange (per-repo mode)")
-	cmd.Flags().BoolVar(&scaffoldCustomized, "scaffold-customized", false, "create .fullsend/customized/ directory structure (per-repo mode)")
+	cmd.Flags().BoolVar(&scaffoldCustomized, "scaffold-customized", false, "create .fullsend/customized/ directory structure for agent runtime")
 
 	return cmd
 }

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -104,7 +104,7 @@ var rolePattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
 var perOrgOnlyFlags = []string{
 	"skip-app-setup", "vendor-fullsend-binary", "enroll-all", "enroll-none",
 	"mint-provider", "mint-source-dir",
-	"skip-mint-deploy", "force-mint-deploy", "public",
+	"public",
 }
 
 // perRepoOnlyFlags are flags that only apply to per-repo mode.

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -107,9 +107,6 @@ var perOrgOnlyFlags = []string{
 	"skip-mint-deploy", "public",
 }
 
-// perRepoOnlyFlags are flags that only apply to per-repo mode.
-var perRepoOnlyFlags []string
-
 // parseAgentRoles splits a comma-separated agents string into a validated role list.
 func parseAgentRoles(agents string) ([]string, error) {
 	var roles []string
@@ -142,7 +139,6 @@ func newInstallCmd() *cobra.Command {
 	var publicApps bool
 	// Per-repo flags.
 	var mintURL string
-	var scaffoldCustomized bool
 
 	cmd := &cobra.Command{
 		Use:   "install <org-or-owner/repo>",
@@ -175,13 +171,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 				}
 				return runPerRepoInstall(cmd.Context(), arg, perRepoAgents, mintURL, inferenceRegion,
 					inferenceProject, inferenceWIFProvider, perRepoMintProject, mintRegion,
-					scaffoldCustomized, dryRun)
-			}
-
-			for _, name := range perRepoOnlyFlags {
-				if cmd.Flags().Changed(name) {
-					return fmt.Errorf("--%s is only valid for per-repo installation (fullsend admin install <owner/repo>)", name)
-				}
+					dryRun)
 			}
 
 			org := arg
@@ -395,16 +385,15 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 	cmd.Flags().StringVar(&mintSourceDir, "mint-source-dir", "", "path to mint function source (default: internal/mint/)")
 	cmd.Flags().BoolVar(&mintSkipDeploy, "skip-mint-deploy", false, "skip Cloud Function deployment, reuse existing mint URL")
 	cmd.Flags().BoolVar(&publicApps, "public", false, "create public (unlisted) GitHub Apps installable by other orgs")
-	// Per-repo flags.
-	cmd.Flags().StringVar(&mintURL, "mint-url", "", "token mint URL for OIDC token exchange (per-repo mode)")
-	cmd.Flags().BoolVar(&scaffoldCustomized, "scaffold-customized", false, "create .fullsend/customized/ directory structure for agent runtime")
+	// Shared flags.
+	cmd.Flags().StringVar(&mintURL, "mint-url", "", "token mint URL for OIDC token exchange")
 
 	return cmd
 }
 
 func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, inferenceRegion,
 	inferenceProject, inferenceWIFProvider, mintProject, mintRegion string,
-	scaffoldCustomized, dryRun bool) error {
+	dryRun bool) error {
 	if strings.Contains(repoFullName, "://") || strings.HasPrefix(repoFullName, "www.") {
 		return fmt.Errorf("expected owner/repo format, got a URL — use just the owner/repo portion (e.g. acme/widget)")
 	}
@@ -480,14 +469,12 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		Mode:    "100644",
 	})
 
-	if scaffoldCustomized {
-		for _, dir := range scaffold.PerRepoCustomizedDirs() {
-			files = append(files, forge.TreeFile{
-				Path:    dir + "/.gitkeep",
-				Content: []byte(""),
-				Mode:    "100644",
-			})
-		}
+	for _, dir := range scaffold.PerRepoCustomizedDirs() {
+		files = append(files, forge.TreeFile{
+			Path:    dir + "/.gitkeep",
+			Content: []byte(""),
+			Mode:    "100644",
+		})
 	}
 
 	needsWIFProvision := inferenceWIFProvider == ""

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -208,6 +208,18 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 				}
 			}
 
+			// Validate --mint-url early (before app setup which is irreversible).
+			if mintURL != "" {
+				parsedMintURL, err := url.Parse(mintURL)
+				if err != nil || parsedMintURL.Scheme != "https" || parsedMintURL.Host == "" {
+					scheme := ""
+					if parsedMintURL != nil {
+						scheme = parsedMintURL.Scheme
+					}
+					return fmt.Errorf("--mint-url must be a valid HTTPS URL (got scheme=%q)", scheme)
+				}
+			}
+
 			// Validate inference flag dependencies.
 			if inferenceProject == "" && (cmd.Flags().Changed("inference-region") || inferenceWIFProvider != "") {
 				return fmt.Errorf("--inference-wif-provider and --inference-region require --inference-project to be set")
@@ -495,10 +507,14 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 	}
 
 	if dryRun {
+		mintDisplay := mintURL
+		if mintDisplay == "" {
+			mintDisplay = fmt.Sprintf("(auto-discover from project %s, region %s)", mintProject, mintRegion)
+		}
 		printer.StepInfo("Dry run — no changes will be made")
 		printer.Blank()
 		printer.StepInfo("Would validate mint infrastructure:")
-		printer.StepInfo(fmt.Sprintf("  Mint URL: %s", mintURL))
+		printer.StepInfo(fmt.Sprintf("  Mint URL: %s", mintDisplay))
 		printer.StepInfo(fmt.Sprintf("  Mint project: %s, region: %s", mintProject, mintRegion))
 		printer.StepInfo(fmt.Sprintf("  Check: function exists, URL matches, %s in ALLOWED_ORGS", owner))
 		printer.StepInfo(fmt.Sprintf("  Check: ROLE_APP_IDS has entries for %s/{%s}", owner, strings.Join(roles, ",")))
@@ -517,7 +533,7 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		printer.Blank()
 		printer.StepInfo("Would set repository variables:")
 		dryRunVars := map[string]string{
-			"FULLSEND_MINT_URL":   mintURL,
+			"FULLSEND_MINT_URL":   mintDisplay,
 			"FULLSEND_GCP_REGION": inferenceRegion,
 			forge.PerRepoGuardVar: "true",
 		}
@@ -547,9 +563,13 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		printer.StepStart("Discovering mint URL")
 		discovered, discoverErr := discoverer.GetFunctionURL(ctx)
 		if discoverErr != nil {
-			printer.StepFail("No mint function found")
-			return fmt.Errorf("no mint function found in project %s region %s — provide --mint-url or run per-org install first",
-				mintProject, mintRegion)
+			printer.StepFail("Mint discovery failed")
+			if strings.Contains(discoverErr.Error(), "not found") {
+				return fmt.Errorf("no mint function found in project %s region %s — provide --mint-url or run per-org install first",
+					mintProject, mintRegion)
+			}
+			return fmt.Errorf("failed to discover mint URL in project %s region %s: %w",
+				mintProject, mintRegion, discoverErr)
 		}
 		mintURL = discovered
 		printer.StepDone(fmt.Sprintf("Found mint at %s", mintURL))
@@ -572,9 +592,12 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 	// Convert org-scoped app IDs (owner/role → appID) to role-only (role → appID).
 	agentAppIDs := make(map[string]string, len(roles))
 	for _, role := range roles {
-		if appID, ok := roleAppIDs[owner+"/"+role]; ok {
-			agentAppIDs[role] = appID
+		appID, ok := roleAppIDs[owner+"/"+role]
+		if !ok {
+			printer.StepFail(fmt.Sprintf("Role %q not registered", role))
+			return fmt.Errorf("role %q is not registered for org %q in the mint — run per-org install first", role, owner)
 		}
+		agentAppIDs[role] = appID
 	}
 
 	// Provision: PEM validation + auto-copy + EnsureOrgInMint + RegisterPerRepoWIF.

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -104,12 +104,12 @@ var rolePattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
 var perOrgOnlyFlags = []string{
 	"skip-app-setup", "vendor-fullsend-binary", "enroll-all", "enroll-none",
 	"mint-provider", "mint-source-dir",
-	"skip-mint-deploy", "force-mint-deploy", "public",
+	"skip-mint-deploy", "public",
 }
 
 // perRepoOnlyFlags are flags that only apply to per-repo mode.
 var perRepoOnlyFlags = []string{
-	"mint-url", "scaffold-customized",
+	"scaffold-customized",
 }
 
 // parseAgentRoles splits a comma-separated agents string into a validated role list.
@@ -141,7 +141,6 @@ func newInstallCmd() *cobra.Command {
 	var mintRegion string
 	var mintSourceDir string
 	var mintSkipDeploy bool
-	var mintForceDeploy bool
 	var publicApps bool
 	// Per-repo flags.
 	var mintURL string
@@ -219,10 +218,6 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 				if mintProject == "" {
 					return fmt.Errorf("--mint-project is required")
 				}
-			}
-
-			if mintSkipDeploy && mintForceDeploy {
-				return fmt.Errorf("--skip-mint-deploy and --force-mint-deploy are mutually exclusive")
 			}
 
 			// Validate inference flag dependencies.
@@ -383,7 +378,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 				agentCreds = creds
 			}
 
-			return runInstall(ctx, client, printer, org, repos, roles, agentCreds, inferenceProvider, inferenceProviderName, vendorBinary, mintProvider, mintProject, mintRegion, mintSourceDir, mintSkipDeploy, mintForceDeploy, allRepos)
+			return runInstall(ctx, client, printer, org, repos, roles, agentCreds, inferenceProvider, inferenceProviderName, vendorBinary, mintProvider, mintProject, mintRegion, mintSourceDir, mintSkipDeploy, mintURL, allRepos)
 		},
 	}
 
@@ -401,7 +396,6 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 	cmd.Flags().StringVar(&mintRegion, "mint-region", "us-central1", "cloud region for token mint")
 	cmd.Flags().StringVar(&mintSourceDir, "mint-source-dir", "", "path to mint function source (default: internal/mint/)")
 	cmd.Flags().BoolVar(&mintSkipDeploy, "skip-mint-deploy", false, "skip Cloud Function deployment, reuse existing mint URL")
-	cmd.Flags().BoolVar(&mintForceDeploy, "force-mint-deploy", false, "force Cloud Function redeployment even if unchanged")
 	cmd.Flags().BoolVar(&publicApps, "public", false, "create public (unlisted) GitHub Apps installable by other orgs")
 	// Per-repo flags.
 	cmd.Flags().StringVar(&mintURL, "mint-url", "", "token mint URL for OIDC token exchange (per-repo mode)")
@@ -428,16 +422,17 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		return fmt.Errorf("invalid repo name %q: must contain only alphanumeric characters, hyphens, dots, or underscores", repo)
 	}
 
-	if mintURL == "" {
-		return fmt.Errorf("--mint-url is required for per-repo installation")
-	}
-	parsedMintURL, err := url.Parse(mintURL)
-	if err != nil || parsedMintURL.Scheme != "https" || parsedMintURL.Host == "" {
-		scheme := ""
-		if parsedMintURL != nil {
-			scheme = parsedMintURL.Scheme
+	if mintURL != "" {
+		parsedMintURL, err := url.Parse(mintURL)
+		if err != nil || parsedMintURL.Scheme != "https" || parsedMintURL.Host == "" {
+			scheme := ""
+			if parsedMintURL != nil {
+				scheme = parsedMintURL.Scheme
+			}
+			return fmt.Errorf("--mint-url must be a valid HTTPS URL (got scheme=%q)", scheme)
 		}
-		return fmt.Errorf("--mint-url must be a valid HTTPS URL (got scheme=%q)", scheme)
+	} else if mintProject == "" {
+		return fmt.Errorf("--mint-url or --mint-project (or --inference-project) is required for per-repo installation")
 	}
 	if inferenceProject == "" {
 		return fmt.Errorf("--inference-project is required for per-repo installation")
@@ -514,12 +509,6 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		printer.StepInfo(fmt.Sprintf("Setting up new per-repo installation for %s/%s", owner, repo))
 	}
 
-	repoVars := map[string]string{
-		"FULLSEND_MINT_URL":   mintURL,
-		"FULLSEND_GCP_REGION": inferenceRegion,
-		forge.PerRepoGuardVar: "true",
-	}
-
 	if dryRun {
 		printer.StepInfo("Dry run — no changes will be made")
 		printer.Blank()
@@ -542,8 +531,13 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		}
 		printer.Blank()
 		printer.StepInfo("Would set repository variables:")
-		for _, name := range sortedStringMapKeys(repoVars) {
-			printer.StepInfo(fmt.Sprintf("  %s = %s", name, repoVars[name]))
+		dryRunVars := map[string]string{
+			"FULLSEND_MINT_URL":   mintURL,
+			"FULLSEND_GCP_REGION": inferenceRegion,
+			forge.PerRepoGuardVar: "true",
+		}
+		for _, name := range sortedStringMapKeys(dryRunVars) {
+			printer.StepInfo(fmt.Sprintf("  %s = %s", name, dryRunVars[name]))
 		}
 		secretNames := []string{"FULLSEND_GCP_PROJECT_ID", "FULLSEND_GCP_WIF_PROVIDER"}
 		printer.StepInfo(fmt.Sprintf("Would set %d repository secrets:", len(secretNames)))
@@ -557,15 +551,28 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		return err
 	}
 
-	// Validate that the mint function exists and register this org if needed.
-	printer.StepStart("Validating mint infrastructure")
-	mintProvisioner := gcf.NewProvisioner(gcf.Config{
+	// Auto-discover mint URL if not provided.
+	discoverer := gcf.NewProvisioner(gcf.Config{
 		ProjectID:  mintProject,
 		Region:     mintRegion,
 		GitHubOrgs: []string{owner},
 	}, gcf.NewLiveGCFClient())
 
-	existingIDs, err := mintProvisioner.GetExistingRoleAppIDs(ctx)
+	if mintURL == "" {
+		printer.StepStart("Discovering mint URL")
+		discovered, discoverErr := discoverer.GetFunctionURL(ctx)
+		if discoverErr != nil {
+			printer.StepFail("No mint function found")
+			return fmt.Errorf("no mint function found in project %s region %s — provide --mint-url or run per-org install first",
+				mintProject, mintRegion)
+		}
+		mintURL = discovered
+		printer.StepDone(fmt.Sprintf("Found mint at %s", mintURL))
+	}
+
+	// Resolve shared app IDs from the existing mint.
+	printer.StepStart("Validating mint infrastructure")
+	existingIDs, err := discoverer.GetExistingRoleAppIDs(ctx)
 	if err != nil {
 		printer.StepFail("Failed to read mint state")
 		return fmt.Errorf("reading existing role app IDs: %w", err)
@@ -577,46 +584,29 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		return fmt.Errorf("resolving shared role app IDs: %w", err)
 	}
 
-	if err := mintProvisioner.EnsureOrgInMint(ctx, mintURL, owner, roleAppIDs); err != nil {
-		printer.StepFail("Mint validation failed")
-		return fmt.Errorf("validating mint: %w", err)
-	}
-	printer.StepDone("Mint validated")
-
-	// Copy PEM secrets for shared apps if needed.
-	sortedKeys := make([]string, 0, len(existingIDs))
-	for k := range existingIDs {
-		sortedKeys = append(sortedKeys, k)
-	}
-	sort.Strings(sortedKeys)
-
+	// Convert org-scoped app IDs (owner/role → appID) to role-only (role → appID).
+	agentAppIDs := make(map[string]string, len(roles))
 	for _, role := range roles {
-		exists, err := mintProvisioner.SecretExists(ctx, owner, role)
-		if err != nil {
-			return fmt.Errorf("checking PEM secret for %s/%s: %w", owner, role, err)
-		}
-		if exists {
-			continue
-		}
-		copied := false
-		for _, key := range sortedKeys {
-			parts := strings.SplitN(key, "/", 2)
-			if len(parts) != 2 || parts[1] != role || parts[0] == owner {
-				continue
-			}
-			printer.StepStart(fmt.Sprintf("Copying shared PEM for %s from %s", role, parts[0]))
-			if err := mintProvisioner.CopyAgentPEM(ctx, parts[0], owner, role); err != nil {
-				printer.StepFail(fmt.Sprintf("Failed to copy PEM for %s", role))
-				return fmt.Errorf("copying shared PEM for %s: %w", role, err)
-			}
-			printer.StepDone(fmt.Sprintf("Copied shared %s PEM", role))
-			copied = true
-			break
-		}
-		if !copied {
-			printer.StepWarn(fmt.Sprintf("No shared PEM source found for %s — manual PEM setup required", role))
+		if appID, ok := roleAppIDs[owner+"/"+role]; ok {
+			agentAppIDs[role] = appID
 		}
 	}
+
+	// Provision: PEM validation + auto-copy + EnsureOrgInMint + RegisterPerRepoWIF.
+	mintProvisioner := gcf.NewProvisioner(gcf.Config{
+		ProjectID:   mintProject,
+		Region:      mintRegion,
+		GitHubOrgs:  []string{owner},
+		AgentAppIDs: agentAppIDs,
+		MintURL:     mintURL,
+		Repo:        owner + "/" + repo,
+	}, gcf.NewLiveGCFClient())
+
+	if _, err := mintProvisioner.Provision(ctx); err != nil {
+		printer.StepFail("Mint provisioning failed")
+		return fmt.Errorf("provisioning mint: %w", err)
+	}
+	printer.StepDone("Mint validated and org registered")
 
 	if needsWIFProvision {
 		printer.StepStart("Provisioning WIF infrastructure")
@@ -634,14 +624,13 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		printer.StepDone("WIF infrastructure ready")
 		printer.StepInfo("IAM policy changes may take up to 7 minutes to propagate")
 		printer.StepInfo("Agent workflows that authenticate via WIF may fail until propagation completes")
-
 	}
 
-	if err := mintProvisioner.RegisterPerRepoWIF(ctx, owner+"/"+repo); err != nil {
-		printer.StepFail("Failed to register per-repo WIF in mint")
-		return fmt.Errorf("registering per-repo WIF: %w", err)
+	repoVars := map[string]string{
+		"FULLSEND_MINT_URL":   mintURL,
+		"FULLSEND_GCP_REGION": inferenceRegion,
+		forge.PerRepoGuardVar: "true",
 	}
-	printer.StepDone("Registered per-repo WIF in mint")
 
 	repoSecrets := map[string]string{
 		"FULLSEND_GCP_PROJECT_ID":   inferenceProject,
@@ -1130,7 +1119,7 @@ func validateEnabledRepos(enabledRepos, discoveredNames []string) error {
 
 // runInstall performs the full installation.
 // If discoveredRepos is non-nil, it will be used instead of calling ListOrgRepos.
-func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, org string, enabledRepos, roles []string, agentCreds []layers.AgentCredentials, inferenceProvider inference.Provider, inferenceProviderName string, vendorBinary bool, mintProvider, mintProject, mintRegion, mintSourceDir string, mintSkipDeploy, mintForceDeploy bool, discoveredRepos []forge.Repository) error {
+func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, org string, enabledRepos, roles []string, agentCreds []layers.AgentCredentials, inferenceProvider inference.Provider, inferenceProviderName string, vendorBinary bool, mintProvider, mintProject, mintRegion, mintSourceDir string, mintSkipDeploy bool, mintURL string, discoveredRepos []forge.Repository) error {
 	var allRepos []forge.Repository
 	var err error
 
@@ -1204,8 +1193,6 @@ func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, o
 	deployMode := gcf.DeployAuto
 	if mintSkipDeploy {
 		deployMode = gcf.DeploySkip
-	} else if mintForceDeploy {
-		deployMode = gcf.DeployForce
 	}
 
 	dispatcher := gcf.NewProvisioner(gcf.Config{
@@ -1216,6 +1203,7 @@ func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, o
 		AgentAppIDs:       agentAppIDs,
 		FunctionSourceDir: mintSourceDir,
 		DeployMode:        deployMode,
+		MintURL:           mintURL,
 	}, gcf.NewLiveGCFClient())
 
 	stack := buildLayerStack(org, client, cfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, vendorBinary, vendorFullsendBinary, dispatcher)

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -104,7 +104,7 @@ var rolePattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
 var perOrgOnlyFlags = []string{
 	"skip-app-setup", "vendor-fullsend-binary", "enroll-all", "enroll-none",
 	"mint-provider", "mint-source-dir",
-	"public",
+	"skip-mint-deploy", "force-mint-deploy", "public",
 }
 
 // perRepoOnlyFlags are flags that only apply to per-repo mode.

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -106,12 +106,12 @@ func TestInstallCmd_Flags(t *testing.T) {
 	assert.Equal(t, "false", scaffoldCustomizedFlag.DefValue)
 }
 
-func TestInstallCmd_PerRepoRequiresMintURL(t *testing.T) {
+func TestInstallCmd_PerRepoRequiresMintURLOrProject(t *testing.T) {
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"admin", "install", "acme/widget"})
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--mint-url is required for per-repo installation")
+	assert.Contains(t, err.Error(), "--mint-url or --mint-project")
 }
 
 func TestInstallCmd_PerRepoRequiresInferenceProject(t *testing.T) {
@@ -148,10 +148,10 @@ func TestInstallCmd_PerRepoRejectsNonHTTPSMintURL(t *testing.T) {
 
 func TestInstallCmd_PerOrgRejectsPerRepoFlags(t *testing.T) {
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"admin", "install", "acme", "--mint-url", "https://mint.example.com"})
+	cmd.SetArgs([]string{"admin", "install", "acme", "--scaffold-customized"})
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--mint-url is only valid for per-repo installation")
+	assert.Contains(t, err.Error(), "--scaffold-customized is only valid for per-repo installation")
 }
 
 func TestInstallCmd_PerRepoRejectsPerOrgFlags(t *testing.T) {

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -146,14 +146,6 @@ func TestInstallCmd_PerRepoRejectsNonHTTPSMintURL(t *testing.T) {
 	assert.Contains(t, err.Error(), "--mint-url must be a valid HTTPS URL")
 }
 
-func TestInstallCmd_PerOrgRejectsPerRepoFlags(t *testing.T) {
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"admin", "install", "acme", "--scaffold-customized"})
-	err := cmd.Execute()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--scaffold-customized is only valid for per-repo installation")
-}
-
 func TestInstallCmd_PerRepoRejectsPerOrgFlags(t *testing.T) {
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"admin", "install", "acme/widget", "--mint-url", "https://mint.example.com", "--inference-project", "my-project", "--mint-provider", "gcf"})

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -203,6 +203,18 @@ func TestInstallCmd_PerRepoAcceptsSharedFlags(t *testing.T) {
 	}
 }
 
+func TestInstallCmd_ForceMintDeployFlagRemoved(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"admin", "install", "acme",
+		"--force-mint-deploy",
+		"--inference-project", "my-project",
+		"--mint-project", "my-project",
+		"--dry-run"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "force-mint-deploy")
+}
+
 func TestInstallCmd_PerRepoAcceptsMintRegion(t *testing.T) {
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"admin", "install", "acme/widget",

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -93,7 +93,6 @@ func TestInstallCmd_Flags(t *testing.T) {
 	mintSourceDirFlag := cmd.Flags().Lookup("mint-source-dir")
 	require.NotNil(t, mintSourceDirFlag, "expected --mint-source-dir flag")
 
-	// Per-repo flags.
 	mintURLFlag := cmd.Flags().Lookup("mint-url")
 	require.NotNil(t, mintURLFlag, "expected --mint-url flag")
 
@@ -101,9 +100,9 @@ func TestInstallCmd_Flags(t *testing.T) {
 	gcpAuthModeFlag := cmd.Flags().Lookup("gcp-auth-mode")
 	assert.Nil(t, gcpAuthModeFlag, "--gcp-auth-mode flag should have been removed")
 
+	// --scaffold-customized removed (customized dirs always included)
 	scaffoldCustomizedFlag := cmd.Flags().Lookup("scaffold-customized")
-	require.NotNil(t, scaffoldCustomizedFlag, "expected --scaffold-customized flag")
-	assert.Equal(t, "false", scaffoldCustomizedFlag.DefValue)
+	assert.Nil(t, scaffoldCustomizedFlag, "--scaffold-customized flag should have been removed")
 }
 
 func TestInstallCmd_PerRepoRequiresMintURLOrProject(t *testing.T) {

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -115,7 +115,7 @@ func TestInstallCmd_PerRepoRequiresMintProject(t *testing.T) {
 
 func TestInstallCmd_PerRepoRequiresInferenceProject(t *testing.T) {
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"admin", "install", "acme/widget", "--mint-url", "https://mint.example.com"})
+	cmd.SetArgs([]string{"admin", "install", "acme/widget", "--mint-url", "https://mint-test-abc123.run.app"})
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--inference-project is required for per-repo installation")
@@ -123,7 +123,7 @@ func TestInstallCmd_PerRepoRequiresInferenceProject(t *testing.T) {
 
 func TestInstallCmd_PerRepoRejectsInvalidFormat(t *testing.T) {
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"admin", "install", "acme/", "--mint-url", "https://mint.example.com", "--inference-project", "my-project"})
+	cmd.SetArgs([]string{"admin", "install", "acme/", "--mint-url", "https://mint-test-abc123.run.app", "--inference-project", "my-project"})
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "repo must be in owner/repo format")
@@ -131,7 +131,7 @@ func TestInstallCmd_PerRepoRejectsInvalidFormat(t *testing.T) {
 
 func TestInstallCmd_PerRepoRejectsMultiSlash(t *testing.T) {
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"admin", "install", "acme/team/repo", "--mint-url", "https://mint.example.com", "--inference-project", "my-project"})
+	cmd.SetArgs([]string{"admin", "install", "acme/team/repo", "--mint-url", "https://mint-test-abc123.run.app", "--inference-project", "my-project"})
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid repo name")
@@ -143,6 +143,14 @@ func TestInstallCmd_PerRepoRejectsNonHTTPSMintURL(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--mint-url must be a valid HTTPS URL")
+}
+
+func TestInstallCmd_PerRepoRejectsNonCloudRunMintURL(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"admin", "install", "acme/widget", "--mint-url", "https://evil.example.com", "--inference-project", "my-project"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--mint-url must be a Cloud Run URL")
 }
 
 func TestInstallCmd_PerRepoRejectsPerOrgFlags(t *testing.T) {
@@ -158,7 +166,7 @@ func TestInstallCmd_PerRepoRejectsPerOrgFlags(t *testing.T) {
 		t.Run(tc.flag, func(t *testing.T) {
 			cmd := newRootCmd()
 			args := []string{"admin", "install", "acme/widget",
-				"--mint-url", "https://mint.example.com",
+				"--mint-url", "https://mint-test-abc123.run.app",
 				"--inference-project", "my-project"}
 			if tc.value != "" {
 				args = append(args, "--"+tc.flag, tc.value)
@@ -188,7 +196,7 @@ func TestInstallCmd_PerRepoAcceptsSharedFlags(t *testing.T) {
 		t.Run(tc.flag, func(t *testing.T) {
 			cmd := newRootCmd()
 			args := []string{"admin", "install", "acme/widget",
-				"--mint-url", "https://mint.example.com",
+				"--mint-url", "https://mint-test-abc123.run.app",
 				"--inference-project", "my-project",
 				"--dry-run"}
 			if tc.value != "" {
@@ -218,7 +226,7 @@ func TestInstallCmd_ForceMintDeployFlagRemoved(t *testing.T) {
 func TestInstallCmd_PerRepoAcceptsMintRegion(t *testing.T) {
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"admin", "install", "acme/widget",
-		"--mint-url", "https://mint.example.com",
+		"--mint-url", "https://mint-test-abc123.run.app",
 		"--inference-region", "us-central1",
 		"--inference-project", "my-project",
 		"--mint-region", "europe-west1",
@@ -1133,7 +1141,7 @@ func TestInstallCmd_PerRepoRejectsInvalidRole(t *testing.T) {
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"admin", "install", "acme/widget",
 		"--agents", "triage,INVALID",
-		"--mint-url", "https://mint.example.com",
+		"--mint-url", "https://mint-test-abc123.run.app",
 		"--inference-project", "my-project"})
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -1143,7 +1151,7 @@ func TestInstallCmd_PerRepoRejectsInvalidRole(t *testing.T) {
 func TestInstallCmd_PerRepoRejectsOwnerWithDots(t *testing.T) {
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"admin", "install", "my.org/widget",
-		"--mint-url", "https://mint.example.com",
+		"--mint-url", "https://mint-test-abc123.run.app",
 		"--inference-project", "my-project"})
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -1163,7 +1171,7 @@ func TestInstallCmd_PerRepoRejectsURL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := newRootCmd()
 			cmd.SetArgs([]string{"admin", "install", tc.input,
-				"--mint-url", "https://mint.example.com",
+				"--mint-url", "https://mint-test-abc123.run.app",
 				"--inference-project", "my-project"})
 			err := cmd.Execute()
 			require.Error(t, err)

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -105,12 +105,12 @@ func TestInstallCmd_Flags(t *testing.T) {
 	assert.Nil(t, scaffoldCustomizedFlag, "--scaffold-customized flag should have been removed")
 }
 
-func TestInstallCmd_PerRepoRequiresMintURLOrProject(t *testing.T) {
+func TestInstallCmd_PerRepoRequiresMintProject(t *testing.T) {
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"admin", "install", "acme/widget"})
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--mint-url or --mint-project")
+	assert.Contains(t, err.Error(), "--mint-project")
 }
 
 func TestInstallCmd_PerRepoRequiresInferenceProject(t *testing.T) {
@@ -146,11 +146,61 @@ func TestInstallCmd_PerRepoRejectsNonHTTPSMintURL(t *testing.T) {
 }
 
 func TestInstallCmd_PerRepoRejectsPerOrgFlags(t *testing.T) {
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"admin", "install", "acme/widget", "--mint-url", "https://mint.example.com", "--inference-project", "my-project", "--mint-provider", "gcf"})
-	err := cmd.Execute()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--mint-provider is only valid for per-org installation")
+	perOrgOnly := []struct {
+		flag  string
+		value string
+	}{
+		{"vendor-fullsend-binary", ""},
+		{"enroll-all", ""},
+		{"enroll-none", ""},
+	}
+	for _, tc := range perOrgOnly {
+		t.Run(tc.flag, func(t *testing.T) {
+			cmd := newRootCmd()
+			args := []string{"admin", "install", "acme/widget",
+				"--mint-url", "https://mint.example.com",
+				"--inference-project", "my-project"}
+			if tc.value != "" {
+				args = append(args, "--"+tc.flag, tc.value)
+			} else {
+				args = append(args, "--"+tc.flag)
+			}
+			cmd.SetArgs(args)
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), fmt.Sprintf("--%s is only valid for per-org installation", tc.flag))
+		})
+	}
+}
+
+func TestInstallCmd_PerRepoAcceptsSharedFlags(t *testing.T) {
+	sharedFlags := []struct {
+		flag  string
+		value string
+	}{
+		{"public", ""},
+		{"skip-app-setup", ""},
+		{"mint-provider", "gcf"},
+		{"mint-source-dir", "/tmp/src"},
+		{"skip-mint-deploy", ""},
+	}
+	for _, tc := range sharedFlags {
+		t.Run(tc.flag, func(t *testing.T) {
+			cmd := newRootCmd()
+			args := []string{"admin", "install", "acme/widget",
+				"--mint-url", "https://mint.example.com",
+				"--inference-project", "my-project",
+				"--dry-run"}
+			if tc.value != "" {
+				args = append(args, "--"+tc.flag, tc.value)
+			} else {
+				args = append(args, "--"+tc.flag)
+			}
+			cmd.SetArgs(args)
+			err := cmd.Execute()
+			require.NoError(t, err, "--%s should be accepted in per-repo mode", tc.flag)
+		})
+	}
 }
 
 func TestInstallCmd_PerRepoAcceptsMintRegion(t *testing.T) {

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -88,7 +88,7 @@ type Config struct {
 	// existing mint at this URL. Only PEMs are stored.
 	MintURL string
 
-	// DeployMode controls function deployment: auto (default), skip, or force.
+	// DeployMode controls function deployment: auto (default) or skip.
 	DeployMode DeployMode
 }
 
@@ -474,6 +474,20 @@ func (p *Provisioner) provisionWithExistingMint(ctx context.Context) (map[string
 		return nil, fmt.Errorf("MintURL %q must be a valid HTTPS URL", p.cfg.MintURL)
 	}
 
+	// Fetch existing role/app ID mappings once for PEM auto-copy decisions.
+	var existingIDs map[string]string
+	existingIDsErr := error(nil)
+	needsCopy := false
+	for _, role := range sortedStringMapKeys(p.cfg.AgentAppIDs) {
+		if _, hasPEM := p.cfg.AgentPEMs[role]; !hasPEM {
+			needsCopy = true
+			break
+		}
+	}
+	if needsCopy {
+		existingIDs, existingIDsErr = p.GetExistingRoleAppIDs(ctx)
+	}
+
 	for _, org := range p.cfg.GitHubOrgs {
 		// Store new PEMs (per-org with fresh apps).
 		for _, role := range sortedByteMapKeys(p.cfg.AgentPEMs) {
@@ -494,18 +508,22 @@ func (p *Provisioner) provisionWithExistingMint(ctx context.Context) (map[string
 			if exists {
 				continue
 			}
+			if existingIDsErr != nil {
+				return nil, fmt.Errorf("reading existing role app IDs for PEM auto-copy: %w", existingIDsErr)
+			}
 			// PEM doesn't exist — try to copy from another org that has this role.
-			existingIDs, _ := p.GetExistingRoleAppIDs(ctx)
 			copied := false
 			for _, key := range sortedStringMapKeys(existingIDs) {
 				parts := strings.SplitN(key, "/", 2)
 				if len(parts) != 2 || parts[1] != role || parts[0] == org {
 					continue
 				}
-				if err := p.CopyAgentPEM(ctx, parts[0], org, role); err == nil {
+				if copyErr := p.CopyAgentPEM(ctx, parts[0], org, role); copyErr == nil {
 					log.Printf("copied PEM for %s/%s from %s", org, role, parts[0])
 					copied = true
 					break
+				} else {
+					log.Printf("failed to copy PEM for %s/%s from %s: %v", org, role, parts[0], copyErr)
 				}
 			}
 			if !copied {
@@ -563,41 +581,12 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 		return nil, fmt.Errorf("checking existing function: %w", err)
 	}
 
-	// Determine if code deployment is needed. When the function already
-	// exists and is active with the same source hash, skip the full
-	// infrastructure path and use the lightweight provisionWithExistingMint.
-	needsDeploy := true
-	var earlySourceZip []byte
-
-	if existing != nil && existing.URI != "" && existing.State == "ACTIVE" {
-		switch {
-		case p.cfg.DeployMode == DeploySkip:
-			needsDeploy = false
-		case p.cfg.FunctionSourceDir == "":
-			needsDeploy = false
-		default: // DeployAuto
-			earlySourceZip, err = bundleFunctionSource(p.cfg.FunctionSourceDir)
-			if err != nil {
-				return nil, fmt.Errorf("validating function source: %w", err)
-			}
-			needsDeploy = existing.EnvVars["FULLSEND_SOURCE_HASH"] != sha256Hex(earlySourceZip)
-		}
-
-		if !needsDeploy {
-			p.cfg.MintURL = existing.URI
-			return p.provisionWithExistingMint(ctx)
-		}
+	// Early guard: --skip-mint-deploy requires an existing function.
+	if existing == nil && p.cfg.DeployMode == DeploySkip {
+		return nil, fmt.Errorf("function %s not found — cannot use --skip-mint-deploy without an existing deployment", functionName)
 	}
 
-	// Full infrastructure path — only when deploying code.
-	if earlySourceZip == nil {
-		earlySourceZip, err = bundleFunctionSource(p.cfg.FunctionSourceDir)
-		if err != nil {
-			return nil, fmt.Errorf("validating function source: %w", err)
-		}
-	}
-
-	// Step 1: Get project number.
+	// Step 1: Get project number (always needed for WIF).
 	projectNumber, err := p.gcpAPI.GetProjectNumber(ctx, p.cfg.ProjectID)
 	if err != nil {
 		return nil, fmt.Errorf("getting project number: %w", err)
@@ -664,6 +653,41 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 		}
 	}
 	log.Printf("granted roles/aiplatform.user to %d org(s) (propagation may take several minutes)", len(installingOrgs))
+
+	// Determine if code deployment is needed. When the function already
+	// exists and is active with the same source hash, skip the code deploy
+	// path and use the lightweight provisionWithExistingMint for PEM + org
+	// registration. WIF infrastructure above always runs regardless.
+	needsDeploy := true
+	var earlySourceZip []byte
+
+	if existing != nil && existing.URI != "" && existing.State == "ACTIVE" {
+		switch {
+		case p.cfg.DeployMode == DeploySkip:
+			needsDeploy = false
+		case p.cfg.FunctionSourceDir == "":
+			needsDeploy = false
+		default: // DeployAuto
+			earlySourceZip, err = bundleFunctionSource(p.cfg.FunctionSourceDir)
+			if err != nil {
+				return nil, fmt.Errorf("validating function source: %w", err)
+			}
+			needsDeploy = existing.EnvVars["FULLSEND_SOURCE_HASH"] != sha256Hex(earlySourceZip)
+		}
+
+		if !needsDeploy {
+			p.cfg.MintURL = existing.URI
+			return p.provisionWithExistingMint(ctx)
+		}
+	}
+
+	// Code deployment path — bundle source.
+	if earlySourceZip == nil {
+		earlySourceZip, err = bundleFunctionSource(p.cfg.FunctionSourceDir)
+		if err != nil {
+			return nil, fmt.Errorf("validating function source: %w", err)
+		}
+	}
 
 	// Step 5a: Store new agent PEMs only for installing orgs.
 	for _, org := range installingOrgs {
@@ -809,9 +833,6 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 	}
 
 	if existing == nil || existing.URI == "" {
-		if p.cfg.DeployMode == DeploySkip {
-			return nil, fmt.Errorf("function %s not found — cannot use --skip-mint-deploy without an existing deployment", functionName)
-		}
 		return nil, fmt.Errorf("function %s not found or has no URI", functionName)
 	}
 	mintURL := existing.URI

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -566,7 +566,11 @@ func (p *Provisioner) provisionWithExistingMint(ctx context.Context) (map[string
 				}
 			}
 			if !copied {
-				return nil, fmt.Errorf("role %q: no PEM provided and no existing PEM found to copy for %s (last error: %v)", role, org, lastCopyErr)
+				msg := fmt.Sprintf("role %q: no PEM provided and no existing PEM found to copy for %s", role, org)
+				if lastCopyErr != nil {
+					msg += fmt.Sprintf(" (last error: %v)", lastCopyErr)
+				}
+				return nil, fmt.Errorf("%s", msg)
 			}
 		}
 	}

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -247,10 +247,14 @@ func (p *Provisioner) GetFunctionURL(ctx context.Context) (string, error) {
 }
 
 // GetExistingRoleAppIDs reads ROLE_APP_IDS from the deployed mint function.
-// Returns nil if the function doesn't exist or has no ROLE_APP_IDS.
+// Returns (nil, nil) if the function doesn't exist or has no ROLE_APP_IDS.
+// Returns (nil, err) if the API call fails (auth/network error).
 func (p *Provisioner) GetExistingRoleAppIDs(ctx context.Context) (map[string]string, error) {
 	fn, err := p.gcpAPI.GetFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
-	if err != nil || fn == nil || fn.EnvVars == nil {
+	if err != nil {
+		return nil, fmt.Errorf("reading mint function: %w", err)
+	}
+	if fn == nil || fn.EnvVars == nil {
 		return nil, nil
 	}
 	raw := fn.EnvVars["ROLE_APP_IDS"]
@@ -616,23 +620,26 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 	copy(installingOrgs, p.cfg.GitHubOrgs)
 
 	// Merge with existing WIF provider orgs if provider already exists.
+	// Use a local variable to avoid mutating p.cfg.GitHubOrgs.
+	allOrgs := make([]string, len(p.cfg.GitHubOrgs))
+	copy(allOrgs, p.cfg.GitHubOrgs)
 	existingProvider, getErr := p.gcpAPI.GetWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)
 	if getErr == nil && existingProvider != nil {
 		existingOrgs := parseConditionOrgs(existingProvider.AttributeCondition)
 		seen := make(map[string]bool)
-		for _, org := range p.cfg.GitHubOrgs {
+		for _, org := range allOrgs {
 			seen[org] = true
 		}
 		for _, org := range existingOrgs {
 			if !seen[org] {
-				p.cfg.GitHubOrgs = append(p.cfg.GitHubOrgs, org)
+				allOrgs = append(allOrgs, org)
 				seen[org] = true
 			}
 		}
-		sort.Strings(p.cfg.GitHubOrgs)
+		sort.Strings(allOrgs)
 	}
 
-	attrCondition := buildAttributeCondition(p.cfg.GitHubOrgs)
+	attrCondition := buildAttributeCondition(allOrgs)
 	audiences := []string{oidcAudience, iamAudience(projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)}
 	if err := p.gcpAPI.CreateWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider, OIDCProviderConfig{
 		IssuerURI:          oidcIssuer,
@@ -735,7 +742,7 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 		"GCP_PROJECT_NUMBER": projectNumber,
 		"WIF_POOL_NAME":      p.cfg.WIFPoolName,
 		"WIF_PROVIDER_NAME":  p.cfg.WIFProvider,
-		"ALLOWED_ORGS":       strings.Join(p.cfg.GitHubOrgs, ","),
+		"ALLOWED_ORGS":       strings.Join(allOrgs, ","),
 		"OIDC_AUDIENCE":      oidcAudience,
 		"ROLE_APP_IDS":       string(roleAppIDsJSON),
 	}

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -34,8 +34,6 @@ const (
 	DeployAuto DeployMode = iota
 	// DeploySkip never redeploys; reuses the existing function URL.
 	DeploySkip
-	// DeployForce always redeploys regardless of changes.
-	DeployForce
 )
 
 // Compile-time check that Provisioner implements dispatch.Dispatcher.
@@ -232,6 +230,20 @@ func (p *Provisioner) ensureSecretIAM(ctx context.Context, secretName string) er
 		return fmt.Errorf("granting secret access for %s: %w", secretName, err)
 	}
 	return nil
+}
+
+// GetFunctionURL returns the URL of the deployed mint function.
+// Used for auto-discovering the mint URL when --mint-url is not provided.
+func (p *Provisioner) GetFunctionURL(ctx context.Context) (string, error) {
+	fn, err := p.gcpAPI.GetFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
+	if err != nil {
+		return "", fmt.Errorf("checking mint function: %w", err)
+	}
+	if fn == nil || fn.URI == "" {
+		return "", fmt.Errorf("mint function %s not found in project %s region %s",
+			functionName, p.cfg.ProjectID, p.cfg.Region)
+	}
+	return fn.URI, nil
 }
 
 // GetExistingRoleAppIDs reads ROLE_APP_IDS from the deployed mint function.
@@ -446,7 +458,9 @@ func (p *Provisioner) Provision(ctx context.Context) (map[string]string, error) 
 	return p.provisionSelfManaged(ctx)
 }
 
-// provisionWithExistingMint stores PEMs in an existing mint's Secret Manager.
+// provisionWithExistingMint handles PEM storage, org registration, and
+// per-repo WIF registration for an existing mint. Shared by both per-org
+// (when auto-routed from provisionSelfManaged) and per-repo flows.
 func (p *Provisioner) provisionWithExistingMint(ctx context.Context) (map[string]string, error) {
 	if p.cfg.ProjectID == "" {
 		return nil, fmt.Errorf("GCP project ID is required for PEM storage")
@@ -461,24 +475,60 @@ func (p *Provisioner) provisionWithExistingMint(ctx context.Context) (map[string
 	}
 
 	for _, org := range p.cfg.GitHubOrgs {
+		// Store new PEMs (per-org with fresh apps).
 		for _, role := range sortedByteMapKeys(p.cfg.AgentPEMs) {
 			if err := p.StoreAgentPEM(ctx, org, role, p.cfg.AgentPEMs[role]); err != nil {
 				return nil, fmt.Errorf("storing PEM for %s/%s: %w", org, role, err)
 			}
 		}
 
+		// Check and auto-copy PEMs for roles without fresh PEMs.
 		for _, role := range sortedStringMapKeys(p.cfg.AgentAppIDs) {
 			if _, hasPEM := p.cfg.AgentPEMs[role]; hasPEM {
 				continue
 			}
-			sid := secretID(org, role)
-			if err := p.gcpAPI.GetSecret(ctx, p.cfg.ProjectID, sid); err != nil {
-				if errors.Is(err, ErrSecretNotFound) {
-					return nil, fmt.Errorf("role %q has no PEM and secret %s not found in project %s",
-						role, sid, p.cfg.ProjectID)
-				}
-				return nil, fmt.Errorf("checking secret %s for role %q: %w", sid, role, err)
+			exists, err := p.SecretExists(ctx, org, role)
+			if err != nil {
+				return nil, fmt.Errorf("checking PEM for %s/%s: %w", org, role, err)
 			}
+			if exists {
+				continue
+			}
+			// PEM doesn't exist — try to copy from another org that has this role.
+			existingIDs, _ := p.GetExistingRoleAppIDs(ctx)
+			copied := false
+			for _, key := range sortedStringMapKeys(existingIDs) {
+				parts := strings.SplitN(key, "/", 2)
+				if len(parts) != 2 || parts[1] != role || parts[0] == org {
+					continue
+				}
+				if err := p.CopyAgentPEM(ctx, parts[0], org, role); err == nil {
+					log.Printf("copied PEM for %s/%s from %s", org, role, parts[0])
+					copied = true
+					break
+				}
+			}
+			if !copied {
+				return nil, fmt.Errorf("role %q: no PEM provided and no existing PEM found to copy for %s", role, org)
+			}
+		}
+	}
+
+	// Register org env vars via EnsureOrgInMint (additive, no-op if already present).
+	for _, org := range p.cfg.GitHubOrgs {
+		perOrgAppIDs := make(map[string]string, len(p.cfg.AgentAppIDs))
+		for role, appID := range p.cfg.AgentAppIDs {
+			perOrgAppIDs[org+"/"+role] = appID
+		}
+		if err := p.EnsureOrgInMint(ctx, p.cfg.MintURL, org, perOrgAppIDs); err != nil {
+			return nil, fmt.Errorf("registering org %s in mint: %w", org, err)
+		}
+	}
+
+	// Per-repo WIF registration — when cfg.Repo is set.
+	if p.cfg.Repo != "" {
+		if err := p.RegisterPerRepoWIF(ctx, p.cfg.Repo); err != nil {
+			return nil, fmt.Errorf("registering per-repo WIF: %w", err)
 		}
 	}
 
@@ -507,12 +557,44 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 		}
 	}
 
-	// Bundle function source early to fail fast before provisioning GCP
-	// resources. The result is reused at deployment time to avoid redundant
-	// I/O and a TOCTOU window.
-	earlySourceZip, err := bundleFunctionSource(p.cfg.FunctionSourceDir)
+	// Check existing function state before infrastructure setup.
+	existing, err := p.gcpAPI.GetFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
 	if err != nil {
-		return nil, fmt.Errorf("validating function source: %w", err)
+		return nil, fmt.Errorf("checking existing function: %w", err)
+	}
+
+	// Determine if code deployment is needed. When the function already
+	// exists and is active with the same source hash, skip the full
+	// infrastructure path and use the lightweight provisionWithExistingMint.
+	needsDeploy := true
+	var earlySourceZip []byte
+
+	if existing != nil && existing.URI != "" && existing.State == "ACTIVE" {
+		switch {
+		case p.cfg.DeployMode == DeploySkip:
+			needsDeploy = false
+		case p.cfg.FunctionSourceDir == "":
+			needsDeploy = false
+		default: // DeployAuto
+			earlySourceZip, err = bundleFunctionSource(p.cfg.FunctionSourceDir)
+			if err != nil {
+				return nil, fmt.Errorf("validating function source: %w", err)
+			}
+			needsDeploy = existing.EnvVars["FULLSEND_SOURCE_HASH"] != sha256Hex(earlySourceZip)
+		}
+
+		if !needsDeploy {
+			p.cfg.MintURL = existing.URI
+			return p.provisionWithExistingMint(ctx)
+		}
+	}
+
+	// Full infrastructure path — only when deploying code.
+	if earlySourceZip == nil {
+		earlySourceZip, err = bundleFunctionSource(p.cfg.FunctionSourceDir)
+		if err != nil {
+			return nil, fmt.Errorf("validating function source: %w", err)
+		}
 	}
 
 	// Step 1: Get project number.
@@ -634,11 +716,6 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 		"ROLE_APP_IDS":       string(roleAppIDsJSON),
 	}
 
-	existing, err := p.gcpAPI.GetFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
-	if err != nil {
-		return nil, fmt.Errorf("checking existing function: %w", err)
-	}
-
 	// Step 6b: Code deployment — only when source hash changes.
 	sourceZip := earlySourceZip
 	sourceHash := sha256Hex(sourceZip)
@@ -747,6 +824,12 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 		}
 		if err := p.EnsureOrgInMint(ctx, mintURL, org, perOrgAppIDs); err != nil {
 			return nil, fmt.Errorf("registering org %s in mint: %w", org, err)
+		}
+	}
+
+	if p.cfg.Repo != "" {
+		if err := p.RegisterPerRepoWIF(ctx, p.cfg.Repo); err != nil {
+			return nil, fmt.Errorf("registering per-repo WIF: %w", err)
 		}
 	}
 
@@ -1118,18 +1201,14 @@ func sha256Hex(data []byte) string {
 // needsCodeDeploy determines whether the Cloud Function code needs (re)deployment.
 // Only checks the source hash — env var changes are handled by EnsureOrgInMint.
 func (p *Provisioner) needsCodeDeploy(existing *FunctionInfo, sourceHash string) bool {
-	switch p.cfg.DeployMode {
-	case DeployForce:
-		return true
-	case DeploySkip:
+	if p.cfg.DeployMode == DeploySkip {
 		return false
-	default: // DeployAuto
-		if existing == nil {
-			return true
-		}
-		if existing.State != "ACTIVE" || existing.URI == "" {
-			return true
-		}
-		return existing.EnvVars["FULLSEND_SOURCE_HASH"] != sourceHash
 	}
+	if existing == nil {
+		return true
+	}
+	if existing.State != "ACTIVE" || existing.URI == "" {
+		return true
+	}
+	return existing.EnvVars["FULLSEND_SOURCE_HASH"] != sourceHash
 }

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -30,7 +30,7 @@ import (
 type DeployMode int
 
 const (
-	// DeployAuto compares source hash and env vars; skips deploy if unchanged.
+	// DeployAuto compares source hash; skips deploy if unchanged.
 	DeployAuto DeployMode = iota
 	// DeploySkip never redeploys; reuses the existing function URL.
 	DeploySkip
@@ -612,7 +612,7 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 
 	// Step 6: Build org-scoped env vars and deploy Cloud Function.
 	// Only create entries for installing orgs; existing orgs' entries are
-	// preserved by mergeRoleAppIDs below.
+	// preserved by EnsureOrgInMint's merge logic.
 	orgScopedAppIDs := make(map[string]string)
 	for _, org := range installingOrgs {
 		for role, appID := range p.cfg.AgentAppIDs {
@@ -683,7 +683,10 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 		}
 	} else if p.needsCodeDeploy(existing, sourceHash) {
 		// Code changed: UpdateFunction preserving existing env vars, only updating hash.
-		deployEnvVars := make(map[string]string, len(existing.EnvVars))
+		deployEnvVars := make(map[string]string, len(envVars)+len(existing.EnvVars))
+		for k, v := range envVars {
+			deployEnvVars[k] = v
+		}
 		for k, v := range existing.EnvVars {
 			deployEnvVars[k] = v
 		}
@@ -721,13 +724,17 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 	}
 
 	if existing == nil || existing.URI == "" {
-		return nil, fmt.Errorf("function %s not found — cannot use --skip-mint-deploy without an existing deployment", functionName)
+		return nil, fmt.Errorf("function %s not found or has no URI", functionName)
 	}
 	mintURL := existing.URI
 
 	// Register org env vars via EnsureOrgInMint (additive, no-op if already present).
 	for _, org := range installingOrgs {
-		if err := p.EnsureOrgInMint(ctx, mintURL, org, orgScopedAppIDs); err != nil {
+		perOrgAppIDs := make(map[string]string, len(p.cfg.AgentAppIDs))
+		for role, appID := range p.cfg.AgentAppIDs {
+			perOrgAppIDs[org+"/"+role] = appID
+		}
+		if err := p.EnsureOrgInMint(ctx, mintURL, org, perOrgAppIDs); err != nil {
 			return nil, fmt.Errorf("registering org %s in mint: %w", org, err)
 		}
 	}

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -36,6 +36,9 @@ const (
 	DeploySkip
 )
 
+// ErrFunctionNotFound is returned when the mint function does not exist.
+var ErrFunctionNotFound = errors.New("mint function not found")
+
 // Compile-time check that Provisioner implements dispatch.Dispatcher.
 var _ dispatch.Dispatcher = (*Provisioner)(nil)
 
@@ -232,47 +235,68 @@ func (p *Provisioner) ensureSecretIAM(ctx context.Context, secretName string) er
 	return nil
 }
 
-// GetFunctionURL returns the URL of the deployed mint function.
-// Used for auto-discovering the mint URL when --mint-url is not provided.
-func (p *Provisioner) GetFunctionURL(ctx context.Context) (string, error) {
+// MintDiscovery holds the results of a single GetFunction call, providing
+// both the URL and existing role-to-app-ID mappings.
+type MintDiscovery struct {
+	URL        string
+	RoleAppIDs map[string]string
+}
+
+// DiscoverMint fetches the mint function once and returns its URL and
+// ROLE_APP_IDS in a single API call. Returns ErrFunctionNotFound (wrapped)
+// if the function does not exist.
+func (p *Provisioner) DiscoverMint(ctx context.Context) (*MintDiscovery, error) {
 	fn, err := p.gcpAPI.GetFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
 	if err != nil {
-		return "", fmt.Errorf("checking mint function: %w", err)
+		return nil, fmt.Errorf("checking mint function: %w", err)
 	}
 	if fn == nil || fn.URI == "" {
-		return "", fmt.Errorf("mint function %s not found in project %s region %s",
-			functionName, p.cfg.ProjectID, p.cfg.Region)
+		return nil, fmt.Errorf("%w: %s in project %s region %s",
+			ErrFunctionNotFound, functionName, p.cfg.ProjectID, p.cfg.Region)
 	}
-	return fn.URI, nil
+
+	result := &MintDiscovery{URL: fn.URI}
+	if fn.EnvVars != nil {
+		if raw := fn.EnvVars["ROLE_APP_IDS"]; raw != "" {
+			var m map[string]string
+			if err := json.Unmarshal([]byte(raw), &m); err == nil {
+				result.RoleAppIDs = m
+			}
+		}
+	}
+	return result, nil
+}
+
+// GetFunctionURL returns the URL of the deployed mint function.
+func (p *Provisioner) GetFunctionURL(ctx context.Context) (string, error) {
+	d, err := p.DiscoverMint(ctx)
+	if err != nil {
+		return "", err
+	}
+	return d.URL, nil
 }
 
 // GetExistingRoleAppIDs reads ROLE_APP_IDS from the deployed mint function.
 // Returns (nil, nil) if the function doesn't exist or has no ROLE_APP_IDS.
-// Returns (nil, err) if the API call fails (auth/network error).
 func (p *Provisioner) GetExistingRoleAppIDs(ctx context.Context) (map[string]string, error) {
-	fn, err := p.gcpAPI.GetFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
+	d, err := p.DiscoverMint(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("reading mint function: %w", err)
+		if errors.Is(err, ErrFunctionNotFound) {
+			return nil, nil
+		}
+		return nil, err
 	}
-	if fn == nil || fn.EnvVars == nil {
-		return nil, nil
-	}
-	raw := fn.EnvVars["ROLE_APP_IDS"]
-	if raw == "" {
-		return nil, nil
-	}
-	var m map[string]string
-	if err := json.Unmarshal([]byte(raw), &m); err != nil {
-		return nil, nil
-	}
-	return m, nil
+	return d.RoleAppIDs, nil
 }
 
 // EnsureOrgInMint validates that a mint function exists at expectedURL and
 // that the given org is registered in ALLOWED_ORGS and ROLE_APP_IDS. If the
 // org is missing, it updates the function's env vars to include it.
-// Not safe for concurrent calls — run per-repo installs sequentially when
-// sharing a mint.
+//
+// WARNING: read-modify-write without locking — concurrent calls from
+// parallel per-repo installs sharing the same mint can race, causing one
+// update to overwrite the other. Run installs sequentially when sharing
+// a mint, or accept that a lost update will be corrected on the next run.
 func (p *Provisioner) EnsureOrgInMint(ctx context.Context, expectedURL string, org string, roleAppIDs map[string]string) error {
 	org = strings.ToLower(org)
 
@@ -474,8 +498,10 @@ func (p *Provisioner) provisionWithExistingMint(ctx context.Context) (map[string
 	}
 
 	parsedURL, err := url.Parse(p.cfg.MintURL)
-	if err != nil || parsedURL.Scheme != "https" || parsedURL.Host == "" {
-		return nil, fmt.Errorf("MintURL %q must be a valid HTTPS URL", p.cfg.MintURL)
+	if err != nil || parsedURL.Scheme != "https" ||
+		(!strings.HasSuffix(parsedURL.Host, ".run.app") &&
+			!strings.HasSuffix(parsedURL.Host, ".cloudfunctions.net")) {
+		return nil, fmt.Errorf("MintURL %q must be a valid Cloud Run URL (.run.app or .cloudfunctions.net)", p.cfg.MintURL)
 	}
 
 	// Fetch existing role/app ID mappings once for PEM auto-copy decisions.
@@ -515,11 +541,15 @@ func (p *Provisioner) provisionWithExistingMint(ctx context.Context) (map[string
 			if existingIDsErr != nil {
 				return nil, fmt.Errorf("reading existing role app IDs for PEM auto-copy: %w", existingIDsErr)
 			}
-			// PEM doesn't exist — try to copy from another org that has this role.
+			// PEM doesn't exist — try to copy from another org that has the
+			// same app (matched by app ID) for this role.
 			copied := false
 			for _, key := range sortedStringMapKeys(existingIDs) {
 				parts := strings.SplitN(key, "/", 2)
 				if len(parts) != 2 || parts[1] != role || parts[0] == org {
+					continue
+				}
+				if p.cfg.AgentAppIDs[role] != "" && existingIDs[key] != p.cfg.AgentAppIDs[role] {
 					continue
 				}
 				if copyErr := p.CopyAgentPEM(ctx, parts[0], org, role); copyErr == nil {
@@ -668,23 +698,32 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 	needsDeploy := true
 	var earlySourceZip []byte
 
-	if existing != nil && existing.URI != "" && existing.State == "ACTIVE" {
-		switch {
-		case p.cfg.DeployMode == DeploySkip:
-			needsDeploy = false
-		case p.cfg.FunctionSourceDir == "":
-			needsDeploy = false
-		default: // DeployAuto
-			earlySourceZip, err = bundleFunctionSource(p.cfg.FunctionSourceDir)
-			if err != nil {
-				return nil, fmt.Errorf("validating function source: %w", err)
-			}
-			needsDeploy = existing.EnvVars["FULLSEND_SOURCE_HASH"] != sha256Hex(earlySourceZip)
+	if existing != nil && existing.URI != "" {
+		if existing.State != "ACTIVE" && p.cfg.DeployMode == DeploySkip {
+			return nil, fmt.Errorf("mint function exists but is in %s state; cannot proceed with --skip-mint-deploy", existing.State)
 		}
 
-		if !needsDeploy {
-			p.cfg.MintURL = existing.URI
-			return p.provisionWithExistingMint(ctx)
+		if existing.State == "ACTIVE" {
+			switch {
+			case p.cfg.DeployMode == DeploySkip:
+				needsDeploy = false
+			case p.cfg.FunctionSourceDir == "":
+				needsDeploy = false
+			default: // DeployAuto
+				earlySourceZip, err = bundleFunctionSource(p.cfg.FunctionSourceDir)
+				if err != nil {
+					return nil, fmt.Errorf("validating function source: %w", err)
+				}
+				needsDeploy = existing.EnvVars["FULLSEND_SOURCE_HASH"] != sha256Hex(earlySourceZip)
+			}
+
+			if !needsDeploy {
+				if err := p.gcpAPI.SetCloudRunInvoker(ctx, p.cfg.ProjectID, p.cfg.Region, functionName); err != nil {
+					return nil, fmt.Errorf("setting function invoker policy: %w", err)
+				}
+				p.cfg.MintURL = existing.URI
+				return p.provisionWithExistingMint(ctx)
+			}
 		}
 	}
 
@@ -1227,7 +1266,10 @@ func sha256Hex(data []byte) string {
 }
 
 // needsCodeDeploy determines whether the Cloud Function code needs (re)deployment.
-// Only checks the source hash — env var changes are handled by EnsureOrgInMint.
+// Only checks the source hash — org-level env vars (ALLOWED_ORGS, ROLE_APP_IDS)
+// are handled separately by EnsureOrgInMint. Infrastructure env vars set during
+// initial deploy (FULLSEND_SOURCE_HASH, GCP_PROJECT_ID) are NOT reconciled on
+// subsequent runs; a code redeploy is required to update them.
 func (p *Provisioner) needsCodeDeploy(existing *FunctionInfo, sourceHash string) bool {
 	if p.cfg.DeployMode == DeploySkip {
 		return false

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -682,13 +682,21 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 			return nil, fmt.Errorf("function %s deployed but not found or has no URI", functionName)
 		}
 	} else if p.needsCodeDeploy(existing, sourceHash) {
-		// Code changed: UpdateFunction preserving existing env vars, only updating hash.
-		deployEnvVars := make(map[string]string, len(envVars)+len(existing.EnvVars))
-		for k, v := range envVars {
-			deployEnvVars[k] = v
-		}
+		// Code changed: start from existing env vars (preserves org data,
+		// PER_REPO_WIF_REPOS, etc.), then override infrastructure keys
+		// with current config values. EnsureOrgInMint handles org registration.
+		deployEnvVars := make(map[string]string, len(existing.EnvVars)+6)
 		for k, v := range existing.EnvVars {
 			deployEnvVars[k] = v
+		}
+		for _, k := range []string{"GCP_PROJECT_NUMBER", "WIF_POOL_NAME", "WIF_PROVIDER_NAME", "OIDC_AUDIENCE"} {
+			if v, ok := envVars[k]; ok {
+				deployEnvVars[k] = v
+			}
+		}
+		deployEnvVars["ALLOWED_ROLES"] = deriveAllowedRoles(deployEnvVars["ROLE_APP_IDS"])
+		if deployEnvVars["ALLOWED_WORKFLOW_FILES"] == "" {
+			deployEnvVars["ALLOWED_WORKFLOW_FILES"] = "*"
 		}
 		deployEnvVars["FULLSEND_SOURCE_HASH"] = sourceHash
 
@@ -724,6 +732,9 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 	}
 
 	if existing == nil || existing.URI == "" {
+		if p.cfg.DeployMode == DeploySkip {
+			return nil, fmt.Errorf("function %s not found — cannot use --skip-mint-deploy without an existing deployment", functionName)
+		}
 		return nil, fmt.Errorf("function %s not found or has no URI", functionName)
 	}
 	mintURL := existing.URI

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -639,77 +639,98 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 		return nil, fmt.Errorf("checking existing function: %w", err)
 	}
 
-	// Merge with existing function config (additive multi-org support).
-	if existing != nil && existing.EnvVars != nil {
-		mergeAllowedOrgs(existing.EnvVars, envVars)
-		mergeRoleAppIDs(existing.EnvVars, envVars)
-		if v := existing.EnvVars["ALLOWED_WORKFLOW_FILES"]; v != "" {
-			envVars["ALLOWED_WORKFLOW_FILES"] = v
-		}
-		if v := existing.EnvVars["PER_REPO_WIF_REPOS"]; v != "" {
-			envVars["PER_REPO_WIF_REPOS"] = v
-		}
-	}
+	// Step 6b: Code deployment — only when source hash changes.
+	sourceZip := earlySourceZip
+	sourceHash := sha256Hex(sourceZip)
 
-	envVars["ALLOWED_ROLES"] = deriveAllowedRoles(envVars["ROLE_APP_IDS"])
-
-	if envVars["ALLOWED_WORKFLOW_FILES"] == "" {
-		envVars["ALLOWED_WORKFLOW_FILES"] = "*"
-	}
-
-	if p.cfg.DeployMode == DeploySkip {
-		if existing == nil || existing.URI == "" {
-			return nil, fmt.Errorf("function %s not found — cannot use --skip-mint-deploy without an existing deployment", functionName)
+	if existing == nil && p.cfg.DeployMode != DeploySkip {
+		// First deploy: CreateFunction with full env vars including org registration.
+		// Mint's init() fatals on missing env vars, so we must set them all at once.
+		envVars["ALLOWED_ROLES"] = deriveAllowedRoles(envVars["ROLE_APP_IDS"])
+		if envVars["ALLOWED_WORKFLOW_FILES"] == "" {
+			envVars["ALLOWED_WORKFLOW_FILES"] = "*"
 		}
-	} else {
-		sourceZip := earlySourceZip
-		sourceHash := sha256Hex(sourceZip)
 		envVars["FULLSEND_SOURCE_HASH"] = sourceHash
 
-		needsDeploy := p.shouldDeploy(existing, envVars)
+		storageSource, err := p.gcpAPI.UploadFunctionSource(ctx, p.cfg.ProjectID, p.cfg.Region, sourceZip)
+		if err != nil {
+			return nil, fmt.Errorf("uploading function source: %w", err)
+		}
 
-		if needsDeploy {
-			storageSource, err := p.gcpAPI.UploadFunctionSource(ctx, p.cfg.ProjectID, p.cfg.Region, sourceZip)
-			if err != nil {
-				return nil, fmt.Errorf("uploading function source: %w", err)
-			}
+		saEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", saName, p.cfg.ProjectID)
+		fnCfg := FunctionConfig{
+			ServiceAccount: saEmail,
+			EnvVars:        envVars,
+			StorageSource:  storageSource,
+			EntryPoint:     "ServeHTTP",
+			Runtime:        "go126",
+		}
 
-			saEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", saName, p.cfg.ProjectID)
-			fnCfg := FunctionConfig{
-				ServiceAccount: saEmail,
-				EnvVars:        envVars,
-				StorageSource:  storageSource,
-				EntryPoint:     "ServeHTTP",
-				Runtime:        "go126",
-			}
+		opName, err := p.gcpAPI.CreateFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, fnCfg)
+		if err != nil {
+			return nil, fmt.Errorf("deploying function: %w", err)
+		}
+		if err := p.gcpAPI.WaitForOperation(ctx, opName); err != nil {
+			return nil, fmt.Errorf("waiting for function deployment: %w", err)
+		}
 
-			var opName string
-			if existing != nil {
-				opName, err = p.gcpAPI.UpdateFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, fnCfg)
-				if err != nil {
-					return nil, fmt.Errorf("updating function: %w", err)
-				}
-			} else {
-				opName, err = p.gcpAPI.CreateFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, fnCfg)
-				if err != nil {
-					return nil, fmt.Errorf("deploying function: %w", err)
-				}
-			}
+		existing, err = p.gcpAPI.GetFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
+		if err != nil {
+			return nil, fmt.Errorf("querying function URL: %w", err)
+		}
+		if existing == nil || existing.URI == "" {
+			return nil, fmt.Errorf("function %s deployed but not found or has no URI", functionName)
+		}
+	} else if p.needsCodeDeploy(existing, sourceHash) {
+		// Code changed: UpdateFunction preserving existing env vars, only updating hash.
+		deployEnvVars := make(map[string]string, len(existing.EnvVars))
+		for k, v := range existing.EnvVars {
+			deployEnvVars[k] = v
+		}
+		deployEnvVars["FULLSEND_SOURCE_HASH"] = sourceHash
 
-			if err := p.gcpAPI.WaitForOperation(ctx, opName); err != nil {
-				return nil, fmt.Errorf("waiting for function deployment: %w", err)
-			}
+		storageSource, err := p.gcpAPI.UploadFunctionSource(ctx, p.cfg.ProjectID, p.cfg.Region, sourceZip)
+		if err != nil {
+			return nil, fmt.Errorf("uploading function source: %w", err)
+		}
 
-			existing, err = p.gcpAPI.GetFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
-			if err != nil {
-				return nil, fmt.Errorf("querying function URL: %w", err)
-			}
-			if existing == nil || existing.URI == "" {
-				return nil, fmt.Errorf("function %s deployed but not found or has no URI", functionName)
-			}
+		saEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", saName, p.cfg.ProjectID)
+		fnCfg := FunctionConfig{
+			ServiceAccount: saEmail,
+			EnvVars:        deployEnvVars,
+			StorageSource:  storageSource,
+			EntryPoint:     "ServeHTTP",
+			Runtime:        "go126",
+		}
+
+		opName, err := p.gcpAPI.UpdateFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, fnCfg)
+		if err != nil {
+			return nil, fmt.Errorf("updating function: %w", err)
+		}
+		if err := p.gcpAPI.WaitForOperation(ctx, opName); err != nil {
+			return nil, fmt.Errorf("waiting for function deployment: %w", err)
+		}
+
+		existing, err = p.gcpAPI.GetFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
+		if err != nil {
+			return nil, fmt.Errorf("querying function URL: %w", err)
+		}
+		if existing == nil || existing.URI == "" {
+			return nil, fmt.Errorf("function %s deployed but not found or has no URI", functionName)
 		}
 	}
+
+	if existing == nil || existing.URI == "" {
+		return nil, fmt.Errorf("function %s not found — cannot use --skip-mint-deploy without an existing deployment", functionName)
+	}
 	mintURL := existing.URI
+
+	// Register org env vars via EnsureOrgInMint (additive, no-op if already present).
+	for _, org := range installingOrgs {
+		if err := p.EnsureOrgInMint(ctx, mintURL, org, orgScopedAppIDs); err != nil {
+			return nil, fmt.Errorf("registering org %s in mint: %w", org, err)
+		}
+	}
 
 	parsedURL, err := url.Parse(mintURL)
 	if err != nil || parsedURL.Scheme != "https" ||
@@ -1071,25 +1092,14 @@ func bundleFunctionSource(dir string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func envVarsEqual(a, b map[string]string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k, v := range a {
-		if b[k] != v {
-			return false
-		}
-	}
-	return true
-}
-
 func sha256Hex(data []byte) string {
 	h := sha256.Sum256(data)
 	return hex.EncodeToString(h[:])
 }
 
-// shouldDeploy determines whether the Cloud Function needs (re)deployment.
-func (p *Provisioner) shouldDeploy(existing *FunctionInfo, desiredEnvVars map[string]string) bool {
+// needsCodeDeploy determines whether the Cloud Function code needs (re)deployment.
+// Only checks the source hash — env var changes are handled by EnsureOrgInMint.
+func (p *Provisioner) needsCodeDeploy(existing *FunctionInfo, sourceHash string) bool {
 	switch p.cfg.DeployMode {
 	case DeployForce:
 		return true
@@ -1102,6 +1112,6 @@ func (p *Provisioner) shouldDeploy(existing *FunctionInfo, desiredEnvVars map[st
 		if existing.State != "ACTIVE" || existing.URI == "" {
 			return true
 		}
-		return !envVarsEqual(existing.EnvVars, desiredEnvVars)
+		return existing.EnvVars["FULLSEND_SOURCE_HASH"] != sourceHash
 	}
 }

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -88,7 +88,8 @@ type Config struct {
 	AgentAppIDs map[string]string
 
 	// MintURL, if set, skips infrastructure deployment and uses the
-	// existing mint at this URL. Only PEMs are stored.
+	// existing mint at this URL for PEM storage, org registration,
+	// per-repo WIF, and PEM auto-copy.
 	MintURL string
 
 	// DeployMode controls function deployment: auto (default) or skip.
@@ -259,7 +260,9 @@ func (p *Provisioner) DiscoverMint(ctx context.Context) (*MintDiscovery, error) 
 	if fn.EnvVars != nil {
 		if raw := fn.EnvVars["ROLE_APP_IDS"]; raw != "" {
 			var m map[string]string
-			if err := json.Unmarshal([]byte(raw), &m); err == nil {
+			if err := json.Unmarshal([]byte(raw), &m); err != nil {
+				log.Printf("warning: malformed ROLE_APP_IDS in mint function: %v", err)
+			} else {
 				result.RoleAppIDs = m
 			}
 		}
@@ -544,6 +547,7 @@ func (p *Provisioner) provisionWithExistingMint(ctx context.Context) (map[string
 			// PEM doesn't exist — try to copy from another org that has the
 			// same app (matched by app ID) for this role.
 			copied := false
+			var lastCopyErr error
 			for _, key := range sortedStringMapKeys(existingIDs) {
 				parts := strings.SplitN(key, "/", 2)
 				if len(parts) != 2 || parts[1] != role || parts[0] == org {
@@ -558,10 +562,11 @@ func (p *Provisioner) provisionWithExistingMint(ctx context.Context) (map[string
 					break
 				} else {
 					log.Printf("failed to copy PEM for %s/%s from %s: %v", org, role, parts[0], copyErr)
+					lastCopyErr = copyErr
 				}
 			}
 			if !copied {
-				return nil, fmt.Errorf("role %q: no PEM provided and no existing PEM found to copy for %s", role, org)
+				return nil, fmt.Errorf("role %q: no PEM provided and no existing PEM found to copy for %s (last error: %v)", role, org, lastCopyErr)
 			}
 		}
 	}

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -382,6 +382,7 @@ func TestProvisioner_Provision_FullFlow(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []string{
+		"GetFunction", // auto-routing check (no existing function → full deploy)
 		"GetProjectNumber",
 		"CreateServiceAccount",
 		"CreateWIFPool",
@@ -392,7 +393,6 @@ func TestProvisioner_Provision_FullFlow(t *testing.T) {
 		"CreateSecret",
 		"AddSecretVersion",
 		"SetSecretIAMBinding",
-		"GetFunction",
 		"UploadFunctionSource",
 		"CreateFunction",
 		"WaitForOperation",
@@ -536,7 +536,7 @@ func TestProvisioner_Provision_SkipsRedeployWhenUnchanged(t *testing.T) {
 	assert.Equal(t, "https://fullsend-mint-abc123.run.app", vars["FULLSEND_MINT_URL"])
 }
 
-func TestProvisioner_Provision_ForceDeployAlwaysDeploys(t *testing.T) {
+func TestProvisioner_Provision_SameHashAutoRoutesToExistingMint(t *testing.T) {
 	srcDir := fakeFunctionSourceDir(t)
 	sourceZip, err := bundleFunctionSource(srcDir)
 	require.NoError(t, err)
@@ -566,15 +566,17 @@ func TestProvisioner_Provision_ForceDeployAlwaysDeploys(t *testing.T) {
 		AgentPEMs:         singleRolePEMs(),
 		AgentAppIDs:       singleRoleAppIDs(),
 		FunctionSourceDir: srcDir,
-		DeployMode:        DeployForce,
 	}, fake)
 
 	vars, err := p.Provision(context.Background())
 	require.NoError(t, err)
 
-	assert.Contains(t, fake.calls, "UploadFunctionSource")
-	assert.Contains(t, fake.calls, "UpdateFunction")
-	assert.Contains(t, fake.calls, "WaitForOperation")
+	// Same hash → auto-routed to provisionWithExistingMint, skipping full infrastructure.
+	assert.NotContains(t, fake.calls, "UploadFunctionSource")
+	assert.NotContains(t, fake.calls, "CreateFunction")
+	assert.NotContains(t, fake.calls, "UpdateFunction")
+	assert.NotContains(t, fake.calls, "GetProjectNumber")
+	assert.NotContains(t, fake.calls, "CreateServiceAccount")
 	assert.Equal(t, "https://fullsend-mint-abc123.run.app", vars["FULLSEND_MINT_URL"])
 }
 
@@ -772,6 +774,14 @@ func TestProvisioner_Provision_SecretNotFoundCreatesNew(t *testing.T) {
 func TestProvisioner_Provision_BundledMode(t *testing.T) {
 	fake := newFakeGCFClient()
 	fake.errs["GetSecret"] = ErrSecretNotFound
+	fake.functionInfo = &FunctionInfo{
+		Name: "projects/shared-project/locations/us-central1/functions/fullsend-mint",
+		State: "ACTIVE",
+		URI:  "https://fullsend-mint-shared.run.app",
+		EnvVars: map[string]string{
+			"ALLOWED_ORGS": "test-org",
+		},
+	}
 
 	p := newTestProvisioner(Config{
 		ProjectID: "shared-project",
@@ -949,6 +959,15 @@ func TestProvisioner_Provision_NoPEMs_APIError(t *testing.T) {
 
 func TestProvisioner_Provision_BundledMode_NoPEMs_SecretsExist(t *testing.T) {
 	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		Name:  "projects/shared-project/locations/us-central1/functions/fullsend-mint",
+		State: "ACTIVE",
+		URI:   "https://fullsend-mint-shared.run.app",
+		EnvVars: map[string]string{
+			"ALLOWED_ORGS": "test-org",
+			"ROLE_APP_IDS": `{"test-org/coder":"12345"}`,
+		},
+	}
 
 	p := newTestProvisioner(Config{
 		ProjectID:  "shared-project",
@@ -980,7 +999,7 @@ func TestProvisioner_Provision_BundledMode_NoPEMs_SecretsMissing(t *testing.T) {
 
 	_, err := p.Provision(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no PEM and secret")
+	assert.Contains(t, err.Error(), "no PEM provided and no existing PEM found to copy")
 }
 
 func TestProvisioner_Provision_BundledMode_NoPEMs_APIError(t *testing.T) {
@@ -1003,6 +1022,15 @@ func TestProvisioner_Provision_BundledMode_NoPEMs_APIError(t *testing.T) {
 
 func TestProvisioner_Provision_BundledMode_PartialPEMs(t *testing.T) {
 	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		Name:  "projects/shared-project/locations/us-central1/functions/fullsend-mint",
+		State: "ACTIVE",
+		URI:   "https://fullsend-mint-shared.run.app",
+		EnvVars: map[string]string{
+			"ALLOWED_ORGS": "test-org",
+			"ROLE_APP_IDS": `{"test-org/coder":"12345","test-org/triage":"67890"}`,
+		},
+	}
 
 	p := newTestProvisioner(Config{
 		ProjectID:   "shared-project",

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -842,7 +842,7 @@ func TestProvisioner_Provision_BundledMode_InvalidMintURL(t *testing.T) {
 
 			_, err := p.Provision(context.Background())
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "must be a valid HTTPS URL")
+			assert.Contains(t, err.Error(), "must be a valid Cloud Run URL")
 		})
 	}
 }
@@ -1933,7 +1933,7 @@ func TestGetExistingRoleAppIDs_GetFunctionError(t *testing.T) {
 	m, err := p.GetExistingRoleAppIDs(context.Background())
 	require.Error(t, err)
 	assert.Nil(t, m)
-	assert.Contains(t, err.Error(), "reading mint function")
+	assert.Contains(t, err.Error(), "checking mint function")
 }
 
 // --- GetFunctionURL tests ---
@@ -2007,7 +2007,7 @@ func TestProvisioner_Provision_NonActiveFunction_TriggersDeploy(t *testing.T) {
 func TestProvisioner_Provision_BundledMode_PEMAutoCopy(t *testing.T) {
 	fake := newFakeGCFClient()
 	fake.functionInfo = &FunctionInfo{
-		URI: "https://mint.example.com",
+		URI: "https://fullsend-mint-abc123.run.app",
 		EnvVars: map[string]string{
 			"ROLE_APP_IDS":  `{"source-org/coder":"12345"}`,
 			"ALLOWED_ORGS":  "source-org",
@@ -2028,12 +2028,12 @@ func TestProvisioner_Provision_BundledMode_PEMAutoCopy(t *testing.T) {
 		ProjectID:   "my-project",
 		GitHubOrgs:  []string{"target-org"},
 		AgentAppIDs: map[string]string{"coder": "12345"},
-		MintURL:     "https://mint.example.com",
+		MintURL:     "https://fullsend-mint-abc123.run.app",
 	}, fake)
 
 	vars, err := p.Provision(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, "https://mint.example.com", vars["FULLSEND_MINT_URL"])
+	assert.Equal(t, "https://fullsend-mint-abc123.run.app", vars["FULLSEND_MINT_URL"])
 
 	// Verify CopyAgentPEM was called (AccessSecretVersion + AddSecretVersion).
 	assert.Contains(t, fake.calls, "AccessSecretVersion")

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -622,7 +622,7 @@ func TestProvisioner_Provision_SkipDeployNoExistingFunction(t *testing.T) {
 
 	_, err := p.Provision(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "skip-mint-deploy")
+	assert.Contains(t, err.Error(), "not found or has no URI")
 }
 
 func TestProvisioner_Provision_CodeChanged_UpdatesFunction(t *testing.T) {

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -571,12 +571,16 @@ func TestProvisioner_Provision_SameHashAutoRoutesToExistingMint(t *testing.T) {
 	vars, err := p.Provision(context.Background())
 	require.NoError(t, err)
 
-	// Same hash → auto-routed to provisionWithExistingMint, skipping full infrastructure.
+	// Same hash → WIF infrastructure still runs, but code deploy is skipped.
+	assert.Contains(t, fake.calls, "GetProjectNumber")
+	assert.Contains(t, fake.calls, "CreateServiceAccount")
+	assert.Contains(t, fake.calls, "CreateWIFPool")
+	assert.Contains(t, fake.calls, "CreateWIFProvider")
+	assert.Contains(t, fake.calls, "SetProjectIAMBinding")
+	// Code deploy skipped — auto-routed to provisionWithExistingMint for PEM + org registration.
 	assert.NotContains(t, fake.calls, "UploadFunctionSource")
 	assert.NotContains(t, fake.calls, "CreateFunction")
 	assert.NotContains(t, fake.calls, "UpdateFunction")
-	assert.NotContains(t, fake.calls, "GetProjectNumber")
-	assert.NotContains(t, fake.calls, "CreateServiceAccount")
 	assert.Equal(t, "https://fullsend-mint-abc123.run.app", vars["FULLSEND_MINT_URL"])
 }
 

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -622,7 +622,7 @@ func TestProvisioner_Provision_SkipDeployNoExistingFunction(t *testing.T) {
 
 	_, err := p.Provision(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found or has no URI")
+	assert.Contains(t, err.Error(), "skip-mint-deploy")
 }
 
 func TestProvisioner_Provision_CodeChanged_UpdatesFunction(t *testing.T) {

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -362,6 +362,12 @@ func TestProvisioner_Provision_FullFlow(t *testing.T) {
 		Name:  "projects/my-project/locations/us-central1/functions/fullsend-mint",
 		State: "ACTIVE",
 		URI:   "https://fullsend-mint-abc123.run.app",
+		EnvVars: map[string]string{
+			"ALLOWED_ORGS":          "test-org",
+			"ROLE_APP_IDS":          `{"test-org/coder":"12345"}`,
+			"ALLOWED_ROLES":         "coder",
+			"ALLOWED_WORKFLOW_FILES": "*",
+		},
 	}
 
 	p := newTestProvisioner(Config{
@@ -391,6 +397,7 @@ func TestProvisioner_Provision_FullFlow(t *testing.T) {
 		"CreateFunction",
 		"WaitForOperation",
 		"GetFunction",
+		"GetFunction", // EnsureOrgInMint checks env vars (no-op after first deploy)
 		"SetCloudRunInvoker",
 	}
 	assert.Equal(t, expected, fake.calls)
@@ -591,10 +598,13 @@ func TestProvisioner_Provision_SkipDeployReusesExisting(t *testing.T) {
 	vars, err := p.Provision(context.Background())
 	require.NoError(t, err)
 
+	// No code deployment.
 	assert.NotContains(t, fake.calls, "UploadFunctionSource")
 	assert.NotContains(t, fake.calls, "CreateFunction")
 	assert.NotContains(t, fake.calls, "UpdateFunction")
-	assert.NotContains(t, fake.calls, "WaitForOperation")
+
+	// EnsureOrgInMint still registers the org via env-var-only update.
+	assert.Contains(t, fake.calls, "UpdateFunctionEnvVars")
 	assert.Equal(t, "https://fullsend-mint-abc123.run.app", vars["FULLSEND_MINT_URL"])
 }
 
@@ -612,7 +622,102 @@ func TestProvisioner_Provision_SkipDeployNoExistingFunction(t *testing.T) {
 
 	_, err := p.Provision(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--skip-mint-deploy")
+	assert.Contains(t, err.Error(), "skip-mint-deploy")
+}
+
+func TestProvisioner_Provision_CodeChanged_UpdatesFunction(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		Name:  "projects/my-project/locations/us-central1/functions/fullsend-mint",
+		State: "ACTIVE",
+		URI:   "https://fullsend-mint-abc123.run.app",
+		EnvVars: map[string]string{
+			"GCP_PROJECT_NUMBER":     "123456789",
+			"WIF_POOL_NAME":         "fullsend-pool",
+			"WIF_PROVIDER_NAME":     "github-oidc",
+			"ALLOWED_ORGS":          "test-org",
+			"OIDC_AUDIENCE":         "fullsend-mint",
+			"ALLOWED_ROLES":         "coder",
+			"ROLE_APP_IDS":          `{"test-org/coder":"12345"}`,
+			"FULLSEND_SOURCE_HASH":  "old-hash-that-wont-match",
+			"ALLOWED_WORKFLOW_FILES": "*",
+		},
+	}
+
+	p := newTestProvisioner(Config{
+		ProjectID:         "my-project",
+		GitHubOrgs:        []string{"test-org"},
+		AgentPEMs:         singleRolePEMs(),
+		AgentAppIDs:       singleRoleAppIDs(),
+		FunctionSourceDir: fakeFunctionSourceDir(t),
+	}, fake)
+
+	vars, err := p.Provision(context.Background())
+	require.NoError(t, err)
+
+	// Code deploy happens via UpdateFunction (not CreateFunction).
+	assert.Contains(t, fake.calls, "UploadFunctionSource")
+	assert.Contains(t, fake.calls, "UpdateFunction")
+	assert.NotContains(t, fake.calls, "CreateFunction")
+
+	// UpdateFunction preserves existing env vars, only updating the hash.
+	require.NotNil(t, fake.lastCreateFunctionEnvVars)
+	assert.Equal(t, "test-org", fake.lastCreateFunctionEnvVars["ALLOWED_ORGS"])
+	assert.NotEqual(t, "old-hash-that-wont-match", fake.lastCreateFunctionEnvVars["FULLSEND_SOURCE_HASH"])
+
+	assert.Equal(t, "https://fullsend-mint-abc123.run.app", vars["FULLSEND_MINT_URL"])
+}
+
+func TestProvisioner_Provision_SameCodeNewOrg_EnvVarOnlyUpdate(t *testing.T) {
+	srcDir := fakeFunctionSourceDir(t)
+	sourceZip, err := bundleFunctionSource(srcDir)
+	require.NoError(t, err)
+	srcHash := sha256Hex(sourceZip)
+
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		Name:  "projects/my-project/locations/us-central1/functions/fullsend-mint",
+		State: "ACTIVE",
+		URI:   "https://fullsend-mint-abc123.run.app",
+		EnvVars: map[string]string{
+			"GCP_PROJECT_NUMBER":     "123456789",
+			"WIF_POOL_NAME":         "fullsend-pool",
+			"WIF_PROVIDER_NAME":     "github-oidc",
+			"ALLOWED_ORGS":          "existing-org",
+			"OIDC_AUDIENCE":         "fullsend-mint",
+			"ALLOWED_ROLES":         "coder",
+			"ROLE_APP_IDS":          `{"existing-org/coder":"99999"}`,
+			"FULLSEND_SOURCE_HASH":  srcHash,
+			"ALLOWED_WORKFLOW_FILES": "*",
+		},
+	}
+
+	p := newTestProvisioner(Config{
+		ProjectID:         "my-project",
+		GitHubOrgs:        []string{"new-org"},
+		AgentPEMs:         singleRolePEMs(),
+		AgentAppIDs:       singleRoleAppIDs(),
+		FunctionSourceDir: srcDir,
+	}, fake)
+
+	vars, err := p.Provision(context.Background())
+	require.NoError(t, err)
+
+	// No code deployment — same source hash.
+	assert.NotContains(t, fake.calls, "UploadFunctionSource")
+	assert.NotContains(t, fake.calls, "CreateFunction")
+	assert.NotContains(t, fake.calls, "UpdateFunction")
+
+	// EnsureOrgInMint adds the new org via env-var-only update.
+	assert.Contains(t, fake.calls, "UpdateFunctionEnvVars")
+
+	// Verify new org was added to ALLOWED_ORGS alongside existing.
+	require.NotNil(t, fake.lastUpdateFunctionEnvVars)
+	allowedOrgs := fake.lastUpdateFunctionEnvVars["ALLOWED_ORGS"]
+	assert.Contains(t, allowedOrgs, "new-org")
+	assert.Contains(t, allowedOrgs, "existing-org")
+
+	assert.Equal(t, "https://fullsend-mint-abc123.run.app", vars["FULLSEND_MINT_URL"])
 }
 
 func TestProvisioner_Provision_SecretExistsSkipsCreation(t *testing.T) {
@@ -1372,8 +1477,11 @@ func TestProvisioner_Provision_MultiOrg_MergeDoesNotOverwriteExistingPEMs(t *tes
 		fake.lastWIFProviderConfig.AttributeCondition)
 
 	// ROLE_APP_IDS should preserve existing-org's entries and add new-org's.
-	assert.Contains(t, fake.lastCreateFunctionEnvVars["ROLE_APP_IDS"], `"existing-org/coder":"999"`)
-	assert.Contains(t, fake.lastCreateFunctionEnvVars["ROLE_APP_IDS"], `"new-org/coder"`)
+	// After the refactor, code deploy preserves existing env vars, and
+	// EnsureOrgInMint merges the new org's entries via UpdateFunctionEnvVars.
+	require.NotNil(t, fake.lastUpdateFunctionEnvVars, "expected EnsureOrgInMint to update env vars")
+	assert.Contains(t, fake.lastUpdateFunctionEnvVars["ROLE_APP_IDS"], `"existing-org/coder":"999"`)
+	assert.Contains(t, fake.lastUpdateFunctionEnvVars["ROLE_APP_IDS"], `"new-org/coder"`)
 }
 
 // --- ProvisionWIF tests ---

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -1925,6 +1925,121 @@ func TestGetExistingRoleAppIDs_MalformedJSON(t *testing.T) {
 	assert.Nil(t, m)
 }
 
+func TestGetExistingRoleAppIDs_GetFunctionError(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.errs["GetFunction"] = fmt.Errorf("permission denied")
+
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	m, err := p.GetExistingRoleAppIDs(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, m)
+	assert.Contains(t, err.Error(), "reading mint function")
+}
+
+// --- GetFunctionURL tests ---
+
+func TestGetFunctionURL_ReturnsURL(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		URI:   "https://fullsend-mint-abc123.run.app",
+		State: "ACTIVE",
+	}
+
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	url, err := p.GetFunctionURL(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "https://fullsend-mint-abc123.run.app", url)
+}
+
+func TestGetFunctionURL_NoFunction(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = nil
+
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	_, err := p.GetFunctionURL(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestGetFunctionURL_EmptyURI(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		State: "ACTIVE",
+		URI:   "",
+	}
+
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	_, err := p.GetFunctionURL(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// --- Provision with non-ACTIVE function ---
+
+func TestProvisioner_Provision_NonActiveFunction_TriggersDeploy(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		Name:  "projects/my-project/locations/us-central1/functions/fullsend-mint",
+		State: "FAILED",
+		URI:   "https://fullsend-mint-abc123.run.app",
+		EnvVars: map[string]string{
+			"FULLSEND_SOURCE_HASH": "different-hash",
+		},
+	}
+	p := newTestProvisioner(Config{
+		ProjectID:         "my-project",
+		GitHubOrgs:        []string{"test-org"},
+		AgentPEMs:         singleRolePEMs(),
+		AgentAppIDs:       singleRoleAppIDs(),
+		FunctionSourceDir: fakeFunctionSourceDir(t),
+	}, fake)
+
+	vars, err := p.Provision(context.Background())
+	require.NoError(t, err)
+
+	// Non-ACTIVE function should trigger full deploy path (UpdateFunction).
+	assert.Contains(t, fake.calls, "UpdateFunction")
+	assert.Equal(t, "https://fullsend-mint-abc123.run.app", vars["FULLSEND_MINT_URL"])
+}
+
+// --- PEM auto-copy in provisionWithExistingMint ---
+
+func TestProvisioner_Provision_BundledMode_PEMAutoCopy(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		URI: "https://mint.example.com",
+		EnvVars: map[string]string{
+			"ROLE_APP_IDS":  `{"source-org/coder":"12345"}`,
+			"ALLOWED_ORGS":  "source-org",
+			"ALLOWED_ROLES": "coder",
+		},
+	}
+	// SecretExists returns false for target-org's coder PEM (triggers auto-copy).
+	// GetSecret uses the secrets map; missing key → ErrSecretNotFound.
+	fake.secrets = map[string]bool{
+		"fullsend-source-org--coder-app-pem": true,
+	}
+	// AccessSecretVersion uses the secretData map for the source org's PEM.
+	fake.secretData = map[string][]byte{
+		"fullsend-source-org--coder-app-pem": []byte("test-pem-data"),
+	}
+
+	p := newTestProvisioner(Config{
+		ProjectID:   "my-project",
+		GitHubOrgs:  []string{"target-org"},
+		AgentAppIDs: map[string]string{"coder": "12345"},
+		MintURL:     "https://mint.example.com",
+	}, fake)
+
+	vars, err := p.Provision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "https://mint.example.com", vars["FULLSEND_MINT_URL"])
+
+	// Verify CopyAgentPEM was called (AccessSecretVersion + AddSecretVersion).
+	assert.Contains(t, fake.calls, "AccessSecretVersion")
+	assert.Contains(t, fake.calls, "AddSecretVersion")
+}
+
 // --- EnsureOrgInMint tests ---
 
 func TestEnsureOrgInMint_OrgAlreadyCovered(t *testing.T) {


### PR DESCRIPTION
## Summary

Unifies per-org and per-repo mint provisioning through `Provision()`. Separates code deployment from env var registration — previously `shouldDeploy` compared all env vars, causing a full Cloud Function code redeployment whenever a new org was added. Now `needsCodeDeploy` checks only `FULLSEND_SOURCE_HASH`, and org registration uses `EnsureOrgInMint` which calls `UpdateFunctionEnvVars` (env-var-only Cloud Run update, seconds instead of minutes).

### What changed

- **Deploy decision**: `shouldDeploy` (compared all env vars) → `needsCodeDeploy` (checks only source hash)
- **WIF infrastructure**: Steps 2-4b (SA, pool, provider, IAM binding) always run regardless of deploy decision, ensuring new orgs get WIF access even when code hasn't changed
- **Org registration**: Delegated to `EnsureOrgInMint` after the deploy decision — runs unconditionally, additive merge via `UpdateFunctionEnvVars`
- **Per-repo unification**: Per-repo install now calls `Provision()` instead of manual orchestration
- **Auto-discovery**: Mint URL auto-discovered from `--mint-project`/`--mint-region` when `--mint-url` not provided
- **Flag cleanup**: `--force-mint-deploy` and `--scaffold-customized` removed; `--mint-url` now shared between per-org and per-repo
- **Removed**: `envVarsEqual`, `DeployForce` (no longer needed)

### Deploy behavior matrix

| Scenario | Code deploy | Env var update | WIF update |
|----------|-------------|----------------|------------|
| First install | `CreateFunction` (full) | built-in | yes |
| New org, same code | skip | `UpdateFunctionEnvVars` | yes |
| Code changed | `UpdateFunction` (full) | `EnsureOrgInMint` after | yes |
| `--skip-mint-deploy` | skip | `UpdateFunctionEnvVars` | yes |

### Bug fixes

- `--skip-mint-deploy` previously skipped the entire deploy block, silently dropping org registration. Now `EnsureOrgInMint` always runs regardless of deploy mode
- Early `--mint-url` HTTPS validation in per-org path (before irreversible app setup)
- Early guard for `--skip-mint-deploy` + no existing function (fails fast instead of bundling source first)
- `GetExistingRoleAppIDs` errors propagated instead of silently swallowed in PEM auto-copy
- `CopyAgentPEM` failures logged for debuggability
- Dry-run shows auto-discovery placeholder when `--mint-url` not provided
- Discovery error distinguishes "not found" from API/auth failures
- Per-repo install errors on missing role instead of silently omitting it

### Validation hardening

- `validateMintURL` now enforces Cloud Run domain suffix (`.run.app` / `.cloudfunctions.net`) matching the provisioner check — rejects invalid URLs before irreversible app creation
- `DiscoverMint` logs a warning on malformed `ROLE_APP_IDS` JSON instead of silently returning nil (prevents silent duplicate app creation)
- PEM auto-copy surfaces the last `CopyAgentPEM` error in the final error message when all copy candidates fail
- `log.Printf` in CLI replaced with `printer.StepWarn` for consistent structured output
- Added `StepDone` calls for `DiscoverMint` `ErrFunctionNotFound` path to prevent spinner from hanging
- `Config.MintURL` doc comment updated to reflect expanded `provisionWithExistingMint` behavior
- ADR 0033 step 6 fixed `.yml` → `.yaml` to match generated scaffold file

## Test plan

- [x] `go test ./... -count=1` — all tests pass
- [x] `go vet ./...` — clean
- [x] New test: `SameHashAutoRoutesToExistingMint` — verifies WIF runs but code deploy is skipped
- [x] New test: `SameCodeNewOrg_EnvVarOnlyUpdate` — new org triggers env-var-only update
- [x] New test: `CodeChanged_UpdatesFunction` — different hash triggers `UpdateFunction`
- [x] New test: `PerRepoRejectsNonCloudRunMintURL` — validates domain suffix check
- [x] Updated test: `SkipDeployReusesExisting` — verifies `EnsureOrgInMint` still registers org
- [x] Updated test: `SkipDeployNoExistingFunction` — verifies early guard error