### PR TITLE
fix(mint): route per-org workflow_call repos to default WIF provider

### DIFF
--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -576,7 +576,14 @@ func runPerRepoInstall(ctx context.Context, repoFullName, agents, mintURL, infer
 		printer.StepDone("WIF infrastructure ready")
 		printer.StepInfo("IAM policy changes may take up to 7 minutes to propagate")
 		printer.StepInfo("Agent workflows that authenticate via WIF may fail until propagation completes")
+
 	}
+
+	if err := mintProvisioner.RegisterPerRepoWIF(ctx, owner+"/"+repo); err != nil {
+		printer.StepFail("Failed to register per-repo WIF in mint")
+		return fmt.Errorf("registering per-repo WIF: %w", err)
+	}
+	printer.StepDone("Registered per-repo WIF in mint")
 
 	repoSecrets := map[string]string{
 		"FULLSEND_GCP_PROJECT_ID":   inferenceProject,

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -346,6 +346,56 @@ func (p *Provisioner) EnsureOrgInMint(ctx context.Context, expectedURL string, o
 	return nil
 }
 
+// RegisterPerRepoWIF adds a repo to the mint's PER_REPO_WIF_REPOS env var
+// so the mint routes OIDC tokens from that repo to a dedicated WIF provider
+// instead of the org-level default. Idempotent — skips repos already listed.
+// Not safe for concurrent calls — run per-repo installs sequentially when
+// sharing a mint.
+func (p *Provisioner) RegisterPerRepoWIF(ctx context.Context, repo string) error {
+	parts := strings.SplitN(repo, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("repo must be in owner/repo format, got %q", repo)
+	}
+	if strings.Contains(repo, ",") {
+		return fmt.Errorf("repo name cannot contain commas, got %q", repo)
+	}
+
+	fn, err := p.gcpAPI.GetFunction(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
+	if err != nil {
+		return fmt.Errorf("getting mint function: %w", err)
+	}
+	if fn == nil {
+		return fmt.Errorf("mint function not found")
+	}
+	if fn.EnvVars == nil {
+		fn.EnvVars = make(map[string]string)
+	}
+
+	repo = strings.ToLower(repo)
+	existing := fn.EnvVars["PER_REPO_WIF_REPOS"]
+	for _, entry := range strings.Split(existing, ",") {
+		if strings.ToLower(strings.TrimSpace(entry)) == repo {
+			return nil
+		}
+	}
+
+	updated := make(map[string]string, len(fn.EnvVars))
+	for k, v := range fn.EnvVars {
+		updated[k] = v
+	}
+	if existing == "" {
+		updated["PER_REPO_WIF_REPOS"] = repo
+	} else {
+		updated["PER_REPO_WIF_REPOS"] = existing + "," + repo
+	}
+
+	opName, err := p.gcpAPI.UpdateFunctionEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated)
+	if err != nil {
+		return fmt.Errorf("updating PER_REPO_WIF_REPOS: %w", err)
+	}
+	return p.gcpAPI.WaitForOperation(ctx, opName)
+}
+
 // Provision creates the GCP infrastructure for the token mint.
 //
 // When MintURL is empty, deploys the full mint infrastructure:
@@ -595,6 +645,9 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 		mergeRoleAppIDs(existing.EnvVars, envVars)
 		if v := existing.EnvVars["ALLOWED_WORKFLOW_FILES"]; v != "" {
 			envVars["ALLOWED_WORKFLOW_FILES"] = v
+		}
+		if v := existing.EnvVars["PER_REPO_WIF_REPOS"]; v != "" {
+			envVars["PER_REPO_WIF_REPOS"] = v
 		}
 	}
 

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -2066,3 +2066,112 @@ func TestEnsureOrgInMint_PreservesExistingAllowedWorkflowFiles(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ".github/workflows/ci.yml", fake.lastUpdateFunctionEnvVars["ALLOWED_WORKFLOW_FILES"])
 }
+
+func TestRegisterPerRepoWIF_AddsNewRepo(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		URI:     "https://mint.example.com",
+		EnvVars: map[string]string{},
+	}
+
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.RegisterPerRepoWIF(context.Background(), "acme-corp/my-service")
+	require.NoError(t, err)
+	assert.Contains(t, fake.calls, "UpdateFunctionEnvVars")
+	assert.Equal(t, "acme-corp/my-service", fake.lastUpdateFunctionEnvVars["PER_REPO_WIF_REPOS"])
+}
+
+func TestRegisterPerRepoWIF_AppendsToExisting(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		URI: "https://mint.example.com",
+		EnvVars: map[string]string{
+			"PER_REPO_WIF_REPOS": "acme-corp/first-repo",
+		},
+	}
+
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.RegisterPerRepoWIF(context.Background(), "acme-corp/second-repo")
+	require.NoError(t, err)
+	assert.Equal(t, "acme-corp/first-repo,acme-corp/second-repo", fake.lastUpdateFunctionEnvVars["PER_REPO_WIF_REPOS"])
+}
+
+func TestRegisterPerRepoWIF_Idempotent(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		URI: "https://mint.example.com",
+		EnvVars: map[string]string{
+			"PER_REPO_WIF_REPOS": "acme-corp/my-service",
+		},
+	}
+
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.RegisterPerRepoWIF(context.Background(), "acme-corp/my-service")
+	require.NoError(t, err)
+	assert.NotContains(t, fake.calls, "UpdateFunctionEnvVars")
+}
+
+func TestRegisterPerRepoWIF_FunctionNotFound(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = nil
+
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.RegisterPerRepoWIF(context.Background(), "acme-corp/my-service")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mint function not found")
+}
+
+func TestRegisterPerRepoWIF_LowercasesRepo(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		URI:     "https://mint.example.com",
+		EnvVars: map[string]string{},
+	}
+
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.RegisterPerRepoWIF(context.Background(), "Acme-Corp/My-Service")
+	require.NoError(t, err)
+	assert.Equal(t, "acme-corp/my-service", fake.lastUpdateFunctionEnvVars["PER_REPO_WIF_REPOS"])
+}
+
+func TestRegisterPerRepoWIF_RejectsInvalidFormat(t *testing.T) {
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, newFakeGCFClient())
+
+	tests := []struct {
+		name, repo string
+	}{
+		{"no slash", "just-a-name"},
+		{"empty owner", "/repo"},
+		{"empty repo", "owner/"},
+		{"comma injection", "legit/repo,evil/repo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := p.RegisterPerRepoWIF(context.Background(), tt.repo)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestRegisterPerRepoWIF_NilEnvVars(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		URI:     "https://mint.example.com",
+		EnvVars: nil,
+	}
+
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.RegisterPerRepoWIF(context.Background(), "acme-corp/my-service")
+	require.NoError(t, err)
+	assert.Equal(t, "acme-corp/my-service", fake.lastUpdateFunctionEnvVars["PER_REPO_WIF_REPOS"])
+}
+
+func TestRegisterPerRepoWIF_GetFunctionError(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.errs["GetFunction"] = fmt.Errorf("permission denied")
+
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.RegisterPerRepoWIF(context.Background(), "acme-corp/my-service")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "getting mint function")
+}

--- a/internal/mint/main.go
+++ b/internal/mint/main.go
@@ -331,6 +331,7 @@ type Handler struct {
 	allowedWorkflows   []string
 	oidcAudience       string
 	defaultWIFProvider string
+	perRepoWIFRepos    map[string]bool
 }
 
 // NewHandler creates a Handler with production defaults.
@@ -398,6 +399,15 @@ func NewHandler(pemAccessor PEMAccessor, tokenValidator TokenValidator) *Handler
 		for _, entry := range strings.Split(wf, ",") {
 			if trimmed := strings.TrimSpace(entry); trimmed != "" {
 				h.allowedWorkflows = append(h.allowedWorkflows, trimmed)
+			}
+		}
+	}
+
+	h.perRepoWIFRepos = make(map[string]bool)
+	if raw := os.Getenv("PER_REPO_WIF_REPOS"); raw != "" {
+		for _, entry := range strings.Split(raw, ",") {
+			if trimmed := strings.TrimSpace(entry); trimmed != "" {
+				h.perRepoWIFRepos[strings.ToLower(trimmed)] = true
 			}
 		}
 	}
@@ -619,14 +629,17 @@ func (h *Handler) prevalidateOIDCToken(token string) (*oidcClaims, error) {
 }
 
 // resolveWIFProvider returns the WIF provider name to use for STS validation
-// based on the repository claim. Org-level .fullsend repos use the default
-// provider; per-repo repos use a dynamically constructed provider ID.
+// based on the repository claim. Repos in the perRepoWIFRepos registry use a
+// dedicated per-repo provider; all others (including .fullsend) use the default.
 func (h *Handler) resolveWIFProvider(repository string) string {
 	parts := strings.SplitN(repository, "/", 2)
-	if len(parts) == 2 && parts[1] == ".fullsend" {
+	if len(parts) != 2 {
 		return h.defaultWIFProvider
 	}
-	if len(parts) == 2 {
+	if parts[1] == ".fullsend" {
+		return h.defaultWIFProvider
+	}
+	if h.perRepoWIFRepos[strings.ToLower(repository)] {
 		return buildRepoProviderID(parts[0], parts[1])
 	}
 	return h.defaultWIFProvider

--- a/internal/mint/main_test.go
+++ b/internal/mint/main_test.go
@@ -1166,7 +1166,10 @@ func TestHandler_MultiOrg_WrongOrg(t *testing.T) {
 }
 
 func TestResolveWIFProvider(t *testing.T) {
-	h := &Handler{defaultWIFProvider: "github-oidc"}
+	h := &Handler{
+		defaultWIFProvider: "github-oidc",
+		perRepoWIFRepos:    map[string]bool{"acme-corp/my-service": true},
+	}
 
 	t.Run("dotFullsend uses default provider", func(t *testing.T) {
 		got := h.resolveWIFProvider("acme-corp/.fullsend")
@@ -1175,7 +1178,7 @@ func TestResolveWIFProvider(t *testing.T) {
 		}
 	})
 
-	t.Run("per-repo uses dynamic provider", func(t *testing.T) {
+	t.Run("registered per-repo uses dynamic provider", func(t *testing.T) {
 		got := h.resolveWIFProvider("acme-corp/my-service")
 		want := buildRepoProviderID("acme-corp", "my-service")
 		if got != want {
@@ -1183,10 +1186,25 @@ func TestResolveWIFProvider(t *testing.T) {
 		}
 	})
 
+	t.Run("unregistered repo falls back to default", func(t *testing.T) {
+		got := h.resolveWIFProvider("acme-corp/other-repo")
+		if got != "github-oidc" {
+			t.Fatalf("expected github-oidc for unregistered repo, got %s", got)
+		}
+	})
+
 	t.Run("unparseable falls back to default", func(t *testing.T) {
 		got := h.resolveWIFProvider("no-slash")
 		if got != "github-oidc" {
 			t.Fatalf("expected github-oidc for unparseable repo, got %s", got)
+		}
+	})
+
+	t.Run("case-insensitive lookup", func(t *testing.T) {
+		got := h.resolveWIFProvider("Acme-Corp/My-Service")
+		want := buildRepoProviderID("Acme-Corp", "My-Service")
+		if got != want {
+			t.Fatalf("expected %s, got %s", want, got)
 		}
 	})
 }
@@ -1249,6 +1267,7 @@ func TestPrevalidateOIDCToken_MissingRepository(t *testing.T) {
 
 func TestServeHTTP_PerRepoProvider(t *testing.T) {
 	setMintEnv(t)
+	t.Setenv("PER_REPO_WIF_REPOS", "test-org/integration-service")
 	pemData, err := generateTestRSAKey()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

- The mint's `resolveWIFProvider` assumed any non-`.fullsend` repo needed a dedicated per-repo WIF provider (`gh-owner-repo`). In per-org mode with `workflow_call`, the OIDC token's `repository` claim is the caller repo (e.g., `my-app`), not `.fullsend`, so the mint constructed a provider ID that didn't exist and STS returned 400/403.
- Adds a `PER_REPO_WIF_REPOS` env var registry so only explicitly registered repos use per-repo providers; unregistered repos correctly fall back to the org-level default.
- Auto-registers repos during `fullsend admin install <owner/repo>` and preserves the registry across mint redeploys.

## Test plan

- [x] `TestResolveWIFProvider` — 5 cases: `.fullsend`→default, registered→per-repo, unregistered→default, unparseable→default, case-insensitive
- [x] `TestServeHTTP_PerRepoProvider` — updated to set `PER_REPO_WIF_REPOS` env var
- [x] `TestRegisterPerRepoWIF_*` — 8 tests: adds new, appends, idempotent, function-not-found, lowercases, rejects invalid format (4 subcases), nil env vars, get-function error
- [x] All existing mint and provisioner tests pass
- [ ] Manual: verify existing per-repo installs (halfsend/test-repo, nonflux/integration-service) still resolve correctly after populating `PER_REPO_WIF_REPOS`
- [ ] Manual: verify per-org repos fall through to default provider instead of non-existent per-repo provider