### PR TITLE
fix(#958): allow retro agent to download GitHub Actions artifacts

### DIFF
--- a/internal/scaffold/fullsend-repo/policies/retro.yaml
+++ b/internal/scaffold/fullsend-repo/policies/retro.yaml
@@ -47,3 +47,19 @@ network_policies:
     binaries:
       - path: "**/gh"
       - path: "**/node"
+
+  github_artifacts:
+    name: github-artifacts
+    endpoints:
+      - host: "*.blob.core.windows.net"
+        port: 443
+        protocol: tcp
+        enforcement: enforce
+        access: allow
+      - host: "*.actions.githubusercontent.com"
+        port: 443
+        protocol: tcp
+        enforcement: enforce
+        access: allow
+    binaries:
+      - path: "**/gh"


### PR DESCRIPTION
## Summary

- Adds `github_artifacts` network policy to the retro agent sandbox, allowing `gh` to follow GitHub's artifact/log download redirects to `*.blob.core.windows.net` (Azure Blob Storage) and `*.actions.githubusercontent.com` (GitHub Actions CDN)
- Root cause: `gh run download` hits `api.github.com` (allowed), but GitHub responds with a 302 redirect to blob storage (blocked), so artifact downloads silently fail

## Test plan

- [x] Apply equivalent change to `fullsend-ai/.fullsend` repo to test immediately
- [x] Trigger a `/retro` on an issue with a failed agent run and verify the retro agent can download and analyze the transcript artifact
- [x] Check sandbox logs for any remaining network policy denials

Closes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)