### PR TITLE
feat: add --skip-mint-check for self-provisioned mint services

### DIFF
--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -128,7 +128,10 @@ func validateMintURL(raw string) error {
 	if err := validateMintURLHTTPS(raw); err != nil {
 		return err
 	}
-	parsed, _ := url.Parse(raw)
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return err
+	}
 	if !strings.HasSuffix(parsed.Host, ".run.app") &&
 		!strings.HasSuffix(parsed.Host, ".cloudfunctions.net") {
 		return fmt.Errorf("--mint-url must be a Cloud Run URL (.run.app or .cloudfunctions.net), got host %q", parsed.Host)
@@ -144,6 +147,9 @@ func validateMintURLHTTPS(raw string) error {
 			scheme = parsed.Scheme
 		}
 		return fmt.Errorf("--mint-url must be a valid HTTPS URL (got scheme=%q)", scheme)
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("--mint-url must not contain embedded credentials (userinfo)")
 	}
 	return nil
 }
@@ -228,6 +234,10 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 					MintSkipDeploy:      mintSkipDeploy,
 					SkipMintCheck:       skipMintCheck,
 				})
+			}
+
+			if cmd.Flags().Changed("skip-mint-check") {
+				return fmt.Errorf("--skip-mint-check is only valid for per-repo installation (fullsend admin install <owner/repo>)")
 			}
 
 			org := arg

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -155,6 +155,13 @@ func validateMintURL(raw string) error {
 	return nil
 }
 
+func validateSkipMintCheck(mintURL string) error {
+	if mintURL == "" {
+		return fmt.Errorf("--mint-url is required when using --skip-mint-check")
+	}
+	return validateMintURLHTTPS(mintURL)
+}
+
 func validateMintURLHTTPS(raw string) error {
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
@@ -277,10 +284,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 			}
 
 			if skipMintCheck {
-				if mintURL == "" {
-					return fmt.Errorf("--mint-url is required when using --skip-mint-check")
-				}
-				if err := validateMintURLHTTPS(mintURL); err != nil {
+				if err := validateSkipMintCheck(mintURL); err != nil {
 					return err
 				}
 			} else {
@@ -429,7 +433,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 			printer.Blank()
 
 			if dryRun {
-				return runDryRun(ctx, client, printer, org, repos, roles, inferenceProvider, inferenceProviderName, allRepos)
+				return runDryRun(ctx, client, printer, org, repos, roles, inferenceProvider, inferenceProviderName, skipMintCheck, mintURL, allRepos)
 			}
 
 			if err := checkInstallScopes(ctx, client, printer); err != nil {
@@ -478,7 +482,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 	cmd.Flags().StringVar(&mintRegion, "mint-region", "us-central1", "cloud region for token mint")
 	cmd.Flags().StringVar(&mintSourceDir, "mint-source-dir", "", "path to mint function source (default: internal/mint/)")
 	cmd.Flags().BoolVar(&mintSkipDeploy, "skip-mint-deploy", false, "skip Cloud Function deployment, reuse existing mint URL")
-	cmd.Flags().BoolVar(&skipMintCheck, "skip-mint-check", false, "skip all GCP-based mint validation and app setup; trust the provided --mint-url")
+	cmd.Flags().BoolVar(&skipMintCheck, "skip-mint-check", false, "skip mint validation, GCP provisioning, and app setup; requires --mint-url")
 	cmd.Flags().BoolVar(&publicApps, "public", false, "create public (unlisted) GitHub Apps installable by other orgs")
 	// Shared flags.
 	cmd.Flags().StringVar(&mintURL, "mint-url", "", "token mint URL for OIDC token exchange")
@@ -519,10 +523,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 	}
 
 	if skipMintCheck {
-		if mintURL == "" {
-			return fmt.Errorf("--mint-url is required when using --skip-mint-check")
-		}
-		if err := validateMintURLHTTPS(mintURL); err != nil {
+		if err := validateSkipMintCheck(mintURL); err != nil {
 			return err
 		}
 	} else if mintURL != "" {
@@ -1044,7 +1045,7 @@ func newAnalyzeCmd() *cobra.Command {
 
 // runDryRun builds a layer stack with empty credentials and analyzes.
 // If discoveredRepos is non-nil, it will be used instead of calling ListOrgRepos.
-func runDryRun(ctx context.Context, client forge.Client, printer *ui.Printer, org string, enabledRepos, roles []string, inferenceProvider inference.Provider, inferenceProviderName string, discoveredRepos []forge.Repository) error {
+func runDryRun(ctx context.Context, client forge.Client, printer *ui.Printer, org string, enabledRepos, roles []string, inferenceProvider inference.Provider, inferenceProviderName string, skipMintCheck bool, mintURL string, discoveredRepos []forge.Repository) error {
 	printer.Header("Dry run - analyzing what install would do")
 	printer.Blank()
 
@@ -1099,7 +1100,12 @@ func runDryRun(ctx context.Context, client forge.Client, printer *ui.Printer, or
 	}
 
 	enrolledRepoIDs := collectEnrolledRepoIDs(allRepos, enabledRepos)
-	dispatcher := gcf.NewProvisioner(gcf.Config{}, nil)
+	var dispatcher dispatch.Dispatcher
+	if skipMintCheck {
+		dispatcher = &skipMintDispatcher{mintURL: mintURL}
+	} else {
+		dispatcher = gcf.NewProvisioner(gcf.Config{}, nil)
+	}
 	stack := buildLayerStack(org, client, cfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, false, nil, dispatcher)
 
 	if err := runPreflight(ctx, stack, layers.OpInstall, client, printer); err != nil {

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -106,6 +106,22 @@ var perOrgOnlyFlags = []string{
 	"vendor-fullsend-binary", "enroll-all", "enroll-none",
 }
 
+// skipMintDispatcher implements dispatch.Dispatcher for --skip-mint-check mode.
+// It returns the user-provided mint URL without making any GCP API calls.
+type skipMintDispatcher struct {
+	mintURL string
+}
+
+func (d *skipMintDispatcher) Name() string                        { return "skip-mint-check" }
+func (d *skipMintDispatcher) OrgSecretNames() []string            { return nil }
+func (d *skipMintDispatcher) OrgVariableNames() []string          { return []string{"FULLSEND_MINT_URL"} }
+func (d *skipMintDispatcher) StoreAgentPEM(context.Context, string, string, []byte) error {
+	return nil
+}
+func (d *skipMintDispatcher) Provision(context.Context) (map[string]string, error) {
+	return map[string]string{"FULLSEND_MINT_URL": d.mintURL}, nil
+}
+
 type perRepoInstallConfig struct {
 	RepoFullName        string
 	Agents              string
@@ -236,10 +252,6 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 				})
 			}
 
-			if cmd.Flags().Changed("skip-mint-check") {
-				return fmt.Errorf("--skip-mint-check is only valid for per-repo installation (fullsend admin install <owner/repo>)")
-			}
-
 			org := arg
 			if err := validateOrgName(org); err != nil {
 				return err
@@ -264,20 +276,29 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 				return err
 			}
 
-			// Validate mint provider (only required for real installs, not dry-run).
-			if !dryRun {
-				if mintProvider != "gcf" {
-					return fmt.Errorf("--mint-provider must be 'gcf'")
+			if skipMintCheck {
+				if mintURL == "" {
+					return fmt.Errorf("--mint-url is required when using --skip-mint-check")
 				}
-				if mintProject == "" {
-					return fmt.Errorf("--mint-project is required")
-				}
-			}
-
-			// Validate --mint-url early (before app setup which is irreversible).
-			if mintURL != "" {
-				if err := validateMintURL(mintURL); err != nil {
+				if err := validateMintURLHTTPS(mintURL); err != nil {
 					return err
+				}
+			} else {
+				// Validate mint provider (only required for real installs, not dry-run).
+				if !dryRun {
+					if mintProvider != "gcf" {
+						return fmt.Errorf("--mint-provider must be 'gcf'")
+					}
+					if mintProject == "" {
+						return fmt.Errorf("--mint-project is required")
+					}
+				}
+
+				// Validate --mint-url early (before app setup which is irreversible).
+				if mintURL != "" {
+					if err := validateMintURL(mintURL); err != nil {
+						return err
+					}
 				}
 			}
 
@@ -418,7 +439,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 
 			// Pre-copy PEM secrets for shared public apps before app setup.
 			var sharedSlugs map[string]string
-			if mintProject != "" && !skipAppSetup {
+			if mintProject != "" && !skipAppSetup && !skipMintCheck {
 				slugs, err := copySharedAppPEMs(ctx, client, printer, org, roles, mintProject, mintRegion)
 				if err != nil {
 					return err
@@ -428,7 +449,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 
 			// Collect agent credentials via app setup.
 			var agentCreds []layers.AgentCredentials
-			if !skipAppSetup {
+			if !skipAppSetup && !skipMintCheck {
 				if err := ensureConfigRepoExists(ctx, client, printer, org); err != nil {
 					return err
 				}
@@ -439,7 +460,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 				agentCreds = creds
 			}
 
-			return runInstall(ctx, client, printer, org, repos, roles, agentCreds, inferenceProvider, inferenceProviderName, vendorBinary, mintProvider, mintProject, mintRegion, mintSourceDir, mintSkipDeploy, mintURL, allRepos)
+			return runInstall(ctx, client, printer, org, repos, roles, agentCreds, inferenceProvider, inferenceProviderName, vendorBinary, mintProvider, mintProject, mintRegion, mintSourceDir, mintSkipDeploy, mintURL, skipMintCheck, allRepos)
 		},
 	}
 
@@ -1344,7 +1365,7 @@ func validateEnabledRepos(enabledRepos, discoveredNames []string) error {
 
 // runInstall performs the full installation.
 // If discoveredRepos is non-nil, it will be used instead of calling ListOrgRepos.
-func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, org string, enabledRepos, roles []string, agentCreds []layers.AgentCredentials, inferenceProvider inference.Provider, inferenceProviderName string, vendorBinary bool, mintProvider, mintProject, mintRegion, mintSourceDir string, mintSkipDeploy bool, mintURL string, discoveredRepos []forge.Repository) error {
+func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, org string, enabledRepos, roles []string, agentCreds []layers.AgentCredentials, inferenceProvider inference.Provider, inferenceProviderName string, vendorBinary bool, mintProvider, mintProject, mintRegion, mintSourceDir string, mintSkipDeploy bool, mintURL string, skipMintCheck bool, discoveredRepos []forge.Repository) error {
 	var allRepos []forge.Repository
 	var err error
 
@@ -1396,42 +1417,47 @@ func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, o
 		return fmt.Errorf("getting authenticated user: %w", err)
 	}
 
-	// Build the mint infrastructure provisioner.
-	agentPEMs := make(map[string][]byte)
-	agentAppIDs := make(map[string]string)
-	for _, ac := range agentCreds {
-		if ac.AppID != 0 {
-			agentAppIDs[ac.Role] = strconv.Itoa(ac.AppID)
-			if ac.PEM != "" {
-				agentPEMs[ac.Role] = []byte(ac.PEM)
+	var disp dispatch.Dispatcher
+	if skipMintCheck {
+		disp = &skipMintDispatcher{mintURL: mintURL}
+	} else {
+		// Build the mint infrastructure provisioner.
+		agentPEMs := make(map[string][]byte)
+		agentAppIDs := make(map[string]string)
+		for _, ac := range agentCreds {
+			if ac.AppID != 0 {
+				agentAppIDs[ac.Role] = strconv.Itoa(ac.AppID)
+				if ac.PEM != "" {
+					agentPEMs[ac.Role] = []byte(ac.PEM)
+				}
 			}
 		}
-	}
-	if len(agentAppIDs) == 0 {
-		return fmt.Errorf("OIDC mint requires at least one agent with credentials")
+		if len(agentAppIDs) == 0 {
+			return fmt.Errorf("OIDC mint requires at least one agent with credentials")
+		}
+
+		if mintSourceDir == "" {
+			mintSourceDir = gcf.DefaultFunctionSourceDir()
+		}
+
+		deployMode := gcf.DeployAuto
+		if mintSkipDeploy {
+			deployMode = gcf.DeploySkip
+		}
+
+		disp = gcf.NewProvisioner(gcf.Config{
+			ProjectID:         mintProject,
+			Region:            mintRegion,
+			GitHubOrgs:        []string{org},
+			AgentPEMs:         agentPEMs,
+			AgentAppIDs:       agentAppIDs,
+			FunctionSourceDir: mintSourceDir,
+			DeployMode:        deployMode,
+			MintURL:           mintURL,
+		}, gcf.NewLiveGCFClient())
 	}
 
-	if mintSourceDir == "" {
-		mintSourceDir = gcf.DefaultFunctionSourceDir()
-	}
-
-	deployMode := gcf.DeployAuto
-	if mintSkipDeploy {
-		deployMode = gcf.DeploySkip
-	}
-
-	dispatcher := gcf.NewProvisioner(gcf.Config{
-		ProjectID:         mintProject,
-		Region:            mintRegion,
-		GitHubOrgs:        []string{org},
-		AgentPEMs:         agentPEMs,
-		AgentAppIDs:       agentAppIDs,
-		FunctionSourceDir: mintSourceDir,
-		DeployMode:        deployMode,
-		MintURL:           mintURL,
-	}, gcf.NewLiveGCFClient())
-
-	stack := buildLayerStack(org, client, cfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, vendorBinary, vendorFullsendBinary, dispatcher)
+	stack := buildLayerStack(org, client, cfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, vendorBinary, vendorFullsendBinary, disp)
 
 	if err := runPreflight(ctx, stack, layers.OpInstall, client, printer); err != nil {
 		return err

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -121,9 +121,22 @@ type perRepoInstallConfig struct {
 	MintProvider        string
 	MintSourceDir       string
 	MintSkipDeploy      bool
+	SkipMintCheck       bool
 }
 
 func validateMintURL(raw string) error {
+	if err := validateMintURLHTTPS(raw); err != nil {
+		return err
+	}
+	parsed, _ := url.Parse(raw)
+	if !strings.HasSuffix(parsed.Host, ".run.app") &&
+		!strings.HasSuffix(parsed.Host, ".cloudfunctions.net") {
+		return fmt.Errorf("--mint-url must be a Cloud Run URL (.run.app or .cloudfunctions.net), got host %q", parsed.Host)
+	}
+	return nil
+}
+
+func validateMintURLHTTPS(raw string) error {
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
 		scheme := ""
@@ -131,10 +144,6 @@ func validateMintURL(raw string) error {
 			scheme = parsed.Scheme
 		}
 		return fmt.Errorf("--mint-url must be a valid HTTPS URL (got scheme=%q)", scheme)
-	}
-	if !strings.HasSuffix(parsed.Host, ".run.app") &&
-		!strings.HasSuffix(parsed.Host, ".cloudfunctions.net") {
-		return fmt.Errorf("--mint-url must be a Cloud Run URL (.run.app or .cloudfunctions.net), got host %q", parsed.Host)
 	}
 	return nil
 }
@@ -168,6 +177,7 @@ func newInstallCmd() *cobra.Command {
 	var mintRegion string
 	var mintSourceDir string
 	var mintSkipDeploy bool
+	var skipMintCheck bool
 	var publicApps bool
 	// Per-repo flags.
 	var mintURL string
@@ -216,6 +226,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 					MintProvider:        mintProvider,
 					MintSourceDir:       mintSourceDir,
 					MintSkipDeploy:      mintSkipDeploy,
+					SkipMintCheck:       skipMintCheck,
 				})
 			}
 
@@ -436,6 +447,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 	cmd.Flags().StringVar(&mintRegion, "mint-region", "us-central1", "cloud region for token mint")
 	cmd.Flags().StringVar(&mintSourceDir, "mint-source-dir", "", "path to mint function source (default: internal/mint/)")
 	cmd.Flags().BoolVar(&mintSkipDeploy, "skip-mint-deploy", false, "skip Cloud Function deployment, reuse existing mint URL")
+	cmd.Flags().BoolVar(&skipMintCheck, "skip-mint-check", false, "skip all GCP-based mint validation and app setup; trust the provided --mint-url")
 	cmd.Flags().BoolVar(&publicApps, "public", false, "create public (unlisted) GitHub Apps installable by other orgs")
 	// Shared flags.
 	cmd.Flags().StringVar(&mintURL, "mint-url", "", "token mint URL for OIDC token exchange")
@@ -458,6 +470,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 	mintProvider := c.MintProvider
 	mintSourceDir := c.MintSourceDir
 	mintSkipDeploy := c.MintSkipDeploy
+	skipMintCheck := c.SkipMintCheck
 
 	if strings.Contains(repoFullName, "://") || strings.HasPrefix(repoFullName, "www.") {
 		return fmt.Errorf("expected owner/repo format, got a URL — use just the owner/repo portion (e.g. acme/widget)")
@@ -474,12 +487,19 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 		return fmt.Errorf("invalid repo name %q: must contain only alphanumeric characters, hyphens, dots, or underscores", repo)
 	}
 
-	if mintURL != "" {
+	if skipMintCheck {
+		if mintURL == "" {
+			return fmt.Errorf("--mint-url is required when using --skip-mint-check")
+		}
+		if err := validateMintURLHTTPS(mintURL); err != nil {
+			return err
+		}
+	} else if mintURL != "" {
 		if err := validateMintURL(mintURL); err != nil {
 			return err
 		}
 	}
-	if mintProject == "" && mintURL == "" {
+	if mintProject == "" && mintURL == "" && !skipMintCheck {
 		return fmt.Errorf("--mint-project (or --inference-project) is required for per-repo installation")
 	}
 	if inferenceProject == "" {
@@ -561,48 +581,53 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 	var agentAppIDs map[string]string
 	var agentPEMs map[string][]byte
 
-	discoverer := gcf.NewProvisioner(gcf.Config{
-		ProjectID:  mintProject,
-		Region:     mintRegion,
-		GitHubOrgs: []string{owner},
-	}, gcf.NewLiveGCFClient())
-
 	var existingIDs map[string]string
 
-	if mintURL != "" {
+	if skipMintCheck {
 		mintFound = true
-		// Mint URL provided — still discover role IDs from the function
-		// to resolve existing apps. Skipped in dry-run to avoid requiring
-		// GCP credentials for preview-only invocations.
-		if mintProject != "" && !dryRun {
-			printer.StepStart("Resolving app IDs from mint")
+		printer.StepDone(fmt.Sprintf("Using self-provisioned mint at %s (--skip-mint-check)", mintURL))
+	} else {
+		discoverer := gcf.NewProvisioner(gcf.Config{
+			ProjectID:  mintProject,
+			Region:     mintRegion,
+			GitHubOrgs: []string{owner},
+		}, gcf.NewLiveGCFClient())
+
+		if mintURL != "" {
+			mintFound = true
+			// Mint URL provided — still discover role IDs from the function
+			// to resolve existing apps. Skipped in dry-run to avoid requiring
+			// GCP credentials for preview-only invocations.
+			if mintProject != "" && !dryRun {
+				printer.StepStart("Resolving app IDs from mint")
+				discovery, discoverErr := discoverer.DiscoverMint(ctx)
+				if discoverErr != nil {
+					if !errors.Is(discoverErr, gcf.ErrFunctionNotFound) {
+						printer.StepFail("Failed to read mint state")
+						return fmt.Errorf("reading mint state: %w", discoverErr)
+					}
+					printer.StepDone("Mint function not found in project — will discover apps from setup")
+				} else {
+					existingIDs = discovery.RoleAppIDs
+					printer.StepDone("Resolved app IDs from mint")
+				}
+			}
+		} else if mintProject != "" {
+			printer.StepStart("Discovering mint infrastructure")
 			discovery, discoverErr := discoverer.DiscoverMint(ctx)
 			if discoverErr != nil {
 				if !errors.Is(discoverErr, gcf.ErrFunctionNotFound) {
-					printer.StepFail("Failed to read mint state")
-					return fmt.Errorf("reading mint state: %w", discoverErr)
+					printer.StepFail("Mint discovery failed")
+					return fmt.Errorf("failed to discover mint in project %s region %s: %w",
+						mintProject, mintRegion, discoverErr)
 				}
-				printer.StepDone("Mint function not found in project — will discover apps from setup")
+				printer.StepDone("No existing mint found — will deploy")
 			} else {
+				mintURL = discovery.URL
+				mintFound = true
 				existingIDs = discovery.RoleAppIDs
-				printer.StepDone("Resolved app IDs from mint")
+				printer.StepDone(fmt.Sprintf("Found mint at %s", mintURL))
 			}
-		}
-	} else if mintProject != "" {
-		printer.StepStart("Discovering mint infrastructure")
-		discovery, discoverErr := discoverer.DiscoverMint(ctx)
-		if discoverErr != nil {
-			if !errors.Is(discoverErr, gcf.ErrFunctionNotFound) {
-				printer.StepFail("Mint discovery failed")
-				return fmt.Errorf("failed to discover mint in project %s region %s: %w",
-					mintProject, mintRegion, discoverErr)
-			}
-			printer.StepDone("No existing mint found — will deploy")
-		} else {
-			mintURL = discovery.URL
-			mintFound = true
-			existingIDs = discovery.RoleAppIDs
-			printer.StepDone(fmt.Sprintf("Found mint at %s", mintURL))
 		}
 	}
 
@@ -636,23 +661,31 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 		}
 		printer.StepInfo("Dry run — no changes will be made")
 		printer.Blank()
-		if !appsFound && !skipAppSetup {
-			printer.StepInfo(fmt.Sprintf("Would create GitHub Apps for roles: %s", strings.Join(roles, ", ")))
-			if publicApps {
-				printer.StepInfo("  Apps would be public (unlisted)")
+		if skipMintCheck {
+			printer.StepInfo("Mint checks skipped (--skip-mint-check):")
+			printer.StepInfo(fmt.Sprintf("  Mint URL (trusted): %s", mintURL))
+			printer.StepInfo("  App setup: skipped")
+			printer.StepInfo("  GCP mint validation: skipped")
+			printer.StepInfo("  PEM storage: skipped")
+		} else {
+			if !appsFound && !skipAppSetup {
+				printer.StepInfo(fmt.Sprintf("Would create GitHub Apps for roles: %s", strings.Join(roles, ", ")))
+				if publicApps {
+					printer.StepInfo("  Apps would be public (unlisted)")
+				}
+				printer.Blank()
 			}
-			printer.Blank()
-		}
-		if !mintFound {
-			printer.StepInfo(fmt.Sprintf("Would deploy token mint to project %s, region %s", mintProject, mintRegion))
-			printer.Blank()
-		}
-		printer.StepInfo("Mint infrastructure:")
-		printer.StepInfo(fmt.Sprintf("  Mint URL: %s", mintDisplay))
-		printer.StepInfo(fmt.Sprintf("  Mint project: %s, region: %s", mintProject, mintRegion))
-		if mintFound {
-			printer.StepInfo(fmt.Sprintf("  Would register %s in ALLOWED_ORGS", owner))
-			printer.StepInfo(fmt.Sprintf("  Would set ROLE_APP_IDS entries for %s/{%s}", owner, strings.Join(roles, ",")))
+			if !mintFound {
+				printer.StepInfo(fmt.Sprintf("Would deploy token mint to project %s, region %s", mintProject, mintRegion))
+				printer.Blank()
+			}
+			printer.StepInfo("Mint infrastructure:")
+			printer.StepInfo(fmt.Sprintf("  Mint URL: %s", mintDisplay))
+			printer.StepInfo(fmt.Sprintf("  Mint project: %s, region: %s", mintProject, mintRegion))
+			if mintFound {
+				printer.StepInfo(fmt.Sprintf("  Would register %s in ALLOWED_ORGS", owner))
+				printer.StepInfo(fmt.Sprintf("  Would set ROLE_APP_IDS entries for %s/{%s}", owner, strings.Join(roles, ",")))
+			}
 		}
 		printer.Blank()
 		if needsWIFProvision {
@@ -690,10 +723,10 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 		return err
 	}
 
-	needAppSetup := !appsFound && !skipAppSetup
-	needMintDeploy := !mintFound
+	needAppSetup := !appsFound && !skipAppSetup && !skipMintCheck
+	needMintDeploy := !mintFound && !skipMintCheck
 
-	if skipAppSetup && !appsFound {
+	if !skipMintCheck && skipAppSetup && !appsFound {
 		if !mintFound {
 			return fmt.Errorf("no mint function found in project %s region %s and --skip-app-setup prevents creating one", mintProject, mintRegion)
 		}
@@ -736,7 +769,9 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 		}
 	}
 
-	if needMintDeploy {
+	if skipMintCheck {
+		printer.StepDone(fmt.Sprintf("Skipping mint provisioning (--skip-mint-check), using %s", mintURL))
+	} else if needMintDeploy {
 		if mintProvider != "gcf" {
 			return fmt.Errorf("--mint-provider must be 'gcf' for mint deployment")
 		}

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -1275,14 +1275,42 @@ func TestInstallCmd_SkipMintCheckAcceptsNonCloudRunURL(t *testing.T) {
 }
 
 func TestInstallCmd_SkipMintCheckSkipsMintProject(t *testing.T) {
+	// Without --skip-mint-check and without --mint-project/--mint-url, an error is returned.
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"admin", "install", "acme/widget",
+	cmd.SetArgs([]string{"admin", "install", "acme/widget"})
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	// With --skip-mint-check, --mint-project is not required.
+	cmd2 := newRootCmd()
+	cmd2.SetArgs([]string{"admin", "install", "acme/widget",
 		"--skip-mint-check",
 		"--mint-url", "https://mint.example.com/v1/token",
 		"--inference-project", "my-project",
 		"--dry-run"})
+	err2 := cmd2.Execute()
+	require.NoError(t, err2)
+}
+
+func TestInstallCmd_SkipMintCheckRejectsPerOrg(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"admin", "install", "acme",
+		"--skip-mint-check",
+		"--mint-url", "https://mint.example.com/v1/token"})
 	err := cmd.Execute()
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--skip-mint-check is only valid for per-repo")
+}
+
+func TestInstallCmd_SkipMintCheckRejectsUserinfo(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"admin", "install", "acme/widget",
+		"--skip-mint-check",
+		"--mint-url", "https://user:pass@mint.example.com/v1/token",
+		"--inference-project", "my-project"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not contain embedded credentials")
 }
 
 func TestInstallCmd_SkipMintCheckRejectsHTTP(t *testing.T) {

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -1254,3 +1254,44 @@ func TestResolveSharedRoleAppIDs_SameOrgUsesOwnEntry(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "100", result["acme-corp/coder"])
 }
+
+func TestInstallCmd_SkipMintCheckRequiresMintURL(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"admin", "install", "acme/widget", "--skip-mint-check", "--inference-project", "my-project"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--mint-url is required when using --skip-mint-check")
+}
+
+func TestInstallCmd_SkipMintCheckAcceptsNonCloudRunURL(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"admin", "install", "acme/widget",
+		"--skip-mint-check",
+		"--mint-url", "https://mint.example.com/v1/token",
+		"--inference-project", "my-project",
+		"--dry-run"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestInstallCmd_SkipMintCheckSkipsMintProject(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"admin", "install", "acme/widget",
+		"--skip-mint-check",
+		"--mint-url", "https://mint.example.com/v1/token",
+		"--inference-project", "my-project",
+		"--dry-run"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestInstallCmd_SkipMintCheckRejectsHTTP(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"admin", "install", "acme/widget",
+		"--skip-mint-check",
+		"--mint-url", "http://mint.example.com",
+		"--inference-project", "my-project"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--mint-url must be a valid HTTPS URL")
+}

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -1292,14 +1292,13 @@ func TestInstallCmd_SkipMintCheckSkipsMintProject(t *testing.T) {
 	require.NoError(t, err2)
 }
 
-func TestInstallCmd_SkipMintCheckRejectsPerOrg(t *testing.T) {
+func TestInstallCmd_SkipMintCheckPerOrgRequiresMintURL(t *testing.T) {
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"admin", "install", "acme",
-		"--skip-mint-check",
-		"--mint-url", "https://mint.example.com/v1/token"})
+		"--skip-mint-check"})
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--skip-mint-check is only valid for per-repo")
+	assert.Contains(t, err.Error(), "--mint-url is required when using --skip-mint-check")
 }
 
 func TestInstallCmd_SkipMintCheckRejectsUserinfo(t *testing.T) {

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -103,6 +103,13 @@ func TestInstallCmd_Flags(t *testing.T) {
 	// --scaffold-customized removed (customized dirs always included)
 	scaffoldCustomizedFlag := cmd.Flags().Lookup("scaffold-customized")
 	assert.Nil(t, scaffoldCustomizedFlag, "--scaffold-customized flag should have been removed")
+
+	skipMintCheckFlag := cmd.Flags().Lookup("skip-mint-check")
+	require.NotNil(t, skipMintCheckFlag, "expected --skip-mint-check flag")
+	assert.Equal(t, "false", skipMintCheckFlag.DefValue)
+
+	skipMintDeployFlag := cmd.Flags().Lookup("skip-mint-deploy")
+	require.NotNil(t, skipMintDeployFlag, "expected --skip-mint-deploy flag")
 }
 
 func TestInstallCmd_PerRepoRequiresMintProject(t *testing.T) {
@@ -1321,4 +1328,48 @@ func TestInstallCmd_SkipMintCheckRejectsHTTP(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--mint-url must be a valid HTTPS URL")
+}
+
+func TestSkipMintDispatcher(t *testing.T) {
+	d := &skipMintDispatcher{mintURL: "https://mint.example.com/v1/token"}
+	assert.Equal(t, "skip-mint-check", d.Name())
+	assert.Nil(t, d.OrgSecretNames())
+	assert.Equal(t, []string{"FULLSEND_MINT_URL"}, d.OrgVariableNames())
+	assert.NoError(t, d.StoreAgentPEM(context.Background(), "org", "role", []byte("pem")))
+	vars, err := d.Provision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"FULLSEND_MINT_URL": "https://mint.example.com/v1/token"}, vars)
+}
+
+func TestValidateMintURLHTTPS(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{"valid URL", "https://mint.example.com/v1/token", ""},
+		{"valid with port", "https://mint.example.com:8443/v1", ""},
+		{"http rejected", "http://mint.example.com", "HTTPS URL"},
+		{"empty string", "", "HTTPS URL"},
+		{"no host", "https://", "HTTPS URL"},
+		{"userinfo", "https://user:pass@host.com", "embedded credentials"},
+		{"username only", "https://user@host.com", "embedded credentials"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateMintURLHTTPS(tc.input)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateSkipMintCheck(t *testing.T) {
+	require.Error(t, validateSkipMintCheck(""))
+	require.Error(t, validateSkipMintCheck("http://example.com"))
+	require.NoError(t, validateSkipMintCheck("https://mint.example.com/v1/token"))
 }


### PR DESCRIPTION
## Summary

- Adds `--skip-mint-check` CLI flag to `fullsend admin install` that allows users to point at a self-provisioned mint service without requiring GCP IAM access to the mint project
- When set, relaxes mint URL validation to any HTTPS URL, skips all GCP discovery/provisioning (Secret Manager, Cloud Functions, WIF), and skips GitHub App creation
- `--mint-project` becomes optional; `FULLSEND_MINT_URL` repo variable is still set for runtime workflows

Resolves #983

## Test plan

- [x] `TestInstallCmd_SkipMintCheckRequiresMintURL` — errors when `--skip-mint-check` without `--mint-url`
- [x] `TestInstallCmd_SkipMintCheckAcceptsNonCloudRunURL` — accepts arbitrary HTTPS URL with `--dry-run`
- [x] `TestInstallCmd_SkipMintCheckSkipsMintProject` — no `--mint-project` required
- [x] `TestInstallCmd_SkipMintCheckRejectsHTTP` — still rejects non-HTTPS URLs
- [x] All existing CLI tests pass (`go test ./internal/cli/...`)
- [x] `go vet ./...` clean
- [x] `make lint` clean