### PR TITLE
feat: parameterize app set prefix for GitHub App selection

### DIFF
--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -86,7 +86,19 @@ fullsend admin install "$FIRST_ORG" \
 
 The `--public` flag creates GitHub Apps as public unlisted — they won't appear in the marketplace but can be installed by other organizations via their installation URL.
 
-**Additional orgs (reuse existing mint):**
+When the first org uses a custom app set prefix, pass `--app-set` so the apps are named accordingly:
+
+```bash
+fullsend admin install "$FIRST_ORG" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-project "$GCP_PROJECT" \
+  --public \
+  --app-set "$FIRST_ORG"
+```
+
+This creates public apps named `{first-org}-fullsend`, `{first-org}-coder`, etc.
+
+**Additional orgs (install existing public apps):**
 
 ```bash
 fullsend admin install "$ADDITIONAL_ORG" \
@@ -94,7 +106,18 @@ fullsend admin install "$ADDITIONAL_ORG" \
   --mint-project "$GCP_PROJECT"
 ```
 
-The installer auto-detects the existing mint function and skips code redeployment. WIF infrastructure is always updated (adding the new org to the WIF provider's attribute condition and granting Vertex AI IAM access), and the new org is registered in the mint's env vars. You can also pass `--mint-url "$MINT_URL"` explicitly to skip the auto-discovery step. PEMs use org-scoped naming (`fullsend-{org}--{role}-app-pem`), so each org's secrets are stored independently. For public apps (shared across orgs), the provisioner stores the same PEM under each org's scoped key.
+The installer auto-detects shared public apps by matching installed app IDs against the mint's `ROLE_APP_IDS`. It copies PEM secrets from the source org to the new org's scoped key and records the actual app slug in `config.yaml`, so subsequent operations find the correct app regardless of naming convention.
+
+If the public apps were created with a custom `--app-set`, pass the same value so the CLI uses the correct slug prefix for convention-based lookups:
+
+```bash
+fullsend admin install "$ADDITIONAL_ORG" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-project "$GCP_PROJECT" \
+  --app-set "$FIRST_ORG"
+```
+
+You can also pass `--mint-url "$MINT_URL"` explicitly to skip the auto-discovery step. PEMs use org-scoped naming (`fullsend-{org}--{role}-app-pem`), so each org's secrets are stored independently. For public apps (shared across orgs), the provisioner copies the same PEM under each org's scoped key.
 
 > **Note:** Multi-org with `--public` requires all orgs to share the same GitHub Apps. Private apps (the default) are single-org only.
 
@@ -211,7 +234,7 @@ Per-repo accepts all flags except `--vendor-fullsend-binary`, `--enroll-all`, an
 
 By default, the installer creates GitHub Apps with the `fullsend` prefix (e.g., `fullsend-fullsend`, `fullsend-coder`, `fullsend-review`). Organizations that need their own set of apps — for example, to use org-specific permissions or to register multiple app sets on the same mint — can pass `--app-set` to override the prefix.
 
-**Install with a custom app set:**
+### Creating a custom app set
 
 ```bash
 fullsend admin install "$ORG_NAME" \
@@ -222,7 +245,20 @@ fullsend admin install "$ORG_NAME" \
 
 This creates apps named `{org}-fullsend`, `{org}-coder`, `{org}-review`, etc. The app set prefix is stored in the `.fullsend/config.yaml` slug mappings, so subsequent operations (permission checks, PEM recovery) find the correct apps automatically.
 
-**Uninstall with a custom app set:**
+### Using existing public apps from another app set
+
+When a mint already has public apps registered under a custom app set (e.g., `konflux-ci-fullsend`, `konflux-ci-coder`), additional orgs installing those apps must pass the same `--app-set` so the CLI resolves the correct slugs:
+
+```bash
+fullsend admin install "$NEW_ORG" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-project "$GCP_PROJECT" \
+  --app-set konflux-ci
+```
+
+The installer detects that the public apps are already installed in the org (matched by app ID from the mint's `ROLE_APP_IDS`), copies PEM secrets to the new org's scoped key, and skips app creation. The `--app-set` value ensures convention-based slug lookups match the existing apps.
+
+### Uninstalling a custom app set
 
 When uninstalling an org that used a custom app set, pass the same `--app-set` value so the CLI generates the correct fallback slugs if the config repo is unavailable:
 
@@ -230,7 +266,8 @@ When uninstalling an org that used a custom app set, pass the same `--app-set` v
 fullsend admin uninstall "$ORG_NAME" --app-set "$ORG_NAME"
 ```
 
-**Constraints:**
+### Constraints
+
 - App set names must be lowercase alphanumeric with optional hyphens (no leading/trailing hyphens, no consecutive hyphens), max 39 characters
 - The app set prefix only affects GitHub App slugs — GCP secret naming (`fullsend-{org}--{role}-app-pem`) and mint `ROLE_APP_IDS` keys (`{org}/{role}`) are independent of the app set
 

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -268,7 +268,7 @@ fullsend admin uninstall "$ORG_NAME" --app-set "$ORG_NAME"
 
 ### Constraints
 
-- App set names must be lowercase alphanumeric with optional hyphens (no leading/trailing hyphens, no consecutive hyphens), max 39 characters
+- App set names must be lowercase alphanumeric with optional hyphens (no leading/trailing hyphens, no consecutive hyphens), max 23 characters (GitHub App names are limited to 34 characters, and the role suffix is appended)
 - The app set prefix only affects GitHub App slugs — GCP secret naming (`fullsend-{org}--{role}-app-pem`) and mint `ROLE_APP_IDS` keys (`{org}/{role}`) are independent of the app set
 
 ---

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -63,6 +63,7 @@ Additional mint flags:
 | `--mint-region` | `us-central1` | Cloud region for the token mint function |
 | `--mint-url` | | Use an existing mint at this URL instead of deploying one |
 | `--public` | `false` | Create public unlisted GitHub Apps (for multi-org) |
+| `--app-set` | `fullsend` | App set name prefix for GitHub Apps (see [Custom app sets](#custom-app-sets)) |
 | `--skip-app-setup` | `false` | Skip GitHub App creation (reuse existing apps) |
 | `--skip-mint-deploy` | `false` | Skip Cloud Function deployment, reuse existing mint URL |
 
@@ -203,6 +204,35 @@ fullsend admin install "$ORG_NAME/$REPO_NAME" \
 Per-repo accepts all flags except `--vendor-fullsend-binary`, `--enroll-all`, and `--enroll-none` (which only apply to org-wide enrollment).
 
 > **`--mint-region` note:** Per-repo uses the same `--mint-region` default (`us-central1`) as per-org. When reusing a mint deployed to a non-default region, pass `--mint-region` explicitly so auto-discovery finds the correct function.
+
+---
+
+## Custom app sets
+
+By default, the installer creates GitHub Apps with the `fullsend` prefix (e.g., `fullsend-fullsend`, `fullsend-coder`, `fullsend-review`). Organizations that need their own set of apps — for example, to use org-specific permissions or to register multiple app sets on the same mint — can pass `--app-set` to override the prefix.
+
+**Install with a custom app set:**
+
+```bash
+fullsend admin install "$ORG_NAME" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-project "$GCP_PROJECT" \
+  --app-set "$ORG_NAME"
+```
+
+This creates apps named `{org}-fullsend`, `{org}-coder`, `{org}-review`, etc. The app set prefix is stored in the `.fullsend/config.yaml` slug mappings, so subsequent operations (permission checks, PEM recovery) find the correct apps automatically.
+
+**Uninstall with a custom app set:**
+
+When uninstalling an org that used a custom app set, pass the same `--app-set` value so the CLI generates the correct fallback slugs if the config repo is unavailable:
+
+```bash
+fullsend admin uninstall "$ORG_NAME" --app-set "$ORG_NAME"
+```
+
+**Constraints:**
+- App set names must be lowercase alphanumeric with optional hyphens (no leading/trailing hyphens, no consecutive hyphens), max 39 characters
+- The app set prefix only affects GitHub App slugs — GCP secret naming (`fullsend-{org}--{role}-app-pem`) and mint `ROLE_APP_IDS` keys (`{org}/{role}`) are independent of the app set
 
 ---
 

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -247,13 +247,13 @@ This creates apps named `{org}-fullsend`, `{org}-coder`, `{org}-review`, etc. Th
 
 ### Using existing public apps from another app set
 
-When a mint already has public apps registered under a custom app set (e.g., `konflux-ci-fullsend`, `konflux-ci-coder`), additional orgs installing those apps must pass the same `--app-set` so the CLI resolves the correct slugs:
+When a mint already has public apps registered under a custom app set (e.g., `fullsend-ai-fullsend`, `fullsend-ai-coder`), additional orgs installing those apps must pass the same `--app-set` so the CLI resolves the correct slugs:
 
 ```bash
 fullsend admin install "$NEW_ORG" \
   --inference-project "$GCP_PROJECT" \
   --mint-project "$GCP_PROJECT" \
-  --app-set konflux-ci
+  --app-set fullsend-ai
 ```
 
 The installer detects that the public apps are already installed in the org (matched by app ID from the mint's `ROLE_APP_IDS`), copies PEM secrets to the new org's scoped key, and skips app creation. The `--app-set` value ensures convention-based slug lookups match the existing apps.

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -233,7 +233,7 @@ func runFullInstall(t *testing.T, env *e2eEnv) ([]layers.AgentCredentials, *conf
 
 			t.Logf("Attempt %d/%d for role %s failed: %v", attempt, maxAttempts, role, runErr)
 			if attempt < maxAttempts {
-				slug := appsetup.AppSlug(role)
+				slug := appsetup.AppSlug(appsetup.DefaultAppSet, role)
 				t.Logf("Cleaning up potentially stale app %s before retry", slug)
 				if delErr := deleteAppViaPlaywright(env.page, slug, t.Logf, env.screenshotDir); delErr != nil {
 					t.Logf("Warning: cleanup of %s failed (may not exist): %v", slug, delErr)

--- a/e2e/admin/cleanup.go
+++ b/e2e/admin/cleanup.go
@@ -52,7 +52,7 @@ func cleanupStaleResources(ctx context.Context, client forge.Client, page playwr
 			t.Logf("[cleanup] App %s not found or could not delete: %v", slug, delErr)
 		}
 
-		newSlug := appsetup.AppSlug(appsetup.DefaultAppSet, role) // current convention: fullsend-ai-triage, etc.
+		newSlug := appsetup.AppSlug(appsetup.DefaultAppSet, role) // current convention: fullsend-triage, etc.
 		if newSlug != slug {
 			t.Logf("[cleanup] Attempting to delete app %s (if it exists)", newSlug)
 			if delErr := deleteAppViaPlaywright(page, newSlug, t.Logf, screenshotDir); delErr != nil {
@@ -77,7 +77,7 @@ func cleanupStaleResources(ctx context.Context, client forge.Client, page playwr
 		for _, inst := range installations {
 			// Safe: testOrg is a dedicated E2E org with no production apps.
 			isStale := strings.HasPrefix(inst.AppSlug, testOrg+"-") || // v6: halfsend-*
-				strings.HasPrefix(inst.AppSlug, appsetup.DefaultAppSet+"-") || // current: fullsend-ai-*
+				strings.HasPrefix(inst.AppSlug, appsetup.DefaultAppSet+"-") || // current: fullsend-*
 				strings.HasPrefix(inst.AppSlug, "fullsend-") // legacy: fullsend-triage, fullsend-halfsend-*, etc.
 			if isStale {
 				t.Logf("[cleanup] Deleting stale installed app: %s", inst.AppSlug)

--- a/e2e/admin/cleanup.go
+++ b/e2e/admin/cleanup.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/playwright-community/playwright-go"
 
+	"github.com/fullsend-ai/fullsend/internal/appsetup"
 	"github.com/fullsend-ai/fullsend/internal/forge"
 )
 
@@ -51,11 +52,19 @@ func cleanupStaleResources(ctx context.Context, client forge.Client, page playwr
 			t.Logf("[cleanup] App %s not found or could not delete: %v", slug, delErr)
 		}
 
-		newSlug := "fullsend-" + role // OIDC convention: fullsend-triage, etc.
+		newSlug := appsetup.AppSlug(appsetup.DefaultAppSet, role) // current convention: fullsend-ai-triage, etc.
 		if newSlug != slug {
 			t.Logf("[cleanup] Attempting to delete app %s (if it exists)", newSlug)
 			if delErr := deleteAppViaPlaywright(page, newSlug, t.Logf, screenshotDir); delErr != nil {
 				t.Logf("[cleanup] App %s not found or could not delete: %v", newSlug, delErr)
+			}
+		}
+
+		legacySlug := "fullsend-" + role // legacy convention: fullsend-triage, etc.
+		if legacySlug != slug && legacySlug != newSlug {
+			t.Logf("[cleanup] Attempting to delete app %s (if it exists)", legacySlug)
+			if delErr := deleteAppViaPlaywright(page, legacySlug, t.Logf, screenshotDir); delErr != nil {
+				t.Logf("[cleanup] App %s not found or could not delete: %v", legacySlug, delErr)
 			}
 		}
 	}
@@ -68,7 +77,8 @@ func cleanupStaleResources(ctx context.Context, client forge.Client, page playwr
 		for _, inst := range installations {
 			// Safe: testOrg is a dedicated E2E org with no production apps.
 			isStale := strings.HasPrefix(inst.AppSlug, testOrg+"-") || // v6: halfsend-*
-				strings.HasPrefix(inst.AppSlug, "fullsend-") // OIDC + old: fullsend-triage, fullsend-halfsend-*, etc.
+				strings.HasPrefix(inst.AppSlug, appsetup.DefaultAppSet+"-") || // current: fullsend-ai-*
+				strings.HasPrefix(inst.AppSlug, "fullsend-") // legacy: fullsend-triage, fullsend-halfsend-*, etc.
 			if isStale {
 				t.Logf("[cleanup] Deleting stale installed app: %s", inst.AppSlug)
 				if delErr := deleteAppViaPlaywright(page, inst.AppSlug, t.Logf, screenshotDir); delErr != nil {

--- a/internal/appsetup/appsetup.go
+++ b/internal/appsetup/appsetup.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -169,8 +170,26 @@ func (s *Setup) WithPublicApps(public bool) *Setup {
 	return s
 }
 
+// validAppSet matches lowercase alphanumeric strings with optional hyphens,
+// not starting or ending with a hyphen.
+var validAppSet = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// ValidateAppSet checks that an app set prefix is non-empty and contains only
+// lowercase alphanumeric characters and hyphens (no leading/trailing hyphens).
+func ValidateAppSet(appSet string) error {
+	if appSet == "" {
+		return fmt.Errorf("app set prefix must not be empty")
+	}
+	if !validAppSet.MatchString(appSet) {
+		return fmt.Errorf("app set prefix %q must contain only lowercase alphanumeric characters and hyphens", appSet)
+	}
+	return nil
+}
+
 // WithAppSet sets the app set prefix for GitHub App naming.
 // Apps are named "{appSet}-{role}" (e.g., "fullsend-ai-coder").
+// The appSet must be non-empty and contain only lowercase alphanumeric
+// characters and hyphens.
 func (s *Setup) WithAppSet(appSet string) *Setup {
 	s.appSet = appSet
 	return s

--- a/internal/appsetup/appsetup.go
+++ b/internal/appsetup/appsetup.go
@@ -127,6 +127,7 @@ type Setup struct {
 	storeSecret  StoreSecretFunc
 	permErrors   []string
 	publicApps   bool
+	appSet       string
 }
 
 // NewSetup creates a new Setup instance.
@@ -136,6 +137,7 @@ func NewSetup(client forge.Client, prompter Prompter, browser BrowserOpener, pri
 		prompter: prompter,
 		browser:  browser,
 		ui:       printer,
+		appSet:   DefaultAppSet,
 	}
 }
 
@@ -167,6 +169,13 @@ func (s *Setup) WithPublicApps(public bool) *Setup {
 	return s
 }
 
+// WithAppSet sets the app set prefix for GitHub App naming.
+// Apps are named "{appSet}-{role}" (e.g., "fullsend-ai-coder").
+func (s *Setup) WithAppSet(appSet string) *Setup {
+	s.appSet = appSet
+	return s
+}
+
 // Run creates or reuses a GitHub App for the given org and role.
 //
 // The flow:
@@ -178,7 +187,7 @@ func (s *Setup) WithPublicApps(public bool) *Setup {
 //  5. If not found, run the manifest flow to create a new app.
 //  6. After creation, store the PEM immediately, then install on the org.
 func (s *Setup) Run(ctx context.Context, org, role string) (*AppCredentials, error) {
-	slug := AppSlug(role)
+	slug := AppSlug(s.appSet, role)
 	s.ui.StepStart(fmt.Sprintf("Checking for existing app: %s", slug))
 
 	inst, found, err := s.findExistingInstallation(ctx, org, role, slug)
@@ -489,7 +498,7 @@ func (s *Setup) checkPermissions(inst *forge.Installation, org, role string) {
 		s.ui.StepWarn(fmt.Sprintf("app %s: permissions not available, skipping check", inst.AppSlug))
 		return
 	}
-	expected := ghTypes.AgentAppConfig(org, role).Permissions
+	expected := ghTypes.AgentAppConfig(org, role, s.appSet).Permissions
 	data, _ := json.Marshal(expected)
 	var want map[string]string
 	_ = json.Unmarshal(data, &want)
@@ -544,7 +553,7 @@ func (s *Setup) runManifestFlow(ctx context.Context, org, role string) (*AppCred
 
 	// Build the manifest with redirect_url included — GitHub requires it
 	// inside the JSON manifest, not as a separate form field.
-	appCfg := ghTypes.AgentAppConfig(org, role)
+	appCfg := ghTypes.AgentAppConfig(org, role, s.appSet)
 	appCfg.RedirectURL = callbackURL
 	appCfg.Public = s.publicApps
 	manifest, err := json.Marshal(appCfg)
@@ -750,7 +759,13 @@ func (s *Setup) ensureInstalled(ctx context.Context, org, slug string) error {
 	}
 }
 
-// AppSlug returns the conventional app slug for a given role.
-func AppSlug(role string) string {
-	return "fullsend-" + role
+// DefaultAppSet is the default app set prefix for GitHub Apps.
+// A SaaS multi-org deployment uses this prefix so that the same set of
+// public apps (e.g., fullsend-ai-fullsend, fullsend-ai-coder) can be
+// installed across multiple organizations.
+const DefaultAppSet = "fullsend-ai"
+
+// AppSlug returns the conventional app slug for a given app set and role.
+func AppSlug(appSet, role string) string {
+	return appSet + "-" + role
 }

--- a/internal/appsetup/appsetup.go
+++ b/internal/appsetup/appsetup.go
@@ -781,10 +781,9 @@ func (s *Setup) ensureInstalled(ctx context.Context, org, slug string) error {
 }
 
 // DefaultAppSet is the default app set prefix for GitHub Apps.
-// A SaaS multi-org deployment uses this prefix so that the same set of
-// public apps (e.g., fullsend-ai-fullsend, fullsend-ai-coder) can be
-// installed across multiple organizations.
-const DefaultAppSet = "fullsend-ai"
+// Orgs that created apps under a different prefix (e.g., "konflux-ci")
+// pass --app-set explicitly.
+const DefaultAppSet = "fullsend"
 
 // AppSlug returns the conventional app slug for a given app set and role.
 func AppSlug(appSet, role string) string {

--- a/internal/appsetup/appsetup.go
+++ b/internal/appsetup/appsetup.go
@@ -170,18 +170,20 @@ func (s *Setup) WithPublicApps(public bool) *Setup {
 	return s
 }
 
-// validAppSet matches lowercase alphanumeric strings with optional hyphens,
-// not starting or ending with a hyphen.
-var validAppSet = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+// appSetPattern validates app set slugs: lowercase alphanumeric with hyphens,
+// must start with a letter or digit, no leading/trailing/consecutive hyphens.
+var appSetPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
-// ValidateAppSet checks that an app set prefix is non-empty and contains only
-// lowercase alphanumeric characters and hyphens (no leading/trailing hyphens).
+// ValidateAppSet checks that an app set slug is well-formed.
 func ValidateAppSet(appSet string) error {
 	if appSet == "" {
-		return fmt.Errorf("app set prefix must not be empty")
+		return fmt.Errorf("app set must not be empty")
 	}
-	if !validAppSet.MatchString(appSet) {
-		return fmt.Errorf("app set prefix %q must contain only lowercase alphanumeric characters and hyphens", appSet)
+	if len(appSet) > 39 {
+		return fmt.Errorf("app set %q exceeds max length of 39 characters", appSet)
+	}
+	if !appSetPattern.MatchString(appSet) {
+		return fmt.Errorf("app set %q must be lowercase alphanumeric with hyphens (e.g., fullsend-ai)", appSet)
 	}
 	return nil
 }

--- a/internal/appsetup/appsetup.go
+++ b/internal/appsetup/appsetup.go
@@ -781,7 +781,7 @@ func (s *Setup) ensureInstalled(ctx context.Context, org, slug string) error {
 }
 
 // DefaultAppSet is the default app set prefix for GitHub Apps.
-// Orgs that created apps under a different prefix (e.g., "konflux-ci")
+// Orgs that created apps under a different prefix (e.g., "fullsend-ai")
 // pass --app-set explicitly.
 const DefaultAppSet = "fullsend"
 

--- a/internal/appsetup/appsetup.go
+++ b/internal/appsetup/appsetup.go
@@ -175,12 +175,15 @@ func (s *Setup) WithPublicApps(public bool) *Setup {
 var appSetPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
 // ValidateAppSet checks that an app set slug is well-formed.
+// The max length is 23 characters because the final GitHub App name is
+// "{appSet}-{role}" and GitHub limits app names to 34 characters.
+// The longest built-in role is "prioritize" (10 chars), so: 23 + 1 + 10 = 34.
 func ValidateAppSet(appSet string) error {
 	if appSet == "" {
 		return fmt.Errorf("app set must not be empty")
 	}
-	if len(appSet) > 39 {
-		return fmt.Errorf("app set %q exceeds max length of 39 characters", appSet)
+	if len(appSet) > 23 {
+		return fmt.Errorf("app set %q exceeds max length of 23 characters (GitHub App names are limited to 34 characters, and the role suffix is appended)", appSet)
 	}
 	if !appSetPattern.MatchString(appSet) {
 		return fmt.Errorf("app set %q must be lowercase alphanumeric with hyphens (e.g., fullsend-ai)", appSet)
@@ -190,8 +193,7 @@ func ValidateAppSet(appSet string) error {
 
 // WithAppSet sets the app set prefix for GitHub App naming.
 // Apps are named "{appSet}-{role}" (e.g., "fullsend-ai-coder").
-// The appSet must be non-empty and contain only lowercase alphanumeric
-// characters and hyphens.
+// Callers must validate appSet via ValidateAppSet before calling this method.
 func (s *Setup) WithAppSet(appSet string) *Setup {
 	s.appSet = appSet
 	return s

--- a/internal/appsetup/appsetup_test.go
+++ b/internal/appsetup/appsetup_test.go
@@ -73,15 +73,37 @@ func TestAppSlug(t *testing.T) {
 }
 
 func TestValidateAppSet(t *testing.T) {
-	assert.NoError(t, ValidateAppSet("fullsend-ai"))
-	assert.NoError(t, ValidateAppSet("custom"))
-	assert.NoError(t, ValidateAppSet("my-org-apps"))
-	assert.Error(t, ValidateAppSet(""))
-	assert.Error(t, ValidateAppSet("-leading"))
-	assert.Error(t, ValidateAppSet("trailing-"))
-	assert.Error(t, ValidateAppSet("has spaces"))
-	assert.Error(t, ValidateAppSet("UPPERCASE"))
-	assert.Error(t, ValidateAppSet("special!chars"))
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid simple", "fullsend", false},
+		{"valid with hyphen", "fullsend-ai", false},
+		{"valid multi hyphen", "my-custom-app", false},
+		{"valid numeric", "app2", false},
+		{"valid starts with number", "42apps", false},
+		{"empty", "", true},
+		{"uppercase", "FullSend", true},
+		{"leading hyphen", "-fullsend", true},
+		{"trailing hyphen", "fullsend-", true},
+		{"consecutive hyphens", "full--send", true},
+		{"underscore", "full_send", true},
+		{"space", "full send", true},
+		{"special chars", "special!chars", true},
+		{"too long", "a23456789012345678901234567890123456789x", true},
+		{"max length ok", "a2345678901234567890123456789012345678x", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAppSet(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestSetup_NonDefaultAppSet_FlowsThrough(t *testing.T) {
@@ -539,6 +561,26 @@ func TestSetup_CorrectPermissions_NoError(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NoError(t, setup.PermissionErrors())
+}
+
+func TestSetup_DefaultAppSet(t *testing.T) {
+	client := &forge.FakeClient{
+		Installations: []forge.Installation{
+			{ID: 100, AppID: 10, AppSlug: "fullsend-ai-coder"},
+		},
+		AppClientIDs: map[string]string{
+			"fullsend-ai-coder": "Iv1.default123",
+		},
+	}
+	printer := ui.New(&discardWriter{})
+
+	s := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer).
+		WithSecretExists(func(_ string) (bool, error) { return true, nil })
+
+	creds, err := s.Run(context.Background(), "myorg", "coder")
+	require.NoError(t, err)
+	assert.Equal(t, "fullsend-ai-coder", creds.Slug)
+	assert.Equal(t, "Iv1.default123", creds.ClientID)
 }
 
 // --- PEM recovery tests ---

--- a/internal/appsetup/appsetup_test.go
+++ b/internal/appsetup/appsetup_test.go
@@ -91,8 +91,8 @@ func TestValidateAppSet(t *testing.T) {
 		{"underscore", "full_send", true},
 		{"space", "full send", true},
 		{"special chars", "special!chars", true},
-		{"too long", "a23456789012345678901234567890123456789x", true},
-		{"max length ok", "a2345678901234567890123456789012345678x", false},
+		{"too long", "a2345678901234567890123x", true},
+		{"max length ok", "a234567890123456789012x", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/appsetup/appsetup_test.go
+++ b/internal/appsetup/appsetup_test.go
@@ -567,10 +567,10 @@ func TestSetup_CorrectPermissions_NoError(t *testing.T) {
 func TestSetup_DefaultAppSet(t *testing.T) {
 	client := &forge.FakeClient{
 		Installations: []forge.Installation{
-			{ID: 100, AppID: 10, AppSlug: "fullsend-ai-coder"},
+			{ID: 100, AppID: 10, AppSlug: "fullsend-coder"},
 		},
 		AppClientIDs: map[string]string{
-			"fullsend-ai-coder": "Iv1.default123",
+			"fullsend-coder": "Iv1.default123",
 		},
 	}
 	printer := ui.New(&discardWriter{})
@@ -580,7 +580,7 @@ func TestSetup_DefaultAppSet(t *testing.T) {
 
 	creds, err := s.Run(context.Background(), "myorg", "coder")
 	require.NoError(t, err)
-	assert.Equal(t, "fullsend-ai-coder", creds.Slug)
+	assert.Equal(t, "fullsend-coder", creds.Slug)
 	assert.Equal(t, "Iv1.default123", creds.ClientID)
 }
 

--- a/internal/appsetup/appsetup_test.go
+++ b/internal/appsetup/appsetup_test.go
@@ -540,6 +540,7 @@ func TestSetup_CorrectPermissions_NoError(t *testing.T) {
 				Permissions: map[string]string{
 					"actions":               "write",
 					"contents":              "write",
+					"variables":             "read",
 					"workflows":             "write",
 					"issues":                "read",
 					"pull_requests":         "write",

--- a/internal/appsetup/appsetup_test.go
+++ b/internal/appsetup/appsetup_test.go
@@ -66,10 +66,10 @@ func (f *fakeBrowser) Open(_ context.Context, url string) error {
 // --- tests ---
 
 func TestAppSlug(t *testing.T) {
-	assert.Equal(t, "fullsend-fullsend", AppSlug("fullsend"))
-	assert.Equal(t, "fullsend-triage", AppSlug("triage"))
-	assert.Equal(t, "fullsend-coder", AppSlug("coder"))
-	assert.Equal(t, "fullsend-review", AppSlug("review"))
+	assert.Equal(t, "fullsend-ai-fullsend", AppSlug("fullsend-ai", "fullsend"))
+	assert.Equal(t, "fullsend-ai-triage", AppSlug("fullsend-ai", "triage"))
+	assert.Equal(t, "custom-coder", AppSlug("custom", "coder"))
+	assert.Equal(t, "fullsend-review", AppSlug("fullsend", "review"))
 }
 
 func TestSetup_ExistingApp_SecretExists_AutoReuse(t *testing.T) {
@@ -86,6 +86,7 @@ func TestSetup_ExistingApp_SecretExists_AutoReuse(t *testing.T) {
 	printer := ui.New(&discardWriter{})
 
 	s := NewSetup(client, prompter, browser, printer).
+		WithAppSet("fullsend").
 		WithSecretExists(func(_ string) (bool, error) {
 			return true, nil
 		})
@@ -115,6 +116,7 @@ func TestSetup_ExistingApp_Reuse_StoreSecretNotCalled(t *testing.T) {
 
 	storeCalled := false
 	s := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer).
+		WithAppSet("fullsend").
 		WithSecretExists(func(_ string) (bool, error) { return true, nil }).
 		WithStoreSecret(func(_ context.Context, _, _ string) error {
 			storeCalled = true
@@ -136,6 +138,7 @@ func TestSetup_RecoverCreatedApp_PEMExists(t *testing.T) {
 	printer := ui.New(&discardWriter{})
 
 	s := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer).
+		WithAppSet("fullsend").
 		WithSecretExists(func(_ string) (bool, error) { return true, nil })
 
 	creds, err := s.recoverCreatedApp(context.Background(), "myorg", "coder", "fullsend-coder")
@@ -155,6 +158,7 @@ func TestSetup_RecoverCreatedApp_KnownSlug(t *testing.T) {
 	printer := ui.New(&discardWriter{})
 
 	s := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer).
+		WithAppSet("fullsend").
 		WithKnownSlugs(map[string]string{"coder": "custom-coder-app"}).
 		WithSecretExists(func(_ string) (bool, error) { return true, nil })
 
@@ -170,6 +174,7 @@ func TestSetup_RecoverCreatedApp_NoPEM(t *testing.T) {
 	printer := ui.New(&discardWriter{})
 
 	s := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer).
+		WithAppSet("fullsend").
 		WithSecretExists(func(_ string) (bool, error) { return false, nil })
 
 	creds, err := s.recoverCreatedApp(context.Background(), "myorg", "coder", "fullsend-coder")
@@ -181,7 +186,8 @@ func TestSetup_RecoverCreatedApp_NoSecretExistsFunc(t *testing.T) {
 	client := &forge.FakeClient{}
 	printer := ui.New(&discardWriter{})
 
-	s := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer)
+	s := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer).
+		WithAppSet("fullsend")
 
 	creds, err := s.recoverCreatedApp(context.Background(), "myorg", "coder", "fullsend-coder")
 	require.NoError(t, err)
@@ -202,6 +208,7 @@ func TestSetup_ExistingApp_NoSecret(t *testing.T) {
 	printer := ui.New(&discardWriter{})
 
 	s := NewSetup(client, prompter, browser, printer).
+		WithAppSet("fullsend").
 		WithSecretExists(func(_ string) (bool, error) {
 			return false, nil
 		})
@@ -223,6 +230,7 @@ func TestSetup_ExistingApp_ClientIDLookupFails(t *testing.T) {
 	printer := ui.New(&discardWriter{})
 
 	s := NewSetup(client, prompter, browser, printer).
+		WithAppSet("fullsend").
 		WithSecretExists(func(_ string) (bool, error) {
 			return true, nil
 		})
@@ -246,6 +254,7 @@ func TestSetup_KnownSlug_Match(t *testing.T) {
 	printer := ui.New(&discardWriter{})
 
 	s := NewSetup(client, prompter, browser, printer).
+		WithAppSet("fullsend").
 		WithKnownSlugs(map[string]string{"coder": "custom-slug-name"}).
 		WithSecretExists(func(_ string) (bool, error) {
 			return true, nil
@@ -269,7 +278,8 @@ func TestSetup_NoExistingApp(t *testing.T) {
 	browser := newFakeBrowser()
 	printer := ui.New(&discardWriter{})
 
-	s := NewSetup(client, prompter, browser, printer)
+	s := NewSetup(client, prompter, browser, printer).
+		WithAppSet("fullsend")
 
 	// No existing app → manifest flow is started. Use a short context
 	// timeout so the test doesn't hang waiting for a GitHub callback.
@@ -297,7 +307,8 @@ func TestManifestFlow_HTMLForm(t *testing.T) {
 	browser := newFakeBrowser()
 	printer := ui.New(&discardWriter{})
 
-	s := NewSetup(client, &fakePrompter{}, browser, printer)
+	s := NewSetup(client, &fakePrompter{}, browser, printer).
+		WithAppSet("fullsend")
 
 	// Use a short timeout — we only need the server to start and serve the
 	// HTML page, not complete the full manifest flow.
@@ -403,6 +414,7 @@ func TestSetup_StalePermissions_AllRolesChecked(t *testing.T) {
 	printer := ui.New(&discardWriter{})
 
 	setup := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer).
+		WithAppSet("fullsend").
 		WithSecretExists(func(_ string) (bool, error) { return true, nil })
 
 	// Run both roles — each should succeed individually.
@@ -439,6 +451,7 @@ func TestSetup_StalePermissions_IncludesInstallationURL(t *testing.T) {
 	printer := ui.New(&discardWriter{})
 
 	setup := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer).
+		WithAppSet("fullsend").
 		WithSecretExists(func(_ string) (bool, error) { return true, nil })
 
 	_, err := setup.Run(context.Background(), "myorg", "fullsend")
@@ -480,6 +493,7 @@ func TestSetup_CorrectPermissions_NoError(t *testing.T) {
 	printer := ui.New(&discardWriter{})
 
 	setup := NewSetup(client, &fakePrompter{}, newFakeBrowser(), printer).
+		WithAppSet("fullsend").
 		WithSecretExists(func(_ string) (bool, error) { return true, nil })
 
 	_, err := setup.Run(context.Background(), "myorg", "fullsend")
@@ -520,6 +534,7 @@ func existingAppSetup(t *testing.T, prompter *fakePrompter) (*Setup, *forge.Fake
 	}
 	printer := ui.New(&discardWriter{})
 	s := NewSetup(client, prompter, newFakeBrowser(), printer).
+		WithAppSet("fullsend").
 		WithSecretExists(func(_ string) (bool, error) { return false, nil })
 	return s, client
 }

--- a/internal/appsetup/appsetup_test.go
+++ b/internal/appsetup/appsetup_test.go
@@ -540,7 +540,7 @@ func TestSetup_CorrectPermissions_NoError(t *testing.T) {
 				Permissions: map[string]string{
 					"actions":               "write",
 					"contents":              "write",
-					"variables":             "read",
+					"actions_variables":     "read",
 					"workflows":             "write",
 					"issues":                "read",
 					"pull_requests":         "write",

--- a/internal/appsetup/appsetup_test.go
+++ b/internal/appsetup/appsetup_test.go
@@ -72,6 +72,45 @@ func TestAppSlug(t *testing.T) {
 	assert.Equal(t, "fullsend-review", AppSlug("fullsend", "review"))
 }
 
+func TestValidateAppSet(t *testing.T) {
+	assert.NoError(t, ValidateAppSet("fullsend-ai"))
+	assert.NoError(t, ValidateAppSet("custom"))
+	assert.NoError(t, ValidateAppSet("my-org-apps"))
+	assert.Error(t, ValidateAppSet(""))
+	assert.Error(t, ValidateAppSet("-leading"))
+	assert.Error(t, ValidateAppSet("trailing-"))
+	assert.Error(t, ValidateAppSet("has spaces"))
+	assert.Error(t, ValidateAppSet("UPPERCASE"))
+	assert.Error(t, ValidateAppSet("special!chars"))
+}
+
+func TestSetup_NonDefaultAppSet_FlowsThrough(t *testing.T) {
+	client := &forge.FakeClient{
+		Installations: []forge.Installation{
+			{ID: 200, AppID: 20, AppSlug: "custom-prefix-fullsend"},
+		},
+		AppClientIDs: map[string]string{
+			"custom-prefix-fullsend": "Iv1.custom123",
+		},
+	}
+	prompter := &fakePrompter{}
+	browser := newFakeBrowser()
+	printer := ui.New(&discardWriter{})
+
+	s := NewSetup(client, prompter, browser, printer).
+		WithAppSet("custom-prefix").
+		WithSecretExists(func(_ string) (bool, error) {
+			return true, nil
+		})
+
+	creds, err := s.Run(context.Background(), "myorg", "fullsend")
+	require.NoError(t, err)
+
+	assert.Equal(t, 20, creds.AppID)
+	assert.Equal(t, "custom-prefix-fullsend", creds.Slug)
+	assert.Equal(t, "Iv1.custom123", creds.ClientID)
+}
+
 func TestSetup_ExistingApp_SecretExists_AutoReuse(t *testing.T) {
 	client := &forge.FakeClient{
 		Installations: []forge.Installation{

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -227,6 +227,10 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
   configuration directory. No config repo or cross-repo dispatch needed.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := appsetup.ValidateAppSet(appSet); err != nil {
+				return fmt.Errorf("invalid --app-set value: %w", err)
+			}
+
 			arg := args[0]
 			if strings.Contains(arg, "/") {
 				for _, name := range perOrgOnlyFlags {
@@ -967,6 +971,7 @@ func vendorFullsendBinary(ctx context.Context, client forge.Client, printer *ui.
 
 func newUninstallCmd() *cobra.Command {
 	var yolo bool
+	var appSet string
 
 	cmd := &cobra.Command{
 		Use:   "uninstall <org>",
@@ -977,6 +982,10 @@ func newUninstallCmd() *cobra.Command {
 			org := args[0]
 			if err := validateOrgName(org); err != nil {
 				return err
+			}
+
+			if err := appsetup.ValidateAppSet(appSet); err != nil {
+				return fmt.Errorf("invalid --app-set value: %w", err)
 			}
 
 			token, err := resolveToken()
@@ -1005,11 +1014,12 @@ func newUninstallCmd() *cobra.Command {
 				}
 			}
 
-			return runUninstall(ctx, client, printer, org)
+			return runUninstall(ctx, client, printer, org, appSet)
 		},
 	}
 
 	cmd.Flags().BoolVar(&yolo, "yolo", false, "skip confirmation prompt")
+	cmd.Flags().StringVar(&appSet, "app-set", appsetup.DefaultAppSet, "app set name prefix for GitHub Apps (must match the value used during install)")
 
 	return cmd
 }
@@ -1493,7 +1503,7 @@ func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, o
 }
 
 // runUninstall tears down the fullsend installation.
-func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer, org string) error {
+func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer, org, appSet string) error {
 	// Try to load agent slugs from existing config. If the .fullsend repo
 	// is already gone (e.g., previous partial uninstall), fall back to the
 	// default naming convention so we can still guide the user to delete
@@ -1515,7 +1525,7 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 	if len(agentSlugs) == 0 {
 		// Config unavailable — assume default app naming convention.
 		for _, role := range config.DefaultAgentRoles() {
-			agentSlugs = append(agentSlugs, appsetup.AppSlug(appsetup.DefaultAppSet, role))
+			agentSlugs = append(agentSlugs, appsetup.AppSlug(appSet, role))
 		}
 		if err != nil {
 			printer.StepInfo("Config repo unavailable; using default app names")

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -138,6 +138,7 @@ type perRepoInstallConfig struct {
 	MintSourceDir       string
 	MintSkipDeploy      bool
 	SkipMintCheck       bool
+	AppSet              string
 }
 
 func validateMintURL(raw string) error {
@@ -208,6 +209,7 @@ func newInstallCmd() *cobra.Command {
 	var mintSkipDeploy bool
 	var skipMintCheck bool
 	var publicApps bool
+	var appSet string
 	// Per-repo flags.
 	var mintURL string
 
@@ -256,6 +258,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 					MintSourceDir:       mintSourceDir,
 					MintSkipDeploy:      mintSkipDeploy,
 					SkipMintCheck:       skipMintCheck,
+					AppSet:              appSet,
 				})
 			}
 
@@ -457,7 +460,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 				if err := ensureConfigRepoExists(ctx, client, printer, org); err != nil {
 					return err
 				}
-				creds, err := runAppSetup(ctx, client, printer, org, roles, mintProject, publicApps, sharedSlugs)
+				creds, err := runAppSetup(ctx, client, printer, org, roles, mintProject, publicApps, sharedSlugs, appSet)
 				if err != nil {
 					return err
 				}
@@ -484,6 +487,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 	cmd.Flags().BoolVar(&mintSkipDeploy, "skip-mint-deploy", false, "skip Cloud Function deployment, reuse existing mint URL")
 	cmd.Flags().BoolVar(&skipMintCheck, "skip-mint-check", false, "skip mint validation, GCP provisioning, and app setup; requires --mint-url")
 	cmd.Flags().BoolVar(&publicApps, "public", false, "create public (unlisted) GitHub Apps installable by other orgs")
+	cmd.Flags().StringVar(&appSet, "app-set", appsetup.DefaultAppSet, "app set name prefix for GitHub Apps (e.g., fullsend-ai creates fullsend-ai-fullsend, fullsend-ai-coder)")
 	// Shared flags.
 	cmd.Flags().StringVar(&mintURL, "mint-url", "", "token mint URL for OIDC token exchange")
 
@@ -784,7 +788,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 			sharedSlugs = slugs
 		}
 
-		creds, credErr := runAppSetup(ctx, client, printer, owner, roles, mintProject, publicApps, sharedSlugs)
+		creds, credErr := runAppSetup(ctx, client, printer, owner, roles, mintProject, publicApps, sharedSlugs, c.AppSet)
 		if credErr != nil {
 			return credErr
 		}
@@ -1231,12 +1235,13 @@ func copySharedAppPEMs(ctx context.Context, client forge.Client, printer *ui.Pri
 // runAppSetup creates or reuses GitHub Apps for each role. When mintProject is
 // non-empty, PEMs are also stored in GCP Secret Manager during app creation so
 // they survive partial provisioning failures.
-func runAppSetup(ctx context.Context, client forge.Client, printer *ui.Printer, org string, roles []string, mintProject string, publicApps bool, sharedSlugs map[string]string) ([]layers.AgentCredentials, error) {
+func runAppSetup(ctx context.Context, client forge.Client, printer *ui.Printer, org string, roles []string, mintProject string, publicApps bool, sharedSlugs map[string]string, appSet string) ([]layers.AgentCredentials, error) {
 	printer.Header("Setting up GitHub Apps")
 	printer.Blank()
 
 	setup := appsetup.NewSetup(client, appsetup.StdinPrompter{}, appsetup.DefaultBrowser{}, printer).
-		WithPublicApps(publicApps)
+		WithPublicApps(publicApps).
+		WithAppSet(appSet)
 
 	// Merge known slugs: config-based first, then shared app overrides.
 	knownSlugs := loadKnownSlugs(ctx, client, org)
@@ -1510,7 +1515,7 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 	if len(agentSlugs) == 0 {
 		// Config unavailable — assume default app naming convention.
 		for _, role := range config.DefaultAgentRoles() {
-			agentSlugs = append(agentSlugs, appsetup.AppSlug(role))
+			agentSlugs = append(agentSlugs, appsetup.AppSlug(appsetup.DefaultAppSet, role))
 		}
 		if err != nil {
 			printer.StepInfo("Config repo unavailable; using default app names")

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -228,7 +228,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := appsetup.ValidateAppSet(appSet); err != nil {
-				return fmt.Errorf("invalid --app-set value: %w", err)
+				return fmt.Errorf("invalid --app-set: %w", err)
 			}
 
 			arg := args[0]
@@ -983,6 +983,9 @@ func newUninstallCmd() *cobra.Command {
 			if err := validateOrgName(org); err != nil {
 				return err
 			}
+			if err := appsetup.ValidateAppSet(appSet); err != nil {
+				return fmt.Errorf("invalid --app-set: %w", err)
+			}
 
 			if err := appsetup.ValidateAppSet(appSet); err != nil {
 				return fmt.Errorf("invalid --app-set value: %w", err)
@@ -1019,7 +1022,7 @@ func newUninstallCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&yolo, "yolo", false, "skip confirmation prompt")
-	cmd.Flags().StringVar(&appSet, "app-set", appsetup.DefaultAppSet, "app set name prefix for GitHub Apps (must match the value used during install)")
+	cmd.Flags().StringVar(&appSet, "app-set", appsetup.DefaultAppSet, "app set name prefix for GitHub Apps (used for fallback slug generation when config is unavailable)")
 
 	return cmd
 }

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -491,7 +491,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 	cmd.Flags().BoolVar(&mintSkipDeploy, "skip-mint-deploy", false, "skip Cloud Function deployment, reuse existing mint URL")
 	cmd.Flags().BoolVar(&skipMintCheck, "skip-mint-check", false, "skip mint validation, GCP provisioning, and app setup; requires --mint-url")
 	cmd.Flags().BoolVar(&publicApps, "public", false, "create public (unlisted) GitHub Apps installable by other orgs")
-	cmd.Flags().StringVar(&appSet, "app-set", appsetup.DefaultAppSet, "app set name prefix for GitHub Apps (e.g., fullsend-ai creates fullsend-ai-fullsend, fullsend-ai-coder)")
+	cmd.Flags().StringVar(&appSet, "app-set", appsetup.DefaultAppSet, "app set name prefix for GitHub Apps (e.g., konflux-ci creates konflux-ci-fullsend, konflux-ci-coder)")
 	// Shared flags.
 	cmd.Flags().StringVar(&mintURL, "mint-url", "", "token mint URL for OIDC token exchange")
 

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -987,10 +987,6 @@ func newUninstallCmd() *cobra.Command {
 				return fmt.Errorf("invalid --app-set: %w", err)
 			}
 
-			if err := appsetup.ValidateAppSet(appSet); err != nil {
-				return fmt.Errorf("invalid --app-set value: %w", err)
-			}
-
 			token, err := resolveToken()
 			if err != nil {
 				return err

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -491,7 +491,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 	cmd.Flags().BoolVar(&mintSkipDeploy, "skip-mint-deploy", false, "skip Cloud Function deployment, reuse existing mint URL")
 	cmd.Flags().BoolVar(&skipMintCheck, "skip-mint-check", false, "skip mint validation, GCP provisioning, and app setup; requires --mint-url")
 	cmd.Flags().BoolVar(&publicApps, "public", false, "create public (unlisted) GitHub Apps installable by other orgs")
-	cmd.Flags().StringVar(&appSet, "app-set", appsetup.DefaultAppSet, "app set name prefix for GitHub Apps (e.g., konflux-ci creates konflux-ci-fullsend, konflux-ci-coder)")
+	cmd.Flags().StringVar(&appSet, "app-set", appsetup.DefaultAppSet, "app set name prefix for GitHub Apps (e.g., fullsend-ai creates fullsend-ai-fullsend, fullsend-ai-coder)")
 	// Shared flags.
 	cmd.Flags().StringVar(&mintURL, "mint-url", "", "token mint URL for OIDC token exchange")
 

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -110,6 +110,20 @@ func TestInstallCmd_Flags(t *testing.T) {
 
 	skipMintDeployFlag := cmd.Flags().Lookup("skip-mint-deploy")
 	require.NotNil(t, skipMintDeployFlag, "expected --skip-mint-deploy flag")
+
+	appSetFlag := cmd.Flags().Lookup("app-set")
+	require.NotNil(t, appSetFlag, "expected --app-set flag")
+	assert.Equal(t, "fullsend", appSetFlag.DefValue)
+}
+
+func TestInstallCmd_InvalidAppSet(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"admin", "install", "myorg",
+		"--inference-project", "proj", "--mint-project", "proj",
+		"--app-set", "INVALID"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --app-set")
 }
 
 func TestInstallCmd_PerRepoRequiresMintProject(t *testing.T) {
@@ -198,6 +212,7 @@ func TestInstallCmd_PerRepoAcceptsSharedFlags(t *testing.T) {
 		{"mint-provider", "gcf"},
 		{"mint-source-dir", "/tmp/src"},
 		{"skip-mint-deploy", ""},
+		{"app-set", "custom-prefix"},
 	}
 	for _, tc := range sharedFlags {
 		t.Run(tc.flag, func(t *testing.T) {
@@ -282,6 +297,10 @@ func TestUninstallCmd_Flags(t *testing.T) {
 
 	yoloFlag := cmd.Flags().Lookup("yolo")
 	require.NotNil(t, yoloFlag, "expected --yolo flag")
+
+	appSetFlag := cmd.Flags().Lookup("app-set")
+	require.NotNil(t, appSetFlag, "expected --app-set flag")
+	assert.Equal(t, "fullsend", appSetFlag.DefValue)
 }
 
 func TestAnalyzeCmd_RequiresOrg(t *testing.T) {

--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -48,7 +48,7 @@ func DefaultAgentRoles() []string {
 // issues:read permission. Subscribing to "issue_comment" requires issues:read
 // or issues:write. Mismatches cause the manifest to be rejected. Every Events
 // entry below must have a corresponding permission.
-func AgentAppConfig(org, role string) AppConfig {
+func AgentAppConfig(org, role, appSet string) AppConfig {
 	base := AppConfig{
 		URL: fmt.Sprintf("https://github.com/%s", org),
 		// hook_attributes is required by the manifest spec even when we
@@ -59,7 +59,7 @@ func AgentAppConfig(org, role string) AppConfig {
 		},
 	}
 
-	base.Name = fmt.Sprintf("fullsend-%s", role)
+	base.Name = fmt.Sprintf("%s-%s", appSet, role)
 
 	switch role{
 	case "fullsend":

--- a/internal/forge/github/types_test.go
+++ b/internal/forge/github/types_test.go
@@ -113,6 +113,14 @@ func TestAgentAppConfig_UnknownRole(t *testing.T) {
 	assert.Contains(t, cfg.Events, "issues")
 }
 
+func TestAgentAppConfig_DefaultAppSet(t *testing.T) {
+	cfg := AgentAppConfig("myorg", "coder", "fullsend-ai")
+	assert.Equal(t, "fullsend-ai-coder", cfg.Name)
+
+	cfg = AgentAppConfig("myorg", "fullsend", "fullsend-ai")
+	assert.Equal(t, "fullsend-ai-fullsend", cfg.Name)
+}
+
 func TestAppConfig_RedirectURL_InJSON(t *testing.T) {
 	cfg := AgentAppConfig("myorg", "fullsend", "fullsend")
 	cfg.RedirectURL = "http://127.0.0.1:12345/callback"

--- a/internal/forge/github/types_test.go
+++ b/internal/forge/github/types_test.go
@@ -113,12 +113,20 @@ func TestAgentAppConfig_UnknownRole(t *testing.T) {
 	assert.Contains(t, cfg.Events, "issues")
 }
 
-func TestAgentAppConfig_DefaultAppSet(t *testing.T) {
+func TestAgentAppConfig_CustomAppSet(t *testing.T) {
 	cfg := AgentAppConfig("myorg", "coder", "fullsend-ai")
 	assert.Equal(t, "fullsend-ai-coder", cfg.Name)
 
 	cfg = AgentAppConfig("myorg", "fullsend", "fullsend-ai")
 	assert.Equal(t, "fullsend-ai-fullsend", cfg.Name)
+}
+
+func TestAgentAppConfig_DefaultAppSet(t *testing.T) {
+	cfg := AgentAppConfig("myorg", "coder", "fullsend")
+	assert.Equal(t, "fullsend-coder", cfg.Name)
+
+	cfg = AgentAppConfig("myorg", "fullsend", "fullsend")
+	assert.Equal(t, "fullsend-fullsend", cfg.Name)
 }
 
 func TestAppConfig_RedirectURL_InJSON(t *testing.T) {

--- a/internal/forge/github/types_test.go
+++ b/internal/forge/github/types_test.go
@@ -15,7 +15,7 @@ func TestDefaultAgentRoles(t *testing.T) {
 }
 
 func TestAgentAppConfig_Fullsend(t *testing.T) {
-	cfg := AgentAppConfig("myorg", "fullsend")
+	cfg := AgentAppConfig("myorg", "fullsend", "fullsend")
 
 	assert.Equal(t, "fullsend-fullsend", cfg.Name)
 	assert.NotEmpty(t, cfg.Description)
@@ -37,7 +37,7 @@ func TestAgentAppConfig_Fullsend(t *testing.T) {
 }
 
 func TestAgentAppConfig_Triage(t *testing.T) {
-	cfg := AgentAppConfig("myorg", "triage")
+	cfg := AgentAppConfig("myorg", "triage", "fullsend")
 
 	assert.Equal(t, "fullsend-triage", cfg.Name)
 	assert.Equal(t, "write", cfg.Permissions.Issues)
@@ -48,7 +48,7 @@ func TestAgentAppConfig_Triage(t *testing.T) {
 }
 
 func TestAgentAppConfig_Coder(t *testing.T) {
-	cfg := AgentAppConfig("myorg", "coder")
+	cfg := AgentAppConfig("myorg", "coder", "fullsend")
 
 	assert.Equal(t, "fullsend-coder", cfg.Name)
 	assert.Equal(t, "write", cfg.Permissions.Issues)
@@ -64,7 +64,7 @@ func TestAgentAppConfig_Coder(t *testing.T) {
 }
 
 func TestAgentAppConfig_Review(t *testing.T) {
-	cfg := AgentAppConfig("myorg", "review")
+	cfg := AgentAppConfig("myorg", "review", "fullsend")
 
 	assert.Equal(t, "fullsend-review", cfg.Name)
 	assert.Equal(t, "write", cfg.Permissions.PullRequests)
@@ -76,7 +76,7 @@ func TestAgentAppConfig_Review(t *testing.T) {
 }
 
 func TestAgentAppConfig_Prioritize(t *testing.T) {
-	cfg := AgentAppConfig("myorg", "prioritize")
+	cfg := AgentAppConfig("myorg", "prioritize", "fullsend")
 
 	assert.Equal(t, "fullsend-prioritize", cfg.Name)
 	assert.Equal(t, "write", cfg.Permissions.OrganizationProjects)
@@ -89,7 +89,7 @@ func TestAgentAppConfig_Prioritize(t *testing.T) {
 }
 
 func TestAgentAppConfig_Retro(t *testing.T) {
-	cfg := AgentAppConfig("myorg", "retro")
+	cfg := AgentAppConfig("myorg", "retro", "fullsend")
 
 	assert.Equal(t, "fullsend-retro", cfg.Name)
 	assert.Equal(t, "read", cfg.Permissions.Actions)
@@ -103,7 +103,7 @@ func TestAgentAppConfig_Retro(t *testing.T) {
 }
 
 func TestAgentAppConfig_UnknownRole(t *testing.T) {
-	cfg := AgentAppConfig("myorg", "custom-bot")
+	cfg := AgentAppConfig("myorg", "custom-bot", "fullsend")
 
 	assert.Equal(t, "fullsend-custom-bot", cfg.Name)
 	assert.Equal(t, "read", cfg.Permissions.Issues)
@@ -114,7 +114,7 @@ func TestAgentAppConfig_UnknownRole(t *testing.T) {
 }
 
 func TestAppConfig_RedirectURL_InJSON(t *testing.T) {
-	cfg := AgentAppConfig("myorg", "fullsend")
+	cfg := AgentAppConfig("myorg", "fullsend", "fullsend")
 	cfg.RedirectURL = "http://127.0.0.1:12345/callback"
 
 	data, err := json.Marshal(cfg)


### PR DESCRIPTION
## Summary
- Introduce configurable app set prefix (default: `fullsend`) for GitHub App naming, changing from hardcoded `fullsend-{role}` to `{appSet}-{role}` (e.g., `fullsend-ai-fullsend`, `fullsend-ai-coder`)
- Add `--app-set` flag to `fullsend admin install` and `fullsend admin uninstall` for custom prefixes in multi-org SaaS environments
- Fixes incorrect app selection when a shared mint project has multiple GitHub Apps registered
- Add input validation for app set slugs (lowercase alphanumeric, hyphens, max 23 characters)
- Document custom app sets in admin installation guide

## What does NOT change
- GCP secret naming (`fullsend-{org}--{role}-app-pem`) — independent of app set
- Mint `ROLE_APP_IDS` keys (`{org}/{role}`) — independent of app set
- Default behavior — `DefaultAppSet = "fullsend"` preserves backward compatibility with existing installations

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/appsetup/ ./internal/forge/github/` — all pass
- [x] `go vet ./...` — no issues
- [x] `make lint` — passes
- [ ] Verify `--app-set fullsend-ai` creates apps named `fullsend-ai-fullsend`, `fullsend-ai-coder`, etc.
- [ ] Verify default behavior uses `fullsend` prefix without explicit flag
- [ ] Verify `--app-set custom` creates apps named `custom-fullsend`, `custom-coder`, etc.
- [ ] Verify uninstall fallback uses `fullsend` prefix for default app slug generation