### PR TITLE
fix: add variables:read permission for per-repo guard check

### DIFF
--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -368,7 +368,7 @@ Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
 				// If every eligible repo was skipped due to guard-check errors,
 				// the token likely lacks the required scope — fail loudly.
 				if eligibleCount > 0 && skippedErrors == eligibleCount {
-					return fmt.Errorf("all %d repos were skipped due to guard-check errors — verify your token has actions:read scope", eligibleCount)
+					return fmt.Errorf("all %d repos were skipped due to guard-check errors — verify your token has variables:read scope", eligibleCount)
 				}
 				msg := fmt.Sprintf("Enrolling %d repositories (excluding %s)", len(repos), forge.ConfigRepoName)
 				if skippedPerRepo-skippedErrors > 0 {

--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -9,6 +9,7 @@ type AppPermissions struct {
 	PullRequests         string `json:"pull_requests,omitempty"`
 	Checks               string `json:"checks,omitempty"`
 	Contents             string `json:"contents,omitempty"`
+	Variables            string `json:"variables,omitempty"`
 	Workflows            string `json:"workflows,omitempty"`
 	Administration       string `json:"administration,omitempty"`
 	Members              string `json:"members,omitempty"`
@@ -66,6 +67,7 @@ func AgentAppConfig(org, role string) AppConfig {
 		base.Permissions = AppPermissions{
 			Actions:              "write",
 			Contents:             "write",
+			Variables:            "read",
 			Workflows:            "write",
 			Issues:               "read",
 			PullRequests:         "write",

--- a/internal/forge/github/types_test.go
+++ b/internal/forge/github/types_test.go
@@ -28,6 +28,7 @@ func TestAgentAppConfig_Fullsend(t *testing.T) {
 	assert.Equal(t, "read", cfg.Permissions.Checks)
 	assert.Equal(t, "write", cfg.Permissions.Administration)
 	assert.Equal(t, "read", cfg.Permissions.Members)
+	assert.Equal(t, "read", cfg.Permissions.Variables)
 	assert.Equal(t, "read", cfg.Permissions.OrganizationProjects)
 
 	assert.Contains(t, cfg.Events, "issues")

--- a/internal/layers/enrollment.go
+++ b/internal/layers/enrollment.go
@@ -243,7 +243,7 @@ func (l *EnrollmentLayer) Analyze(ctx context.Context) (*LayerReport, error) {
 	totalRepos := len(l.enabledRepos) + len(l.disabledRepos)
 	if totalRepos > 0 && len(guardFailed) == totalRepos {
 		report.Details = append(report.Details,
-			fmt.Sprintf("all %d repos failed guard check — verify your token has actions:read scope", totalRepos))
+			fmt.Sprintf("all %d repos failed guard check — verify your token has variables:read scope", totalRepos))
 	}
 
 	for _, r := range perRepo {

--- a/internal/mint/main.go
+++ b/internal/mint/main.go
@@ -746,7 +746,7 @@ var rolePermissions = map[string]map[string]string{
 	"fix":      {"contents": "write", "pull_requests": "write", "issues": "write", "metadata": "read"},
 	"retro":       {"actions": "read", "contents": "read", "pull_requests": "read", "issues": "write", "metadata": "read"},
 	"prioritize":  {"contents": "read", "issues": "write", "organization_projects": "write", "metadata": "read"},
-	"fullsend":    {"actions": "write", "contents": "write", "pull_requests": "write", "workflows": "write", "metadata": "read"},
+	"fullsend":    {"actions": "write", "contents": "write", "pull_requests": "write", "variables": "read", "workflows": "write", "metadata": "read"},
 }
 
 // createInstallationToken exchanges a JWT for an installation access token,

--- a/internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh
+++ b/internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh
@@ -90,7 +90,9 @@ check_per_repo_guard() {
     return 1
   fi
   # Non-404 error (permissions, network) — skip to be safe.
-  echo "::warning::Skipping $action of $repo — could not check per-repo guard variable (exit code $rc)"
+  local api_msg
+  api_msg=$(printf '%s' "$resp" | jq -r '.message // empty' 2>/dev/null | tr -d '\n\r')
+  echo "::warning::Skipping $action of $repo — could not check per-repo guard variable (exit code $rc${api_msg:+: $api_msg})"
   return 0
 }
 


### PR DESCRIPTION
## Summary

- The `FULLSEND_PER_REPO_INSTALL` guard introduced in #967 fails in reconcile workflows because the `fullsend` role token lacks the `variables:read` fine-grained permission
- `GET /repos/{owner}/{repo}/actions/variables/{name}` returns 403 ("You must have the repository variables fine-grained permission"), causing `check_per_repo_guard` to skip every repo
- Observed in [rh-hemartin-fullsendai/.fullsend run #25918852230](https://github.com/rh-hemartin-fullsendai/.fullsend/actions/runs/25918852230/job/76182302688): `Enrolled: 0, Unenrolled: 0, Skipped: 2, Failed: 0`

## Changes

1. **`internal/forge/github/types.go`** — Add `Variables` field to `AppPermissions` struct; add `Variables: "read"` to `fullsend` App manifest
2. **`internal/mint/main.go`** — Add `"variables": "read"` to `fullsend` role in `rolePermissions`
3. **`internal/layers/enrollment.go`** — Fix error message: `actions:read` → `variables:read`
4. **`internal/scaffold/fullsend-repo/scripts/reconcile-repos.sh`** — Include API error message in warning output for easier debugging

## Deployment note

After merging, existing `fullsend-fullsend` GitHub Apps need the new `variables: read` permission approved. `fullsend admin install --analyze` will flag this automatically. After updating App permissions in GitHub settings and re-approving, re-deploy the mint Cloud Function so the new `rolePermissions` take effect.

## Test plan

- [x] `go test ./internal/layers/...` — pass
- [x] `go test ./internal/forge/github/...` — pass
- [x] `go test ./internal/mint/...` — pass (separate module)
- [ ] Manual: re-run reconcile workflow after deploying mint + updating App permissions