### PR TITLE
fix: use actions_variables instead of variables for GitHub API key

### DIFF
--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -9,7 +9,7 @@ type AppPermissions struct {
 	PullRequests         string `json:"pull_requests,omitempty"`
 	Checks               string `json:"checks,omitempty"`
 	Contents             string `json:"contents,omitempty"`
-	Variables            string `json:"variables,omitempty"`
+	Variables            string `json:"actions_variables,omitempty"`
 	Workflows            string `json:"workflows,omitempty"`
 	Administration       string `json:"administration,omitempty"`
 	Members              string `json:"members,omitempty"`

--- a/internal/mint/main.go
+++ b/internal/mint/main.go
@@ -746,7 +746,7 @@ var rolePermissions = map[string]map[string]string{
 	"fix":      {"contents": "write", "pull_requests": "write", "issues": "write", "metadata": "read"},
 	"retro":       {"actions": "read", "contents": "read", "pull_requests": "read", "issues": "write", "metadata": "read"},
 	"prioritize":  {"contents": "read", "issues": "write", "organization_projects": "write", "metadata": "read"},
-	"fullsend":    {"actions": "write", "contents": "write", "pull_requests": "write", "variables": "read", "workflows": "write", "metadata": "read"},
+	"fullsend":    {"actions": "write", "actions_variables": "read", "contents": "write", "pull_requests": "write", "workflows": "write", "metadata": "read"},
 }
 
 // createInstallationToken exchanges a JWT for an installation access token,


### PR DESCRIPTION
## Summary

- Fix JSON tag in `AppPermissions.Variables` from `"variables"` to `"actions_variables"` to match GitHub's API field name
- Fix `fullsend` role in mint `rolePermissions` to use `"actions_variables"` key so minted tokens actually receive the permission

Closes #997
Related: #996

## How to verify

Check the app's permissions as GitHub returns them:

```bash
gh api apps/fullsend-fullsend --jq '.permissions'
```

The key for repo variables is `actions_variables`, not `variables`.

## Test plan

- [x] `go vet` passes on both modules
- [x] `go test ./internal/forge/github/` passes
- [x] `go test ./...` passes in mint module
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)