### PR TITLE
feat: support --vendor-fullsend-binary in per-repo mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,11 +63,19 @@ runs:
         }
 
         # Use vendored binary if present (placed by fullsend admin install --vendor-fullsend-binary).
+        # Per-org mode stores it at bin/fullsend (in .fullsend config repo);
+        # per-repo mode stores it at .fullsend/bin/fullsend (in the target repo).
         # GitHub Contents API does not preserve the executable bit, so check -f not -x.
-        if [[ -f "${GITHUB_WORKSPACE}/bin/fullsend" ]]; then
-          echo "Using vendored fullsend binary from bin/fullsend"
+        VENDORED=""
+        if [[ -f "${GITHUB_WORKSPACE}/.fullsend/bin/fullsend" ]]; then
+          VENDORED="${GITHUB_WORKSPACE}/.fullsend/bin/fullsend"
+        elif [[ -f "${GITHUB_WORKSPACE}/bin/fullsend" ]]; then
+          VENDORED="${GITHUB_WORKSPACE}/bin/fullsend"
+        fi
+        if [[ -n "${VENDORED}" ]]; then
+          echo "Using vendored fullsend binary from ${VENDORED#"${GITHUB_WORKSPACE}/"}"
           mkdir -p "${RUNNER_TEMP}/fullsend"
-          cp "${GITHUB_WORKSPACE}/bin/fullsend" "${RUNNER_TEMP}/fullsend/fullsend"
+          cp "${VENDORED}" "${RUNNER_TEMP}/fullsend/fullsend"
           chmod +x "${RUNNER_TEMP}/fullsend/fullsend"
           echo "${RUNNER_TEMP}/fullsend" >> "${GITHUB_PATH}"
           exit 0

--- a/docs/ADRs/0033-per-repo-installation-mode.md
+++ b/docs/ADRs/0033-per-repo-installation-mode.md
@@ -267,7 +267,6 @@ Shared flags (valid for both per-org and per-repo):
 
 Per-org-only flags are rejected when an `owner/repo` argument is given:
 - `--enroll-all`, `--enroll-none` — control org-wide repository enrollment
-- `--vendor-fullsend-binary` — uploads a development binary to the `.fullsend` config repo
 
 All other flags are shared between per-org and per-repo modes — per-repo can create GitHub Apps, deploy a mint, and manage public apps when existing infrastructure is not found.
 

--- a/docs/ADRs/0033-per-repo-installation-mode.md
+++ b/docs/ADRs/0033-per-repo-installation-mode.md
@@ -265,7 +265,11 @@ Shared flags (valid for both per-org and per-repo):
 - `--mint-source-dir` — path to mint function source directory
 - `--app-set` — app set name prefix for GitHub Apps (default: `fullsend-ai`)
 
-Per-org-only flags (`--vendor-fullsend-binary`, `--enroll-all`, `--enroll-none`) are rejected when an `owner/repo` argument is given. All other flags are shared between per-org and per-repo modes — per-repo can create GitHub Apps, deploy a mint, and manage public apps when existing infrastructure is not found.
+Per-org-only flags are rejected when an `owner/repo` argument is given:
+- `--enroll-all`, `--enroll-none` — control org-wide repository enrollment
+- `--vendor-fullsend-binary` — uploads a development binary to the `.fullsend` config repo
+
+All other flags are shared between per-org and per-repo modes — per-repo can create GitHub Apps, deploy a mint, and manage public apps when existing infrastructure is not found.
 
 **Per-repo install steps**:
 

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -122,7 +122,7 @@ The installer automatically provisions [Workload Identity Federation (WIF)](http
 | `--skip-mint-check` | `false` | Skip mint validation, GCP provisioning, and app setup; requires `--mint-url` |
 | `--enroll-all` | `false` | Enroll all repositories without prompting (per-org only) |
 | `--enroll-none` | `false` | Skip repository enrollment without prompting (per-org only) |
-| `--vendor-fullsend-binary` | `false` | Cross-compile and upload the fullsend binary into `.fullsend/bin/` for development iteration |
+| `--vendor-fullsend-binary` | `false` | Cross-compile and vendor the fullsend binary for development iteration |
 
 The `--skip-mint-check` flag bypasses all mint validation, GCP provisioning, and app setup. It requires `--mint-url` to be set and only validates that the URL uses HTTPS. This is useful when the mint infrastructure is managed externally or you want to skip GCP API calls entirely.
 

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -122,7 +122,7 @@ The installer automatically provisions [Workload Identity Federation (WIF)](http
 | `--skip-mint-check` | `false` | Skip mint validation, GCP provisioning, and app setup; requires `--mint-url` |
 | `--enroll-all` | `false` | Enroll all repositories without prompting (per-org only) |
 | `--enroll-none` | `false` | Skip repository enrollment without prompting (per-org only) |
-| `--vendor-fullsend-binary` | `false` | Cross-compile and upload the fullsend binary into `.fullsend/bin/` for development iteration (per-org only) |
+| `--vendor-fullsend-binary` | `false` | Cross-compile and upload the fullsend binary into `.fullsend/bin/` for development iteration |
 
 The `--skip-mint-check` flag bypasses all mint validation, GCP provisioning, and app setup. It requires `--mint-url` to be set and only validates that the URL uses HTTPS. This is useful when the mint infrastructure is managed externally or you want to skip GCP API calls entirely.
 
@@ -424,7 +424,7 @@ fullsend admin install "$ORG_NAME/$REPO_NAME" \
 
 ### Per-repo flags
 
-Per-repo accepts all `admin install` flags except `--vendor-fullsend-binary`, `--enroll-all`, and `--enroll-none` (which only apply to org-wide enrollment). Per-repo install requires only `repo` and `workflow` OAuth scopes when reusing existing apps. Creating new apps requires `admin:org`.
+Per-repo accepts all `admin install` flags except `--enroll-all` and `--enroll-none` (which only apply to org-wide enrollment). Per-repo install requires only `repo` and `workflow` OAuth scopes when reusing existing apps. Creating new apps requires `admin:org`.
 
 > **`--mint-region` note:** Per-repo uses the same `--mint-region` default (`us-central1`) as per-org. When reusing a mint deployed to a non-default region, pass `--mint-region` explicitly so auto-discovery finds the correct function.
 

--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -113,10 +113,11 @@ Both per-org and per-repo modes share the same core pipeline. The code follows t
 │  │  ┌──────────────────────────────────────────┐              │ │
 │  │  │ Per-org:  create .fullsend config repo    │              │ │
 │  │  │           push reusable workflows         │              │ │
-│  │  │           vendor fullsend binary          │              │ │
+│  │  │           vendor fullsend binary (opt)    │              │ │
 │  │  │                                           │              │ │
 │  │  │ Per-repo: write .fullsend/ dir in repo    │              │ │
 │  │  │           push shim workflow template     │              │ │
+│  │  │           vendor fullsend binary (opt)    │              │ │
 │  │  └──────────────────────────────────────────┘              │ │
 │  └──────────┬─────────────────────────────────────────────────┘ │
 │             ▼                                                   │
@@ -161,7 +162,7 @@ Both modes call the same functions (`runAppSetup`, `gcf.NewProvisioner`, `Provis
 | **2. App setup** | `runAppSetup()` → PEMs + App IDs | All 7 roles by default | Excludes "fullsend" role |
 | **3. Mint** | `gcf.Provision()` or `EnsureOrgInMint()` | — | + `RegisterPerRepoWIF()` |
 | **4. WIF** | `ProvisionWIF()` | Org-wide provider ID | `BuildRepoProviderID()` (repo-scoped) |
-| **5. Scaffold** | `scaffold.PerRepoCustomizedDirs()` / `WalkFullsendRepo()` | Creates `.fullsend` repo, pushes workflows + binary | Writes `.fullsend/` dir + shim workflow in target repo |
+| **5. Scaffold** | `scaffold.PerRepoCustomizedDirs()` / `WalkFullsendRepo()` | Creates `.fullsend` repo, pushes workflows + optional binary | Writes `.fullsend/` dir + shim workflow + optional binary in target repo |
 | **6. Secrets** | Same secret names, same API calls | Config repo + org variable | Target repo + `PER_REPO_GUARD` |
 | **7. Enrollment** | — | `EnrollmentLayer` enables repos | No-op (self-contained) |
 
@@ -185,7 +186,7 @@ Install:      process 1→7 (forward)
 Uninstall:    process 7→1 (reverse)
 ```
 
-Per-repo mode does not use the layer stack — it runs the same phases inline in `runPerRepoInstall()` since there's no need for composable uninstall ordering with a single repo.
+Per-repo mode does not use the layer stack — it runs the same phases inline in `runPerRepoInstall()` since there's no need for composable uninstall ordering with a single repo. Binary vendoring (when `--vendor-fullsend-binary` is set) and stale binary cleanup are handled inline rather than through `VendorBinaryLayer`.
 
 ---
 

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -547,7 +547,7 @@ func vendorBinaryForE2E(t *testing.T, env *e2eEnv) {
 	require.NoError(t, err, "building fullsend binary: %s", string(out))
 
 	t.Log("Uploading vendored binary to .fullsend/bin/fullsend...")
-	err = layers.VendorBinary(context.Background(), env.client, testOrg, tmpBinary.Name())
+	err = layers.VendorBinary(context.Background(), env.client, testOrg, forge.ConfigRepoName, tmpBinary.Name())
 	require.NoError(t, err, "vendoring binary")
 	t.Log("Vendored binary uploaded successfully")
 }

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -547,7 +547,7 @@ func vendorBinaryForE2E(t *testing.T, env *e2eEnv) {
 	require.NoError(t, err, "building fullsend binary: %s", string(out))
 
 	t.Log("Uploading vendored binary to .fullsend/bin/fullsend...")
-	err = layers.VendorBinary(context.Background(), env.client, testOrg, forge.ConfigRepoName, tmpBinary.Name())
+	err = layers.VendorBinary(context.Background(), env.client, testOrg, forge.ConfigRepoName, layers.VendoredBinaryPath, tmpBinary.Name())
 	require.NoError(t, err, "vendoring binary")
 	t.Log("Vendored binary uploaded successfully")
 }

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -546,7 +546,7 @@ func vendorBinaryForE2E(t *testing.T, env *e2eEnv) {
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "building fullsend binary: %s", string(out))
 
-	t.Log("Uploading vendored binary to .fullsend/bin/fullsend...")
+	t.Logf("Uploading vendored binary to %s...", layers.VendoredBinaryPath)
 	err = layers.VendorBinary(context.Background(), env.client, testOrg, forge.ConfigRepoName, layers.VendoredBinaryPath, tmpBinary.Name())
 	require.NoError(t, err, "vendoring binary")
 	t.Log("Vendored binary uploaded successfully")

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -808,7 +808,10 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 		}
 		if vendorBinary {
 			printer.Blank()
-			printer.StepInfo("Would cross-compile and upload vendored binary to .fullsend/bin/fullsend")
+			printer.StepInfo(fmt.Sprintf("Would cross-compile and upload vendored binary to %s", layers.VendoredBinaryPathPerRepo))
+		} else {
+			printer.Blank()
+			printer.StepInfo(fmt.Sprintf("Would remove stale vendored binary at %s (if present)", layers.VendoredBinaryPathPerRepo))
 		}
 		return nil
 	}
@@ -986,6 +989,19 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 		if err := vendorFullsendBinary(ctx, client, printer, owner, repo); err != nil {
 			return fmt.Errorf("vendoring binary: %w", err)
 		}
+	} else {
+		// Clean up any vendored binary left from a previous install.
+		_, err := client.GetFileContent(ctx, owner, repo, layers.VendoredBinaryPathPerRepo)
+		if err == nil {
+			printer.StepStart("Removing stale vendored binary")
+			if err := client.DeleteFile(ctx, owner, repo, layers.VendoredBinaryPathPerRepo, "chore: remove vendored binary"); err != nil {
+				printer.StepFail("Failed to remove vendored binary")
+				return fmt.Errorf("deleting vendored binary: %w", err)
+			}
+			printer.StepDone("Removed stale vendored binary")
+		} else if !forge.IsNotFound(err) {
+			return fmt.Errorf("checking for vendored binary: %w", err)
+		}
 	}
 
 	printer.Blank()
@@ -994,8 +1010,15 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 }
 
 // vendorFullsendBinary cross-compiles the fullsend binary for linux/amd64
-// and uploads it to .fullsend/bin/fullsend via layers.VendorBinary.
+// and uploads it via layers.VendorBinary. Per-org mode uploads to bin/fullsend
+// in the .fullsend config repo; per-repo mode uploads to .fullsend/bin/fullsend
+// in the target repo.
 func vendorFullsendBinary(ctx context.Context, client forge.Client, printer *ui.Printer, owner, repo string) error {
+	destPath := layers.VendoredBinaryPath
+	if repo != forge.ConfigRepoName {
+		destPath = layers.VendoredBinaryPathPerRepo
+	}
+
 	printer.StepStart("Cross-compiling fullsend for linux/amd64")
 
 	tmpBinary, err := os.CreateTemp("", "fullsend-linux-amd64-*")
@@ -1018,8 +1041,8 @@ func vendorFullsendBinary(ctx context.Context, client forge.Client, printer *ui.
 	}
 	printer.StepDone("Cross-compiled fullsend for linux/amd64")
 
-	printer.StepStart("Uploading vendored binary to .fullsend/bin/fullsend")
-	if err := layers.VendorBinary(ctx, client, owner, repo, tmpBinary.Name()); err != nil {
+	printer.StepStart(fmt.Sprintf("Uploading vendored binary to %s", destPath))
+	if err := layers.VendorBinary(ctx, client, owner, repo, destPath, tmpBinary.Name()); err != nil {
 		printer.StepFail("Failed to upload vendored binary")
 		return err
 	}

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -519,7 +519,7 @@ Inference authentication:
 	cmd.Flags().StringVar(&agents, "agents", strings.Join(config.DefaultAgentRoles(), ","), "comma-separated agent roles")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview changes without making them")
 	cmd.Flags().BoolVar(&skipAppSetup, "skip-app-setup", false, "skip GitHub App creation/setup")
-	cmd.Flags().BoolVar(&vendorBinary, "vendor-fullsend-binary", false, "cross-compile and upload the fullsend binary into .fullsend/bin/ for development iteration")
+	cmd.Flags().BoolVar(&vendorBinary, "vendor-fullsend-binary", false, "cross-compile and vendor the fullsend binary for development iteration")
 	cmd.Flags().BoolVar(&enrollAllFlag, "enroll-all", false, "enroll all repositories without prompting")
 	cmd.Flags().BoolVar(&enrollNoneFlag, "enroll-none", false, "skip repository enrollment without prompting")
 	cmd.Flags().StringVar(&inferenceProject, "inference-project", "", "GCP project ID for inference (Agent Platform)")
@@ -991,14 +991,15 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 		}
 	} else {
 		// Clean up any vendored binary left from a previous install.
+		// Mirrors VendorBinaryLayer.Install cleanup logic for per-org mode.
 		_, err := client.GetFileContent(ctx, owner, repo, layers.VendoredBinaryPathPerRepo)
 		if err == nil {
-			printer.StepStart("Removing stale vendored binary")
+			printer.StepStart("removing stale vendored binary")
 			if err := client.DeleteFile(ctx, owner, repo, layers.VendoredBinaryPathPerRepo, "chore: remove vendored binary"); err != nil {
-				printer.StepFail("Failed to remove vendored binary")
+				printer.StepFail("failed to remove vendored binary")
 				return fmt.Errorf("deleting vendored binary: %w", err)
 			}
-			printer.StepDone("Removed stale vendored binary")
+			printer.StepDone("removed stale vendored binary")
 		} else if !forge.IsNotFound(err) {
 			return fmt.Errorf("checking for vendored binary: %w", err)
 		}

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -103,7 +103,7 @@ var rolePattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
 
 // perOrgOnlyFlags are flags that only apply to per-org mode.
 var perOrgOnlyFlags = []string{
-	"vendor-fullsend-binary", "enroll-all", "enroll-none",
+	"enroll-all", "enroll-none",
 }
 
 // skipMintDispatcher implements dispatch.Dispatcher for --skip-mint-check mode.
@@ -139,6 +139,7 @@ type perRepoInstallConfig struct {
 	MintSkipDeploy      bool
 	SkipMintCheck       bool
 	AppSet              string
+	VendorBinary        bool
 }
 
 // wifProviderPattern validates the full WIF provider resource name format
@@ -292,6 +293,7 @@ Inference authentication:
 					MintSkipDeploy:      mintSkipDeploy,
 					SkipMintCheck:       skipMintCheck,
 					AppSet:              appSet,
+					VendorBinary:        vendorBinary,
 				})
 			}
 
@@ -553,6 +555,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 	mintSourceDir := c.MintSourceDir
 	mintSkipDeploy := c.MintSkipDeploy
 	skipMintCheck := c.SkipMintCheck
+	vendorBinary := c.VendorBinary
 
 	if strings.Contains(repoFullName, "://") || strings.HasPrefix(repoFullName, "www.") {
 		return fmt.Errorf("expected owner/repo format, got a URL — use just the owner/repo portion (e.g. acme/widget)")
@@ -803,6 +806,10 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 		for _, name := range secretNames {
 			printer.StepInfo(fmt.Sprintf("  %s", name))
 		}
+		if vendorBinary {
+			printer.Blank()
+			printer.StepInfo("Would cross-compile and upload vendored binary to .fullsend/bin/fullsend")
+		}
 		return nil
 	}
 
@@ -975,6 +982,12 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 	}
 	printer.StepDone(fmt.Sprintf("Set %d repository secrets", len(repoSecrets)))
 
+	if vendorBinary {
+		if err := vendorFullsendBinary(ctx, client, printer, owner, repo); err != nil {
+			return fmt.Errorf("vendoring binary: %w", err)
+		}
+	}
+
 	printer.Blank()
 	printer.StepDone(fmt.Sprintf("Per-repo installation complete for %s/%s", owner, repo))
 	return nil
@@ -982,7 +995,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 
 // vendorFullsendBinary cross-compiles the fullsend binary for linux/amd64
 // and uploads it to .fullsend/bin/fullsend via layers.VendorBinary.
-func vendorFullsendBinary(ctx context.Context, client forge.Client, printer *ui.Printer, org string) error {
+func vendorFullsendBinary(ctx context.Context, client forge.Client, printer *ui.Printer, owner, repo string) error {
 	printer.StepStart("Cross-compiling fullsend for linux/amd64")
 
 	tmpBinary, err := os.CreateTemp("", "fullsend-linux-amd64-*")
@@ -1006,7 +1019,7 @@ func vendorFullsendBinary(ctx context.Context, client forge.Client, printer *ui.
 	printer.StepDone("Cross-compiled fullsend for linux/amd64")
 
 	printer.StepStart("Uploading vendored binary to .fullsend/bin/fullsend")
-	if err := layers.VendorBinary(ctx, client, org, tmpBinary.Name()); err != nil {
+	if err := layers.VendorBinary(ctx, client, owner, repo, tmpBinary.Name()); err != nil {
 		printer.StepFail("Failed to upload vendored binary")
 		return err
 	}
@@ -1784,7 +1797,7 @@ func buildLayerStack(
 	return layers.NewStack(
 		layers.NewConfigRepoLayer(org, client, cfg, printer, privateRepo),
 		layers.NewWorkflowsLayer(org, client, printer, user),
-		layers.NewVendorBinaryLayer(org, client, printer, vendorBinary, vendorFn),
+		layers.NewVendorBinaryLayer(org, forge.ConfigRepoName, client, printer, vendorBinary, vendorFn),
 		layers.NewSecretsLayer(org, client, agentCreds, printer).WithOIDCMode(),
 		layers.NewInferenceLayer(org, client, inferenceProvider, printer),
 		dispatchLayer,

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -179,7 +179,6 @@ func TestInstallCmd_PerRepoRejectsPerOrgFlags(t *testing.T) {
 		flag  string
 		value string
 	}{
-		{"vendor-fullsend-binary", ""},
 		{"enroll-all", ""},
 		{"enroll-none", ""},
 	}
@@ -214,6 +213,7 @@ func TestInstallCmd_PerRepoAcceptsSharedFlags(t *testing.T) {
 		{"mint-source-dir", "/tmp/src"},
 		{"skip-mint-deploy", ""},
 		{"app-set", "custom-prefix"},
+		{"vendor-fullsend-binary", ""},
 	}
 	for _, tc := range sharedFlags {
 		t.Run(tc.flag, func(t *testing.T) {
@@ -1092,7 +1092,7 @@ func TestCheckInstallScopes_SyncWithLayers(t *testing.T) {
 		layers.NewInferenceLayer("test-org", nil, nil, ui.New(&discardWriter{})),
 		layers.NewOIDCDispatchLayer("test-org", nil, nil, nil, ui.New(&discardWriter{})),
 		layers.NewEnrollmentLayer("test-org", nil, nil, nil, ui.New(&discardWriter{})),
-		layers.NewVendorBinaryLayer("test-org", nil, ui.New(&discardWriter{}), false, nil),
+		layers.NewVendorBinaryLayer("test-org", ".fullsend", nil, ui.New(&discardWriter{}), false, nil),
 	)
 	layerScopes := stack.CollectRequiredScopes(layers.OpInstall)
 

--- a/internal/layers/vendor.go
+++ b/internal/layers/vendor.go
@@ -8,10 +8,17 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/forge"
 )
 
-// VendorBinary uploads a pre-built fullsend binary to .fullsend/bin/fullsend.
+const (
+	// VendoredBinaryPath is the upload path inside the per-org .fullsend config repo.
+	VendoredBinaryPath = "bin/fullsend"
+	// VendoredBinaryPathPerRepo is the upload path inside a per-repo target repo.
+	VendoredBinaryPathPerRepo = ".fullsend/bin/fullsend"
+)
+
+// VendorBinary uploads a pre-built fullsend binary to the given destPath.
 // CI workflows detect this file and use it instead of downloading from
 // GitHub releases, enabling development iteration without cutting a release.
-func VendorBinary(ctx context.Context, client forge.Client, owner, repo, binaryPath string) error {
+func VendorBinary(ctx context.Context, client forge.Client, owner, repo, destPath, binaryPath string) error {
 	const maxBinarySize = 100 * 1024 * 1024 // 100 MB (GitHub Contents API limit)
 	info, err := os.Stat(binaryPath)
 	if err != nil {
@@ -28,7 +35,7 @@ func VendorBinary(ctx context.Context, client forge.Client, owner, repo, binaryP
 		return fmt.Errorf("reading binary %s: %w", binaryPath, err)
 	}
 	if err := client.CreateOrUpdateFile(ctx, owner, repo,
-		"bin/fullsend", "chore: vendor fullsend binary for development", data); err != nil {
+		destPath, "chore: vendor fullsend binary for development", data); err != nil {
 		return fmt.Errorf("uploading vendored binary: %w", err)
 	}
 	return nil

--- a/internal/layers/vendor.go
+++ b/internal/layers/vendor.go
@@ -11,7 +11,7 @@ import (
 // VendorBinary uploads a pre-built fullsend binary to .fullsend/bin/fullsend.
 // CI workflows detect this file and use it instead of downloading from
 // GitHub releases, enabling development iteration without cutting a release.
-func VendorBinary(ctx context.Context, client forge.Client, org, binaryPath string) error {
+func VendorBinary(ctx context.Context, client forge.Client, owner, repo, binaryPath string) error {
 	const maxBinarySize = 100 * 1024 * 1024 // 100 MB (GitHub Contents API limit)
 	info, err := os.Stat(binaryPath)
 	if err != nil {
@@ -27,7 +27,7 @@ func VendorBinary(ctx context.Context, client forge.Client, org, binaryPath stri
 	if err != nil {
 		return fmt.Errorf("reading binary %s: %w", binaryPath, err)
 	}
-	if err := client.CreateOrUpdateFile(ctx, org, forge.ConfigRepoName,
+	if err := client.CreateOrUpdateFile(ctx, owner, repo,
 		"bin/fullsend", "chore: vendor fullsend binary for development", data); err != nil {
 		return fmt.Errorf("uploading vendored binary: %w", err)
 	}

--- a/internal/layers/vendorbinary.go
+++ b/internal/layers/vendorbinary.go
@@ -11,7 +11,7 @@ import (
 // VendorFunc is a callback that cross-compiles and uploads a vendored binary.
 type VendorFunc func(ctx context.Context, client forge.Client, printer *ui.Printer, owner, repo string) error
 
-// VendorBinaryLayer manages the vendored development binary in .fullsend/bin/.
+// VendorBinaryLayer manages the vendored development binary.
 //
 // When enabled (--vendor-fullsend-binary flag), it calls a VendorFunc callback
 // to cross-compile and upload the binary. When disabled (the default), it
@@ -91,8 +91,9 @@ func (l *VendorBinaryLayer) Install(ctx context.Context) error {
 	return nil
 }
 
-// Uninstall is a no-op. The vendored binary is removed when the config repo
-// is deleted by the ConfigRepoLayer.
+// Uninstall is a no-op. In per-org mode the vendored binary is removed when
+// the config repo is deleted by ConfigRepoLayer. In per-repo mode the binary
+// lives in the target repo and is cleaned up on re-install with vendor disabled.
 func (l *VendorBinaryLayer) Uninstall(_ context.Context) error { return nil }
 
 // Analyze assesses the current state of the vendored binary.

--- a/internal/layers/vendorbinary.go
+++ b/internal/layers/vendorbinary.go
@@ -8,7 +8,6 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
-
 // VendorFunc is a callback that cross-compiles and uploads a vendored binary.
 type VendorFunc func(ctx context.Context, client forge.Client, printer *ui.Printer, owner, repo string) error
 
@@ -44,6 +43,15 @@ func NewVendorBinaryLayer(org, repo string, client forge.Client, printer *ui.Pri
 
 func (l *VendorBinaryLayer) Name() string { return "vendor-binary" }
 
+// binaryPath returns the upload path for the vendored binary based on the
+// target repo: per-org uses bin/fullsend, per-repo uses .fullsend/bin/fullsend.
+func (l *VendorBinaryLayer) binaryPath() string {
+	if l.repo != forge.ConfigRepoName {
+		return VendoredBinaryPathPerRepo
+	}
+	return VendoredBinaryPath
+}
+
 // RequiredScopes returns the scopes needed for the given operation.
 func (l *VendorBinaryLayer) RequiredScopes(op Operation) []string {
 	switch op {
@@ -65,7 +73,8 @@ func (l *VendorBinaryLayer) Install(ctx context.Context) error {
 	}
 
 	// Disabled — clean up any vendored binary left from a previous install.
-	_, err := l.client.GetFileContent(ctx, l.org, l.repo, VendoredBinaryPath)
+	path := l.binaryPath()
+	_, err := l.client.GetFileContent(ctx, l.org, l.repo, path)
 	if err != nil {
 		if forge.IsNotFound(err) {
 			return nil
@@ -74,7 +83,7 @@ func (l *VendorBinaryLayer) Install(ctx context.Context) error {
 	}
 
 	l.ui.StepStart("removing stale vendored binary")
-	if err := l.client.DeleteFile(ctx, l.org, l.repo, VendoredBinaryPath, "chore: remove vendored binary"); err != nil {
+	if err := l.client.DeleteFile(ctx, l.org, l.repo, path, "chore: remove vendored binary"); err != nil {
 		l.ui.StepFail("failed to remove vendored binary")
 		return fmt.Errorf("deleting vendored binary: %w", err)
 	}
@@ -90,7 +99,7 @@ func (l *VendorBinaryLayer) Uninstall(_ context.Context) error { return nil }
 func (l *VendorBinaryLayer) Analyze(ctx context.Context) (*LayerReport, error) {
 	report := &LayerReport{Name: l.Name()}
 
-	_, err := l.client.GetFileContent(ctx, l.org, l.repo, VendoredBinaryPath)
+	_, err := l.client.GetFileContent(ctx, l.org, l.repo, l.binaryPath())
 	if err != nil {
 		if forge.IsNotFound(err) {
 			if l.enabled {

--- a/internal/layers/vendorbinary.go
+++ b/internal/layers/vendorbinary.go
@@ -8,7 +8,6 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
-const vendoredBinaryPath = "bin/fullsend"
 
 // VendorFunc is a callback that cross-compiles and uploads a vendored binary.
 type VendorFunc func(ctx context.Context, client forge.Client, printer *ui.Printer, owner, repo string) error
@@ -66,7 +65,7 @@ func (l *VendorBinaryLayer) Install(ctx context.Context) error {
 	}
 
 	// Disabled — clean up any vendored binary left from a previous install.
-	_, err := l.client.GetFileContent(ctx, l.org, l.repo, vendoredBinaryPath)
+	_, err := l.client.GetFileContent(ctx, l.org, l.repo, VendoredBinaryPath)
 	if err != nil {
 		if forge.IsNotFound(err) {
 			return nil
@@ -75,7 +74,7 @@ func (l *VendorBinaryLayer) Install(ctx context.Context) error {
 	}
 
 	l.ui.StepStart("removing stale vendored binary")
-	if err := l.client.DeleteFile(ctx, l.org, l.repo, vendoredBinaryPath, "chore: remove vendored binary"); err != nil {
+	if err := l.client.DeleteFile(ctx, l.org, l.repo, VendoredBinaryPath, "chore: remove vendored binary"); err != nil {
 		l.ui.StepFail("failed to remove vendored binary")
 		return fmt.Errorf("deleting vendored binary: %w", err)
 	}
@@ -91,7 +90,7 @@ func (l *VendorBinaryLayer) Uninstall(_ context.Context) error { return nil }
 func (l *VendorBinaryLayer) Analyze(ctx context.Context) (*LayerReport, error) {
 	report := &LayerReport{Name: l.Name()}
 
-	_, err := l.client.GetFileContent(ctx, l.org, l.repo, vendoredBinaryPath)
+	_, err := l.client.GetFileContent(ctx, l.org, l.repo, VendoredBinaryPath)
 	if err != nil {
 		if forge.IsNotFound(err) {
 			if l.enabled {

--- a/internal/layers/vendorbinary.go
+++ b/internal/layers/vendorbinary.go
@@ -11,7 +11,7 @@ import (
 const vendoredBinaryPath = "bin/fullsend"
 
 // VendorFunc is a callback that cross-compiles and uploads a vendored binary.
-type VendorFunc func(ctx context.Context, client forge.Client, printer *ui.Printer, org string) error
+type VendorFunc func(ctx context.Context, client forge.Client, printer *ui.Printer, owner, repo string) error
 
 // VendorBinaryLayer manages the vendored development binary in .fullsend/bin/.
 //
@@ -21,6 +21,7 @@ type VendorFunc func(ctx context.Context, client forge.Client, printer *ui.Print
 // binary from shadowing released versions.
 type VendorBinaryLayer struct {
 	org      string
+	repo     string
 	client   forge.Client
 	ui       *ui.Printer
 	enabled  bool
@@ -31,9 +32,10 @@ type VendorBinaryLayer struct {
 var _ Layer = (*VendorBinaryLayer)(nil)
 
 // NewVendorBinaryLayer creates a new VendorBinaryLayer.
-func NewVendorBinaryLayer(org string, client forge.Client, printer *ui.Printer, enabled bool, vendorFn VendorFunc) *VendorBinaryLayer {
+func NewVendorBinaryLayer(org, repo string, client forge.Client, printer *ui.Printer, enabled bool, vendorFn VendorFunc) *VendorBinaryLayer {
 	return &VendorBinaryLayer{
 		org:      org,
+		repo:     repo,
 		client:   client,
 		ui:       printer,
 		enabled:  enabled,
@@ -60,11 +62,11 @@ func (l *VendorBinaryLayer) Install(ctx context.Context) error {
 		if l.vendorFn == nil {
 			return fmt.Errorf("vendor function not configured")
 		}
-		return l.vendorFn(ctx, l.client, l.ui, l.org)
+		return l.vendorFn(ctx, l.client, l.ui, l.org, l.repo)
 	}
 
 	// Disabled — clean up any vendored binary left from a previous install.
-	_, err := l.client.GetFileContent(ctx, l.org, forge.ConfigRepoName, vendoredBinaryPath)
+	_, err := l.client.GetFileContent(ctx, l.org, l.repo, vendoredBinaryPath)
 	if err != nil {
 		if forge.IsNotFound(err) {
 			return nil
@@ -73,7 +75,7 @@ func (l *VendorBinaryLayer) Install(ctx context.Context) error {
 	}
 
 	l.ui.StepStart("removing stale vendored binary")
-	if err := l.client.DeleteFile(ctx, l.org, forge.ConfigRepoName, vendoredBinaryPath, "chore: remove vendored binary"); err != nil {
+	if err := l.client.DeleteFile(ctx, l.org, l.repo, vendoredBinaryPath, "chore: remove vendored binary"); err != nil {
 		l.ui.StepFail("failed to remove vendored binary")
 		return fmt.Errorf("deleting vendored binary: %w", err)
 	}
@@ -89,7 +91,7 @@ func (l *VendorBinaryLayer) Uninstall(_ context.Context) error { return nil }
 func (l *VendorBinaryLayer) Analyze(ctx context.Context) (*LayerReport, error) {
 	report := &LayerReport{Name: l.Name()}
 
-	_, err := l.client.GetFileContent(ctx, l.org, forge.ConfigRepoName, vendoredBinaryPath)
+	_, err := l.client.GetFileContent(ctx, l.org, l.repo, vendoredBinaryPath)
 	if err != nil {
 		if forge.IsNotFound(err) {
 			if l.enabled {

--- a/internal/layers/vendorbinary_test.go
+++ b/internal/layers/vendorbinary_test.go
@@ -197,3 +197,87 @@ func TestVendorBinaryLayer_Analyze_Error(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "checking for vendored binary")
 }
+
+// binaryPath tests — per-org vs per-repo path selection.
+
+func TestVendorBinaryLayer_BinaryPath_PerOrg(t *testing.T) {
+	layer, _ := newVendorBinaryLayer(t, &forge.FakeClient{}, false, nil)
+	assert.Equal(t, VendoredBinaryPath, layer.binaryPath())
+}
+
+func TestVendorBinaryLayer_BinaryPath_PerRepo(t *testing.T) {
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	layer := NewVendorBinaryLayer("test-org", "my-repo", &forge.FakeClient{}, printer, false, nil)
+	assert.Equal(t, VendoredBinaryPathPerRepo, layer.binaryPath())
+}
+
+// Per-repo mode tests — verify correct paths are used for cleanup and analyze.
+
+func TestVendorBinaryLayer_PerRepo_DisabledDeletesBinary(t *testing.T) {
+	client := &forge.FakeClient{
+		FileContents: map[string][]byte{
+			"test-org/my-repo/.fullsend/bin/fullsend": []byte("binary-data"),
+		},
+	}
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	layer := NewVendorBinaryLayer("test-org", "my-repo", client, printer, false, nil)
+
+	err := layer.Install(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, client.DeletedFiles, 1)
+	assert.Equal(t, "my-repo", client.DeletedFiles[0].Repo)
+	assert.Equal(t, VendoredBinaryPathPerRepo, client.DeletedFiles[0].Path)
+}
+
+func TestVendorBinaryLayer_PerRepo_Analyze_EnabledPresent(t *testing.T) {
+	client := &forge.FakeClient{
+		FileContents: map[string][]byte{
+			"test-org/my-repo/.fullsend/bin/fullsend": []byte("binary-data"),
+		},
+	}
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	layer := NewVendorBinaryLayer("test-org", "my-repo", client, printer, true, nil)
+
+	report, err := layer.Analyze(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, StatusInstalled, report.Status)
+	assert.Contains(t, report.Details, "vendored binary present")
+}
+
+func TestVendorBinaryLayer_PerRepo_Analyze_DisabledPresent(t *testing.T) {
+	client := &forge.FakeClient{
+		FileContents: map[string][]byte{
+			"test-org/my-repo/.fullsend/bin/fullsend": []byte("binary-data"),
+		},
+	}
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	layer := NewVendorBinaryLayer("test-org", "my-repo", client, printer, false, nil)
+
+	report, err := layer.Analyze(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, StatusDegraded, report.Status)
+	assert.Contains(t, report.Details, "stale vendored binary present")
+}
+
+func TestVendorBinaryLayer_PerRepo_EnabledCallsVendorFn(t *testing.T) {
+	client := &forge.FakeClient{}
+	called := false
+	vendorFn := func(ctx context.Context, c forge.Client, p *ui.Printer, owner, repo string) error {
+		called = true
+		assert.Equal(t, "test-org", owner)
+		assert.Equal(t, "my-repo", repo)
+		return nil
+	}
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	layer := NewVendorBinaryLayer("test-org", "my-repo", client, printer, true, vendorFn)
+
+	err := layer.Install(context.Background())
+	require.NoError(t, err)
+	assert.True(t, called, "vendor function should have been called with per-repo args")
+}

--- a/internal/layers/vendorbinary_test.go
+++ b/internal/layers/vendorbinary_test.go
@@ -17,7 +17,7 @@ func newVendorBinaryLayer(t *testing.T, client *forge.FakeClient, enabled bool, 
 	t.Helper()
 	var buf bytes.Buffer
 	printer := ui.New(&buf)
-	layer := NewVendorBinaryLayer("test-org", client, printer, enabled, vendorFn)
+	layer := NewVendorBinaryLayer("test-org", ".fullsend", client, printer, enabled, vendorFn)
 	return layer, &buf
 }
 
@@ -37,9 +37,10 @@ func TestVendorBinaryLayer_RequiredScopes(t *testing.T) {
 func TestVendorBinaryLayer_EnabledCallsVendorFn(t *testing.T) {
 	client := &forge.FakeClient{}
 	called := false
-	vendorFn := func(ctx context.Context, c forge.Client, p *ui.Printer, org string) error {
+	vendorFn := func(ctx context.Context, c forge.Client, p *ui.Printer, owner, repo string) error {
 		called = true
-		assert.Equal(t, "test-org", org)
+		assert.Equal(t, "test-org", owner)
+		assert.Equal(t, ".fullsend", repo)
 		return nil
 	}
 
@@ -52,7 +53,7 @@ func TestVendorBinaryLayer_EnabledCallsVendorFn(t *testing.T) {
 
 func TestVendorBinaryLayer_EnabledVendorFnError(t *testing.T) {
 	client := &forge.FakeClient{}
-	vendorFn := func(_ context.Context, _ forge.Client, _ *ui.Printer, _ string) error {
+	vendorFn := func(_ context.Context, _ forge.Client, _ *ui.Printer, _, _ string) error {
 		return errors.New("cross-compile failed")
 	}
 


### PR DESCRIPTION
## Summary
- Removed `--vendor-fullsend-binary` from `perOrgOnlyFlags` so it works in both per-org and per-repo install modes
- Parameterized `VendorBinary()`, `VendorBinaryLayer`, and `vendorFullsendBinary()` to accept an explicit repo target instead of hardcoding `forge.ConfigRepoName`
- Added vendor binary wiring to `runPerRepoInstall` (including dry-run output)
- Updated docs to remove "(per-org only)" from the flag description

## Test plan
- [x] `make go-test` passes (cli and layers packages)
- [x] `make go-vet` clean
- [x] `make lint` passes
- [x] `--vendor-fullsend-binary` added to `PerRepoAcceptsSharedFlags` test table
- [x] Removed from `PerRepoRejectsPerOrgFlags` test table
- [x] `VendorBinaryLayer` tests updated with repo parameter