### PR TITLE
docs: note per-org preference for fullsend-ai self-install

### DIFF
--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -230,6 +230,20 @@ The uninstall preflight will prompt you to add the `delete_repo` scope if it is 
 
 Per-repo mode installs fullsend for a single repository without requiring an org-wide `.fullsend` config repo. It's fully self-contained — creating GitHub Apps, deploying a token mint, and configuring WIF as needed.
 
+> **Installing fullsend in the `fullsend-ai` org:** When installing fullsend for
+> `fullsend-ai/fullsend` itself, prefer **per-org mode** (`fullsend admin install fullsend-ai`).
+> Per-repo mode technically works but creates a circular reference: the per-repo
+> shim workflow calls `fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v0`,
+> which in turn calls reusable stage workflows in the same repo, which check out
+> `fullsend-ai/fullsend@v0` again for upstream defaults and use
+> `fullsend-ai/fullsend@v0` as the composite action. The repo ends up
+> simultaneously serving as the source of reusable workflows, the source of the
+> composite action, the caller repo, and the target repo being acted on. Per-org
+> mode avoids this by placing the shim in `fullsend-ai/fullsend` and the agent
+> workflows in a separate `fullsend-ai/.fullsend` config repo, keeping the
+> reference chain unidirectional: target repo → `.fullsend` → upstream
+> `fullsend-ai/fullsend`.
+
 ### First-time install (no prior infrastructure)
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a callout in the per-repo installation guide noting that `fullsend-ai/fullsend` should use per-org mode
- Per-repo mode creates a circular reference where the repo simultaneously serves as reusable workflow source, composite action, caller, and target
- Per-org mode keeps the reference chain unidirectional: target repo → `.fullsend` → upstream `fullsend-ai/fullsend`

## Test plan
- [ ] Verify the note renders correctly in the installation guide
- [ ] Confirm no broken markdown links