### PR TITLE
fix: correct install-binary.sh path in cutting-releases skill

### DIFF
--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use when the user wants to tag a release, cut a release candidate, or ship a
   new version. Also use when asking about release process, versioning, or how
   GoReleaser is configured.
-allowed-tools: Read, Grep, Glob, AskUserQuestion, Bash(git tag:*), Bash(git log:*), Bash(git diff:*), Bash(git pull:*), Bash(git push:*), Bash(gh release:*), Bash(gh run:*), Bash(git checkout:*), Bash(bash scripts/install-binary.sh:*)
+allowed-tools: Read, Grep, Glob, AskUserQuestion, Bash(git tag:*), Bash(git log:*), Bash(git diff:*), Bash(git pull:*), Bash(git push:*), Bash(gh release:*), Bash(gh run:*), Bash(git checkout:*), Bash(bash skills/cutting-releases/scripts/install-binary.sh:*)
 ---
 
 # Cutting Releases
@@ -117,10 +117,10 @@ Check that the title, changelog, and binary assets look correct.
 ### 9. Install the binary locally
 
 Ask the user where to install (default: `~/.local/bin/`), then run
-[scripts/install-binary.sh](scripts/install-binary.sh):
+the install script from this skill's base directory:
 
 ```bash
-bash scripts/install-binary.sh <tag> [install-dir]
+bash <base-dir>/scripts/install-binary.sh <tag> [install-dir]
 ```
 
 The script downloads the release archive, verifies its SHA-256 checksum


### PR DESCRIPTION
## Summary
- Fixed the install script path in the cutting-releases skill — it referenced `scripts/install-binary.sh` but the script lives at `skills/cutting-releases/scripts/install-binary.sh`
- Updated step 9 instructions to use `<base-dir>` convention (matching analyze-transcript skill)
- Tightened `allowed-tools` pattern to match the actual repo-relative path

## Test plan
- [ ] Load the cutting-releases skill and verify step 9 references `<base-dir>/scripts/install-binary.sh`
- [ ] Confirm the allowed-tools pattern matches `bash skills/cutting-releases/scripts/install-binary.sh v0.8.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)