### PR TITLE
fix: correct dispatch stage-to-role mappings and default roles

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -242,8 +242,7 @@ jobs:
           fi
           STAGE_ROLE="$STAGE"
           case "$STAGE" in
-            code) STAGE_ROLE="coder" ;;
-            retro|prioritize) STAGE_ROLE="fullsend" ;;
+            code|fix) STAGE_ROLE="coder" ;;
           esac
           ROLES=$(yq '.roles[]' .fullsend/config.yaml 2>/dev/null || echo "")
           if [[ -n "$ROLES" ]] && ! echo "$ROLES" | grep -Fqx "$STAGE_ROLE"; then

--- a/docs/ADRs/0033-per-repo-installation-mode.md
+++ b/docs/ADRs/0033-per-repo-installation-mode.md
@@ -254,7 +254,7 @@ Shared flags (valid for both per-org and per-repo):
 - `--mint-url` — token mint URL for OIDC token exchange (optional; auto-discovered from `--mint-project`/`--mint-region` if omitted)
 - `--mint-project` — GCP project containing the mint function (defaults to `--inference-project` in per-repo)
 - `--mint-region` — cloud region for the mint function (default: `us-central1`)
-- `--agents` — comma-separated agent roles (default: `fullsend,triage,coder,review,fix`)
+- `--agents` — comma-separated agent roles (default: `fullsend,triage,coder,review,retro,prioritize`)
 - `--dry-run` — preview changes without making them
 - `--skip-app-setup` — skip GitHub App creation (reuse existing apps)
 - `--skip-mint-deploy` — skip Cloud Function deployment, reuse existing mint URL

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -62,7 +62,7 @@ The installer automatically provisions [Workload Identity Federation (WIF)](http
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--agents` | `fullsend,triage,coder,review,fix` | Comma-separated agent roles to provision |
+| `--agents` | `fullsend,triage,coder,review,retro,prioritize` | Comma-separated agent roles to provision |
 | `--dry-run` | `false` | Preview changes without making them |
 | `--inference-project` | | GCP project ID for inference (Agent Platform) |
 | `--inference-region` | `global` | GCP region for inference |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,17 +63,17 @@ func ValidProviders() []string {
 }
 
 // DefaultAgentRoles returns the standard set of agent roles installed
-// when no custom roles are specified. This excludes optional roles
-// like "prioritize" that must be explicitly requested via --agents.
+// when no custom roles are specified. The fix stage reuses the coder
+// app (role: coder) so it does not need a separate app or PEM.
 func DefaultAgentRoles() []string {
-	return []string{"fullsend", "triage", "coder", "review", "fix"}
+	return []string{"fullsend", "triage", "coder", "review", "retro", "prioritize"}
 }
 
 // PerRepoDefaultRoles returns agent roles for per-repo installation.
 // The "fullsend" dispatch role is excluded because per-repo mode uses
 // the target repo's shim workflow for dispatch instead of a separate app.
 func PerRepoDefaultRoles() []string {
-	return []string{"triage", "coder", "review", "fix"}
+	return []string{"triage", "coder", "review", "retro", "prioritize"}
 }
 
 // NewOrgConfig creates a new OrgConfig with sensible defaults.

--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -38,7 +38,7 @@ type AppConfig struct {
 
 // DefaultAgentRoles returns the standard set of agent roles.
 func DefaultAgentRoles() []string {
-	return []string{"fullsend", "triage", "coder", "review", "fix"}
+	return []string{"fullsend", "triage", "coder", "review", "retro", "prioritize"}
 }
 
 // AgentAppConfig returns the GitHub App configuration for a given agent role.

--- a/internal/forge/github/types_test.go
+++ b/internal/forge/github/types_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestDefaultAgentRoles(t *testing.T) {
 	roles := DefaultAgentRoles()
-	require.Len(t, roles, 5)
-	assert.Equal(t, []string{"fullsend", "triage", "coder", "review", "fix"}, roles)
+	require.Len(t, roles, 6)
+	assert.Equal(t, []string{"fullsend", "triage", "coder", "review", "retro", "prioritize"}, roles)
 }
 
 func TestAgentAppConfig_Fullsend(t *testing.T) {

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -256,8 +256,7 @@ jobs:
           set -euo pipefail
           STAGE_ROLE="$STAGE"
           case "$STAGE" in
-            code) STAGE_ROLE="coder" ;;
-            retro|prioritize) STAGE_ROLE="fullsend" ;;
+            code|fix) STAGE_ROLE="coder" ;;
           esac
 
           ROLES=$(yq '.defaults.roles[]' config.yaml 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

- Map `fix` stage to `coder` role in dispatch, matching that `fix.yml` mints a coder token — no separate fix app needed
- Remove `retro|prioritize → fullsend` mapping since those workflows mint their own tokens (`role: retro`, `role: prioritize`) and need their own apps/PEMs
- Add `retro` and `prioritize` to `DefaultAgentRoles()` so they are installed by default
- Remove `fix` from `DefaultAgentRoles()` since it reuses the coder app

**Before:** `[fullsend, triage, coder, review, fix]`
**After:** `[fullsend, triage, coder, review, retro, prioritize]`

## Test plan

- [ ] Verify `fix` stage dispatches when `defaults.roles` contains `coder` but not `fix`
- [ ] Verify `retro` and `prioritize` are created by default install (no `--agents` needed)
- [ ] Verify `code` stage still dispatches correctly (no regression)
- [ ] Verify existing installs with `fix` in config.yaml still validate (fix remains a valid role)