### PR TITLE
fix: add extract-transcript-error.sh to executableFiles

### DIFF
--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -36,6 +36,7 @@ var executableFiles = map[string]struct{}{
 	"scripts/setup-prioritize.sh":            {},
 	"scripts/pre-retro.sh":                   {},
 	"scripts/validate-output-schema.sh":      {},
+	"scripts/extract-transcript-error.sh":    {},
 	"scripts/validate-output-schema-test.sh": {},
 	"scripts/validate-source-repo.sh":        {},
 }


### PR DESCRIPTION
## Summary

- Add `scripts/extract-transcript-error.sh` to the `executableFiles` map in `internal/scaffold/scaffold.go`
- The script was executable on disk but missing from the map, causing `TestFileModeMatchesFilesystem` to fail

## Test plan

- [x] `TestFileModeMatchesFilesystem` passes
- [x] `go vet ./...` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)