### PR TITLE
fix: always write inference secrets on install

### DIFF
--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -535,6 +535,10 @@ func (f *FakeClient) CreateRepoSecret(_ context.Context, owner, repo, name, valu
 		Name:  name,
 		Value: value,
 	})
+	if f.Secrets == nil {
+		f.Secrets = make(map[string]bool)
+	}
+	f.Secrets[owner+"/"+repo+"/"+name] = true
 	return nil
 }
 

--- a/internal/inference/inference.go
+++ b/internal/inference/inference.go
@@ -11,7 +11,8 @@ type Provider interface {
 
 	// Provision acquires credentials and returns secrets to store.
 	// Returns a map of secret-name → secret-value pairs to store
-	// as repo secrets on .fullsend.
+	// as repo secrets on .fullsend. Implementations must be
+	// idempotent — Install calls Provision on every run.
 	Provision(ctx context.Context) (map[string]string, error)
 
 	// SecretNames returns the names of secrets this provider manages,

--- a/internal/layers/inference.go
+++ b/internal/layers/inference.go
@@ -45,50 +45,33 @@ func (l *InferenceLayer) RequiredScopes(op Operation) []string {
 }
 
 // Install provisions inference credentials and stores them as repo secrets.
-// If all expected secrets already exist, provisioning is skipped to maintain
-// idempotency (avoids unnecessary re-provisioning).
+// Secrets are written unconditionally because the GitHub Secrets API does not
+// expose values, so we cannot detect stale entries. The API PUT is an upsert,
+// making repeated writes safe.
 func (l *InferenceLayer) Install(ctx context.Context) error {
 	if l.provider == nil {
 		l.ui.StepInfo("no inference provider configured, skipping")
 		return nil
 	}
 
-	// Check if secrets already exist to avoid re-provisioning.
-	allExist := true
-	for _, name := range l.provider.SecretNames() {
-		exists, err := l.client.RepoSecretExists(ctx, l.org, forge.ConfigRepoName, name)
-		if err != nil {
-			// Can't verify — proceed with provisioning.
-			allExist = false
-			break
-		}
-		if !exists {
-			allExist = false
-			break
-		}
+	l.ui.StepStart(fmt.Sprintf("provisioning %s credentials", l.provider.Name()))
+
+	secrets, err := l.provider.Provision(ctx)
+	if err != nil {
+		l.ui.StepFail(fmt.Sprintf("failed to provision %s credentials", l.provider.Name()))
+		return fmt.Errorf("provisioning %s: %w", l.provider.Name(), err)
 	}
-	if allExist {
-		l.ui.StepDone(fmt.Sprintf("%s credentials already provisioned, skipping", l.provider.Name()))
-	} else {
-		l.ui.StepStart(fmt.Sprintf("provisioning %s credentials", l.provider.Name()))
 
-		secrets, err := l.provider.Provision(ctx)
-		if err != nil {
-			l.ui.StepFail(fmt.Sprintf("failed to provision %s credentials", l.provider.Name()))
-			return fmt.Errorf("provisioning %s: %w", l.provider.Name(), err)
+	for name, value := range secrets {
+		l.ui.StepStart(fmt.Sprintf("storing %s", name))
+		if err := l.client.CreateRepoSecret(ctx, l.org, forge.ConfigRepoName, name, value); err != nil {
+			l.ui.StepFail(fmt.Sprintf("failed to store %s", name))
+			return fmt.Errorf("creating secret %s: %w", name, err)
 		}
-
-		for name, value := range secrets {
-			l.ui.StepStart(fmt.Sprintf("storing %s", name))
-			if err := l.client.CreateRepoSecret(ctx, l.org, forge.ConfigRepoName, name, value); err != nil {
-				l.ui.StepFail(fmt.Sprintf("failed to store %s", name))
-				return fmt.Errorf("creating secret %s: %w", name, err)
-			}
-			l.ui.StepDone(fmt.Sprintf("stored %s", name))
-		}
-
-		l.ui.StepDone(fmt.Sprintf("%s credentials provisioned", l.provider.Name()))
+		l.ui.StepDone(fmt.Sprintf("stored %s", name))
 	}
+
+	l.ui.StepDone(fmt.Sprintf("%s credentials provisioned", l.provider.Name()))
 
 	// Store non-secret variables (e.g. region). Always run — variables are
 	// cheap to set and idempotent, and may be added after initial install.

--- a/internal/layers/inference_test.go
+++ b/internal/layers/inference_test.go
@@ -114,6 +114,21 @@ func TestInferenceLayer_Install_SecretWriteError(t *testing.T) {
 	assert.Contains(t, err.Error(), "permission denied")
 }
 
+func TestInferenceLayer_Install_ProvisionErrorWithExistingSecrets(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.Secrets["test-org/.fullsend/FULLSEND_GCP_WIF_PROVIDER"] = true
+	client.Secrets["test-org/.fullsend/FULLSEND_GCP_PROJECT_ID"] = true
+	provider := vertexProvider()
+	provider.err = errors.New("gcp auth failed")
+	provider.secrets = nil
+	layer, _ := newInferenceLayer(t, client, provider)
+
+	err := layer.Install(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gcp auth failed")
+	assert.Empty(t, client.CreatedSecrets)
+}
+
 func TestInferenceLayer_Install_OverwritesExistingSecrets(t *testing.T) {
 	client := forge.NewFakeClient()
 	client.Secrets["test-org/.fullsend/FULLSEND_GCP_WIF_PROVIDER"] = true

--- a/internal/layers/inference_test.go
+++ b/internal/layers/inference_test.go
@@ -114,22 +114,27 @@ func TestInferenceLayer_Install_SecretWriteError(t *testing.T) {
 	assert.Contains(t, err.Error(), "permission denied")
 }
 
-func TestInferenceLayer_Install_SkipsWhenSecretsExist(t *testing.T) {
+func TestInferenceLayer_Install_OverwritesExistingSecrets(t *testing.T) {
 	client := forge.NewFakeClient()
 	client.Secrets["test-org/.fullsend/FULLSEND_GCP_WIF_PROVIDER"] = true
 	client.Secrets["test-org/.fullsend/FULLSEND_GCP_PROJECT_ID"] = true
 	provider := vertexProvider()
-	layer, buf := newInferenceLayer(t, client, provider)
+	layer, _ := newInferenceLayer(t, client, provider)
 
 	err := layer.Install(context.Background())
 	require.NoError(t, err)
 
-	// Should not have created any new secrets.
-	assert.Empty(t, client.CreatedSecrets)
-	// Should indicate skipping in output.
-	assert.Contains(t, buf.String(), "already provisioned")
+	// Secrets should be written unconditionally (upsert).
+	require.Len(t, client.CreatedSecrets, 2)
 
-	// Variables should still have been written (always runs).
+	secretMap := make(map[string]string)
+	for _, s := range client.CreatedSecrets {
+		secretMap[s.Name] = s.Value
+	}
+	assert.Equal(t, "projects/123/locations/global/workloadIdentityPools/pool/providers/gh", secretMap["FULLSEND_GCP_WIF_PROVIDER"])
+	assert.Equal(t, "my-project", secretMap["FULLSEND_GCP_PROJECT_ID"])
+
+	// Variables should also have been written.
 	require.Len(t, client.Variables, 1)
 	assert.Equal(t, "FULLSEND_GCP_REGION", client.Variables[0].Name)
 }


### PR DESCRIPTION
## Summary
- Remove the idempotency guard in `InferenceLayer.Install()` that skipped secret writes when secrets already existed
- Secrets are now written unconditionally on every install — the GitHub Secrets API PUT is an upsert, making this safe
- Root cause: after migrating from SA impersonation to direct WIF, the `FULLSEND_GCP_WIF_PROVIDER` secret pointed at the wrong pool, but re-running `admin install` never corrected it because the existence check short-circuited

## Test plan
- [x] Updated `TestInferenceLayer_Install_OverwritesExistingSecrets` to verify secrets are written even when they already exist
- [x] All existing inference layer tests pass
- [x] `go vet` clean