### PR TITLE
ci(merge queue): add merge_group triggers for merge queue support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,7 @@ on:
     paths: ['**/*.go', 'go.mod', 'go.sum', 'e2e/**']
   pull_request:
     paths: ['**/*.go', 'go.mod', 'go.sum', 'e2e/**']
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -2,6 +2,7 @@ name: Build Site
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary

- Add `merge_group` trigger to `e2e.yml`[1]
- Add `merge_group` trigger to `site-build.yml`

These ensure CI workflows run during merge queue validation, which is required for GitHub merge queue to gate on their results.

## Test plan

- [ ] Enable merge queue on the repo and verify e2e and site-build workflows trigger on queued PRs
- [ ] Confirm path filters on e2e still work correctly (only Go/e2e file changes trigger runs)

[1] This should remain two commits, as it will be easier to revert if we are seeing many unnecessary runs due to the merge_group event *not* having a way to filter on file paths