### PR TITLE
fix: clear local repo dir before re-extracting on validation loop iteration 2+

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -539,13 +539,16 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary str
 		// 9d. Extract target repo back to host. SafeDownload removes symlinks
 		// and .git/hooks/ after download to prevent sandbox escape.
 		if iteration > 1 {
-			if err := os.RemoveAll(repoSrc); err != nil {
-				printer.StepWarn("clear local repo: " + err.Error())
+			if clearErr := os.RemoveAll(repoSrc); clearErr != nil {
+				printer.StepWarn(fmt.Sprintf("Failed to clear local repo %s: %s", repoSrc, clearErr.Error()))
 			}
 		}
 		repoExtractStart := time.Now()
 		printer.StepStart("Extracting target repo")
 		if err := sandbox.SafeDownload(sandboxName, repoDir, repoSrc); err != nil {
+			if iteration > 1 {
+				return fmt.Errorf("re-extracting target repo (iteration %d): %w", iteration, err)
+			}
 			printer.StepWarn("Failed to extract target repo: " + err.Error())
 		} else {
 			printer.StepDone(fmt.Sprintf("Target repo extracted to %s (%.1fs)", repoSrc, time.Since(repoExtractStart).Seconds()))

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -538,6 +538,11 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary str
 
 		// 9d. Extract target repo back to host. SafeDownload removes symlinks
 		// and .git/hooks/ after download to prevent sandbox escape.
+		if iteration > 1 {
+			if err := os.RemoveAll(repoSrc); err != nil {
+				printer.StepWarn("clear local repo: " + err.Error())
+			}
+		}
 		repoExtractStart := time.Now()
 		printer.StepStart("Extracting target repo")
 		if err := sandbox.SafeDownload(sandboxName, repoDir, repoSrc); err != nil {


### PR DESCRIPTION
## Summary

- Fixes `"File exists (os error 17)"` tar extraction failure when the validation loop runs iteration 2+
- `openshell sandbox download` uses tar extraction that cannot overwrite existing directories — on iteration 2+ the local `repoSrc` still has files from the previous extraction
- Adds `os.RemoveAll(repoSrc)` before `SafeDownload` on iteration 2+, mirroring the sandbox-side cleanup already done for output and transcripts (lines 480-486)

## Root cause

The between-iteration cleanup in `runAgent()` clears sandbox-side output and transcripts but not the local extraction target. When `SafeDownload` re-extracts the target repo into a non-empty directory, the underlying tar extractor fails on pre-existing directories.

Surfaced as a scribe workflow failure after upgrading from fullsend 0.7.0 to 0.8.1 (fullsend-ai/.fullsend#73).

## Test plan

- [x] `make go-vet` — passes
- [x] `make go-test` — `internal/cli` passes (41.4% coverage)
- [x] `make lint` — passes
- [ ] E2E test with a multi-iteration validation loop (scribe or similar agent with `max_iterations > 1`)