### PR TITLE
triage: align control labels with pipeline usage, rename type/feature to feature

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -139,7 +139,7 @@ jobs:
                   fi
                   ;;
                 *)
-                  if has_label "needs-info" && ! has_label "type/feature"; then
+                  if has_label "needs-info" && ! has_label "feature"; then
                     if [[ "${COMMENT_USER_TYPE}" != "Bot" ]]; then
                       if [[ "${COMMENT_AUTHOR_ASSOC}" != "NONE" ]] || is_issue_author; then
                         STAGE="triage"

--- a/docs/guides/user/bugfix-workflow.md
+++ b/docs/guides/user/bugfix-workflow.md
@@ -18,8 +18,7 @@ Issue filed → Triage → ready-to-code → Code Agent → PR opened → Review
                 │                          └── changes requested (planned) ─┘
                 ├── blocked → waiting for dependency
                 ├── duplicate → closed
-                ├── not-ready → waiting for info
-                └── not-reproducible → human intervention
+                └── needs-info → waiting for info
 ```
 
 > **Note:** The automated rework loop (Review → Code Agent on "changes requested") is not yet implemented. Today, a "changes requested" outcome requires human intervention. The planned [fix agent (#197)](https://github.com/fullsend-ai/fullsend/issues/197) will automate this loop.
@@ -43,9 +42,10 @@ These labels track where an issue is in the pipeline:
 |-------|---------|-------------------|
 | `blocked` | Progress depends on another issue or PR | Triage comment links to the blocker; re-triage on edit checks if blocker is resolved |
 | `duplicate` | Same issue already tracked elsewhere | Issue closed, link to canonical issue |
-| `not-ready` | Missing information | Triage comment explains what's needed; add a comment or edit the issue body to fix |
-| `not-reproducible` | Bug couldn't be reproduced in the sandbox | Human intervention required; triage comment documents what was tried |
-| `ready-to-code` | Triage passed | Code agent picks it up |
+| `needs-info` | Missing information | Triage comment explains what's needed; add a comment or edit the issue body to fix |
+| `feature` | Issue categorized as a feature request | Waits for human prioritization before coding |
+| `triaged` | Triage passed but not auto-promoted | Waits for human review (applies to features and uncategorized issues) |
+| `ready-to-code` | Triage passed (bug, docs, performance) | Code agent picks it up |
 | `ready-for-review` | PR ready for review (manual trigger) | Review agents evaluate the PR |
 | `ready-for-merge` | All reviewers unanimously approved | PR can be merged per governance policy |
 | `requires-manual-review` | Reviewers disagreed or flagged security concerns | Human must decide |
@@ -103,10 +103,9 @@ The triage agent:
 
 1. **Checks for duplicates.** Searches existing issues by title, body, and metadata. If it finds a match with high confidence, it labels `duplicate`, posts a comment linking the canonical issue, and closes this one.
 2. **Checks for blocking dependencies.** Searches for open issues or PRs (in this repo or upstream) that must be resolved before work can start. If a blocker is found, it labels `blocked` and posts a comment linking to the blocking issue or PR. On re-triage, it checks whether existing blockers have been resolved.
-3. **Checks information sufficiency.** If the issue body is missing steps to reproduce, expected behavior, or other critical details, it labels `not-ready` and posts a comment explaining what's missing.
-4. **Attempts reproduction.** Runs the reported steps in an isolated sandbox. If the bug cannot be reproduced, it labels `not-reproducible` and posts a detailed comment documenting what was tried.
-5. **Produces a test artifact.** When possible, writes a failing test case aligned with the repo's test framework.
-6. **Hands off.** Labels `ready-to-code` with a summary comment.
+3. **Checks information sufficiency.** If the issue body is missing steps to reproduce, expected behavior, or other critical details, it labels `needs-info` and posts a comment explaining what's missing.
+4. **Produces a test artifact.** When possible, writes a failing test case aligned with the repo's test framework.
+5. **Hands off.** Labels `ready-to-code` with a summary comment.
 
 **If triage gets it wrong:** Add a comment with the missing information, or edit the issue body. Edits to the title or body trigger triage automatically. You can also use `/fs-triage` to force a fresh run — this clears all previous labels and starts from scratch.
 

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -114,7 +114,7 @@ jobs:
                 *)
                   # Non-command issue_comment: auto-triage on needs-info issues
                   # when commenter is a non-bot with association != NONE or is issue author
-                  if has_label "needs-info" && ! has_label "type/feature"; then
+                  if has_label "needs-info" && ! has_label "feature"; then
                     if [[ "${COMMENT_USER_TYPE}" != "Bot" ]]; then
                       if [[ "${COMMENT_AUTHOR_ASSOC}" != "NONE" ]] || is_issue_author; then
                         STAGE="triage"

--- a/internal/scaffold/fullsend-repo/scripts/post-triage-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-triage-test.sh
@@ -145,6 +145,10 @@ run_test "sufficient-feature-gets-triaged" \
   '{"action":"sufficient","reasoning":"all clear","clarity_scores":{"symptom":0.9,"cause":0.85,"reproduction":0.9,"impact":0.8,"overall":0.87},"triage_summary":{"title":"Add dark mode","severity":"medium","category":"feature","problem":"No dark mode","root_cause_hypothesis":"Not implemented","reproduction_steps":["step 1"],"environment":"Linux","impact":"All users","recommended_fix":"Add theme toggle","proposed_test_case":"test_dark_mode"},"comment":"## Triage Summary\n\nThis is a feature."}' \
   "gh api repos/test-org/test-repo/issues/42/labels -f labels[]=triaged --silent"
 
+run_test "sufficient-feature-gets-feature-label" \
+  '{"action":"sufficient","reasoning":"all clear","clarity_scores":{"symptom":0.9,"cause":0.85,"reproduction":0.9,"impact":0.8,"overall":0.87},"triage_summary":{"title":"Add dark mode","severity":"medium","category":"feature","problem":"No dark mode","root_cause_hypothesis":"Not implemented","reproduction_steps":["step 1"],"environment":"Linux","impact":"All users","recommended_fix":"Add theme toggle","proposed_test_case":"test_dark_mode"},"comment":"## Triage Summary\n\nThis is a feature."}' \
+  "gh api repos/test-org/test-repo/issues/42/labels -f labels[]=feature --silent"
+
 run_test "sufficient-other-gets-triaged" \
   '{"action":"sufficient","reasoning":"all clear","clarity_scores":{"symptom":0.9,"cause":0.85,"reproduction":0.9,"impact":0.8,"overall":0.87},"triage_summary":{"title":"Misc","severity":"low","category":"other","problem":"Misc","root_cause_hypothesis":"Unclear","reproduction_steps":["step 1"],"environment":"Linux","impact":"Some","recommended_fix":"Investigate","proposed_test_case":"test_misc"},"comment":"## Triage Summary\n\nMisc."}' \
   "gh api repos/test-org/test-repo/issues/42/labels -f labels[]=triaged --silent"
@@ -231,6 +235,10 @@ run_test "label-actions-applied" \
 run_test_stdout "label-actions-control-label-refused" \
   '{"action":"sufficient","reasoning":"all clear","clarity_scores":{"symptom":0.9,"cause":0.85,"reproduction":0.9,"impact":0.8,"overall":0.87},"triage_summary":{"title":"Fix crash","severity":"high","category":"bug","problem":"Crash","root_cause_hypothesis":"Buffer overflow","reproduction_steps":["step 1"],"environment":"Linux","impact":"All users","recommended_fix":"Fix buffer","proposed_test_case":"test_crash"},"comment":"## Triage Summary\n\nReady.","label_actions":{"reason":"Tried to set control label.","actions":[{"action":"add","label":"ready-to-code"}]}}' \
   "::warning::Refused to add control label 'ready-to-code' -- control labels are managed by the triage pipeline"
+
+run_test_stdout "label-actions-feature-control-label-refused" \
+  '{"action":"sufficient","reasoning":"all clear","clarity_scores":{"symptom":0.9,"cause":0.85,"reproduction":0.9,"impact":0.8,"overall":0.87},"triage_summary":{"title":"Fix crash","severity":"high","category":"bug","problem":"Crash","root_cause_hypothesis":"Buffer overflow","reproduction_steps":["step 1"],"environment":"Linux","impact":"All users","recommended_fix":"Fix buffer","proposed_test_case":"test_crash"},"comment":"## Triage Summary\n\nReady.","label_actions":{"reason":"Tried to set feature label.","actions":[{"action":"add","label":"feature"}]}}' \
+  "::warning::Refused to add control label 'feature' -- control labels are managed by the triage pipeline"
 
 run_test "label-actions-absent-still-posts-comment" \
   '{"action":"sufficient","reasoning":"all clear","clarity_scores":{"symptom":0.9,"cause":0.85,"reproduction":0.9,"impact":0.8,"overall":0.87},"triage_summary":{"title":"Fix crash","severity":"high","category":"bug","problem":"Crash","root_cause_hypothesis":"Buffer overflow","reproduction_steps":["step 1"],"environment":"Linux","impact":"All users","recommended_fix":"Fix buffer","proposed_test_case":"test_crash"},"comment":"## Triage Summary\n\nReady."}' \

--- a/internal/scaffold/fullsend-repo/scripts/post-triage.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-triage.sh
@@ -73,9 +73,10 @@ remove_label() {
 }
 
 # Control labels managed by the triage pipeline. The post script refuses to
-# add or remove these via label_actions (same set that pre-triage.sh resets,
-# plus blocked and triaged).
-CONTROL_LABELS=("needs-info" "ready-to-code" "duplicate" "not-ready" "not-reproducible" "type/feature" "blocked" "triaged")
+# add or remove these via label_actions. This list covers labels that the
+# pipeline itself applies (pre-triage.sh resets the first four; the action
+# handlers apply blocked/triaged/feature).
+CONTROL_LABELS=("needs-info" "ready-to-code" "duplicate" "feature" "blocked" "triaged")
 
 is_control_label() {
   local label="$1"
@@ -161,6 +162,11 @@ case "${ACTION}" in
       bug|documentation|performance)
         echo "Applying ready-to-code label (${CATEGORY})..."
         add_label "ready-to-code"
+        ;;
+      feature)
+        echo "Applying feature + triaged labels..."
+        add_label "feature"
+        add_label "triaged"
         ;;
       *)
         echo "Applying triaged label (${CATEGORY})..."

--- a/internal/scaffold/fullsend-repo/scripts/pre-triage.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-triage.sh
@@ -27,13 +27,13 @@ ISSUE_NUMBER=$(basename "${GITHUB_ISSUE_URL}")
 
 echo "Resetting triage labels on ${REPO}#${ISSUE_NUMBER}"
 
-for label in needs-info ready-to-code duplicate not-ready not-reproducible type/feature; do
+for label in needs-info ready-to-code duplicate feature; do
   gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/labels/${label}" -X DELETE --silent 2>/dev/null || true
 done
 
 # Verify no triage labels remain — the pipeline depends on mutual exclusivity.
 REMAINING=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/labels" \
-  --jq '[.[] | select(.name == "needs-info" or .name == "ready-to-code" or .name == "duplicate" or .name == "type/feature") | .name] | join(", ")' 2>/dev/null || echo "VERIFY_FAILED")
+  --jq '[.[] | select(.name == "needs-info" or .name == "ready-to-code" or .name == "duplicate" or .name == "feature") | .name] | join(", ")' 2>/dev/null || echo "VERIFY_FAILED")
 
 if [[ "${REMAINING}" == "VERIFY_FAILED" ]]; then
   echo "ERROR: cannot verify label state — API call failed"

--- a/internal/scaffold/fullsend-repo/skills/issue-labels/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/issue-labels/SKILL.md
@@ -19,9 +19,7 @@ your `label_actions` output -- the post script will refuse them:
 - `needs-info`
 - `ready-to-code`
 - `duplicate`
-- `not-ready`
-- `not-reproducible`
-- `type/feature`
+- `feature`
 - `blocked`
 - `triaged`
 

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -197,7 +197,7 @@ func TestDispatchWorkflowContent(t *testing.T) {
 	assert.Contains(t, s, "pull_request_review")
 	assert.Contains(t, s, "changes_requested")
 	assert.Contains(t, s, "needs-info")
-	assert.Contains(t, s, "type/feature")
+	assert.Contains(t, s, `! has_label "feature"`)
 	assert.Contains(t, s, "opened|synchronize|ready_for_review")
 	// /code must only run on issues, not PRs
 	assert.Contains(t, s, "ISSUE_HAS_PR")


### PR DESCRIPTION
## Summary

- Remove `not-ready` and `not-reproducible` from control labels — no code path ever applied them. `not-ready` is redundant with `needs-info`; `not-reproducible` is tracked for future implementation in #1036 / #1037.
- Rename `type/feature` → `feature` to match the schema's `category` enum and the existing pattern (`bug` doesn't use `type/bug`).
- Add explicit `feature)` case in post-triage.sh that applies both `feature` and `triaged` labels, closing the gap where pre-triage stripped `type/feature` but post-triage never re-applied it.
- Aligned across pre-triage.sh, post-triage.sh, dispatch.yml, and the issue-labels skill.

## Context

Observed in [run 25940860598](https://github.com/fullsend-ai/.fullsend/actions/runs/25940860598/job/76258825925): the triage agent categorized #1032 as `feature`, the post script applied `triaged` but not `type/feature`, and the agent's `label_actions` attempt to add `type/feature` and `ready-to-code` were both refused as control labels. The `ready-to-code` refusal was correct (feature issues shouldn't auto-promote), but `type/feature` was a gap — the pipeline claimed ownership of the label but never applied it.

## Test plan

- [x] `post-triage-test.sh` — all 34 tests pass (2 new: `sufficient-feature-gets-feature-label`, `label-actions-feature-control-label-refused`)
- [x] `make lint` passes
- [x] No remaining references to `type/feature`, `not-ready`, or `not-reproducible` in scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)