### PR TITLE
fix: clear local repo unconditionally before SafeDownload

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -539,15 +539,17 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary str
 		// 9d. Extract target repo back to host. SafeDownload removes symlinks
 		// and .git/hooks/ after download to prevent sandbox escape.
 		if clearErr := os.RemoveAll(repoSrc); clearErr != nil {
-			printer.StepWarn(fmt.Sprintf("Failed to clear local repo %s: %s", repoSrc, clearErr.Error()))
+			return fmt.Errorf("clearing local repo %s before extraction: %w", repoSrc, clearErr)
 		}
 		repoExtractStart := time.Now()
 		printer.StepStart("Extracting target repo")
 		if err := sandbox.SafeDownload(sandboxName, repoDir, repoSrc); err != nil {
+			if es := extractTranscriptErrors(iterTranscriptDir); len(es) > 0 {
+				emitTranscriptErrors(os.Stderr, es)
+			}
 			return fmt.Errorf("extracting target repo (iteration %d): %w", iteration, err)
-		} else {
-			printer.StepDone(fmt.Sprintf("Target repo extracted to %s (%.1fs)", repoSrc, time.Since(repoExtractStart).Seconds()))
 		}
+		printer.StepDone(fmt.Sprintf("Target repo extracted to %s (%.1fs)", repoSrc, time.Since(repoExtractStart).Seconds()))
 
 		// 9e. Run validation.
 		if h.ValidationLoop == nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -538,18 +538,13 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary str
 
 		// 9d. Extract target repo back to host. SafeDownload removes symlinks
 		// and .git/hooks/ after download to prevent sandbox escape.
-		if iteration > 1 {
-			if clearErr := os.RemoveAll(repoSrc); clearErr != nil {
-				printer.StepWarn(fmt.Sprintf("Failed to clear local repo %s: %s", repoSrc, clearErr.Error()))
-			}
+		if clearErr := os.RemoveAll(repoSrc); clearErr != nil {
+			printer.StepWarn(fmt.Sprintf("Failed to clear local repo %s: %s", repoSrc, clearErr.Error()))
 		}
 		repoExtractStart := time.Now()
 		printer.StepStart("Extracting target repo")
 		if err := sandbox.SafeDownload(sandboxName, repoDir, repoSrc); err != nil {
-			if iteration > 1 {
-				return fmt.Errorf("re-extracting target repo (iteration %d): %w", iteration, err)
-			}
-			printer.StepWarn("Failed to extract target repo: " + err.Error())
+			return fmt.Errorf("extracting target repo (iteration %d): %w", iteration, err)
 		} else {
 			printer.StepDone(fmt.Sprintf("Target repo extracted to %s (%.1fs)", repoSrc, time.Since(repoExtractStart).Seconds()))
 		}


### PR DESCRIPTION
## Summary

- Removes the `iteration > 1` guard on the `os.RemoveAll(repoSrc)` cleanup — it must run on **every** iteration, not just 2+
- Makes `SafeDownload` failure a hard error on all iterations (not just 2+)

## Root cause

PR #1038 added `RemoveAll` before `SafeDownload` but guarded it with `iteration > 1`, assuming iteration 1 starts with a clean directory. In practice, the GHA workflow's "Checkout target repository" step populates `target-repo/` **before** fullsend runs. When the agent finishes iteration 1 and `SafeDownload` extracts back into the pre-existing checkout, openshell's tar extractor fails with `"File exists (os error 17)"`.

Evidence: https://github.com/fullsend-ai/.fullsend/actions/runs/25944154001/job/76268502952 — downloaded `fullsend v0.8.2` (which includes #1038) but still failed on iteration 1.

## Test plan

- [x] `go test ./internal/cli/` — passes
- [x] `go vet ./...` — passes
- [ ] Trigger triage/scribe workflow and verify extraction succeeds on iteration 1