### PR TITLE
fix(retro): harden output schema instructions to prevent extra properties

### DIFF
--- a/internal/scaffold/fullsend-repo/agents/retro.md
+++ b/internal/scaffold/fullsend-repo/agents/retro.md
@@ -69,7 +69,20 @@ After gathering findings from subagents:
 
 ## Output
 
-Write a single JSON file to `$FULLSEND_OUTPUT_DIR/agent-result.json`. See the `retro-analysis` skill for the exact schema and writing guidance.
+Write a single JSON file to `$FULLSEND_OUTPUT_DIR/agent-result.json`.
+
+The top-level object must have **exactly two properties** — no others:
+
+```json
+{
+  "summary": "...",
+  "proposals": [...]
+}
+```
+
+The schema enforces `"additionalProperties": false`. Any extra top-level key (e.g., `timeline`, `workflow_quality`, `originating_url`, `metadata`) will fail validation.
+
+See the `retro-analysis` skill for the proposal object schema and writing guidance.
 
 ## Target repo restrictions
 

--- a/internal/scaffold/fullsend-repo/skills/retro-analysis/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/retro-analysis/SKILL.md
@@ -140,6 +140,8 @@ Write a single JSON file to `$FULLSEND_OUTPUT_DIR/agent-result.json` with this s
 }
 ```
 
+**Schema is strict.** The top-level object allows ONLY `summary` and `proposals` — no additional properties. Each proposal object allows ONLY the six fields shown above. The harness validates against `$FULLSEND_OUTPUT_SCHEMA` with `"additionalProperties": false` at both levels. Do not add fields like `timeline`, `metadata`, `workflow_quality`, or `originating_url`.
+
 ### Writing good proposals
 
 - **what_happened:** Tell the story chronologically. Link to specific workflow runs, log lines, PR comments, and review verdicts. Use markdown links.


### PR DESCRIPTION
## Summary
- The retro agent was hallucinating extra top-level JSON fields (`workflow_quality`, `originating_url`, `timeline`) that fail `additionalProperties: false` validation — both retry iterations failed on [run 25946366318](https://github.com/fullsend-ai/.fullsend/actions/runs/25946366318/job/76275203928)
- The agent definition had a vague redirect ("See the retro-analysis skill for the exact schema") and neither document mentioned the schema strictness constraint
- Inlined the exact allowed structure in `agents/retro.md` and added an explicit `additionalProperties: false` warning with negative examples in both the agent definition and `skills/retro-analysis/SKILL.md`

## Why only retro
Other agents (triage, prioritize, review, fix) are less prone because they either inline complete JSON templates for every action variant or use `jq -n` commands that structurally can't produce extra keys. The retro agent delegates to subagents for research then synthesizes output — more creative latitude means more risk of hallucinating extra fields.

## Test plan
- [ ] Trigger a retro run and verify `agent-result.json` passes schema validation on the first iteration