### PR TITLE
fix(retro): use REST API for PR comments to avoid pull_requests:write

### DIFF
--- a/docs/superpowers/specs/2026-05-04-retro-agent-design.md
+++ b/docs/superpowers/specs/2026-05-04-retro-agent-design.md
@@ -184,7 +184,7 @@ A standard dispatch workflow that runs `fullsend run retro` with the provided in
 - **Credential isolation (ADR 0017):** Write credentials (`gh` token with issue-create and comment permissions) are held only by the post-script, outside the sandbox.
 - **Unidirectional control flow (ADR 0016):** The retro agent proposes changes via issues. Changes go through standard review (CODEOWNERS, human approval) and take effect in future invocations, never the current one.
 - **Adversarial feedback risk:** A malicious reviewer could post `/fs-retro` with misleading context to bias the retro agent's proposals. The mitigation is the same human approval gate on the resulting issues — a proposal only takes effect if a maintainer approves and merges the change.
-- **Per-role GitHub App (ADR 0007):** The retro agent gets its own GitHub App with scoped permissions: read access to repos, issues, PRs, workflow runs, and artifacts; write access limited to creating issues and posting comments.
+- **Per-role GitHub App (ADR 0007):** The retro agent gets its own GitHub App with scoped permissions: read access to repos, PRs, workflow runs, and artifacts; write access to issues only. The post-script uses the REST Issues API (`POST /repos/{owner}/{repo}/issues/{number}/comments`) to comment on PRs, which requires only `issues: write` — avoiding `pull_requests: write` and the broader capabilities it grants.
 
 ## Architectural Constraints
 

--- a/docs/superpowers/specs/2026-05-04-retro-agent-design.md
+++ b/docs/superpowers/specs/2026-05-04-retro-agent-design.md
@@ -50,7 +50,7 @@ Read-only. The retro agent needs:
 - No filesystem write capability
 - No push/commit capability
 
-Write credentials are held only by the post-script, outside the sandbox, consistent with ADR 0017 (credential isolation).
+The sandbox and post-script share a single minted token with `issues:write` and `pull_requests:read`. The sandbox uses it for read operations (`gh run view`, `gh pr view`); the post-script uses it to file issues and post comments.
 
 ## Input Assembly
 
@@ -152,7 +152,7 @@ How to know the change had the desired effect. Measurable or observable outcomes
 The post-script reads the proposal files from the output directory and:
 
 1. **Files a GitHub issue** for each proposal in the `target_repo` specified in the frontmatter, using `gh issue create`
-2. **Posts a summary comment** on the originating PR or issue using `gh issue comment <number>`, linking to all filed issues. This works for both PRs and issues since GitHub treats PR comments as issue comments.
+2. **Posts a summary comment** on the originating PR or issue using the REST Issues API (`POST /repos/{owner}/{repo}/issues/{number}/comments` via `gh api`), linking to all filed issues. This endpoint only requires `issues:write` and works for both PRs and issues since GitHub treats PRs as issues in the REST API.
 
 ## Dispatch Integration
 

--- a/internal/scaffold/fullsend-repo/env/retro.env
+++ b/internal/scaffold/fullsend-repo/env/retro.env
@@ -1,6 +1,6 @@
 export ORIGINATING_URL="${ORIGINATING_URL}"
 export RETRO_COMMENT="${RETRO_COMMENT:-}"
 export REPO_FULL_NAME="${REPO_FULL_NAME}"
-# Sandbox receives the read-only token. The write-scoped GH_TOKEN is only
-# available to the post-script running on the host (via runner_env).
+# Sandbox receives the minted token (issues:write, pull_requests:read).
+# The same token is used by the post-script on the host (via runner_env).
 export GH_TOKEN="${RETRO_SANDBOX_TOKEN}"

--- a/internal/scaffold/fullsend-repo/policies/retro.yaml
+++ b/internal/scaffold/fullsend-repo/policies/retro.yaml
@@ -3,8 +3,8 @@ version: 1
 # Sandbox policy for the retro agent.
 #
 # Read-only agent: needs GitHub API (gh run list, gh run view, gh pr view)
-# and Vertex AI for inference. No write access to GitHub — the post-script
-# handles mutations on the runner with a separate write-scoped token.
+# and Vertex AI for inference. The sandbox token has issues:write (needed by
+# the post-script on the runner) but not pull_requests:write or contents:write.
 # curl intentionally excluded to prevent disallowedTools bypass via raw HTTP
 # with the injected GH_TOKEN.
 

--- a/internal/scaffold/fullsend-repo/scripts/post-retro.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-retro.sh
@@ -6,7 +6,7 @@
 #
 # Required env vars:
 #   ORIGINATING_URL — HTML URL of the originating PR or issue
-#   GH_TOKEN        — GitHub token with issues write scope
+#   GH_TOKEN        — GitHub token with issues:write scope (no pull_requests:write needed)
 #
 # The agent writes its result to output/agent-result.json (relative to
 # the iteration directory). This script finds the most recent iteration's output.
@@ -108,7 +108,9 @@ for i in $(seq 0 $((PROPOSAL_COUNT - 1))); do
 done
 
 # Post summary comment on the originating PR/issue.
-# gh issue comment works for both issues and PRs.
+# Uses REST API (not gh issue comment) because the GraphQL addComment mutation
+# requires pull_requests:write for PRs. The REST issues endpoint only needs
+# issues:write, which the retro role already has.
 SUMMARY=$(jq -r '.summary // empty' "${RESULT_FILE}")
 if [[ -z "${SUMMARY}" ]]; then
   echo "ERROR: .summary is missing or empty in agent result"
@@ -122,8 +124,8 @@ else
 fi
 
 echo "Posting summary comment on ${ORIGINATING_REPO}#${ORIGINATING_NUMBER}"
-printf '%s' "${COMMENT}" | gh issue comment "${ORIGINATING_NUMBER}" \
-  --repo "${ORIGINATING_REPO}" \
-  --body-file -
+jq -nc --arg body "${COMMENT}" '{body: $body}' | gh api \
+  "repos/${ORIGINATING_REPO}/issues/${ORIGINATING_NUMBER}/comments" \
+  --input -
 
 echo "Post-retro complete."


### PR DESCRIPTION
## Summary

- Switch `post-retro.sh` from `gh issue comment` (GraphQL `addComment`, requires `pull_requests:write`) to `gh api` REST endpoint (`POST /repos/{owner}/{repo}/issues/{number}/comments`, requires only `issues:write`)
- Correct stale comments in `retro.env`, `retro.yaml` policy, and design spec that inaccurately described credential isolation

## Context

The retro post-script failed with 403 when commenting on PRs ([run log](https://github.com/fullsend-ai/.fullsend/actions/runs/25949907364/job/76285603792)). Root cause: `gh issue comment` uses the GraphQL `addComment` mutation which requires `pull_requests:write` for PR targets, but the retro role only has `issues:write` + `pull_requests:read`.

Rather than escalating to `pull_requests:write`, this PR switches to the REST Issues API which only needs `issues:write` — GitHub treats PRs as issues in the REST API. This preserves least-privilege.

## Test plan

- [x] `TestAgentAppConfig_Retro` passes (no permission changes to Go code)
- [x] `go vet` clean
- [ ] Trigger retro on a PR to verify `gh api` comment succeeds with `issues:write` only
