### PR TITLE
fix: add lychee to code image and fix tar extraction in post-scripts

### DIFF
--- a/images/code/Containerfile
+++ b/images/code/Containerfile
@@ -2,6 +2,7 @@
 #
 # Extends the base fullsend sandbox image with tools needed by the code agent:
 #   - Go (compile + test target repos written in Go)
+#   - lychee (markdown link checker for pre-commit hooks)
 #   - scan-secrets (gitleaks wrapper for code-implementation skill)
 #
 # The base image already provides Claude Code, rsync, gitleaks, tirith,
@@ -79,6 +80,29 @@ ENV PATH="/usr/local/go/bin:${PATH}" \
 ARG GOPLS_VERSION=0.18.1
 RUN GOBIN=/usr/local/go/bin go install "golang.org/x/tools/gopls@v${GOPLS_VERSION}" \
     && gopls version
+
+# ---------------------------------------------------------------------------
+# lychee — markdown link checker used by pre-commit hooks (lint-md-links).
+# Baked into the image so pre-commit hooks work without network access.
+# The release archive nests the binary under lychee-<target>/.
+# To update: bump LYCHEE_VERSION and LYCHEE_SHA256_{AMD64,ARM64} from:
+#   https://github.com/lycheeverse/lychee/releases
+ARG LYCHEE_VERSION=0.24.2
+ARG LYCHEE_SHA256_AMD64=1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a
+ARG LYCHEE_SHA256_ARM64=91a7bd65685da41b90ccb9bc867a3d649a7818042dae04ff405e55a25bddee4c
+RUN case "$TARGETARCH" in \
+      amd64) LY_TRIPLE="x86_64-unknown-linux-gnu";  LY_SHA="$LYCHEE_SHA256_AMD64" ;; \
+      arm64) LY_TRIPLE="aarch64-unknown-linux-gnu"; LY_SHA="$LYCHEE_SHA256_ARM64" ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL \
+      "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-${LY_TRIPLE}.tar.gz" \
+      -o /tmp/lychee.tar.gz \
+    && echo "${LY_SHA}  /tmp/lychee.tar.gz" | sha256sum -c - \
+    && tar xzf /tmp/lychee.tar.gz -C /tmp \
+    && mv "/tmp/lychee-${LY_TRIPLE}/lychee" /usr/local/bin/lychee \
+    && chmod +x /usr/local/bin/lychee \
+    && rm -rf /tmp/lychee.tar.gz "/tmp/lychee-${LY_TRIPLE}"
 
 # ---------------------------------------------------------------------------
 # gitleaks is already installed in the base sandbox image.

--- a/internal/scaffold/fullsend-repo/scripts/post-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-code.sh
@@ -129,8 +129,9 @@ if ! command -v lychee >/dev/null 2>&1; then
     "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
     -o /tmp/lychee.tar.gz \
     && echo "${LYCHEE_SHA256}  /tmp/lychee.tar.gz" | sha256sum -c - \
-    && tar xzf /tmp/lychee.tar.gz -C "${HOME}/.local/bin" lychee \
-    && rm /tmp/lychee.tar.gz
+    && tar xzf /tmp/lychee.tar.gz -C /tmp \
+    && mv /tmp/lychee-x86_64-unknown-linux-gnu/lychee "${HOME}/.local/bin/" \
+    && rm -rf /tmp/lychee.tar.gz /tmp/lychee-x86_64-unknown-linux-gnu
   export PATH="${HOME}/.local/bin:${PATH}"
 fi
 

--- a/internal/scaffold/fullsend-repo/scripts/post-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-code.sh
@@ -36,7 +36,8 @@ set -euo pipefail
 GITLEAKS_VERSION="8.30.1"
 GITLEAKS_SHA256="551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
 LYCHEE_VERSION="0.24.2"
-LYCHEE_SHA256="1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
+LYCHEE_SHA256_AMD64="1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
+LYCHEE_SHA256_ARM64="91a7bd65685da41b90ccb9bc867a3d649a7818042dae04ff405e55a25bddee4c"
 UV_VERSION="0.11.14"
 UV_SHA256="f3b623eb0e6141a7053d571d59a0bdc341e0f238ea8f5f0b4815ddbec9a2a296"
 
@@ -125,13 +126,18 @@ echo "Secret scan passed — no leaks in agent's commit(s)"
 if ! command -v lychee >/dev/null 2>&1; then
   echo "Installing lychee v${LYCHEE_VERSION}..."
   mkdir -p "${HOME}/.local/bin"
+  case "$(uname -m)" in
+    x86_64)  LY_TRIPLE="x86_64-unknown-linux-gnu";  LY_SHA="${LYCHEE_SHA256_AMD64}" ;;
+    aarch64) LY_TRIPLE="aarch64-unknown-linux-gnu"; LY_SHA="${LYCHEE_SHA256_ARM64}" ;;
+    *) echo "::error::Unsupported architecture for lychee: $(uname -m)"; exit 1 ;;
+  esac
   curl -fsSL \
-    "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
+    "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-${LY_TRIPLE}.tar.gz" \
     -o /tmp/lychee.tar.gz \
-    && echo "${LYCHEE_SHA256}  /tmp/lychee.tar.gz" | sha256sum -c - \
+    && echo "${LY_SHA}  /tmp/lychee.tar.gz" | sha256sum -c - \
     && tar xzf /tmp/lychee.tar.gz -C /tmp \
-    && mv /tmp/lychee-x86_64-unknown-linux-gnu/lychee "${HOME}/.local/bin/" \
-    && rm -rf /tmp/lychee.tar.gz /tmp/lychee-x86_64-unknown-linux-gnu
+    && mv "/tmp/lychee-${LY_TRIPLE}/lychee" "${HOME}/.local/bin/" \
+    && rm -rf /tmp/lychee.tar.gz "/tmp/lychee-${LY_TRIPLE}"
   export PATH="${HOME}/.local/bin:${PATH}"
 fi
 

--- a/internal/scaffold/fullsend-repo/scripts/post-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-fix.sh
@@ -178,8 +178,9 @@ if ! command -v lychee >/dev/null 2>&1; then
     "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
     -o /tmp/lychee.tar.gz \
     && echo "${LYCHEE_SHA256}  /tmp/lychee.tar.gz" | sha256sum -c - \
-    && tar xzf /tmp/lychee.tar.gz -C "${HOME}/.local/bin" lychee \
-    && rm /tmp/lychee.tar.gz
+    && tar xzf /tmp/lychee.tar.gz -C /tmp \
+    && mv /tmp/lychee-x86_64-unknown-linux-gnu/lychee "${HOME}/.local/bin/" \
+    && rm -rf /tmp/lychee.tar.gz /tmp/lychee-x86_64-unknown-linux-gnu
   export PATH="${HOME}/.local/bin:${PATH}"
 fi
 

--- a/internal/scaffold/fullsend-repo/scripts/post-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-fix.sh
@@ -71,7 +71,8 @@ PROTECTED_PATHS=(
 GITLEAKS_VERSION="8.30.1"
 GITLEAKS_SHA256="551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
 LYCHEE_VERSION="0.24.2"
-LYCHEE_SHA256="1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
+LYCHEE_SHA256_AMD64="1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
+LYCHEE_SHA256_ARM64="91a7bd65685da41b90ccb9bc867a3d649a7818042dae04ff405e55a25bddee4c"
 UV_VERSION="0.11.14"
 UV_SHA256="f3b623eb0e6141a7053d571d59a0bdc341e0f238ea8f5f0b4815ddbec9a2a296"
 
@@ -174,13 +175,18 @@ fi
 if ! command -v lychee >/dev/null 2>&1; then
   echo "Installing lychee v${LYCHEE_VERSION}..."
   mkdir -p "${HOME}/.local/bin"
+  case "$(uname -m)" in
+    x86_64)  LY_TRIPLE="x86_64-unknown-linux-gnu";  LY_SHA="${LYCHEE_SHA256_AMD64}" ;;
+    aarch64) LY_TRIPLE="aarch64-unknown-linux-gnu"; LY_SHA="${LYCHEE_SHA256_ARM64}" ;;
+    *) echo "::error::Unsupported architecture for lychee: $(uname -m)"; exit 1 ;;
+  esac
   curl -fsSL \
-    "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
+    "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-${LY_TRIPLE}.tar.gz" \
     -o /tmp/lychee.tar.gz \
-    && echo "${LYCHEE_SHA256}  /tmp/lychee.tar.gz" | sha256sum -c - \
+    && echo "${LY_SHA}  /tmp/lychee.tar.gz" | sha256sum -c - \
     && tar xzf /tmp/lychee.tar.gz -C /tmp \
-    && mv /tmp/lychee-x86_64-unknown-linux-gnu/lychee "${HOME}/.local/bin/" \
-    && rm -rf /tmp/lychee.tar.gz /tmp/lychee-x86_64-unknown-linux-gnu
+    && mv "/tmp/lychee-${LY_TRIPLE}/lychee" "${HOME}/.local/bin/" \
+    && rm -rf /tmp/lychee.tar.gz "/tmp/lychee-${LY_TRIPLE}"
   export PATH="${HOME}/.local/bin:${PATH}"
 fi
 


### PR DESCRIPTION
## Summary

- Bake lychee v0.24.2 into `images/code/Containerfile` (multi-arch with SHA256 pinning) so the pre-commit `lint-md-links` hook works inside the sandbox without network access
- Fix tar extraction in `post-code.sh` and `post-fix.sh` — the lychee archive nests the binary under `lychee-x86_64-unknown-linux-gnu/`, so the old `tar xzf ... lychee` command failed with "Not found in archive"
- Extraction now follows the same pattern already used for uv: extract to `/tmp`, then `mv` the binary

Fixes the failure in [actions/runs/25963391100](https://github.com/fullsend-ai/.fullsend/actions/runs/25963391100/job/76322527241) where `lint-md-links` failed with `Executable 'lychee' not found`.

## Test plan

- [ ] CI lint workflow passes (uses `--strip-components=1` — already works)
- [ ] Rebuild code container image to verify lychee is baked in
- [ ] Re-run a code agent job to verify post-script lychee install works