### PR TITLE
fix(mint): accept job_workflow_ref from registered per-repo repos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,12 @@ Fullsend is a platform for fully autonomous agentic development for GitHub-hoste
 
 ## Go code
 
+**Mint function:** The mint Cloud Function source lives in two places that must stay in sync:
+- `internal/mint/main.go` — the source of truth (has its own `go.mod`, tests run from `internal/mint/`)
+- `internal/dispatch/gcf/mintsrc/main.go.embed` — the embedded copy deployed as a GCP Cloud Function
+
+When changing `internal/mint/main.go`, always copy it to `internal/dispatch/gcf/mintsrc/main.go.embed`. If `go.mod` or `go.sum` changed, sync those to `go.mod.embed` and `go.sum.embed` too.
+
 When making changes to Go code under `cmd/` or `internal/`:
 
 1. **Unit tests:** Run `make go-test` (or `go test ./...`) and fix any failures before committing.

--- a/docs/ADRs/0033-per-repo-installation-mode.md
+++ b/docs/ADRs/0033-per-repo-installation-mode.md
@@ -229,9 +229,10 @@ Apps ([ADR 0007](0007-per-role-github-apps.md)), but user-owned. The user
 deploys their own mint and creates their own Apps via `fullsend admin
 install owner/repo --mint-project=my-proj`.
 
-The mint's `job_workflow_ref` validation accepts both patterns:
-- `{org}/.fullsend/.github/workflows/*.yml@*` (per-org)
-- `fullsend-ai/fullsend/.github/workflows/reusable-*.yml@*` (per-repo)
+The mint's `job_workflow_ref` validation accepts three patterns:
+- `{org}/.fullsend/.github/workflows/*.yml@*` (per-org shim workflows)
+- `fullsend-ai/fullsend/.github/workflows/reusable-*.yml@*` (upstream reusable workflows called via `workflow_call`)
+- `{owner}/{repo}/.github/workflows/*.yml@*` where `{owner}/{repo}` is registered in `PER_REPO_WIF_REPOS` (per-repo workflows running directly via `workflow_dispatch`)
 
 The `repository_owner` claim scopes tokens to the calling org/user.
 `ALLOWED_ORGS` on the mint controls which orgs may request tokens.

--- a/internal/dispatch/gcf/mintsrc/main.go.embed
+++ b/internal/dispatch/gcf/mintsrc/main.go.embed
@@ -581,10 +581,12 @@ func (h *Handler) prevalidateOIDCToken(token string) (*oidcClaims, error) {
 		return nil, fmt.Errorf("repository_owner not in allowed orgs")
 	}
 
-	// Validate job_workflow_ref — only .fullsend or upstream fullsend-ai/fullsend
-	// workflows can request tokens. When reusable workflows are called via
-	// workflow_call, the OIDC job_workflow_ref reflects the reusable workflow's
-	// repo (fullsend-ai/fullsend), not the caller's (.fullsend).
+	// Validate job_workflow_ref — only .fullsend, upstream fullsend-ai/fullsend,
+	// or registered per-repo repos can request tokens. When reusable workflows
+	// are called via workflow_call, the OIDC job_workflow_ref reflects the
+	// reusable workflow's repo (fullsend-ai/fullsend), not the caller's
+	// (.fullsend). Per-repo workflows run directly in the target repo, so their
+	// job_workflow_ref references the target repo itself.
 	if claims.JobWorkflowRef == "" {
 		return nil, fmt.Errorf("missing job_workflow_ref claim")
 	}
@@ -598,7 +600,13 @@ func (h *Handler) prevalidateOIDCToken(token string) (*oidcClaims, error) {
 	case strings.HasPrefix(ref, upstreamPrefix):
 		relPath = strings.TrimPrefix(ref, upstreamPrefix)
 	default:
-		return nil, fmt.Errorf("job_workflow_ref does not reference .fullsend or upstream repo")
+		repoKey := strings.ToLower(claims.Repository)
+		repoPrefix := repoKey + "/"
+		if h.perRepoWIFRepos[repoKey] && strings.HasPrefix(ref, repoPrefix) {
+			relPath = strings.TrimPrefix(ref, repoPrefix)
+		} else {
+			return nil, fmt.Errorf("job_workflow_ref does not reference .fullsend, upstream repo, or registered per-repo repo")
+		}
 	}
 
 	// Extract the workflow file path (before @ref).

--- a/internal/mint/main.go
+++ b/internal/mint/main.go
@@ -581,10 +581,12 @@ func (h *Handler) prevalidateOIDCToken(token string) (*oidcClaims, error) {
 		return nil, fmt.Errorf("repository_owner not in allowed orgs")
 	}
 
-	// Validate job_workflow_ref — only .fullsend or upstream fullsend-ai/fullsend
-	// workflows can request tokens. When reusable workflows are called via
-	// workflow_call, the OIDC job_workflow_ref reflects the reusable workflow's
-	// repo (fullsend-ai/fullsend), not the caller's (.fullsend).
+	// Validate job_workflow_ref — only .fullsend, upstream fullsend-ai/fullsend,
+	// or registered per-repo repos can request tokens. When reusable workflows
+	// are called via workflow_call, the OIDC job_workflow_ref reflects the
+	// reusable workflow's repo (fullsend-ai/fullsend), not the caller's
+	// (.fullsend). Per-repo workflows run directly in the target repo, so their
+	// job_workflow_ref references the target repo itself.
 	if claims.JobWorkflowRef == "" {
 		return nil, fmt.Errorf("missing job_workflow_ref claim")
 	}
@@ -598,7 +600,12 @@ func (h *Handler) prevalidateOIDCToken(token string) (*oidcClaims, error) {
 	case strings.HasPrefix(ref, upstreamPrefix):
 		relPath = strings.TrimPrefix(ref, upstreamPrefix)
 	default:
-		return nil, fmt.Errorf("job_workflow_ref does not reference .fullsend or upstream repo")
+		repoKey := strings.ToLower(claims.Repository)
+		if h.perRepoWIFRepos[repoKey] {
+			relPath = strings.TrimPrefix(ref, repoKey+"/")
+		} else {
+			return nil, fmt.Errorf("job_workflow_ref does not reference .fullsend, upstream repo, or registered per-repo repo")
+		}
 	}
 
 	// Extract the workflow file path (before @ref).

--- a/internal/mint/main.go
+++ b/internal/mint/main.go
@@ -601,8 +601,9 @@ func (h *Handler) prevalidateOIDCToken(token string) (*oidcClaims, error) {
 		relPath = strings.TrimPrefix(ref, upstreamPrefix)
 	default:
 		repoKey := strings.ToLower(claims.Repository)
-		if h.perRepoWIFRepos[repoKey] {
-			relPath = strings.TrimPrefix(ref, repoKey+"/")
+		repoPrefix := repoKey + "/"
+		if h.perRepoWIFRepos[repoKey] && strings.HasPrefix(ref, repoPrefix) {
+			relPath = strings.TrimPrefix(ref, repoPrefix)
 		} else {
 			return nil, fmt.Errorf("job_workflow_ref does not reference .fullsend, upstream repo, or registered per-repo repo")
 		}

--- a/internal/mint/main_test.go
+++ b/internal/mint/main_test.go
@@ -598,6 +598,74 @@ func TestHandler_OIDCPrevalidation_BadJobWorkflowRef(t *testing.T) {
 	}
 }
 
+func TestHandler_OIDCPrevalidation_PerRepoWorkflowRef(t *testing.T) {
+	setMintEnv(t)
+	t.Setenv("PER_REPO_WIF_REPOS", "test-org/my-service")
+	h := NewHandler(&fakePEMAccessor{}, &fakeTokenValidator{})
+
+	oidcToken := makeTestOIDCToken(
+		"https://token.actions.githubusercontent.com",
+		"fullsend-mint",
+		"test-org/my-service",
+		"test-org",
+		"test-org/my-service/.github/workflows/gh-classify.yml@refs/heads/main",
+		time.Now().Add(10*time.Minute).Unix(),
+	)
+
+	claims, err := h.prevalidateOIDCToken(oidcToken)
+	if err != nil {
+		t.Fatalf("prevalidation should accept registered per-repo workflow ref: %v", err)
+	}
+	if claims.Repository != "test-org/my-service" {
+		t.Fatalf("expected repository test-org/my-service, got %s", claims.Repository)
+	}
+}
+
+func TestHandler_OIDCPrevalidation_PerRepoUnregistered(t *testing.T) {
+	setMintEnv(t)
+	h := NewHandler(&fakePEMAccessor{}, &fakeTokenValidator{})
+
+	oidcToken := makeTestOIDCToken(
+		"https://token.actions.githubusercontent.com",
+		"fullsend-mint",
+		"test-org/unregistered-repo",
+		"test-org",
+		"test-org/unregistered-repo/.github/workflows/steal-tokens.yml@refs/heads/main",
+		time.Now().Add(10*time.Minute).Unix(),
+	)
+
+	_, err := h.prevalidateOIDCToken(oidcToken)
+	if err == nil {
+		t.Fatal("prevalidation should reject unregistered per-repo workflow ref")
+	}
+	if !strings.Contains(err.Error(), "registered per-repo repo") {
+		t.Fatalf("expected per-repo rejection error, got: %v", err)
+	}
+}
+
+func TestHandler_OIDCPrevalidation_PerRepoNonWorkflowPath(t *testing.T) {
+	setMintEnv(t)
+	t.Setenv("PER_REPO_WIF_REPOS", "test-org/my-service")
+	h := NewHandler(&fakePEMAccessor{}, &fakeTokenValidator{})
+
+	oidcToken := makeTestOIDCToken(
+		"https://token.actions.githubusercontent.com",
+		"fullsend-mint",
+		"test-org/my-service",
+		"test-org",
+		"test-org/my-service/scripts/evil.sh@refs/heads/main",
+		time.Now().Add(10*time.Minute).Unix(),
+	)
+
+	_, err := h.prevalidateOIDCToken(oidcToken)
+	if err == nil {
+		t.Fatal("prevalidation should reject per-repo non-workflow path")
+	}
+	if !strings.Contains(err.Error(), "does not reference a workflow file") {
+		t.Fatalf("expected workflow file error, got: %v", err)
+	}
+}
+
 func TestHandler_OIDCPrevalidation_NonWorkflowPath(t *testing.T) {
 	h := NewHandler(&fakePEMAccessor{}, &fakeTokenValidator{})
 

--- a/internal/mint/main_test.go
+++ b/internal/mint/main_test.go
@@ -666,6 +666,49 @@ func TestHandler_OIDCPrevalidation_PerRepoNonWorkflowPath(t *testing.T) {
 	}
 }
 
+func TestHandler_OIDCPrevalidation_PerRepoCrossRepoRef(t *testing.T) {
+	setMintEnv(t)
+	t.Setenv("PER_REPO_WIF_REPOS", "test-org/my-service,test-org/other-repo")
+	h := NewHandler(&fakePEMAccessor{}, &fakeTokenValidator{})
+
+	oidcToken := makeTestOIDCToken(
+		"https://token.actions.githubusercontent.com",
+		"fullsend-mint",
+		"test-org/my-service",
+		"test-org",
+		"test-org/other-repo/.github/workflows/evil.yml@refs/heads/main",
+		time.Now().Add(10*time.Minute).Unix(),
+	)
+
+	_, err := h.prevalidateOIDCToken(oidcToken)
+	if err == nil {
+		t.Fatal("prevalidation should reject per-repo token with cross-repo job_workflow_ref")
+	}
+}
+
+func TestHandler_OIDCPrevalidation_PerRepoMixedCase(t *testing.T) {
+	setMintEnv(t)
+	t.Setenv("PER_REPO_WIF_REPOS", "Test-Org/My-Service")
+	h := NewHandler(&fakePEMAccessor{}, &fakeTokenValidator{})
+
+	oidcToken := makeTestOIDCToken(
+		"https://token.actions.githubusercontent.com",
+		"fullsend-mint",
+		"test-org/my-service",
+		"test-org",
+		"test-org/my-service/.github/workflows/gh-classify.yml@refs/heads/main",
+		time.Now().Add(10*time.Minute).Unix(),
+	)
+
+	claims, err := h.prevalidateOIDCToken(oidcToken)
+	if err != nil {
+		t.Fatalf("prevalidation should accept per-repo ref with case-insensitive matching: %v", err)
+	}
+	if claims.Repository != "test-org/my-service" {
+		t.Fatalf("expected repository test-org/my-service, got %s", claims.Repository)
+	}
+}
+
 func TestHandler_OIDCPrevalidation_NonWorkflowPath(t *testing.T) {
 	h := NewHandler(&fakePEMAccessor{}, &fakeTokenValidator{})
 
@@ -1364,6 +1407,42 @@ func TestServeHTTP_PerRepoProvider(t *testing.T) {
 
 	// The fake validator succeeds, so the request proceeds to minting.
 	// We verify the correct provider was resolved.
+	want := buildRepoProviderID("test-org", "integration-service")
+	if tv.lastProvider != want {
+		t.Fatalf("expected provider %q, got %q", want, tv.lastProvider)
+	}
+}
+
+func TestServeHTTP_PerRepoDirectWorkflow(t *testing.T) {
+	setMintEnv(t)
+	t.Setenv("PER_REPO_WIF_REPOS", "test-org/integration-service")
+	pemData, err := generateTestRSAKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tv := &fakeTokenValidator{}
+	h := NewHandler(
+		&fakePEMAccessor{pems: map[string][]byte{"test-org/coder": pemData}},
+		tv,
+	)
+
+	// Token from a per-repo workflow_dispatch — job_workflow_ref references the
+	// target repo itself, not .fullsend or fullsend-ai/fullsend.
+	oidcToken := makeTestOIDCToken(
+		"https://token.actions.githubusercontent.com",
+		"fullsend-mint",
+		"test-org/integration-service",
+		"test-org",
+		"test-org/integration-service/.github/workflows/gh-classify.yml@refs/heads/main",
+		time.Now().Add(10*time.Minute).Unix(),
+	)
+
+	body := `{"role":"coder","repos":["test-repo"]}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/token", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+oidcToken)
+	h.ServeHTTP(rec, req)
+
 	want := buildRepoProviderID("test-org", "integration-service")
 	if tv.lastProvider != want {
 		t.Fatalf("expected provider %q, got %q", want, tv.lastProvider)


### PR DESCRIPTION
## Summary

- Per-repo workflows (e.g. `gh-classify.yml`) run directly in the target repo via `workflow_dispatch`, so their OIDC `job_workflow_ref` references the target repo — not `.fullsend` or `fullsend-ai/fullsend`
- The mint's `prevalidateOIDCToken` rejected these with "does not reference .fullsend or upstream repo"
- Fix: check `PER_REPO_WIF_REPOS` in the default branch of the prefix switch — registered per-repo repos are accepted; unregistered repos are still rejected
- Existing `.github/workflows/` path check and `ALLOWED_WORKFLOW_FILES` allowlist still apply

## Test plan

- [x] Registered per-repo workflow ref accepted (`PerRepoWorkflowRef`)
- [x] Unregistered repo still rejected (`PerRepoUnregistered`)
- [x] Per-repo non-workflow path rejected (`PerRepoNonWorkflowPath`)
- [x] All 50 existing mint tests pass (no regressions)
- [x] `go vet` clean
- [ ] e2e: trigger `gh-classify.yml` on `nonflux/integration-service` after mint redeploy