### PR TITLE
fix(dispatch): restore /fs- prefix on slash commands

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -115,18 +115,18 @@ jobs:
           case "${EVENT_NAME}" in
             issue_comment)
               case "${COMMAND}" in
-                /triage)
+                /fs-triage)
                   STAGE="triage"
                   ;;
-                /code)
+                /fs-code)
                   if [[ "${ISSUE_HAS_PR}" == "false" ]]; then
                     STAGE="code"
                   fi
                   ;;
-                /review)
+                /fs-review)
                   STAGE="review"
                   ;;
-                /fix)
+                /fs-fix)
                   if [[ "${ISSUE_HAS_PR}" == "true" ]]; then
                     if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                       STAGE="fix"
@@ -134,7 +134,7 @@ jobs:
                     fi
                   fi
                   ;;
-                /retro|/fullsend)
+                /fs-retro|/fullsend)
                   if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                     if [[ "${COMMAND}" == "/fullsend" ]]; then
                       SECOND_WORD="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | awk '{print $2}')"

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -146,6 +146,11 @@ jobs:
                     fi
                   fi
                   ;;
+                /fs-prioritize)
+                  if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
+                    STAGE="prioritize"
+                  fi
+                  ;;
                 *)
                   if has_label "needs-info" && ! has_label "type/feature"; then
                     if [[ "${COMMENT_USER_TYPE}" != "Bot" ]]; then

--- a/docs/ADRs/0033-per-repo-installation-mode.md
+++ b/docs/ADRs/0033-per-repo-installation-mode.md
@@ -171,7 +171,7 @@ This is the key new artifact, published in `fullsend-ai/fullsend/.github/workflo
 
 The routing logic (identical to per-org `dispatch.yml`) maps:
 - `issues` + `labeled` → stage based on label name (`ready-to-code` → code, `ready-for-review` → review)
-- `issue_comment` + slash commands → `/triage`, `/code`, `/review`, `/fix`, `/retro`
+- `issue_comment` + slash commands → `/fs-triage`, `/fs-code`, `/fs-review`, `/fs-fix`, `/fs-retro`, `/fs-prioritize`
 - `issue_comment` + `needs-info` label (non-command) → auto-triage
 - `pull_request_target` + `opened`/`synchronize`/`ready_for_review` → review
 - `pull_request_target` + `closed` → retro

--- a/docs/ADRs/0034-centralized-shim-routing-via-dispatch.md
+++ b/docs/ADRs/0034-centralized-shim-routing-via-dispatch.md
@@ -99,7 +99,7 @@ The shim has three jobs:
 `dispatch.yml` gains a routing step that maps `event_type` + payload fields to
 a stage name:
 
-- `issue_comment` with `/triage`, `/code`, `/review`, `/fix`, `/retro`
+- `issue_comment` with `/fs-triage`, `/fs-code`, `/fs-review`, `/fs-fix`, `/fs-retro`, `/fs-prioritize`
   commands → corresponding stage
 - `issue_comment` on `needs-info` issue from non-bot → `triage`
 - `issues` + `labeled` with `ready-to-code` or `ready-for-review` → `code`
@@ -126,7 +126,7 @@ The `stage` input to `dispatch.yml` becomes optional. When provided
   prevent script injection from attacker-controlled fields.
 - **Fork-PR blocking** for the fix stage moves to `fix.yml`, where it already
   exists (redundant with the shim's current check).
-- **Author association checks** for `/fix`, `/retro`, `/stop-fix` move to
+- **Author association checks** for `/fs-fix`, `/fs-retro`, `/fs-fix-stop` move to
   `dispatch.yml`'s routing step.
 - **`workflow_call` inputs stay under 10.** The current 5 inputs minus `stage`
   plus `event_action` and `trigger_source` = 6 inputs.

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -83,18 +83,18 @@ jobs:
           case "${EVENT_NAME}" in
             issue_comment)
               case "${COMMAND}" in
-                /triage)
+                /fs-triage)
                   STAGE="triage"
                   ;;
-                /code)
+                /fs-code)
                   if [[ "${ISSUE_HAS_PR}" == "false" ]]; then
                     STAGE="code"
                   fi
                   ;;
-                /review)
+                /fs-review)
                   STAGE="review"
                   ;;
-                /fix)
+                /fs-fix)
                   if [[ "${ISSUE_HAS_PR}" == "true" ]]; then
                     if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                       STAGE="fix"
@@ -102,7 +102,7 @@ jobs:
                     fi
                   fi
                   ;;
-                /retro|/fullsend)
+                /fs-retro|/fullsend)
                   if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                     if [[ "${COMMAND}" == "/fullsend" ]]; then
                       SECOND_WORD="$(echo "${COMMENT_BODY}" | head -1 | awk '{print $2}')"
@@ -114,7 +114,7 @@ jobs:
                     fi
                   fi
                   ;;
-                /prioritize)
+                /fs-prioritize)
                   if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                     STAGE="prioritize"
                   fi

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -77,7 +77,7 @@ jobs:
           # Extract the first word of the comment as the command
           COMMAND=""
           if [[ -n "${COMMENT_BODY:-}" ]]; then
-            COMMAND="$(echo "${COMMENT_BODY}" | head -1 | awk '{print $1}')"
+            COMMAND="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | awk '{print $1}')"
           fi
 
           case "${EVENT_NAME}" in
@@ -105,7 +105,7 @@ jobs:
                 /fs-retro|/fullsend)
                   if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                     if [[ "${COMMAND}" == "/fullsend" ]]; then
-                      SECOND_WORD="$(echo "${COMMENT_BODY}" | head -1 | awk '{print $2}')"
+                      SECOND_WORD="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | awk '{print $2}')"
                       if [[ "${SECOND_WORD}" == "retro" ]]; then
                         STAGE="retro"
                       fi

--- a/internal/scaffold/fullsend-repo/scripts/post-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-fix.sh
@@ -308,7 +308,7 @@ BOT_CAP="${ITERATION_CAP:-5}"
 WARN_THRESHOLD=$(( BOT_CAP - 1 ))
 
 # The needs-human label is based on the bot cap — it signals that the
-# autonomous review→fix loop needs human direction. Human-triggered /fix
+# autonomous review→fix loop needs human direction. Human-triggered /fs-fix
 # runs have a separate, higher cap (ITERATION_CAP_HUMAN).
 if [ "${ITERATION}" -ge "${WARN_THRESHOLD}" ] && is_bot_user "${TRIGGER_SOURCE}"; then
   echo "::warning::Fix iteration ${ITERATION} is approaching bot cap of ${BOT_CAP}"

--- a/internal/scaffold/fullsend-repo/scripts/pre-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-code.sh
@@ -60,7 +60,7 @@ if [[ -z "${GH_TOKEN:-}" ]]; then
   exit 0
 fi
 
-# Allow override via CODE_FORCE (set when /code --force is used).
+# Allow override via CODE_FORCE (set when /fs-code --force is used).
 if [[ "${CODE_FORCE:-}" == "true" ]]; then
   echo "CODE_FORCE=true — skipping existing-PR check"
   exit 0
@@ -103,7 +103,7 @@ if [[ -n "${HUMAN_PR_LINES}" ]]; then
   COMMENT_BODY="An open PR already addresses this issue — skipping automated implementation.
 ${PR_LIST_MD}
 
-To override, comment \`/code --force\` on this issue.
+To override, comment \`/fs-code --force\` on this issue.
 
 <sub>Posted by <a href=\"https://github.com/fullsend-ai/fullsend\">fullsend</a> pre-code check</sub>"
 

--- a/internal/scaffold/fullsend-repo/scripts/pre-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-fix.sh
@@ -78,10 +78,10 @@ if [[ "${ITERATION}" -gt "${CAP}" ]]; then
   if is_bot_user "${TRIGGER_SOURCE}"; then
     echo "::error::Fix iteration ${ITERATION} exceeds bot cap of ${CAP}. Escalating to human."
     echo "::error::The review→fix loop has run ${ITERATION} times without converging."
-    echo "::error::A human can still direct the agent with /fix (up to ${HUMAN_CAP} total iterations)."
+    echo "::error::A human can still direct the agent with /fs-fix (up to ${HUMAN_CAP} total iterations)."
   else
     echo "::error::Fix iteration ${ITERATION} exceeds human cap of ${CAP}."
-    echo "::error::The /fix loop has run ${ITERATION} times. Further attempts are blocked."
+    echo "::error::The /fs-fix loop has run ${ITERATION} times. Further attempts are blocked."
   fi
   exit 1
 fi


### PR DESCRIPTION
## Summary

- PR #906 inadvertently changed all comment command patterns from `/fs-*` to unprefixed (e.g., `/fs-triage` → `/triage`), breaking all slash commands since docs, agent definitions, skills, and shim templates all reference the `/fs-` prefix
- Restores `/fs-triage`, `/fs-code`, `/fs-review`, `/fs-fix`, `/fs-retro`, and `/fs-prioritize` in both `reusable-dispatch.yml` and per-repo `dispatch.yml`
- Adds missing `/fs-prioritize` routing to `reusable-dispatch.yml` for parity with per-repo dispatch
- Fixes user-facing text in `pre-code.sh` referencing `/code --force` instead of `/fs-code --force`
- Replaces `echo` with `printf` in per-repo `dispatch.yml` command parsing to match `reusable-dispatch.yml`
- Updates ADRs 0033 and 0034 to use `/fs-*` prefixed command names
- The `/fullsend` alias and all other changes from PR #906 (human-PR fix gate, stage roles) are preserved

## Test plan

- [x] `make lint` passes
- [x] `make go-test` passes (scaffold test asserts all `/fs-*` prefixes)
- [ ] Verify `/fs-code`, `/fs-review`, `/fs-fix` commands route correctly in a test org
- [ ] Verify `/fullsend retro` alias still works alongside `/fs-retro`