### PR TITLE
fix(sandbox): upload .git directory separately into sandbox

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -322,6 +322,18 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary str
 		printer.StepFail("Failed to copy project code")
 		return fmt.Errorf("copying project code: %w", err)
 	}
+
+	// openshell upload applies .gitignore filtering by default via
+	// git ls-files, which never lists .git/. Upload it separately so the
+	// agent has full git history, refs, and branch state. Uploading .git/
+	// directly bypasses the filter because .git/ itself is not a working
+	// tree, causing openshell to fall back to an unfiltered tar upload.
+	gitDir := filepath.Join(repoSrc, ".git")
+	if fi, statErr := os.Stat(gitDir); statErr == nil && fi.IsDir() {
+		if err := sandbox.Upload(sandboxName, gitDir, filepath.Join(repoDir, ".git")); err != nil {
+			printer.StepWarn("Could not upload .git directory: " + err.Error())
+		}
+	}
 	printer.StepDone(fmt.Sprintf("Project code copied to %s/ (%.1fs)", repoName, time.Since(copyStart).Seconds()))
 
 	// 8a. Inject org-level AGENTS.md if the target repo does not have one.


### PR DESCRIPTION
## Summary

- Upload `.git/` as a separate step after the main repo upload to restore git history in the sandbox
- Since v0.8.0 (May 15), `openshell sandbox upload` strips `.git/` via `git ls-files` filtering, leaving agents with a bare file tree
- Uploading `.git/` directly bypasses the filter because it's not a working tree — openshell falls back to unfiltered tar

## Context

- Root cause analysis and blast radius documented in #1070
- 5 confirmed affected runs since May 15 — agents `git init`, lose history, post-script discards their work
- Verified fix works against openshell v0.0.36 sandbox (`fortunate-pup`)

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] Pre-commit hooks pass
- [x] Verified `.git/` uploads successfully without `--no-git-ignore` via live sandbox test
- [ ] Deploy and confirm next code agent run has `.git/` in sandbox and creates a feature branch

Fixes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)