### PR TITLE
fix: remove empty secrets section from shim workflow-call template

### DIFF
--- a/internal/scaffold/fullsend-repo/templates/shim-workflow-call.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow-call.yaml
@@ -44,7 +44,6 @@ jobs:
     uses: __ORG__/.fullsend/.github/workflows/dispatch.yml@main
     with:
       event_action: ${{ github.event.action }}
-    secrets: {}
 
   stop-fix:
     if: >-

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -111,7 +111,7 @@ func TestShimWorkflowCallTemplateContent(t *testing.T) {
 	assert.Contains(t, s, "event_action:")
 	assert.Contains(t, s, "id-token: write")
 	assert.Contains(t, s, "__ORG__/.fullsend/.github/workflows/dispatch.yml@main")
-	assert.Contains(t, s, "secrets: {}")
+	assert.NotContains(t, s, "secrets: {}")
 	// Dispatch concurrency group (no cancel — thin callers handle per-stage cancellation)
 	assert.Contains(t, s, "fullsend-dispatch-${{")
 	assert.Contains(t, s, "cancel-in-progress: false")


### PR DESCRIPTION
## Summary
- Removes `secrets: {}` from `shim-workflow-call.yaml` template — actionlint flags empty `secrets` sections as a lint error
- Updates the scaffold test assertion from `Contains` to `NotContains` to match

## Test plan
- [ ] `go test ./internal/scaffold/... -run TestShimWorkflowCallTemplateContent` passes
- [ ] Installed shim in an enrolled repo no longer fails `actionlint` with `"secrets" section should not be empty`