### PR TITLE
fix(sandbox): use tarball upload to preserve symlinks

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -332,10 +332,12 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary str
 	if fi, statErr := os.Stat(gitDir); statErr == nil && fi.IsDir() {
 		if err := sandbox.Upload(sandboxName, gitDir, filepath.Join(repoDir, ".git")); err != nil {
 			printer.StepWarn("Could not upload .git directory: " + err.Error())
+		} else {
+			// Only restore symlinks if .git was successfully uploaded
+			if err := sandbox.RestoreSymlinks(sandboxName, repoDir); err != nil {
+				printer.StepWarn("Could not restore symlinks: " + err.Error())
+			}
 		}
-	}
-	if err := sandbox.RestoreSymlinks(sandboxName, repoDir); err != nil {
-		printer.StepWarn("Could not restore symlinks: " + err.Error())
 	}
 	printer.StepDone(fmt.Sprintf("Project code copied to %s/ (%.1fs)", repoName, time.Since(copyStart).Seconds()))
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -314,30 +314,9 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary str
 	// 8. Make project code available (copy repo root into a named subdirectory).
 	copyStart := time.Now()
 	printer.StepStart("Copying project code into sandbox")
-	mkRepoCmd := fmt.Sprintf("mkdir -p %s", repoDir)
-	if _, _, _, err := sandbox.Exec(sandboxName, mkRepoCmd, 10*time.Second); err != nil {
-		return fmt.Errorf("creating repo dir in sandbox: %w", err)
-	}
-	if err := sandbox.Upload(sandboxName, repoSrc+"/.", repoDir+"/"); err != nil {
+	if err := sandbox.UploadDir(sandboxName, repoSrc, repoDir); err != nil {
 		printer.StepFail("Failed to copy project code")
 		return fmt.Errorf("copying project code: %w", err)
-	}
-
-	// openshell upload applies .gitignore filtering by default via
-	// git ls-files, which never lists .git/. Upload it separately so the
-	// agent has full git history, refs, and branch state. Uploading .git/
-	// directly bypasses the filter because .git/ itself is not a working
-	// tree, causing openshell to fall back to an unfiltered tar upload.
-	gitDir := filepath.Join(repoSrc, ".git")
-	if fi, statErr := os.Stat(gitDir); statErr == nil && fi.IsDir() {
-		if err := sandbox.Upload(sandboxName, gitDir, filepath.Join(repoDir, ".git")); err != nil {
-			printer.StepWarn("Could not upload .git directory: " + err.Error())
-		} else {
-			// Only restore symlinks if .git was successfully uploaded
-			if err := sandbox.RestoreSymlinks(sandboxName, repoDir); err != nil {
-				printer.StepWarn("Could not restore symlinks: " + err.Error())
-			}
-		}
 	}
 	printer.StepDone(fmt.Sprintf("Project code copied to %s/ (%.1fs)", repoName, time.Since(copyStart).Seconds()))
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -334,6 +334,9 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary str
 			printer.StepWarn("Could not upload .git directory: " + err.Error())
 		}
 	}
+	if err := sandbox.RestoreSymlinks(sandboxName, repoDir); err != nil {
+		printer.StepWarn("Could not restore symlinks: " + err.Error())
+	}
 	printer.StepDone(fmt.Sprintf("Project code copied to %s/ (%.1fs)", repoName, time.Since(copyStart).Seconds()))
 
 	// 8a. Inject org-level AGENTS.md if the target repo does not have one.

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -272,12 +272,19 @@ func Upload(sandboxName, localPath, remotePath string) error {
 // RestoreSymlinks recreates git-tracked symlinks after a sandbox upload.
 // openshell sandbox upload dereferences symlinks into real directories;
 // this reads the git index for mode-120000 entries and recreates them.
+// See https://github.com/NVIDIA/OpenShell/issues/1425
 func RestoreSymlinks(sandboxName, repoDir string) error {
+	// Shell-escape repoDir to prevent injection
+	escapedDir := strings.ReplaceAll(repoDir, "'", "'\\''")
+
+	// Use tab as field separator to handle paths with spaces correctly.
+	// git ls-files --stage format: <mode> <sha> <stage>\t<path>
+	// We split the first field on spaces to extract mode and sha, then use tab to get the full path.
 	cmd := fmt.Sprintf(
-		`cd %s && git ls-files --stage | awk '$1=="120000"{print $2,$4}' | while IFS=' ' read sha path; do target=$(git cat-file blob "$sha"); rm -rf "$path"; mkdir -p "$(dirname "$path")"; ln -s "$target" "$path"; done`,
-		repoDir,
+		`set -euo pipefail; cd '%s' && git ls-files --stage | awk -F'\t' '/^120000 /{split($1,a," "); print a[2]"\t"$2}' | while IFS=$'\t' read -r sha path; do [ -n "$path" ] || continue; target=$(git cat-file blob "$sha"); rm -rf "$path"; mkdir -p "$(dirname "$path")"; ln -s "$target" "$path"; done`,
+		escapedDir,
 	)
-	_, stderr, exitCode, err := Exec(sandboxName, cmd, 30*time.Second)
+	_, stderr, exitCode, err := Exec(sandboxName, cmd, 60*time.Second)
 	if err != nil {
 		return fmt.Errorf("restoring symlinks in sandbox %q: %w", sandboxName, err)
 	}

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -269,27 +269,35 @@ func Upload(sandboxName, localPath, remotePath string) error {
 	return nil
 }
 
-// RestoreSymlinks recreates git-tracked symlinks after a sandbox upload.
-// openshell sandbox upload dereferences symlinks into real directories;
-// this reads the git index for mode-120000 entries and recreates them.
-// See https://github.com/NVIDIA/OpenShell/issues/1425
-func RestoreSymlinks(sandboxName, repoDir string) error {
-	// Shell-escape repoDir to prevent injection
-	escapedDir := strings.ReplaceAll(repoDir, "'", "'\\''")
-
-	// Use tab as field separator to handle paths with spaces correctly.
-	// git ls-files --stage format: <mode> <sha> <stage>\t<path>
-	// We split the first field on spaces to extract mode and sha, then use tab to get the full path.
-	cmd := fmt.Sprintf(
-		`set -euo pipefail; cd '%s' && git ls-files --stage | awk -F'\t' '/^120000 /{split($1,a," "); print a[2]"\t"$2}' | while IFS=$'\t' read -r sha path; do [ -n "$path" ] || continue; target=$(git cat-file blob "$sha"); rm -rf "$path"; mkdir -p "$(dirname "$path")"; ln -s "$target" "$path"; done`,
-		escapedDir,
-	)
-	_, stderr, exitCode, err := Exec(sandboxName, cmd, 60*time.Second)
+// UploadDir uploads a local directory into a sandbox, preserving symlinks.
+// openshell sandbox upload dereferences symlinks; this builds a local tarball
+// with --no-dereference, uploads it, and extracts it in the sandbox.
+func UploadDir(sandboxName, localPath, remotePath string) error {
+	tmp, err := os.CreateTemp("", "openshell-upload-*.tar.gz")
 	if err != nil {
-		return fmt.Errorf("restoring symlinks in sandbox %q: %w", sandboxName, err)
+		return fmt.Errorf("creating temp tarball: %w", err)
+	}
+	tmpPath := tmp.Name()
+	tmp.Close()
+	defer os.Remove(tmpPath)
+
+	tarCmd := exec.Command("tar", "-czf", tmpPath, "-C", localPath, ".")
+	if out, tarErr := tarCmd.CombinedOutput(); tarErr != nil {
+		return fmt.Errorf("creating tarball of %q: %s: %w", localPath, string(out), tarErr)
+	}
+
+	remoteTar := fmt.Sprintf("/tmp/fs-upload-%s.tar.gz", sandboxName)
+	if err := Upload(sandboxName, tmpPath, remoteTar); err != nil {
+		return err
+	}
+
+	extractCmd := fmt.Sprintf("mkdir -p %s && tar -xzf %s -C %s && rm %s", remotePath, remoteTar, remotePath, remoteTar)
+	_, stderr, exitCode, err := Exec(sandboxName, extractCmd, transferTimeout)
+	if err != nil {
+		return fmt.Errorf("extracting tarball in sandbox %q: %w", sandboxName, err)
 	}
 	if exitCode != 0 {
-		return fmt.Errorf("restoring symlinks in sandbox %q: exit %d: %s", sandboxName, exitCode, stderr)
+		return fmt.Errorf("extracting tarball in sandbox %q: exit %d: %s", sandboxName, exitCode, stderr)
 	}
 	return nil
 }

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -269,6 +269,24 @@ func Upload(sandboxName, localPath, remotePath string) error {
 	return nil
 }
 
+// RestoreSymlinks recreates git-tracked symlinks after a sandbox upload.
+// openshell sandbox upload dereferences symlinks into real directories;
+// this reads the git index for mode-120000 entries and recreates them.
+func RestoreSymlinks(sandboxName, repoDir string) error {
+	cmd := fmt.Sprintf(
+		`cd %s && git ls-files --stage | awk '$1=="120000"{print $2,$4}' | while IFS=' ' read sha path; do target=$(git cat-file blob "$sha"); rm -rf "$path"; mkdir -p "$(dirname "$path")"; ln -s "$target" "$path"; done`,
+		repoDir,
+	)
+	_, stderr, exitCode, err := Exec(sandboxName, cmd, 30*time.Second)
+	if err != nil {
+		return fmt.Errorf("restoring symlinks in sandbox %q: %w", sandboxName, err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("restoring symlinks in sandbox %q: exit %d: %s", sandboxName, exitCode, stderr)
+	}
+	return nil
+}
+
 // Download copies a file or directory from a sandbox to the local machine.
 // The localPath is always treated as a directory by openshell — for single-file
 // downloads use DownloadFile instead.

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -244,3 +244,30 @@ func TestSanitizeDownload_EmptyDir(t *testing.T) {
 	err := sanitizeDownload(dir)
 	assert.NoError(t, err)
 }
+
+func TestRestoreSymlinks_OpenshellNotInPath(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	err := RestoreSymlinks("test-sandbox", "/tmp/workspace/repo")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "restoring symlinks")
+}
+
+func TestRestoreSymlinks_PathWithSpaces(t *testing.T) {
+	// This test validates the shell command construction for paths with spaces.
+	// Full integration testing requires a live sandbox with a git repo containing symlinks.
+	t.Setenv("PATH", "")
+
+	// Even with PATH cleared, we can verify the function handles the path correctly
+	// by checking it doesn't panic with special characters in repoDir.
+	err := RestoreSymlinks("test-sandbox", "/tmp/workspace/repo with spaces")
+	assert.Error(t, err) // Will error due to missing openshell, but shouldn't panic
+}
+
+func TestRestoreSymlinks_PathWithQuotes(t *testing.T) {
+	// Verify shell escaping handles single quotes in repoDir
+	t.Setenv("PATH", "")
+
+	err := RestoreSymlinks("test-sandbox", "/tmp/workspace/repo's name")
+	assert.Error(t, err) // Will error due to missing openshell, but shouldn't panic
+}

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -245,29 +245,10 @@ func TestSanitizeDownload_EmptyDir(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestRestoreSymlinks_OpenshellNotInPath(t *testing.T) {
+func TestUploadDir_OpenshellNotInPath(t *testing.T) {
+	dir := t.TempDir()
 	t.Setenv("PATH", "")
 
-	err := RestoreSymlinks("test-sandbox", "/tmp/workspace/repo")
+	err := UploadDir("test-sandbox", dir, "/tmp/workspace/repo")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "restoring symlinks")
-}
-
-func TestRestoreSymlinks_PathWithSpaces(t *testing.T) {
-	// This test validates the shell command construction for paths with spaces.
-	// Full integration testing requires a live sandbox with a git repo containing symlinks.
-	t.Setenv("PATH", "")
-
-	// Even with PATH cleared, we can verify the function handles the path correctly
-	// by checking it doesn't panic with special characters in repoDir.
-	err := RestoreSymlinks("test-sandbox", "/tmp/workspace/repo with spaces")
-	assert.Error(t, err) // Will error due to missing openshell, but shouldn't panic
-}
-
-func TestRestoreSymlinks_PathWithQuotes(t *testing.T) {
-	// Verify shell escaping handles single quotes in repoDir
-	t.Setenv("PATH", "")
-
-	err := RestoreSymlinks("test-sandbox", "/tmp/workspace/repo's name")
-	assert.Error(t, err) // Will error due to missing openshell, but shouldn't panic
 }


### PR DESCRIPTION
Closes #1133

## Summary

- `openshell sandbox upload` dereferences symlinks into real directories when building the tar archive — confirmed on v0.0.36 and v0.0.42, filed upstream as [NVIDIA/OpenShell#1425](https://github.com/NVIDIA/OpenShell/issues/1425)
- This causes `git status` inside the sandbox to report all git-tracked symlinks as `deleted:`, producing spurious noise and misleading agents into attempting to restore files that were never deleted
- Replace the previous `RestoreSymlinks` post-processing workaround with `UploadDir`: build a local tar archive (GNU tar preserves symlinks by default), upload it, and extract in the sandbox — one step, no git dependency, covers untracked symlinks too
- Also eliminates the separate `.git` upload step since the tarball includes everything

## How it works

`UploadDir` creates a temp tarball with `tar -czf` (symlinks are preserved by default — only `-h`/`--dereference` would follow them), uploads it to `/tmp/fs-upload-<sandbox>.tar.gz`, then execs `mkdir -p <dest> && tar -xzf ... && rm` in the sandbox.

## Test plan

- [x] Reproduced bug with openshell v0.0.36: `find -type l` returns empty, `link-dir` shows as `drwxr-xr-x` instead of symlink
- [x] Verified fix in live sandbox: `find -type l` returns `/sandbox/repo/link-dir`, `ls -la` shows `lrwxrwxrwx -> real-dir`, `git status` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)