### PR TITLE
docs: document platform-provided infrastructure for per-repo install

### DIFF
--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -326,52 +326,47 @@ Per-repo mode installs fullsend for a single repository without requiring an org
 
 When a platform operator has pre-provisioned shared public GitHub Apps and a token mint, you only need to provide a GCP project for inference. This is the simplest installation path — no Apps to create, no mint to deploy, no PEM management.
 
+> This section documents the **SaaS installation profile** defined in [ADR 0033 §6](../../ADRs/0033-per-repo-installation-mode.md#6-credential-models). If you are reusing apps from your own prior per-org installation, see [Reusing existing infrastructure](#reusing-existing-infrastructure) instead.
+
 **Prerequisites:**
 
 - **Org admin approval** to install the shared GitHub Apps on your repository
 - **GCP project** with the [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled for inference
-- **Platform mint URL** — obtain from your platform operator (used for OIDC token exchange and app discovery)
-- **Repository enrollment prerequisites** — enrolling a new repository to an existing mint may require coordination with the platform operator to ensure:
+- **Platform mint details** — obtain from your platform operator:
+  - Mint URL (for OIDC token exchange)
+  - Mint GCP project ID and region (for app discovery and validation via GCP APIs)
+- **Platform operator coordination** — the platform operator must ensure before you run the installer:
   - Your organization is registered in the mint's `ALLOWED_ORGS` configuration
   - The mint has the necessary GitHub App PEMs stored in Secret Manager
-  - Workload Identity Federation (WIF) is configured to accept tokens from your organization or repository
+  - Workload Identity Federation (WIF) is configured to accept tokens from your organization
 
-**Recommended: Assisted installation with mint URL**
+**Recommended: Assisted installation**
 
-Your platform operator provides a mint URL. Pass it directly — no GCP access to the platform project required:
-
-```bash
-fullsend admin install "$ORG_NAME/$REPO_NAME" \
-  --inference-project "$GCP_PROJECT" \
-  --mint-url "$PLATFORM_MINT_URL"
-```
-
-This command:
-- Queries the mint to discover shared app IDs
-- Checks if the shared apps are already installed on your repository
-- If apps are not installed, opens browser windows to install the pre-existing shared apps (requires org admin approval)
-- Validates and updates the mint configuration (registers your org, updates WIF, stores PEM references)
-- Auto-provisions Workload Identity Federation for your repo to authenticate with GCP
-- Generates workflow files and commits scaffold to your repository
-- Sets repository variables and secrets
-
-**Alternative: Discovery from GCP project**
-
-If you have IAM access to the platform operator's GCP project (requires `roles/cloudfunctions.viewer` for discovery and write roles for mint provisioning), you can let the installer discover the mint URL automatically:
+The installer discovers shared apps from the platform mint project and helps you install them:
 
 ```bash
 fullsend admin install "$ORG_NAME/$REPO_NAME" \
   --inference-project "$GCP_PROJECT" \
+  --mint-url "$PLATFORM_MINT_URL" \
   --mint-project "$PLATFORM_MINT_PROJECT" \
   --mint-region "$PLATFORM_MINT_REGION"
 ```
 
+This requires read access (`roles/cloudfunctions.viewer`) to the platform mint project for app discovery, plus write access (`roles/cloudfunctions.developer`, `roles/secretmanager.admin`) for mint validation and org registration. The command:
+- Discovers shared app IDs from the platform mint project via GCP Cloud Functions API
+- Checks if the shared apps are already installed on your repository
+- If apps are not installed, opens browser windows to install the pre-existing shared apps (requires org admin approval)
+- Validates and updates the mint configuration if needed (registers your org, updates WIF, stores PEM references)
+- Auto-provisions Workload Identity Federation for your repo in the inference project
+- Generates workflow files and commits scaffold to your repository
+- Sets repository variables and secrets
+
 > [!NOTE]
-> Most per-repo users will not have access to the platform project. Use this path only if you are a platform operator or have been granted access.
+> Most per-repo users will not have IAM access to the platform project. If you do not have access, ask your platform operator to pre-register your org and use the manual path below.
 
-**Advanced: Manual installation (skip all validation)**
+**Alternative: Manual installation (no platform project access)**
 
-If you've already installed the apps and configured everything manually, use `--skip-mint-check` to bypass all discovery and validation:
+If the platform operator has pre-registered your org and you only have the mint URL, use `--skip-mint-check` to bypass all GCP-based discovery and validation:
 
 ```bash
 fullsend admin install "$ORG_NAME/$REPO_NAME" \
@@ -380,13 +375,13 @@ fullsend admin install "$ORG_NAME/$REPO_NAME" \
   --skip-mint-check
 ```
 
-This assumes:
+This requires the platform operator to have completed the following before you run the installer:
 - The shared GitHub Apps are already installed on your repository
 - Your organization is registered in the mint's `ALLOWED_ORGS`
-- WIF is configured to accept tokens from your organization or repository
+- WIF is configured to accept tokens from your organization
 - All PEMs are stored in Secret Manager
 
-The installer skips all app discovery, mint validation, and GCP provisioning — it only generates workflow files and sets repository variables.
+The installer skips all app discovery, mint validation, and mint-related GCP provisioning — it only generates workflow files and sets repository variables and secrets. WIF infrastructure is still auto-provisioned in the inference project; pass `--inference-wif-provider` to skip this as well if the platform operator provides a pre-existing WIF provider.
 
 ### First-time install (no prior infrastructure)
 
@@ -413,11 +408,7 @@ Creating apps requires `admin:org` OAuth scope (the installer prompts for it). R
 
 ### Reusing existing infrastructure
 
-When a per-org install already exists, per-repo reuses the apps and mint. `ORG_NAME`, `REPO_NAME`, and `GCP_PROJECT` carry over from the first-time install step, or set them now. If you have an existing mint URL, set it too:
-
-```bash
-export MINT_URL="<your-mint-url>"
-```
+When a per-org install already exists in **your own org**, per-repo reuses the apps and mint. If the infrastructure belongs to a separate platform operator (SaaS profile), see [Using platform-provided infrastructure](#using-platform-provided-infrastructure) instead.
 
 ```bash
 fullsend admin install "$ORG_NAME/$REPO_NAME" \

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -335,10 +335,10 @@ When a platform operator has pre-provisioned shared public GitHub Apps and a tok
 - **Platform mint details** — obtain from your platform operator:
   - Mint URL (for OIDC token exchange)
   - Mint GCP project ID and region (for app discovery and validation via GCP APIs)
-- **Platform operator coordination** — the platform operator must ensure before you run the installer:
+- **Platform operator coordination** — the following must be in place before installation (the assisted path handles these automatically if you have IAM access to the platform project; required manually for the `--skip-mint-check` path):
   - Your organization is registered in the mint's `ALLOWED_ORGS` configuration
   - The mint has the necessary GitHub App PEMs stored in Secret Manager
-  - Workload Identity Federation (WIF) is configured to accept tokens from your organization
+  - Mint-side Workload Identity Federation (WIF) is configured to route tokens for your organization
 
 **Recommended: Assisted installation**
 
@@ -352,7 +352,7 @@ fullsend admin install "$ORG_NAME/$REPO_NAME" \
   --mint-region "$PLATFORM_MINT_REGION"
 ```
 
-This requires read access (`roles/cloudfunctions.viewer`) to the platform mint project for app discovery, plus write access (`roles/cloudfunctions.developer`, `roles/secretmanager.admin`) for mint validation and org registration. The command:
+This requires `roles/cloudfunctions.developer` and `roles/secretmanager.admin` on the platform mint project for app discovery, validation, and org registration. WIF auto-provisioning in the inference project additionally requires `roles/iam.workloadIdentityPoolAdmin` and `roles/resourcemanager.projectIamAdmin` on the inference project; pass `--inference-wif-provider` to skip this if you have a pre-existing WIF provider. The command:
 - Discovers shared app IDs from the platform mint project via GCP Cloud Functions API
 - Checks if the shared apps are already installed on your repository
 - If apps are not installed, opens browser windows to install the pre-existing shared apps (requires org admin approval)

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -332,17 +332,37 @@ When a platform operator has pre-provisioned shared public GitHub Apps and a tok
 
 - **Org admin approval** to install the shared GitHub Apps on your repository
 - **GCP project** with the [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled for inference
-- **Platform mint details** — obtain from your platform operator:
-  - Mint URL (for OIDC token exchange; the assisted path discovers this automatically, but providing it explicitly is recommended)
-  - Mint GCP project ID and region (for app discovery and validation via GCP APIs)
-- **Platform operator coordination** — the following must be in place before installation (the assisted path handles these automatically if you have IAM access to the platform project; required manually for the `--skip-mint-check` path):
+- **Mint URL** — obtain from your platform operator (for OIDC token exchange)
+- **Platform operator coordination** — the following must be in place before installation:
   - Your organization is registered in the mint's `ALLOWED_ORGS` configuration
+  - The shared GitHub Apps are installed on your repository
   - The mint has the necessary GitHub App PEMs stored in Secret Manager
   - Mint-side Workload Identity Federation (WIF) is configured to accept OIDC tokens from your organization's repositories
+- **For assisted installation only** — mint GCP project ID and region, plus IAM access to the platform project (see [Alternative: Assisted installation](#alternative-assisted-installation-requires-platform-project-access))
 
-**Recommended: Assisted installation**
+**Recommended: Use the mint URL directly**
 
-The installer discovers shared apps from the platform mint project and helps you install them:
+Most per-repo users will not have IAM access to the platform operator's GCP project. Ask your platform operator for the mint URL and confirm that the following are in place before running the installer:
+
+- The shared GitHub Apps are already installed on your repository
+- Your organization is registered in the mint's `ALLOWED_ORGS`
+- Mint-side WIF is configured to accept tokens from your organization
+- All PEMs are stored in Secret Manager
+
+Then run:
+
+```bash
+fullsend admin install "$ORG_NAME/$REPO_NAME" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-url "$PLATFORM_MINT_URL" \
+  --skip-mint-check
+```
+
+The installer skips all app discovery, mint validation, and mint-related GCP provisioning — it only generates workflow files and sets repository variables and secrets. WIF infrastructure is still auto-provisioned in the inference project; pass `--inference-wif-provider` to skip this as well if the platform operator provides a pre-existing WIF provider.
+
+**Alternative: Assisted installation (requires platform project access)**
+
+If you have IAM access to the platform operator's GCP project, the installer can discover shared apps and handle validation automatically:
 
 ```bash
 fullsend admin install "$ORG_NAME/$REPO_NAME" \
@@ -360,28 +380,6 @@ This requires `roles/cloudfunctions.developer` and `roles/secretmanager.admin` o
 - Auto-provisions Workload Identity Federation for your repo in the inference project
 - Generates workflow files and commits scaffold to your repository
 - Sets repository variables and secrets
-
-> [!NOTE]
-> Most per-repo users will not have IAM access to the platform project. If you do not have access, ask your platform operator to pre-register your org and use the manual path below.
-
-**Alternative: Manual installation (no platform project access)**
-
-If the platform operator has pre-registered your org and you only have the mint URL, use `--skip-mint-check` to bypass all GCP-based discovery and validation:
-
-```bash
-fullsend admin install "$ORG_NAME/$REPO_NAME" \
-  --inference-project "$GCP_PROJECT" \
-  --mint-url "$PLATFORM_MINT_URL" \
-  --skip-mint-check
-```
-
-This requires the platform operator to have completed the following before you run the installer:
-- The shared GitHub Apps are already installed on your repository
-- Your organization is registered in the mint's `ALLOWED_ORGS`
-- Mint-side WIF is configured to accept tokens from your organization
-- All PEMs are stored in Secret Manager
-
-The installer skips all app discovery, mint validation, and mint-related GCP provisioning — it only generates workflow files and sets repository variables and secrets. WIF infrastructure is still auto-provisioned in the inference project; pass `--inference-wif-provider` to skip this as well if the platform operator provides a pre-existing WIF provider.
 
 ### First-time install (no prior infrastructure)
 

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -330,17 +330,34 @@ When a platform operator has pre-provisioned shared public GitHub Apps and a tok
 
 - **Org admin approval** to install the shared GitHub Apps on your repository
 - **GCP project** with the [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled for inference
-- **Platform mint details** — obtain from your platform operator:
-  - Mint URL (for OIDC token exchange)
-  - Mint GCP project ID and region (for app discovery)
+- **Platform mint URL** — obtain from your platform operator (used for OIDC token exchange and app discovery)
 - **Repository enrollment prerequisites** — enrolling a new repository to an existing mint may require coordination with the platform operator to ensure:
   - Your organization is registered in the mint's `ALLOWED_ORGS` configuration
   - The mint has the necessary GitHub App PEMs stored in Secret Manager
   - Workload Identity Federation (WIF) is configured to accept tokens from your organization or repository
 
-**Recommended: Assisted installation**
+**Recommended: Assisted installation with mint URL**
 
-The installer can discover the shared apps from the mint and help you install them:
+Your platform operator provides a mint URL. Pass it directly — no GCP access to the platform project required:
+
+```bash
+fullsend admin install "$ORG_NAME/$REPO_NAME" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-url "$PLATFORM_MINT_URL"
+```
+
+This command:
+- Queries the mint to discover shared app IDs
+- Checks if the shared apps are already installed on your repository
+- If apps are not installed, opens browser windows to install the pre-existing shared apps (requires org admin approval)
+- Validates and updates the mint configuration (registers your org, updates WIF, stores PEM references)
+- Auto-provisions Workload Identity Federation for your repo to authenticate with GCP
+- Generates workflow files and commits scaffold to your repository
+- Sets repository variables and secrets
+
+**Alternative: Discovery from GCP project**
+
+If you have IAM access to the platform operator's GCP project (requires `roles/cloudfunctions.viewer` for discovery and write roles for mint provisioning), you can let the installer discover the mint URL automatically:
 
 ```bash
 fullsend admin install "$ORG_NAME/$REPO_NAME" \
@@ -349,24 +366,8 @@ fullsend admin install "$ORG_NAME/$REPO_NAME" \
   --mint-region "$PLATFORM_MINT_REGION"
 ```
 
-This command:
-- Discovers the mint and shared app IDs from the platform mint project
-- Checks if the shared apps are already installed on your repository
-- If apps are not installed, opens browser windows to install the pre-existing shared apps (requires org admin approval)
-- Validates and updates the mint configuration (registers your org, updates WIF, stores PEM references)
-- Auto-provisions Workload Identity Federation for your repo to authenticate with GCP
-- Generates workflow files and commits scaffold to your repository
-- Sets repository variables and secrets
-
-You can also provide `--mint-url` explicitly to skip mint URL discovery:
-
-```bash
-fullsend admin install "$ORG_NAME/$REPO_NAME" \
-  --inference-project "$GCP_PROJECT" \
-  --mint-project "$PLATFORM_MINT_PROJECT" \
-  --mint-region "$PLATFORM_MINT_REGION" \
-  --mint-url "$PLATFORM_MINT_URL"
-```
+> [!NOTE]
+> Most per-repo users will not have access to the platform project. Use this path only if you are a platform operator or have been granted access.
 
 **Advanced: Manual installation (skip all validation)**
 
@@ -386,10 +387,6 @@ This assumes:
 - All PEMs are stored in Secret Manager
 
 The installer skips all app discovery, mint validation, and GCP provisioning — it only generates workflow files and sets repository variables.
-
-**Mint URL discovery:**
-
-In the future, the installer may support profile-based discovery (e.g., `--profile saas`) to automatically resolve the platform mint URL and project details, eliminating the need to specify them manually.
 
 ### First-time install (no prior infrastructure)
 

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -322,6 +322,75 @@ Per-repo mode installs fullsend for a single repository without requiring an org
 > reference chain unidirectional: target repo → `.fullsend` → upstream
 > `fullsend-ai/fullsend`.
 
+### Using platform-provided infrastructure
+
+When a platform operator has pre-provisioned shared public GitHub Apps and a token mint, you only need to provide a GCP project for inference. This is the simplest installation path — no Apps to create, no mint to deploy, no PEM management.
+
+**Prerequisites:**
+
+- **Org admin approval** to install the shared GitHub Apps on your repository
+- **GCP project** with the [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled for inference
+- **Platform mint details** — obtain from your platform operator:
+  - Mint URL (for OIDC token exchange)
+  - Mint GCP project ID and region (for app discovery)
+- **Repository enrollment prerequisites** — enrolling a new repository to an existing mint may require coordination with the platform operator to ensure:
+  - Your organization is registered in the mint's `ALLOWED_ORGS` configuration
+  - The mint has the necessary GitHub App PEMs stored in Secret Manager
+  - Workload Identity Federation (WIF) is configured to accept tokens from your organization
+
+**Recommended: Assisted installation**
+
+The installer can discover the shared apps from the mint and help you install them:
+
+```bash
+fullsend admin install "$ORG_NAME/$REPO_NAME" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-project "$PLATFORM_MINT_PROJECT" \
+  --mint-region "$PLATFORM_MINT_REGION"
+```
+
+This command:
+- Discovers the mint and shared app IDs from the platform mint project
+- Checks if the shared apps are already installed on your repository
+- If apps are not installed, opens browser windows to install the pre-existing shared apps (requires org admin approval)
+- Validates and updates the mint configuration (registers your org, updates WIF, stores PEM references)
+- Auto-provisions Workload Identity Federation for your repo to authenticate with GCP
+- Generates workflow files and commits scaffold to your repository
+- Sets repository variables and secrets
+
+You can also provide `--mint-url` explicitly to skip mint URL discovery:
+
+```bash
+fullsend admin install "$ORG_NAME/$REPO_NAME" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-project "$PLATFORM_MINT_PROJECT" \
+  --mint-region "$PLATFORM_MINT_REGION" \
+  --mint-url "$PLATFORM_MINT_URL"
+```
+
+**Advanced: Manual installation (skip all validation)**
+
+If you've already installed the apps and configured everything manually, use `--skip-mint-check` to bypass all discovery and validation:
+
+```bash
+fullsend admin install "$ORG_NAME/$REPO_NAME" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-url "$PLATFORM_MINT_URL" \
+  --skip-mint-check
+```
+
+This assumes:
+- The shared GitHub Apps are already installed on your repository
+- Your organization is registered in the mint's `ALLOWED_ORGS`
+- WIF is configured to accept tokens from your repository
+- All PEMs are stored in Secret Manager
+
+The installer skips all app discovery, mint validation, and GCP provisioning — it only generates workflow files and sets repository variables.
+
+**Mint URL discovery:**
+
+In the future, the installer may support profile-based discovery (e.g., `--profile saas`) to automatically resolve the platform mint URL and project details, eliminating the need to specify them manually.
+
 ### First-time install (no prior infrastructure)
 
 Set the variables for your environment:

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -338,7 +338,7 @@ When a platform operator has pre-provisioned shared public GitHub Apps and a tok
   - The shared GitHub Apps are installed on your repository
   - The mint has the necessary GitHub App PEMs stored in Secret Manager
   - Mint-side Workload Identity Federation (WIF) is configured to accept OIDC tokens from your organization's repositories
-- **For assisted installation only** — mint GCP project ID and region, plus IAM access to the platform project (see [Alternative: Assisted installation](#alternative-assisted-installation-requires-platform-project-access))
+- **For assisted installation only** — mint GCP project ID and region, plus IAM access to the platform project (see the alternative path below)
 
 **Recommended: Use the mint URL directly**
 

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -336,7 +336,7 @@ When a platform operator has pre-provisioned shared public GitHub Apps and a tok
 - **Repository enrollment prerequisites** — enrolling a new repository to an existing mint may require coordination with the platform operator to ensure:
   - Your organization is registered in the mint's `ALLOWED_ORGS` configuration
   - The mint has the necessary GitHub App PEMs stored in Secret Manager
-  - Workload Identity Federation (WIF) is configured to accept tokens from your organization
+  - Workload Identity Federation (WIF) is configured to accept tokens from your organization or repository
 
 **Recommended: Assisted installation**
 
@@ -382,7 +382,7 @@ fullsend admin install "$ORG_NAME/$REPO_NAME" \
 This assumes:
 - The shared GitHub Apps are already installed on your repository
 - Your organization is registered in the mint's `ALLOWED_ORGS`
-- WIF is configured to accept tokens from your repository
+- WIF is configured to accept tokens from your organization or repository
 - All PEMs are stored in Secret Manager
 
 The installer skips all app discovery, mint validation, and GCP provisioning — it only generates workflow files and sets repository variables.

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -333,12 +333,12 @@ When a platform operator has pre-provisioned shared public GitHub Apps and a tok
 - **Org admin approval** to install the shared GitHub Apps on your repository
 - **GCP project** with the [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled for inference
 - **Platform mint details** — obtain from your platform operator:
-  - Mint URL (for OIDC token exchange)
+  - Mint URL (for OIDC token exchange; the assisted path discovers this automatically, but providing it explicitly is recommended)
   - Mint GCP project ID and region (for app discovery and validation via GCP APIs)
 - **Platform operator coordination** — the following must be in place before installation (the assisted path handles these automatically if you have IAM access to the platform project; required manually for the `--skip-mint-check` path):
   - Your organization is registered in the mint's `ALLOWED_ORGS` configuration
   - The mint has the necessary GitHub App PEMs stored in Secret Manager
-  - Mint-side Workload Identity Federation (WIF) is configured to route tokens for your organization
+  - Mint-side Workload Identity Federation (WIF) is configured to accept OIDC tokens from your organization's repositories
 
 **Recommended: Assisted installation**
 
@@ -378,7 +378,7 @@ fullsend admin install "$ORG_NAME/$REPO_NAME" \
 This requires the platform operator to have completed the following before you run the installer:
 - The shared GitHub Apps are already installed on your repository
 - Your organization is registered in the mint's `ALLOWED_ORGS`
-- WIF is configured to accept tokens from your organization
+- Mint-side WIF is configured to accept tokens from your organization
 - All PEMs are stored in Secret Manager
 
 The installer skips all app discovery, mint validation, and mint-related GCP provisioning — it only generates workflow files and sets repository variables and secrets. WIF infrastructure is still auto-provisioned in the inference project; pass `--inference-wif-provider` to skip this as well if the platform operator provides a pre-existing WIF provider.


### PR DESCRIPTION
## Summary

Adds documentation for the platform-provided infrastructure installation profile to the per-repo installation guide. This addresses the gap identified in #1077 where ADR 0033 §6 defines the SaaS profile but the installation guide has no corresponding section.

## Changes

Added "Using platform-provided infrastructure" section to `docs/guides/admin/installation.md` with two installation paths:

### 1. Recommended: Assisted installation
- Uses `--mint-project` and `--mint-region` for app discovery from the platform mint
- Installer discovers shared app IDs and checks if they're installed on the repository
- If apps are not installed, opens browser windows to install the pre-existing shared apps (requires org admin approval)
- Validates and updates mint configuration (registers org, updates WIF, stores PEM references)
- Auto-provisions WIF for the repository

Command:
```bash
fullsend admin install "$ORG_NAME/$REPO_NAME" \
  --inference-project "$GCP_PROJECT" \
  --mint-project "$PLATFORM_MINT_PROJECT" \
  --mint-region "$PLATFORM_MINT_REGION"
```

### 2. Advanced: Manual installation (skip all validation)
- Uses `--skip-mint-check` to bypass all discovery, validation, and provisioning
- Assumes apps are already installed and org is registered in the mint
- Only generates workflow files and sets repository variables

Command:
```bash
fullsend admin install "$ORG_NAME/$REPO_NAME" \
  --inference-project "$GCP_PROJECT" \
  --mint-url "$PLATFORM_MINT_URL" \
  --skip-mint-check
```

## Key Implementation Details

Based on code analysis of `internal/cli/admin.go`:
- `--skip-mint-check` implies skipping app setup (sets `needAppSetup = false` via the logic `needAppSetup := !appsFound && !skipAppSetup && !skipMintCheck`)
- Using `--skip-app-setup` alone is only valid when apps are already discovered/installed; otherwise it errors
- The recommended path (without skip flags) allows the installer to help with app installation via browser flow

## Test Plan

- [x] Verified all referenced CLI flags exist in the installer flag definitions
- [x] Ran `SKIP=lint-md-links pre-commit run` - all checks passed
- [x] Confirmed the new section integrates into the guide's flow
- [x] Verified ADR 0033 cross-reference
- [x] Analyzed CLI implementation to ensure flag usage is correct

## Documentation Structure

The section is positioned before "First-time install" as it represents the simplest user-facing installation path when platform infrastructure already exists. The recommended assisted path is presented first, with the manual skip-all-checks path as an advanced option.

Fixes #1077