### PR TITLE
feat: add fetch audit logging for remote resource tracking

### DIFF
--- a/docs/plans/universal-harness-access.md
+++ b/docs/plans/universal-harness-access.md
@@ -1187,12 +1187,14 @@ var RemoteResourcePolicy = ScanPolicy{
 
 ### 8. Audit Logging
 
-**File:** `internal/audit/fetch_log.go` (new)
+**File:** `internal/fetch/audit.go`
 
-All fetches are logged to a structured log:
+All fetches are logged to a structured JSONL log. The caller provides the log
+path directly (better separation of concerns than env-var resolution inside the
+logger). File permissions use `0o600` to match `security.AppendFinding`.
 
 ```go
-package audit
+package fetch
 
 import (
     "encoding/json"
@@ -1202,44 +1204,34 @@ import (
     "time"
 )
 
-type FetchLog struct {
-    TraceID    string    `json:"trace_id"`
-    FetchTime  time.Time `json:"fetch_time"`
-    URL        string    `json:"url"`
-    SHA256     string    `json:"sha256"`
-    FetchType  string    `json:"fetch_type"`  // "static" or "runtime"
-    AllowedBy  string    `json:"allowed_by"`  // which allowed_remote_resources entry matched
+type FetchAuditEntry struct {
+    TraceID   string    `json:"trace_id"`
+    FetchTime time.Time `json:"fetch_time"`
+    URL       string    `json:"url"`
+    SHA256    string    `json:"sha256"`
+    FetchType string    `json:"fetch_type"`
+    AllowedBy string    `json:"allowed_by"`
+    CacheHit  bool      `json:"cache_hit"`
 }
 
-// LogFetch appends a fetch record to the audit log.
-// Note: Audit logs are kept in user home directory for persistence across workspaces.
-// This is configurable via FULLSEND_AUDIT_DIR environment variable.
-func LogFetch(log FetchLog) error {
-    logDir := os.Getenv("FULLSEND_AUDIT_DIR")
-    if logDir == "" {
-        home, err := os.UserHomeDir()
-        if err != nil {
-            return fmt.Errorf("getting home directory for audit logs: %w", err)
-        }
-        logDir = filepath.Join(home, ".cache", "fullsend", "audit")
-    }
-    if err := os.MkdirAll(logDir, 0755); err != nil {
+func AppendFetchAudit(logPath string, entry FetchAuditEntry) error {
+    if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
         return fmt.Errorf("creating audit log directory: %w", err)
     }
-
-    logPath := filepath.Join(logDir, "fetches.jsonl")
-    f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+    f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
     if err != nil {
-        return err
+        return fmt.Errorf("opening audit log: %w", err)
     }
     defer f.Close()
 
-    data, err := json.Marshal(log)
+    data, err := json.Marshal(entry)
     if err != nil {
-        return fmt.Errorf("marshaling fetch log: %w", err)
+        return fmt.Errorf("marshaling audit entry: %w", err)
     }
-    _, err = f.Write(append(data, '\n'))
-    return err
+    if _, err := fmt.Fprintf(f, "%s\n", data); err != nil {
+        return fmt.Errorf("writing audit entry: %w", err)
+    }
+    return nil
 }
 ```
 

--- a/internal/fetch/audit.go
+++ b/internal/fetch/audit.go
@@ -1,0 +1,41 @@
+package fetch
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// FetchAuditEntry is a JSONL audit record for a remote resource fetch.
+type FetchAuditEntry struct {
+	TraceID   string    `json:"trace_id"`
+	FetchTime time.Time `json:"fetch_time"`
+	URL       string    `json:"url"`
+	SHA256    string    `json:"sha256"`
+	FetchType string    `json:"fetch_type"`
+	AllowedBy string    `json:"allowed_by"`
+	CacheHit  bool      `json:"cache_hit"`
+}
+
+// AppendFetchAudit writes a fetch audit entry as a JSON line to the given log path.
+func AppendFetchAudit(logPath string, entry FetchAuditEntry) error {
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return fmt.Errorf("creating audit log directory: %w", err)
+	}
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("opening audit log: %w", err)
+	}
+	defer f.Close()
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshaling audit entry: %w", err)
+	}
+	if _, err := fmt.Fprintf(f, "%s\n", data); err != nil {
+		return fmt.Errorf("writing audit entry: %w", err)
+	}
+	return nil
+}

--- a/internal/fetch/audit_test.go
+++ b/internal/fetch/audit_test.go
@@ -1,0 +1,121 @@
+package fetch
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendFetchAudit_SingleEntry(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+
+	entry := FetchAuditEntry{
+		TraceID:   "trace-001",
+		FetchTime: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+		URL:       "https://example.com/resource",
+		SHA256:    "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		FetchType: "http_get",
+		AllowedBy: "allowlist-rule-1",
+		CacheHit:  false,
+	}
+
+	err := AppendFetchAudit(logPath, entry)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+
+	var got FetchAuditEntry
+	err = json.Unmarshal([]byte(strings.TrimSpace(string(data))), &got)
+	require.NoError(t, err)
+
+	assert.Equal(t, "trace-001", got.TraceID)
+	assert.Equal(t, time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC), got.FetchTime)
+	assert.Equal(t, "https://example.com/resource", got.URL)
+	assert.Equal(t, "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890", got.SHA256)
+	assert.Equal(t, "http_get", got.FetchType)
+	assert.Equal(t, "allowlist-rule-1", got.AllowedBy)
+	assert.False(t, got.CacheHit)
+}
+
+func TestAppendFetchAudit_MultipleEntries(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+
+	for i := range 3 {
+		entry := FetchAuditEntry{
+			TraceID:   fmt.Sprintf("trace-%03d", i),
+			FetchTime: time.Now().UTC(),
+			URL:       fmt.Sprintf("https://example.com/resource/%d", i),
+			SHA256:    "deadbeef",
+			FetchType: "http_get",
+			AllowedBy: "allowlist",
+			CacheHit:  i > 0,
+		}
+		err := AppendFetchAudit(logPath, entry)
+		require.NoError(t, err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	assert.Len(t, lines, 3)
+
+	for _, line := range lines {
+		var got FetchAuditEntry
+		err := json.Unmarshal([]byte(line), &got)
+		assert.NoError(t, err)
+	}
+}
+
+func TestAppendFetchAudit_CreatesParentDirs(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "a", "b", "c", "audit.jsonl")
+
+	entry := FetchAuditEntry{
+		TraceID:   "trace-nested",
+		FetchTime: time.Now().UTC(),
+		URL:       "https://example.com/nested",
+		SHA256:    "cafebabe",
+		FetchType: "http_get",
+		AllowedBy: "allowlist",
+		CacheHit:  true,
+	}
+
+	err := AppendFetchAudit(logPath, entry)
+	require.NoError(t, err)
+
+	_, err = os.Stat(logPath)
+	assert.NoError(t, err)
+}
+
+func TestAppendFetchAudit_JSONFields(t *testing.T) {
+	entry := FetchAuditEntry{
+		TraceID:   "trace-fields",
+		FetchTime: time.Now().UTC(),
+		URL:       "https://example.com/fields",
+		SHA256:    "fieldhash",
+		FetchType: "http_get",
+		AllowedBy: "allowlist",
+		CacheHit:  false,
+	}
+
+	data, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	err = json.Unmarshal(data, &m)
+	require.NoError(t, err)
+
+	expectedKeys := []string{"trace_id", "fetch_time", "url", "sha256", "fetch_type", "allowed_by", "cache_hit"}
+	for _, key := range expectedKeys {
+		assert.Contains(t, m, key)
+	}
+	assert.Len(t, m, len(expectedKeys))
+}


### PR DESCRIPTION
## Summary
- Add `FetchAuditEntry` struct and `AppendFetchAudit` function for JSONL audit logging
- Mirrors existing `security.AppendFinding` pattern
- Foundation for ADR-0038 universal harness access — no callers yet

## Test plan
- [x] Unit tests for single/multiple entries, directory creation, JSON field names
- [x] `go test ./internal/fetch/...` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)