### PR TITLE
fix: filter known slugs by app set when switching app sets

### DIFF
--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -1311,10 +1311,7 @@ func runAppSetup(ctx context.Context, client forge.Client, printer *ui.Printer, 
 		WithStoredAppIDs(storedAppIDs)
 
 	// Merge known slugs: config-based first, then shared app overrides.
-	knownSlugs := loadKnownSlugs(ctx, client, org)
-	if knownSlugs == nil {
-		knownSlugs = make(map[string]string)
-	}
+	knownSlugs := filterSlugsByAppSet(loadKnownSlugs(ctx, client, org), appSet)
 	for role, slug := range sharedSlugs {
 		knownSlugs[role] = slug
 	}
@@ -1898,6 +1895,22 @@ func loadExistingEnabledRepos(ctx context.Context, client forge.Client, org stri
 	}
 	return cfg.EnabledRepos()
 }
+// filterSlugsByAppSet returns a copy of slugs containing only entries whose
+// slug starts with the given app set prefix. Slugs from a previous install
+// with a different app set must not be carried over, as they would cause
+// findExistingInstallation to pick up the wrong app when switching app sets.
+// Always returns a non-nil map.
+func filterSlugsByAppSet(slugs map[string]string, appSet string) map[string]string {
+	prefix := appSet + "-"
+	out := make(map[string]string, len(slugs))
+	for role, slug := range slugs {
+		if strings.HasPrefix(slug, prefix) {
+			out[role] = slug
+		}
+	}
+	return out
+}
+
 // loadKnownSlugs tries to read agent slugs from an existing config.
 func loadKnownSlugs(ctx context.Context, client forge.Client, org string) map[string]string {
 	data, err := client.GetFileContent(ctx, org, forge.ConfigRepoName, "config.yaml")

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -1037,6 +1037,39 @@ func TestLoadExistingEnabledRepos_ReturnsNilWhenNoConfig(t *testing.T) {
 	assert.Nil(t, repos)
 }
 
+func TestFilterSlugsByAppSet_KeepsMatchingSlugs(t *testing.T) {
+	in := map[string]string{
+		"fullsend": "fullsend-ai-fullsend",
+		"coder":    "fullsend-ai-coder",
+	}
+	out := filterSlugsByAppSet(in, "fullsend-ai")
+	assert.Equal(t, in, out)
+}
+
+func TestFilterSlugsByAppSet_DropsNonMatchingSlugs(t *testing.T) {
+	in := map[string]string{
+		"fullsend": "konflux-ci-fullsend",
+		"coder":    "konflux-ci-coder",
+	}
+	out := filterSlugsByAppSet(in, "fullsend-ai")
+	assert.Empty(t, out)
+}
+
+func TestFilterSlugsByAppSet_MixedSlugs(t *testing.T) {
+	in := map[string]string{
+		"fullsend": "fullsend-ai-fullsend",
+		"coder":    "konflux-ci-coder",
+	}
+	out := filterSlugsByAppSet(in, "fullsend-ai")
+	assert.Equal(t, map[string]string{"fullsend": "fullsend-ai-fullsend"}, out)
+}
+
+func TestFilterSlugsByAppSet_NilInputReturnsEmptyMap(t *testing.T) {
+	out := filterSlugsByAppSet(nil, "fullsend-ai")
+	assert.NotNil(t, out)
+	assert.Empty(t, out)
+}
+
 func TestCheckInstallScopes_AllPresent(t *testing.T) {
 	client := &forge.FakeClient{
 		TokenScopes: []string{"repo", "workflow", "admin:org", "read:org"},


### PR DESCRIPTION
When an org already has a fullsend install under a different app set, loadKnownSlugs returns the old slugs from config.yaml. These were being passed directly to findExistingInstallation, which checks knownSlugs before the expected slug — causing it to pick up the old app instead of looking for the new one.

Filter the config-loaded slugs to only those whose slug starts with the requested app set prefix before merging with shared-app overrides.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>