### PR TITLE
fix: accept result.json as fallback in output validation

### DIFF
--- a/internal/scaffold/fullsend-repo/scripts/validate-output-schema.sh
+++ b/internal/scaffold/fullsend-repo/scripts/validate-output-schema.sh
@@ -28,8 +28,16 @@ _output_file="${FULLSEND_OUTPUT_FILE:-agent-result.json}"
 _output_file="$(basename "${_output_file}")"
 RESULT_FILE="${OUTPUT_DIR}/${_output_file}"
 if [[ ! -f "${RESULT_FILE}" ]]; then
-  echo "FAIL: ${RESULT_FILE} not found"
-  exit 1
+  # Agents sometimes write "result.json" instead of "agent-result.json".
+  # Accept the common variant rather than burning a full retry iteration.
+  _fallback="${OUTPUT_DIR}/result.json"
+  if [[ "${_output_file}" == "agent-result.json" && -f "${_fallback}" ]]; then
+    echo "WARN: expected ${RESULT_FILE} but found ${_fallback} — using fallback"
+    RESULT_FILE="${_fallback}"
+  else
+    echo "FAIL: ${RESULT_FILE} not found"
+    exit 1
+  fi
 fi
 echo "Validating: ${RESULT_FILE} against ${FULLSEND_OUTPUT_SCHEMA}"
 


### PR DESCRIPTION
## Summary
- When an agent writes `result.json` instead of `agent-result.json`, the validation script now falls back to the alternate filename instead of immediately failing
- Emits a `WARN` log line so the mismatch remains visible for debugging
- Avoids burning a full retry iteration on a filename mismatch

## Context
Triggered by a review agent run on `konflux-ci/.fullsend` ([job 76613650259](https://github.com/konflux-ci/.fullsend/actions/runs/26058857280/job/76613650259)) where the agent wrote `output/result.json` instead of `output/agent-result.json`. Both iterations failed with `FAIL: output/agent-result.json not found` despite the agent producing valid output.

Refs: #1107

## Test plan
- [ ] Run `validate-output-schema.sh` with `agent-result.json` present — should PASS as before
- [ ] Run with only `result.json` present — should WARN and validate successfully
- [ ] Run with neither file present — should FAIL as before
- [ ] Run with a custom `FULLSEND_OUTPUT_FILE` — fallback should not activate