### PR TITLE
feat: agent self-check tool for output schema validation

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/envfile"
 	"github.com/fullsend-ai/fullsend/internal/harness"
 	"github.com/fullsend-ai/fullsend/internal/sandbox"
+	"github.com/fullsend-ai/fullsend/internal/scaffold"
 	"github.com/fullsend-ai/fullsend/internal/security"
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
@@ -782,6 +783,30 @@ func bootstrapSandbox(sandboxName, repoDir, fullsendBinary string, h *harness.Ha
 		}
 	}
 
+	// Copy the self-check script into the sandbox so agents can validate
+	// output JSON against their schema before finishing. See #1107.
+	if checkScript, err := scaffold.FullsendRepoFile("scripts/fullsend-check-output"); err == nil {
+		tmpCheck, err := os.CreateTemp("", "fullsend-check-output-*")
+		if err != nil {
+			return fmt.Errorf("creating temp file for check script: %w", err)
+		}
+		if _, err := tmpCheck.Write(checkScript); err != nil {
+			tmpCheck.Close()
+			os.Remove(tmpCheck.Name())
+			return fmt.Errorf("writing check script: %w", err)
+		}
+		tmpCheck.Close()
+		remoteBin := fmt.Sprintf("%s/bin/fullsend-check-output", sandbox.SandboxWorkspace)
+		if err := sandbox.Upload(sandboxName, tmpCheck.Name(), remoteBin); err != nil {
+			os.Remove(tmpCheck.Name())
+			return fmt.Errorf("copying check script to sandbox: %w", err)
+		}
+		os.Remove(tmpCheck.Name())
+		if _, _, _, err := sandbox.Exec(sandboxName, fmt.Sprintf("chmod +x %s", remoteBin), 10*time.Second); err != nil {
+			return fmt.Errorf("chmod check script: %w", err)
+		}
+	}
+
 	// Scan plugin definitions for injection before copying into sandbox.
 	if scanPipeline != nil {
 		for _, pluginPath := range h.Plugins {
@@ -853,6 +878,23 @@ func bootstrapEnv(sandboxName, repoDir string, h *harness.Harness) error {
 	lines = append(lines, fmt.Sprintf("export CLAUDE_CONFIG_DIR=%s", sandbox.SandboxClaudeConfig))
 	lines = append(lines, fmt.Sprintf("export FULLSEND_OUTPUT_DIR=%s", outputDir))
 	lines = append(lines, fmt.Sprintf("export FULLSEND_TARGET_REPO_DIR=%s", repoDir))
+
+	// Expose output schema and expected filename inside the sandbox so
+	// agents can self-check output with fullsend-check-output. See #1107.
+	remoteSchemaPath := sandbox.SandboxWorkspace + "/.fullsend/output-schema.json"
+	if schemaHost, ok := h.RunnerEnv["FULLSEND_OUTPUT_SCHEMA"]; ok && schemaHost != "" {
+		if _, statErr := os.Stat(schemaHost); statErr == nil {
+			mkdirCmd := fmt.Sprintf("mkdir -p %s/.fullsend", sandbox.SandboxWorkspace)
+			if _, _, _, execErr := sandbox.Exec(sandboxName, mkdirCmd, 10*time.Second); execErr == nil {
+				if uploadErr := sandbox.Upload(sandboxName, schemaHost, remoteSchemaPath); uploadErr == nil {
+					lines = append(lines, fmt.Sprintf("export FULLSEND_OUTPUT_SCHEMA=%s", remoteSchemaPath))
+				}
+			}
+		}
+	}
+	if outputFile, ok := h.RunnerEnv["FULLSEND_OUTPUT_FILE"]; ok && outputFile != "" {
+		lines = append(lines, fmt.Sprintf("export FULLSEND_OUTPUT_FILE=%s", outputFile))
+	}
 
 	// Source all env files from .env.d/ (populated by host_files with expand: true).
 	lines = append(lines, fmt.Sprintf("for f in %s/.env.d/*.env; do [ -f \"$f\" ] && . \"$f\"; done", sandbox.SandboxWorkspace))

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -788,24 +788,28 @@ func bootstrapSandbox(sandboxName, repoDir, fullsendBinary string, h *harness.Ha
 	checkScript, err := scaffold.FullsendRepoFile("scripts/fullsend-check-output")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "WARNING: could not load self-check script: %v\n", err)
-	} else {
+	} else if err := func() error {
 		tmpCheck, err := os.CreateTemp("", "fullsend-check-output-*")
 		if err != nil {
-			return fmt.Errorf("creating temp file for check script: %w", err)
+			return fmt.Errorf("creating temp file: %w", err)
 		}
 		defer os.Remove(tmpCheck.Name())
 		if _, err := tmpCheck.Write(checkScript); err != nil {
 			tmpCheck.Close()
-			return fmt.Errorf("writing check script: %w", err)
+			return fmt.Errorf("writing temp file: %w", err)
 		}
 		tmpCheck.Close()
+		// Safe: remoteBin is built from the SandboxWorkspace constant.
 		remoteBin := fmt.Sprintf("%s/bin/fullsend-check-output", sandbox.SandboxWorkspace)
 		if err := sandbox.Upload(sandboxName, tmpCheck.Name(), remoteBin); err != nil {
-			return fmt.Errorf("copying check script to sandbox: %w", err)
+			return fmt.Errorf("uploading to sandbox: %w", err)
 		}
 		if _, _, _, err := sandbox.Exec(sandboxName, fmt.Sprintf("chmod +x %s", remoteBin), 10*time.Second); err != nil {
-			return fmt.Errorf("chmod check script: %w", err)
+			return fmt.Errorf("chmod: %w", err)
 		}
+		return nil
+	}(); err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: could not install self-check script: %v\n", err)
 	}
 
 	// Scan plugin definitions for injection before copying into sandbox.
@@ -893,6 +897,7 @@ func bootstrapEnv(sandboxName, repoDir string, h *harness.Harness) error {
 			} else if uploadErr := sandbox.Upload(sandboxName, schemaHost, remoteSchemaPath); uploadErr != nil {
 				fmt.Fprintf(os.Stderr, "WARNING: could not upload output schema: %v\n", uploadErr)
 			} else {
+				// Safe: remoteSchemaPath is built from the SandboxWorkspace constant.
 				lines = append(lines, fmt.Sprintf("export FULLSEND_OUTPUT_SCHEMA=%s", remoteSchemaPath))
 			}
 		}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -785,23 +785,24 @@ func bootstrapSandbox(sandboxName, repoDir, fullsendBinary string, h *harness.Ha
 
 	// Copy the self-check script into the sandbox so agents can validate
 	// output JSON against their schema before finishing. See #1107.
-	if checkScript, err := scaffold.FullsendRepoFile("scripts/fullsend-check-output"); err == nil {
+	checkScript, err := scaffold.FullsendRepoFile("scripts/fullsend-check-output")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: could not load self-check script: %v\n", err)
+	} else {
 		tmpCheck, err := os.CreateTemp("", "fullsend-check-output-*")
 		if err != nil {
 			return fmt.Errorf("creating temp file for check script: %w", err)
 		}
+		defer os.Remove(tmpCheck.Name())
 		if _, err := tmpCheck.Write(checkScript); err != nil {
 			tmpCheck.Close()
-			os.Remove(tmpCheck.Name())
 			return fmt.Errorf("writing check script: %w", err)
 		}
 		tmpCheck.Close()
 		remoteBin := fmt.Sprintf("%s/bin/fullsend-check-output", sandbox.SandboxWorkspace)
 		if err := sandbox.Upload(sandboxName, tmpCheck.Name(), remoteBin); err != nil {
-			os.Remove(tmpCheck.Name())
 			return fmt.Errorf("copying check script to sandbox: %w", err)
 		}
-		os.Remove(tmpCheck.Name())
 		if _, _, _, err := sandbox.Exec(sandboxName, fmt.Sprintf("chmod +x %s", remoteBin), 10*time.Second); err != nil {
 			return fmt.Errorf("chmod check script: %w", err)
 		}
@@ -883,17 +884,21 @@ func bootstrapEnv(sandboxName, repoDir string, h *harness.Harness) error {
 	// agents can self-check output with fullsend-check-output. See #1107.
 	remoteSchemaPath := sandbox.SandboxWorkspace + "/.fullsend/output-schema.json"
 	if schemaHost, ok := h.RunnerEnv["FULLSEND_OUTPUT_SCHEMA"]; ok && schemaHost != "" {
-		if _, statErr := os.Stat(schemaHost); statErr == nil {
+		if _, statErr := os.Stat(schemaHost); statErr != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: schema file not found on host: %s\n", schemaHost)
+		} else {
 			mkdirCmd := fmt.Sprintf("mkdir -p %s/.fullsend", sandbox.SandboxWorkspace)
-			if _, _, _, execErr := sandbox.Exec(sandboxName, mkdirCmd, 10*time.Second); execErr == nil {
-				if uploadErr := sandbox.Upload(sandboxName, schemaHost, remoteSchemaPath); uploadErr == nil {
-					lines = append(lines, fmt.Sprintf("export FULLSEND_OUTPUT_SCHEMA=%s", remoteSchemaPath))
-				}
+			if _, _, _, execErr := sandbox.Exec(sandboxName, mkdirCmd, 10*time.Second); execErr != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: could not create .fullsend dir for schema: %v\n", execErr)
+			} else if uploadErr := sandbox.Upload(sandboxName, schemaHost, remoteSchemaPath); uploadErr != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: could not upload output schema: %v\n", uploadErr)
+			} else {
+				lines = append(lines, fmt.Sprintf("export FULLSEND_OUTPUT_SCHEMA=%s", remoteSchemaPath))
 			}
 		}
 	}
 	if outputFile, ok := h.RunnerEnv["FULLSEND_OUTPUT_FILE"]; ok && outputFile != "" {
-		lines = append(lines, fmt.Sprintf("export FULLSEND_OUTPUT_FILE=%s", outputFile))
+		lines = append(lines, fmt.Sprintf("export FULLSEND_OUTPUT_FILE='%s'", strings.ReplaceAll(outputFile, "'", "'\\''")))
 	}
 
 	// Source all env files from .env.d/ (populated by host_files with expand: true).

--- a/internal/scaffold/fullsend-repo/agents/fix.md
+++ b/internal/scaffold/fullsend-repo/agents/fix.md
@@ -118,6 +118,16 @@ describes the schema. The post-script reads this file to post a summary
 comment on the PR. Without this file, the post-script cannot communicate
 your work back to the reviewer.
 
+After writing the file, validate it before exiting:
+
+```bash
+fullsend-check-output "${FULLSEND_OUTPUT_DIR}/fix-result.json"
+```
+
+If validation fails, read the error output, fix the JSON file, and
+re-run the check. If it still fails after 3 attempts, write the best
+JSON you have and exit.
+
 ## Failure handling
 
 Secret scanning is **non-negotiable**. The `scan-secrets` helper runs before

--- a/internal/scaffold/fullsend-repo/agents/prioritize.md
+++ b/internal/scaffold/fullsend-repo/agents/prioritize.md
@@ -131,7 +131,9 @@ Write the result as JSON to `$FULLSEND_OUTPUT_DIR/agent-result.json`.
   ```bash
   fullsend-check-output "$FULLSEND_OUTPUT_DIR/agent-result.json"
   ```
-  If validation fails, fix the JSON and re-run the check until it passes.
+  If validation fails, read the error output, fix the JSON file, and
+  re-run the check. If it still fails after 3 attempts, write the best
+  JSON you have and exit.
 - Do NOT post comments, apply labels, or modify the issue in any way.
   Your only output is the JSON file. A post-script handles all GitHub
   mutations.

--- a/internal/scaffold/fullsend-repo/agents/prioritize.md
+++ b/internal/scaffold/fullsend-repo/agents/prioritize.md
@@ -127,6 +127,11 @@ Write the result as JSON to `$FULLSEND_OUTPUT_DIR/agent-result.json`.
 - Write ONLY the JSON file. No markdown report, no other output files.
 - The JSON must be valid and parseable. No markdown fences around it,
   no trailing text.
+- After writing the JSON file, validate it before exiting:
+  ```bash
+  fullsend-check-output "$FULLSEND_OUTPUT_DIR/agent-result.json"
+  ```
+  If validation fails, fix the JSON and re-run the check until it passes.
 - Do NOT post comments, apply labels, or modify the issue in any way.
   Your only output is the JSON file. A post-script handles all GitHub
   mutations.

--- a/internal/scaffold/fullsend-repo/agents/retro.md
+++ b/internal/scaffold/fullsend-repo/agents/retro.md
@@ -107,6 +107,13 @@ improvement:
 
 - Write ONLY the JSON file. No other output files.
 - The JSON must be valid and parseable. No markdown fences around it, no trailing text.
+- After writing the JSON file, validate it before exiting:
+  ```bash
+  fullsend-check-output "$FULLSEND_OUTPUT_DIR/agent-result.json"
+  ```
+  If validation fails, read the error output, fix the JSON file, and
+  re-run the check. If it still fails after 3 attempts, write the best
+  JSON you have and exit.
 - Do NOT post comments, create issues, or perform any GitHub mutations. The post-script handles all writes.
 - Do NOT echo untrusted content (issue bodies, PR descriptions, comment text) verbatim into your proposals. Summarize or paraphrase instead.
 - If the workflow went well and you find no meaningful improvements, return an empty proposals array with a summary saying so.

--- a/internal/scaffold/fullsend-repo/agents/review.md
+++ b/internal/scaffold/fullsend-repo/agents/review.md
@@ -263,8 +263,18 @@ jq -n \
   > "$FULLSEND_OUTPUT_DIR/agent-result.json"
 ```
 
-Exit after writing the file. Do NOT call `gh pr review` in pipeline
-mode — the post-script handles all GitHub mutations.
+After writing the file, validate it before exiting:
+
+```bash
+fullsend-check-output "$FULLSEND_OUTPUT_DIR/agent-result.json"
+```
+
+If validation fails, read the error output, fix the JSON file, and
+re-run the check. If it still fails after 3 attempts, write the best
+JSON you have and exit.
+
+Do NOT call `gh pr review` in pipeline mode — the post-script handles
+all GitHub mutations.
 
 ## Exit code contract
 

--- a/internal/scaffold/fullsend-repo/agents/triage.md
+++ b/internal/scaffold/fullsend-repo/agents/triage.md
@@ -218,6 +218,11 @@ Information is sufficient for a developer to investigate and fix.
 
 - Write ONLY the JSON file. No markdown report, no other output files.
 - The JSON must be valid and parseable. No markdown fences around it, no trailing text.
+- After writing the JSON file, validate it before exiting:
+  ```bash
+  fullsend-check-output "$FULLSEND_OUTPUT_DIR/agent-result.json"
+  ```
+  If validation fails, fix the JSON and re-run the check until it passes.
 - Do NOT post comments, apply labels, or modify the issue in any way. Your only output is the JSON file. A post-script handles all GitHub mutations.
 - If you have label recommendations from the `issue-labels` skill, include them in the `label_actions` field. If no labels clearly apply, omit `label_actions` entirely.
 

--- a/internal/scaffold/fullsend-repo/agents/triage.md
+++ b/internal/scaffold/fullsend-repo/agents/triage.md
@@ -222,7 +222,9 @@ Information is sufficient for a developer to investigate and fix.
   ```bash
   fullsend-check-output "$FULLSEND_OUTPUT_DIR/agent-result.json"
   ```
-  If validation fails, fix the JSON and re-run the check until it passes.
+  If validation fails, read the error output, fix the JSON file, and
+  re-run the check. If it still fails after 3 attempts, write the best
+  JSON you have and exit.
 - Do NOT post comments, apply labels, or modify the issue in any way. Your only output is the JSON file. A post-script handles all GitHub mutations.
 - If you have label recommendations from the `issue-labels` skill, include them in the `label_actions` field. If no labels clearly apply, omit `label_actions` entirely.
 

--- a/internal/scaffold/fullsend-repo/scripts/fullsend-check-output
+++ b/internal/scaffold/fullsend-repo/scripts/fullsend-check-output
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# fullsend-check-output — Validate agent output JSON against the declared schema.
+#
+# Usage: fullsend-check-output <path-to-json-file>
+#
+# Agents call this BEFORE finishing to catch schema violations early,
+# rather than waiting for the harness validation_loop to fail post-exit.
+#
+# Required env vars:
+#   FULLSEND_OUTPUT_SCHEMA — path to the JSON Schema file
+#
+# Optional env vars:
+#   FULLSEND_OUTPUT_FILE — expected output filename (default: agent-result.json)
+#
+# Exit codes:
+#   0 — validation passed
+#   1 — validation failed (schema error, missing file, bad JSON)
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: fullsend-check-output <path-to-json-file>"
+  exit 1
+fi
+
+CANDIDATE="$1"
+
+if [[ -z "${FULLSEND_OUTPUT_SCHEMA:-}" ]]; then
+  echo "FAIL: FULLSEND_OUTPUT_SCHEMA is not set"
+  exit 1
+fi
+
+if [[ ! -f "${FULLSEND_OUTPUT_SCHEMA}" ]]; then
+  echo "FAIL: schema file not found: ${FULLSEND_OUTPUT_SCHEMA}"
+  exit 1
+fi
+
+if [[ ! -f "${CANDIDATE}" ]]; then
+  echo "FAIL: output file not found: ${CANDIDATE}"
+  exit 1
+fi
+
+_expected="${FULLSEND_OUTPUT_FILE:-agent-result.json}"
+_actual="$(basename "${CANDIDATE}")"
+if [[ "${_actual}" != "${_expected}" ]]; then
+  echo "WARN: filename is '${_actual}' but harness expects '${_expected}'"
+  echo "      Rename to: $(dirname "${CANDIDATE}")/${_expected}"
+fi
+
+if ! python3 -m json.tool "${CANDIDATE}" > /dev/null 2>&1; then
+  echo "FAIL: ${CANDIDATE} is not valid JSON"
+  exit 1
+fi
+
+python3 -c "
+import json, sys
+from jsonschema import validate, ValidationError, SchemaError
+
+with open(sys.argv[1]) as f:
+    instance = json.load(f)
+with open(sys.argv[2]) as f:
+    schema = json.load(f)
+
+try:
+    validate(instance=instance, schema=schema)
+    print('PASS: output validated against schema')
+except SchemaError as e:
+    print(f'FAIL: invalid schema: {e.message}')
+    sys.exit(1)
+except ValidationError as e:
+    print(f'FAIL: {e.message}')
+    if e.path:
+        print(f'  at: {\".\".join(str(p) for p in e.path)}')
+    if e.context:
+        for sub in e.context[:5]:
+            print(f'  - {sub.message}')
+    sys.exit(1)
+" "${CANDIDATE}" "${FULLSEND_OUTPUT_SCHEMA}"

--- a/internal/scaffold/fullsend-repo/scripts/fullsend-check-output
+++ b/internal/scaffold/fullsend-repo/scripts/fullsend-check-output
@@ -58,6 +58,11 @@ if ! python3 -m json.tool "${CANDIDATE}" > /dev/null 2>&1; then
   exit 1
 fi
 
+if ! python3 -m json.tool "${FULLSEND_OUTPUT_SCHEMA}" > /dev/null 2>&1; then
+  echo "FAIL: schema file is not valid JSON: ${FULLSEND_OUTPUT_SCHEMA}"
+  exit 1
+fi
+
 python3 -c "
 import json, sys
 from jsonschema import validate, ValidationError, SchemaError

--- a/internal/scaffold/fullsend-repo/scripts/fullsend-check-output
+++ b/internal/scaffold/fullsend-repo/scripts/fullsend-check-output
@@ -43,8 +43,14 @@ fi
 _expected="${FULLSEND_OUTPUT_FILE:-agent-result.json}"
 _actual="$(basename "${CANDIDATE}")"
 if [[ "${_actual}" != "${_expected}" ]]; then
-  echo "WARN: filename is '${_actual}' but harness expects '${_expected}'"
+  echo "FAIL: filename is '${_actual}' but harness expects '${_expected}'"
   echo "      Rename to: $(dirname "${CANDIDATE}")/${_expected}"
+  exit 1
+fi
+
+if ! python3 -c "import jsonschema" 2>/dev/null; then
+  echo "FAIL: python3 jsonschema package is not installed"
+  exit 1
 fi
 
 if ! python3 -m json.tool "${CANDIDATE}" > /dev/null 2>&1; then

--- a/internal/scaffold/fullsend-repo/skills/fix-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/fix-review/SKILL.md
@@ -427,7 +427,8 @@ fullsend-check-output "${FULLSEND_OUTPUT_DIR}/fix-result.json"
 ```
 
 If validation fails, read the error output, fix the JSON file, and
-re-run the check. Do not exit until the check passes.
+re-run the check. If it still fails after 3 attempts, write the best
+JSON you have and exit.
 
 ## Partial work
 

--- a/internal/scaffold/fullsend-repo/skills/fix-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/fix-review/SKILL.md
@@ -420,12 +420,14 @@ cat > "${FULLSEND_OUTPUT_DIR}/fix-result.json" << 'FIXEOF'
 FIXEOF
 ```
 
-Validate the JSON is well-formed:
+Validate the output against the schema:
 
 ```bash
-python3 -c "import json; json.load(open('${FULLSEND_OUTPUT_DIR}/fix-result.json'))" \
-  || jq . "${FULLSEND_OUTPUT_DIR}/fix-result.json" > /dev/null
+fullsend-check-output "${FULLSEND_OUTPUT_DIR}/fix-result.json"
 ```
+
+If validation fails, read the error output, fix the JSON file, and
+re-run the check. Do not exit until the check passes.
 
 ## Partial work
 

--- a/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
@@ -305,6 +305,16 @@ Write the result to `$FULLSEND_OUTPUT_DIR/agent-result.json` following
 the output schema in the agent definition (`agents/review.md`). Do NOT
 call `gh pr review` — the post-script handles all GitHub mutations.
 
+After writing the file, validate it before exiting:
+
+```bash
+fullsend-check-output "$FULLSEND_OUTPUT_DIR/agent-result.json"
+```
+
+If validation fails, read the error output, fix the JSON file, and
+re-run the check. If it still fails after 3 attempts, write the best
+JSON you have and exit.
+
 #### Interactive mode (`$FULLSEND_OUTPUT_DIR` is not set)
 
 Post the review directly using the appropriate flag:

--- a/internal/scaffold/fullsend-repo/skills/retro-analysis/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/retro-analysis/SKILL.md
@@ -142,6 +142,15 @@ Write a single JSON file to `$FULLSEND_OUTPUT_DIR/agent-result.json` with this s
 
 **Schema is strict.** The top-level object allows ONLY `summary` and `proposals` — no additional properties. Each proposal object allows ONLY the six fields shown above. The harness validates against `$FULLSEND_OUTPUT_SCHEMA` with `"additionalProperties": false` at both levels. Do not add fields like `timeline`, `metadata`, `workflow_quality`, or `originating_url`.
 
+After writing the file, validate it before exiting:
+
+```bash
+fullsend-check-output "$FULLSEND_OUTPUT_DIR/agent-result.json"
+```
+
+If validation fails, read the error output, fix the JSON file, and
+re-run the check. Do not exit until the check passes.
+
 ### Writing good proposals
 
 - **what_happened:** Tell the story chronologically. Link to specific workflow runs, log lines, PR comments, and review verdicts. Use markdown links.

--- a/internal/scaffold/fullsend-repo/skills/retro-analysis/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/retro-analysis/SKILL.md
@@ -149,7 +149,8 @@ fullsend-check-output "$FULLSEND_OUTPUT_DIR/agent-result.json"
 ```
 
 If validation fails, read the error output, fix the JSON file, and
-re-run the check. Do not exit until the check passes.
+re-run the check. If it still fails after 3 attempts, write the best
+JSON you have and exit.
 
 ### Writing good proposals
 

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -36,6 +36,7 @@ var executableFiles = map[string]struct{}{
 	"scripts/setup-prioritize.sh":            {},
 	"scripts/pre-retro.sh":                   {},
 	"scripts/validate-output-schema.sh":      {},
+	"scripts/fullsend-check-output":          {},
 	"scripts/extract-transcript-error.sh":    {},
 	"scripts/validate-output-schema-test.sh": {},
 	"scripts/validate-source-repo.sh":        {},

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -79,6 +79,7 @@ func TestFullsendRepoFilesExist(t *testing.T) {
 		"scripts/post-code.sh",
 		"scripts/reconcile-repos.sh",
 		"scripts/validate-output-schema.sh",
+		"scripts/fullsend-check-output",
 		"scripts/validate-source-repo.sh",
 		"skills/code-implementation/SKILL.md",
 		"skills/issue-labels/SKILL.md",


### PR DESCRIPTION
## Summary
- New `fullsend-check-output` script available inside the agent sandbox for validating output JSON against the declared schema before finishing
- Harness bootstrap uploads the schema file and check script into the sandbox, setting `FULLSEND_OUTPUT_SCHEMA` and `FULLSEND_OUTPUT_FILE` env vars
- Updated all 5 agents that produce JSON output: pr-review, fix-review, retro-analysis skills + triage, prioritize agent definitions
- Harness `validation_loop` remains as a safety net

## Context
Review agent runs on `konflux-ci/.fullsend` ([run 26058857280](https://github.com/konflux-ci/.fullsend/actions/runs/26058857280), [run 26061236043](https://github.com/konflux-ci/.fullsend/actions/runs/26061236043)) repeatedly fail harness validation because agents write JSON with wrong filenames (`result.json` vs `agent-result.json`) and extra properties (`summary`, `outcome`, `dimension` instead of `category`). Each failure burns a full retry iteration (52s-104s). This gives agents immediate feedback to fix errors in-place.

The check script:
- Validates the file exists
- Warns if the filename doesn't match `$FULLSEND_OUTPUT_FILE` (default: `agent-result.json`)
- Validates JSON is parseable
- Validates against `$FULLSEND_OUTPUT_SCHEMA` with detailed error output (unexpected properties, missing fields, sub-errors)

Closes #1107

## Test plan
- [x] `make go-test` — all tests pass (scaffold embed tests verify new script is tracked)
- [x] `go vet ./...` — clean
- [ ] Deploy and verify agents call `fullsend-check-output` before exiting
- [ ] Verify harness `validation_loop` passes on first iteration when agent self-checks