### PR TITLE
fix(review-agent): move output schema from pr-review skill to agent definition

### DIFF
--- a/internal/scaffold/fullsend-repo/agents/review.md
+++ b/internal/scaffold/fullsend-repo/agents/review.md
@@ -156,13 +156,55 @@ When the change is safe and the only findings are low or info severity,
 approve the PR and mark concrete follow-up work as `actionable: true`
 in the structured result so the post-script can create tracking issues.
 
+The `code-review` skill defines the finding structure. The `pr-review`
+skill defines the review comment format and procedure.
+
 ### Pipeline mode output
 
 When `$FULLSEND_OUTPUT_DIR` is set, write the result to
-`$FULLSEND_OUTPUT_DIR/agent-result.json`. The JSON shape varies by
-action. **Only include fields listed here — the schema is strict
-(`additionalProperties: false`) and will reject unknown fields such as
-`outcome`, `summary`, `prior_review_sha`, or `prior_review_provenance`.**
+`$FULLSEND_OUTPUT_DIR/agent-result.json`. The harness validates this
+against `schemas/review-result.schema.json` (source of truth) before
+the post-script runs. **Only include fields listed below — the schema
+is strict (`additionalProperties: false`) and will reject unknown
+fields such as `outcome`, `summary`, `prior_review_sha`, or
+`prior_review_provenance`.**
+
+**Top-level object** (`additionalProperties: false`):
+
+| Field       | Type    | Always required | Description                                      |
+|-------------|---------|-----------------|--------------------------------------------------|
+| `action`    | string  | yes             | One of: `approve`, `request-changes`, `comment`, `reject`, `failure` |
+| `pr_number` | integer | yes             | PR number (minimum 1)                            |
+| `repo`      | string  | yes             | `owner/repo` format (pattern: `^[^/]+/[^/]+$`)  |
+| `head_sha`  | string  | conditional     | Commit SHA (min 7 chars)                         |
+| `body`      | string  | conditional     | Markdown review comment (min 1 char)             |
+| `findings`  | array   | conditional     | Array of finding objects (min 1 item when present)|
+| `reason`    | string  | conditional     | One of: `tool-failure`, `missing-context`, `ambiguous-findings`, `token-limit` |
+
+**Required fields per action:**
+
+| Action            | Required fields                          |
+|-------------------|------------------------------------------|
+| `approve`         | `body`, `head_sha`                       |
+| `request-changes` | `body`, `head_sha`, `findings`           |
+| `comment`         | `body`, `head_sha`                       |
+| `reject`          | `body`, `head_sha`, `findings`           |
+| `failure`         | `reason`                                 |
+
+**Finding object** (`additionalProperties: false`):
+
+| Field         | Type    | Required | Description                                   |
+|---------------|---------|----------|-----------------------------------------------|
+| `severity`    | string  | yes      | One of: `critical`, `high`, `medium`, `low`, `info` |
+| `category`    | string  | yes      | Finding category (min 1 char)                 |
+| `file`        | string  | yes      | File path (min 1 char)                        |
+| `line`        | integer | no       | Line number (minimum 1)                       |
+| `description` | string  | yes      | Finding description (min 1 char)              |
+| `remediation` | string  | no       | Suggested fix                                 |
+| `actionable`  | boolean | no       | When true on low/info findings in an `approve` result, the post-script creates follow-up issues |
+
+Schema validation failures trigger a harness retry iteration. The jq
+examples below show the exact JSON shape for each action.
 
 For `approve` with no actionable findings, or for `comment`:
 

--- a/internal/scaffold/fullsend-repo/agents/review.md
+++ b/internal/scaffold/fullsend-repo/agents/review.md
@@ -156,8 +156,79 @@ When the change is safe and the only findings are low or info severity,
 approve the PR and mark concrete follow-up work as `actionable: true`
 in the structured result so the post-script can create tracking issues.
 
-The `code-review` skill defines the finding structure. The `pr-review`
-skill defines the GitHub review comment format.
+### Pipeline mode output
+
+When `$FULLSEND_OUTPUT_DIR` is set, write the result to
+`$FULLSEND_OUTPUT_DIR/agent-result.json`. The JSON shape varies by
+action. **Only include fields listed here — the schema is strict
+(`additionalProperties: false`) and will reject unknown fields such as
+`outcome`, `summary`, `prior_review_sha`, or `prior_review_provenance`.**
+
+For `approve` with no actionable findings, or for `comment`:
+
+```bash
+jq -n \
+  --arg action "<action>" \
+  --argjson pr_number <number> \
+  --arg repo "<owner/repo>" \
+  --arg head_sha "<sha>" \
+  --arg body "<markdown review comment>" \
+  '{action: $action, pr_number: $pr_number, repo: $repo,
+    head_sha: $head_sha, body: $body}' \
+  > "$FULLSEND_OUTPUT_DIR/agent-result.json"
+```
+
+For `approve` with actionable low/info findings:
+
+```bash
+jq -n \
+  --arg action "approve" \
+  --argjson pr_number <number> \
+  --arg repo "<owner/repo>" \
+  --arg head_sha "<sha>" \
+  --arg body "<markdown review comment>" \
+  --argjson findings '<findings array>' \
+  '{action: $action, pr_number: $pr_number, repo: $repo,
+    head_sha: $head_sha, body: $body, findings: $findings}' \
+  > "$FULLSEND_OUTPUT_DIR/agent-result.json"
+```
+
+For `request-changes` or `reject`:
+
+```bash
+jq -n \
+  --arg action "<request-changes|reject>" \
+  --argjson pr_number <number> \
+  --arg repo "<owner/repo>" \
+  --arg head_sha "<sha>" \
+  --arg body "<markdown review comment>" \
+  --argjson findings '<findings array>' \
+  '{action: $action, pr_number: $pr_number, repo: $repo,
+    head_sha: $head_sha, body: $body, findings: $findings}' \
+  > "$FULLSEND_OUTPUT_DIR/agent-result.json"
+```
+
+For `failure`:
+
+```bash
+jq -n \
+  --arg action "failure" \
+  --argjson pr_number <number> \
+  --arg repo "<owner/repo>" \
+  --arg reason "<tool-failure|missing-context|ambiguous-findings|token-limit>" \
+  '{action: $action, pr_number: $pr_number, repo: $repo,
+    reason: $reason}' \
+  > "$FULLSEND_OUTPUT_DIR/agent-result.json"
+```
+
+Each finding object has these fields only: `severity`
+(critical/high/medium/low/info), `category`, `file`, `line` (optional
+integer), `description`, `remediation` (optional string), `actionable`
+(optional boolean). For approved reviews, only low/info findings with
+`actionable: true` become follow-up issues.
+
+Exit after writing the file. Do NOT call `gh pr review` in pipeline
+mode — the post-script handles all GitHub mutations.
 
 ## Exit code contract
 

--- a/internal/scaffold/fullsend-repo/agents/review.md
+++ b/internal/scaffold/fullsend-repo/agents/review.md
@@ -263,12 +263,6 @@ jq -n \
   > "$FULLSEND_OUTPUT_DIR/agent-result.json"
 ```
 
-Each finding object has these fields only: `severity`
-(critical/high/medium/low/info), `category`, `file`, `line` (optional
-integer), `description`, `remediation` (optional string), `actionable`
-(optional boolean). For approved reviews, only low/info findings with
-`actionable: true` become follow-up issues.
-
 Exit after writing the file. Do NOT call `gh pr review` in pipeline
 mode — the post-script handles all GitHub mutations.
 

--- a/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
@@ -286,9 +286,11 @@ info-level finding in the review output:
   provenance validation failed (`PRIOR_REVIEW_PROVENANCE` value).
   This review treats all findings as first-time assessments.
 
-Map the outcome to an action value:
+Map the outcome to an action value. `action`, `pr_number`, and `repo`
+are always required (see the agent definition for the full schema).
+The table below lists the **additional** required fields per action:
 
-| Outcome            | Action              | Required fields                    |
+| Outcome            | Action              | Additional required fields         |
 |--------------------|---------------------|------------------------------------|
 | approve            | `approve`           | `body`, `head_sha`; include `findings[]` when low/info findings are actionable follow-up work |
 | request-changes    | `request-changes`   | `body`, `head_sha`, `findings[]`   |

--- a/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
@@ -290,88 +290,9 @@ Map the outcome to an action value:
 
 #### Pipeline mode (`$FULLSEND_OUTPUT_DIR` is set)
 
-Write the result as JSON. Do NOT call `gh pr review` — the post-script
-handles all GitHub mutations. The JSON shape varies by action.
-
-For `approve` with no actionable findings, or for `comment`:
-
-```bash
-jq -n \
-  --arg action "<action>" \
-  --argjson pr_number <number> \
-  --arg repo "<owner/repo>" \
-  --arg head_sha "<sha>" \
-  --arg body "<markdown review comment>" \
-  '{action: $action, pr_number: $pr_number, repo: $repo,
-    head_sha: $head_sha, body: $body}' \
-  > "$FULLSEND_OUTPUT_DIR/agent-result.json"
-```
-
-For `approve` with actionable low/info findings, include structured
-findings alongside the body. Only include findings that are concrete
-follow-up work; set `actionable: true` on those findings.
-
-```bash
-jq -n \
-  --arg action "approve" \
-  --argjson pr_number <number> \
-  --arg repo "<owner/repo>" \
-  --arg head_sha "<sha>" \
-  --arg body "<markdown review comment>" \
-  --argjson findings '<findings array>' \
-  '{action: $action, pr_number: $pr_number, repo: $repo,
-    head_sha: $head_sha, body: $body, findings: $findings}' \
-  > "$FULLSEND_OUTPUT_DIR/agent-result.json"
-```
-
-For `request-changes` or `reject`, include structured findings alongside
-the body:
-
-```bash
-jq -n \
-  --arg action "request-changes" \
-  --argjson pr_number <number> \
-  --arg repo "<owner/repo>" \
-  --arg head_sha "<sha>" \
-  --arg body "<markdown review comment>" \
-  --argjson findings '<findings array>' \
-  '{action: $action, pr_number: $pr_number, repo: $repo,
-    head_sha: $head_sha, body: $body, findings: $findings}' \
-  > "$FULLSEND_OUTPUT_DIR/agent-result.json"
-```
-
-```bash
-jq -n \
-  --arg action "reject" \
-  --argjson pr_number <number> \
-  --arg repo "<owner/repo>" \
-  --arg head_sha "<sha>" \
-  --arg body "<markdown review comment>" \
-  --argjson findings '<findings array>' \
-  '{action: $action, pr_number: $pr_number, repo: $repo,
-    head_sha: $head_sha, body: $body, findings: $findings}' \
-  > "$FULLSEND_OUTPUT_DIR/agent-result.json"
-```
-
-Each finding object has: `severity` (critical/high/medium/low/info),
-`category`, `file`, `line` (optional), `description`, `remediation`
-(optional), and `actionable` (optional boolean). For approved reviews,
-only low/info findings with `actionable: true` become follow-up issues.
-
-For `failure`, provide the reason — body is optional:
-
-```bash
-jq -n \
-  --arg action "failure" \
-  --argjson pr_number <number> \
-  --arg repo "<owner/repo>" \
-  --arg reason "<reason>" \
-  '{action: $action, pr_number: $pr_number, repo: $repo,
-    reason: $reason}' \
-  > "$FULLSEND_OUTPUT_DIR/agent-result.json"
-```
-
-Exit after writing the file.
+Write the result to `$FULLSEND_OUTPUT_DIR/agent-result.json` following
+the output schema in the agent definition (`agents/review.md`). Do NOT
+call `gh pr review` — the post-script handles all GitHub mutations.
 
 #### Interactive mode (`$FULLSEND_OUTPUT_DIR` is not set)
 

--- a/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
@@ -231,9 +231,17 @@ and re-evaluate the overall outcome.
 
 Compose the review comment using this structure:
 
-```markdown
-<!-- **Head SHA:** <sha> -->
+The first line must be an HTML comment embedding the head SHA.
+Construct it by concatenating: the HTML comment open delimiter,
+a space, `**Head SHA:**`, a space, the SHA value, a space, and
+the HTML comment close delimiter. For example, if the SHA were
+`abc123`, the line would read (with no line break):
 
+    [open] **Head SHA:** abc123 [close]
+
+where `[open]` = `<` + `!--` and `[close]` = `--` + `>`.
+
+```markdown
 ## Review
 
 ### Findings
@@ -343,7 +351,7 @@ wins.
   skills first.** Partial reviews miss context and produce unreliable
   verdicts.
 - **Always include the PR head SHA in a hidden HTML comment.** The
-  SHA must appear as `<!-- **Head SHA:** <sha> -->` so the re-review
+  SHA must appear in the format described in step 6 so the re-review
   anchoring script can extract it, but it must not be visible to
   reviewers.
 - **Report failure rather than posting a partial review.** If you cannot


### PR DESCRIPTION
## Summary

- The review agent's JSON output schema (field names, `jq` examples, `agent-result.json` filename) lived entirely in `skills/pr-review/SKILL.md`, unlike triage and code agents which carry this in their agent definition files
- When the skill fails to load, the agent improvises and writes fields outside the strict schema (`outcome`, `summary`, `prior_review_sha`, `prior_review_provenance`), causing `additionalProperties: false` validation failures
- Moves the pipeline-mode output schema to `agents/review.md` with an explicit warning against unknown fields; the skill now delegates to the agent definition for output format
- Adds JSON schema tables (fields, types, constraints, required-per-action rules) alongside the jq examples, with `schemas/review-result.schema.json` marked as source of truth
- Escapes literal HTML comment patterns in `skills/pr-review/SKILL.md` that triggered `fullsend scan context` high-severity `hidden_html_comment` findings (the scanner does line-by-line matching and doesn't respect code fences)

Supersedes fullsend-ai/fullsend#1111.

## Test plan

- [x] `fullsend scan context` on `skills/pr-review/SKILL.md` — clean
- [ ] Review agent produces correct `agent-result.json` when `pr-review` skill is unavailable
- [ ] Review agent produces correct `agent-result.json` on next PR review run

Refs: fullsend-ai/agents#376