### PR TITLE
fix: merge existing orgs in ProvisionWIF to prevent WIF condition clobber

### DIFF
--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -67,7 +67,7 @@ func DefaultFunctionSourceDir() string {
 var githubOrgPattern = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$`)
 
 // githubRepoSlugPattern validates a single GitHub repository name component.
-var githubRepoSlugPattern = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9._-]{0,98}[a-zA-Z0-9])?$`)
+var githubRepoSlugPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,100}$`)
 
 // gcpProjectIDPattern validates GCP project IDs (6-30 chars).
 var gcpProjectIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{4,28}[a-z0-9]$`)
@@ -1200,6 +1200,9 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 		}
 		if !githubRepoSlugPattern.MatchString(parts[0]) || !githubRepoSlugPattern.MatchString(parts[1]) {
 			return "", fmt.Errorf("invalid repo name %q: owner and repo must contain only alphanumeric, hyphens, dots, or underscores", p.cfg.Repo)
+		}
+		if parts[0] == "." || parts[0] == ".." || parts[1] == "." || parts[1] == ".." {
+			return "", fmt.Errorf("invalid repo name %q: owner and repo cannot be \".\" or \"..\"", p.cfg.Repo)
 		}
 		var err error
 		projectNumber, err = p.gcpAPI.GetProjectNumber(ctx, p.cfg.ProjectID)

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -66,6 +66,9 @@ func DefaultFunctionSourceDir() string {
 // hyphens, cannot start or end with a hyphen, max 39 characters.
 var githubOrgPattern = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$`)
 
+// githubRepoSlugPattern validates a single GitHub repository name component.
+var githubRepoSlugPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
 // gcpProjectIDPattern validates GCP project IDs (6-30 chars).
 var gcpProjectIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{4,28}[a-z0-9]$`)
 
@@ -1068,7 +1071,9 @@ func (p *Provisioner) ensureWIFPoolAndProvider(ctx context.Context, installingOr
 	}
 
 	allOrgs := make([]string, len(installingOrgs))
-	copy(allOrgs, installingOrgs)
+	for i, org := range installingOrgs {
+		allOrgs[i] = strings.ToLower(org)
+	}
 	existingProvider, getErr := p.gcpAPI.GetWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)
 	if getErr != nil {
 		// A non-nil error means "unknown state" — proceeding would risk
@@ -1192,8 +1197,8 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			return "", fmt.Errorf("repo must be in owner/repo format, got %q", p.cfg.Repo)
 		}
-		if strings.ContainsAny(p.cfg.Repo, `'"`) {
-			return "", fmt.Errorf("invalid repo name %q: contains quotes", p.cfg.Repo)
+		if !githubRepoSlugPattern.MatchString(parts[0]) || !githubRepoSlugPattern.MatchString(parts[1]) {
+			return "", fmt.Errorf("invalid repo name %q: owner and repo must contain only alphanumeric, hyphens, dots, or underscores", p.cfg.Repo)
 		}
 		var err error
 		projectNumber, err = p.gcpAPI.GetProjectNumber(ctx, p.cfg.ProjectID)

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -67,7 +67,7 @@ func DefaultFunctionSourceDir() string {
 var githubOrgPattern = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$`)
 
 // githubRepoSlugPattern validates a single GitHub repository name component.
-var githubRepoSlugPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+var githubRepoSlugPattern = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9._-]{0,98}[a-zA-Z0-9])?$`)
 
 // gcpProjectIDPattern validates GCP project IDs (6-30 chars).
 var gcpProjectIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{4,28}[a-z0-9]$`)
@@ -1193,6 +1193,7 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 		// Repo-scoped: dedicated provider per repo, no org merge.
 		// Each repo gets a unique provider ID (via BuildRepoProviderID),
 		// so no risk of clobbering another repo's WIF condition.
+		p.cfg.Repo = strings.ToLower(p.cfg.Repo)
 		parts := strings.SplitN(p.cfg.Repo, "/", 2)
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			return "", fmt.Errorf("repo must be in owner/repo format, got %q", p.cfg.Repo)

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -1189,20 +1189,23 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 
 	var projectNumber string
 	providerID := p.cfg.WIFProvider
+	repo := strings.ToLower(p.cfg.Repo)
 	if p.cfg.Repo != "" {
 		// Repo-scoped: dedicated provider per repo, no org merge.
 		// Each repo gets a unique provider ID (via BuildRepoProviderID),
 		// so no risk of clobbering another repo's WIF condition.
-		p.cfg.Repo = strings.ToLower(p.cfg.Repo)
-		parts := strings.SplitN(p.cfg.Repo, "/", 2)
+		parts := strings.SplitN(repo, "/", 2)
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			return "", fmt.Errorf("repo must be in owner/repo format, got %q", p.cfg.Repo)
 		}
-		if !githubRepoSlugPattern.MatchString(parts[0]) || !githubRepoSlugPattern.MatchString(parts[1]) {
-			return "", fmt.Errorf("invalid repo name %q: owner and repo must contain only alphanumeric, hyphens, dots, or underscores", p.cfg.Repo)
+		if !githubOrgPattern.MatchString(parts[0]) || strings.Contains(parts[0], "--") {
+			return "", fmt.Errorf("invalid repo owner %q: must be a valid GitHub org/user name", parts[0])
 		}
-		if parts[0] == "." || parts[0] == ".." || parts[1] == "." || parts[1] == ".." {
-			return "", fmt.Errorf("invalid repo name %q: owner and repo cannot be \".\" or \"..\"", p.cfg.Repo)
+		if !githubRepoSlugPattern.MatchString(parts[1]) {
+			return "", fmt.Errorf("invalid repo name %q: must contain only alphanumeric, hyphens, dots, or underscores", parts[1])
+		}
+		if parts[1] == "." || parts[1] == ".." {
+			return "", fmt.Errorf("invalid repo name %q: cannot be \".\" or \"..\"", parts[1])
 		}
 		var err error
 		projectNumber, err = p.gcpAPI.GetProjectNumber(ctx, p.cfg.ProjectID)
@@ -1213,7 +1216,7 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 			return "", fmt.Errorf("creating WIF pool: %w", err)
 		}
 		providerID = BuildRepoProviderID(parts[0], parts[1])
-		attrCondition := fmt.Sprintf("assertion.repository == '%s'", p.cfg.Repo)
+		attrCondition := fmt.Sprintf("assertion.repository == '%s'", repo)
 		audiences := []string{oidcAudience, iamAudience(projectNumber, p.cfg.WIFPoolName, providerID)}
 		if err := p.gcpAPI.CreateWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, providerID, OIDCProviderConfig{
 			IssuerURI:          oidcIssuer,
@@ -1235,11 +1238,11 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 	// Workflows that rely on these bindings may fail during that window.
 	if p.cfg.Repo != "" {
 		principal := fmt.Sprintf("principalSet://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/attribute.repository/%s",
-			projectNumber, p.cfg.WIFPoolName, p.cfg.Repo)
+			projectNumber, p.cfg.WIFPoolName, repo)
 		if err := p.gcpAPI.SetProjectIAMBinding(ctx, p.cfg.ProjectID, principal, "roles/aiplatform.user"); err != nil {
-			return "", fmt.Errorf("granting Vertex AI access for repo %s: %w", p.cfg.Repo, err)
+			return "", fmt.Errorf("granting Vertex AI access for repo %s: %w", repo, err)
 		}
-		log.Printf("granted roles/aiplatform.user to %s (propagation may take several minutes)", p.cfg.Repo)
+		log.Printf("granted roles/aiplatform.user to %s (propagation may take several minutes)", repo)
 	} else {
 		for _, org := range orgs {
 			principal := fmt.Sprintf("principalSet://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/attribute.repository/%s/.fullsend",

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -668,7 +668,7 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 	projectNumber := wifResult.projectNumber
 	allOrgs := wifResult.allOrgs
 
-	// Step 4b: Grant Vertex AI access to each installing org's .fullsend repo
+	// Step 3: Grant Vertex AI access to each installing org's .fullsend repo
 	// at the project level (direct WIF — no intermediate service account).
 	// IAM policy changes can take up to 7 minutes to propagate.
 	for _, org := range installingOrgs {
@@ -1071,8 +1071,8 @@ func (p *Provisioner) ensureWIFPoolAndProvider(ctx context.Context, installingOr
 				merged[org] = true
 			}
 		}
-		sort.Strings(allOrgs)
 	}
+	sort.Strings(allOrgs)
 
 	attrCondition := buildAttributeCondition(allOrgs)
 	audiences := []string{oidcAudience, iamAudience(projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)}
@@ -1176,6 +1176,12 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 			return "", fmt.Errorf("creating WIF pool: %w", err)
 		}
 		parts := strings.SplitN(p.cfg.Repo, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return "", fmt.Errorf("repo must be in owner/repo format, got %q", p.cfg.Repo)
+		}
+		if strings.ContainsAny(p.cfg.Repo, `'"`) {
+			return "", fmt.Errorf("invalid repo name %q: contains quotes", p.cfg.Repo)
+		}
 		p.cfg.WIFProvider = BuildRepoProviderID(parts[0], parts[1])
 		attrCondition := fmt.Sprintf("assertion.repository == '%s'", p.cfg.Repo)
 		audiences := []string{oidcAudience, iamAudience(projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)}

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -1183,6 +1183,7 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 	}
 
 	var projectNumber string
+	providerID := p.cfg.WIFProvider
 	if p.cfg.Repo != "" {
 		// Repo-scoped: dedicated provider per repo, no org merge.
 		// Each repo gets a unique provider ID (via BuildRepoProviderID),
@@ -1202,10 +1203,10 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 		if err := p.gcpAPI.CreateWIFPool(ctx, projectNumber, p.cfg.WIFPoolName, "Fullsend GitHub OIDC Pool"); err != nil {
 			return "", fmt.Errorf("creating WIF pool: %w", err)
 		}
-		p.cfg.WIFProvider = BuildRepoProviderID(parts[0], parts[1])
+		providerID = BuildRepoProviderID(parts[0], parts[1])
 		attrCondition := fmt.Sprintf("assertion.repository == '%s'", p.cfg.Repo)
-		audiences := []string{oidcAudience, iamAudience(projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)}
-		if err := p.gcpAPI.CreateWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider, OIDCProviderConfig{
+		audiences := []string{oidcAudience, iamAudience(projectNumber, p.cfg.WIFPoolName, providerID)}
+		if err := p.gcpAPI.CreateWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, providerID, OIDCProviderConfig{
 			IssuerURI:          oidcIssuer,
 			AttributeCondition: attrCondition,
 			AllowedAudiences:   audiences,
@@ -1242,7 +1243,7 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 	}
 
 	wifProvider = fmt.Sprintf("projects/%s/locations/global/workloadIdentityPools/%s/providers/%s",
-		projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)
+		projectNumber, p.cfg.WIFPoolName, providerID)
 
 	return wifProvider, nil
 }

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -643,23 +643,12 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 		return nil, fmt.Errorf("function %s not found — cannot use --skip-mint-deploy without an existing deployment", functionName)
 	}
 
-	// Step 1: Get project number (always needed for WIF).
-	projectNumber, err := p.gcpAPI.GetProjectNumber(ctx, p.cfg.ProjectID)
-	if err != nil {
-		return nil, fmt.Errorf("getting project number: %w", err)
-	}
-
-	// Step 2: Create/verify service account.
+	// Step 1: Create/verify service account.
 	if err := p.gcpAPI.CreateServiceAccount(ctx, p.cfg.ProjectID, saName, "Fullsend token mint Cloud Function"); err != nil {
 		return nil, fmt.Errorf("creating service account: %w", err)
 	}
 
-	// Step 3: Create/verify WIF pool.
-	if err := p.gcpAPI.CreateWIFPool(ctx, projectNumber, p.cfg.WIFPoolName, "Fullsend GitHub OIDC Pool"); err != nil {
-		return nil, fmt.Errorf("creating WIF pool: %w", err)
-	}
-
-	// Step 4: Create/verify WIF provider with merged org list.
+	// Step 2: Create/verify WIF pool + provider with merged org list.
 	for _, org := range p.cfg.GitHubOrgs {
 		if strings.ContainsAny(org, `'"`) {
 			return nil, fmt.Errorf("invalid GitHub org name %q: contains quotes", org)
@@ -672,37 +661,12 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 	installingOrgs := make([]string, len(p.cfg.GitHubOrgs))
 	copy(installingOrgs, p.cfg.GitHubOrgs)
 
-	// Merge with existing WIF provider orgs if provider already exists.
-	// Use a local variable to avoid mutating p.cfg.GitHubOrgs.
-	allOrgs := make([]string, len(p.cfg.GitHubOrgs))
-	copy(allOrgs, p.cfg.GitHubOrgs)
-	existingProvider, getErr := p.gcpAPI.GetWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)
-	if getErr != nil {
-		log.Printf("warning: could not read existing WIF provider for merge (proceeding with installing orgs only): %v", getErr)
-	} else if existingProvider != nil {
-		existingOrgs := parseConditionOrgs(existingProvider.AttributeCondition)
-		merged := make(map[string]bool)
-		for _, org := range allOrgs {
-			merged[org] = true
-		}
-		for _, org := range existingOrgs {
-			if !merged[org] {
-				allOrgs = append(allOrgs, org)
-				merged[org] = true
-			}
-		}
-		sort.Strings(allOrgs)
+	wifResult, err := p.ensureWIFPoolAndProvider(ctx, installingOrgs)
+	if err != nil {
+		return nil, err
 	}
-
-	attrCondition := buildAttributeCondition(allOrgs)
-	audiences := []string{oidcAudience, iamAudience(projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)}
-	if err := p.gcpAPI.CreateWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider, OIDCProviderConfig{
-		IssuerURI:          oidcIssuer,
-		AttributeCondition: attrCondition,
-		AllowedAudiences:   audiences,
-	}); err != nil {
-		return nil, fmt.Errorf("creating WIF provider: %w", err)
-	}
+	projectNumber := wifResult.projectNumber
+	allOrgs := wifResult.allOrgs
 
 	// Step 4b: Grant Vertex AI access to each installing org's .fullsend repo
 	// at the project level (direct WIF — no intermediate service account).
@@ -1075,6 +1039,54 @@ func parseConditionOrgs(condition string) []string {
 	return orgs
 }
 
+type wifMergeResult struct {
+	projectNumber string
+	allOrgs       []string
+}
+
+func (p *Provisioner) ensureWIFPoolAndProvider(ctx context.Context, installingOrgs []string) (*wifMergeResult, error) {
+	projectNumber, err := p.gcpAPI.GetProjectNumber(ctx, p.cfg.ProjectID)
+	if err != nil {
+		return nil, fmt.Errorf("getting project number: %w", err)
+	}
+
+	if err := p.gcpAPI.CreateWIFPool(ctx, projectNumber, p.cfg.WIFPoolName, "Fullsend GitHub OIDC Pool"); err != nil {
+		return nil, fmt.Errorf("creating WIF pool: %w", err)
+	}
+
+	allOrgs := make([]string, len(installingOrgs))
+	copy(allOrgs, installingOrgs)
+	existingProvider, getErr := p.gcpAPI.GetWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)
+	if getErr != nil {
+		log.Printf("warning: could not read existing WIF provider for merge (proceeding with installing orgs only): %v", getErr)
+	} else if existingProvider != nil {
+		existingOrgs := parseConditionOrgs(existingProvider.AttributeCondition)
+		merged := make(map[string]bool)
+		for _, org := range allOrgs {
+			merged[org] = true
+		}
+		for _, org := range existingOrgs {
+			if !merged[org] {
+				allOrgs = append(allOrgs, org)
+				merged[org] = true
+			}
+		}
+		sort.Strings(allOrgs)
+	}
+
+	attrCondition := buildAttributeCondition(allOrgs)
+	audiences := []string{oidcAudience, iamAudience(projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)}
+	if err := p.gcpAPI.CreateWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider, OIDCProviderConfig{
+		IssuerURI:          oidcIssuer,
+		AttributeCondition: attrCondition,
+		AllowedAudiences:   audiences,
+	}); err != nil {
+		return nil, fmt.Errorf("creating WIF provider: %w", err)
+	}
+
+	return &wifMergeResult{projectNumber: projectNumber, allOrgs: allOrgs}, nil
+}
+
 // waitForReady polls the function until it responds with 200 OK, ensuring
 // the Cloud Run backing service is warm and the function code is healthy.
 // Uses exponential backoff starting at 2s, doubling each attempt up to 30s.
@@ -1152,52 +1164,35 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 		orgs[i] = lower
 	}
 
-	projectNumber, err := p.gcpAPI.GetProjectNumber(ctx, p.cfg.ProjectID)
-	if err != nil {
-		return "", fmt.Errorf("getting project number: %w", err)
-	}
-
-	if err := p.gcpAPI.CreateWIFPool(ctx, projectNumber, p.cfg.WIFPoolName, "Fullsend GitHub OIDC Pool"); err != nil {
-		return "", fmt.Errorf("creating WIF pool: %w", err)
-	}
-
-	var attrCondition string
+	var projectNumber string
 	if p.cfg.Repo != "" {
+		// Repo-scoped: dedicated provider per repo, no org merge.
+		var err error
+		projectNumber, err = p.gcpAPI.GetProjectNumber(ctx, p.cfg.ProjectID)
+		if err != nil {
+			return "", fmt.Errorf("getting project number: %w", err)
+		}
+		if err := p.gcpAPI.CreateWIFPool(ctx, projectNumber, p.cfg.WIFPoolName, "Fullsend GitHub OIDC Pool"); err != nil {
+			return "", fmt.Errorf("creating WIF pool: %w", err)
+		}
 		parts := strings.SplitN(p.cfg.Repo, "/", 2)
 		p.cfg.WIFProvider = BuildRepoProviderID(parts[0], parts[1])
-		attrCondition = fmt.Sprintf("assertion.repository == '%s'", p.cfg.Repo)
-	} else {
-		// Merge with existing WIF provider orgs to avoid clobbering
-		// other orgs' access when re-installing a single org.
-		allOrgs := make([]string, len(orgs))
-		copy(allOrgs, orgs)
-		existingProvider, getErr := p.gcpAPI.GetWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)
-		if getErr != nil {
-			log.Printf("warning: could not read existing WIF provider for merge (proceeding with installing orgs only): %v", getErr)
-		} else if existingProvider != nil {
-			existingOrgs := parseConditionOrgs(existingProvider.AttributeCondition)
-			merged := make(map[string]bool)
-			for _, org := range allOrgs {
-				merged[org] = true
-			}
-			for _, org := range existingOrgs {
-				if !merged[org] {
-					allOrgs = append(allOrgs, org)
-					merged[org] = true
-				}
-			}
-			sort.Strings(allOrgs)
+		attrCondition := fmt.Sprintf("assertion.repository == '%s'", p.cfg.Repo)
+		audiences := []string{oidcAudience, iamAudience(projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)}
+		if err := p.gcpAPI.CreateWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider, OIDCProviderConfig{
+			IssuerURI:          oidcIssuer,
+			AttributeCondition: attrCondition,
+			AllowedAudiences:   audiences,
+		}); err != nil {
+			return "", fmt.Errorf("creating WIF provider: %w", err)
 		}
-		attrCondition = buildAttributeCondition(allOrgs)
-	}
-
-	audiences := []string{oidcAudience, iamAudience(projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)}
-	if err := p.gcpAPI.CreateWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider, OIDCProviderConfig{
-		IssuerURI:          oidcIssuer,
-		AttributeCondition: attrCondition,
-		AllowedAudiences:   audiences,
-	}); err != nil {
-		return "", fmt.Errorf("creating WIF provider: %w", err)
+	} else {
+		// Org-scoped: shared helper merges with existing orgs.
+		wifResult, err := p.ensureWIFPoolAndProvider(ctx, orgs)
+		if err != nil {
+			return "", err
+		}
+		projectNumber = wifResult.projectNumber
 	}
 
 	// IAM policy changes can take up to 7 minutes to propagate.

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -1165,7 +1165,26 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 		p.cfg.WIFProvider = BuildRepoProviderID(parts[0], parts[1])
 		attrCondition = fmt.Sprintf("assertion.repository == '%s'", p.cfg.Repo)
 	} else {
-		attrCondition = buildAttributeCondition(orgs)
+		// Merge with existing WIF provider orgs to avoid clobbering
+		// other orgs' access when re-installing a single org.
+		allOrgs := make([]string, len(orgs))
+		copy(allOrgs, orgs)
+		existingProvider, getErr := p.gcpAPI.GetWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)
+		if getErr == nil && existingProvider != nil {
+			existingOrgs := parseConditionOrgs(existingProvider.AttributeCondition)
+			seen := make(map[string]bool)
+			for _, org := range allOrgs {
+				seen[org] = true
+			}
+			for _, org := range existingOrgs {
+				if !seen[org] {
+					allOrgs = append(allOrgs, org)
+					seen[org] = true
+				}
+			}
+			sort.Strings(allOrgs)
+		}
+		attrCondition = buildAttributeCondition(allOrgs)
 	}
 
 	audiences := []string{oidcAudience, iamAudience(projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)}

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -677,16 +677,18 @@ func (p *Provisioner) provisionSelfManaged(ctx context.Context) (map[string]stri
 	allOrgs := make([]string, len(p.cfg.GitHubOrgs))
 	copy(allOrgs, p.cfg.GitHubOrgs)
 	existingProvider, getErr := p.gcpAPI.GetWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)
-	if getErr == nil && existingProvider != nil {
+	if getErr != nil {
+		log.Printf("warning: could not read existing WIF provider for merge (proceeding with installing orgs only): %v", getErr)
+	} else if existingProvider != nil {
 		existingOrgs := parseConditionOrgs(existingProvider.AttributeCondition)
-		seen := make(map[string]bool)
+		merged := make(map[string]bool)
 		for _, org := range allOrgs {
-			seen[org] = true
+			merged[org] = true
 		}
 		for _, org := range existingOrgs {
-			if !seen[org] {
+			if !merged[org] {
 				allOrgs = append(allOrgs, org)
-				seen[org] = true
+				merged[org] = true
 			}
 		}
 		sort.Strings(allOrgs)
@@ -1064,10 +1066,10 @@ func parseConditionOrgs(condition string) []string {
 		if strings.HasSuffix(part, fullsendRepoSuffix) {
 			org := strings.TrimSuffix(part, fullsendRepoSuffix)
 			if githubOrgPattern.MatchString(org) {
-				orgs = append(orgs, org)
+				orgs = append(orgs, strings.ToLower(org))
 			}
 		} else if githubOrgPattern.MatchString(part) {
-			orgs = append(orgs, part)
+			orgs = append(orgs, strings.ToLower(part))
 		}
 	}
 	return orgs
@@ -1139,7 +1141,7 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 	orgs := make([]string, len(p.cfg.GitHubOrgs))
 	seen := make(map[string]bool)
 	for i, org := range p.cfg.GitHubOrgs {
-		if !githubOrgPattern.MatchString(org) {
+		if !githubOrgPattern.MatchString(org) || strings.Contains(org, "--") {
 			return "", fmt.Errorf("invalid GitHub org name: %q", org)
 		}
 		lower := strings.ToLower(org)
@@ -1170,16 +1172,18 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 		allOrgs := make([]string, len(orgs))
 		copy(allOrgs, orgs)
 		existingProvider, getErr := p.gcpAPI.GetWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)
-		if getErr == nil && existingProvider != nil {
+		if getErr != nil {
+			log.Printf("warning: could not read existing WIF provider for merge (proceeding with installing orgs only): %v", getErr)
+		} else if existingProvider != nil {
 			existingOrgs := parseConditionOrgs(existingProvider.AttributeCondition)
-			seen := make(map[string]bool)
+			merged := make(map[string]bool)
 			for _, org := range allOrgs {
-				seen[org] = true
+				merged[org] = true
 			}
 			for _, org := range existingOrgs {
-				if !seen[org] {
+				if !merged[org] {
 					allOrgs = append(allOrgs, org)
-					seen[org] = true
+					merged[org] = true
 				}
 			}
 			sort.Strings(allOrgs)

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -1195,17 +1195,21 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 		// Each repo gets a unique provider ID (via BuildRepoProviderID),
 		// so no risk of clobbering another repo's WIF condition.
 		parts := strings.SplitN(repo, "/", 2)
+		origParts := strings.SplitN(p.cfg.Repo, "/", 2)
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			return "", fmt.Errorf("repo must be in owner/repo format, got %q", p.cfg.Repo)
 		}
 		if !githubOrgPattern.MatchString(parts[0]) || strings.Contains(parts[0], "--") {
-			return "", fmt.Errorf("invalid repo owner %q: must be a valid GitHub org/user name", parts[0])
+			return "", fmt.Errorf("invalid repo owner %q: must be a valid GitHub org/user name", origParts[0])
 		}
 		if !githubRepoSlugPattern.MatchString(parts[1]) {
-			return "", fmt.Errorf("invalid repo name %q: must contain only alphanumeric, hyphens, dots, or underscores", parts[1])
+			return "", fmt.Errorf("invalid repo name %q: must contain only alphanumeric, hyphens, dots, or underscores", origParts[1])
 		}
 		if parts[1] == "." || parts[1] == ".." {
-			return "", fmt.Errorf("invalid repo name %q: cannot be \".\" or \"..\"", parts[1])
+			return "", fmt.Errorf("invalid repo name %q: cannot be \".\" or \"..\"", origParts[1])
+		}
+		if strings.HasSuffix(parts[1], ".git") {
+			return "", fmt.Errorf("invalid repo name %q: cannot end with \".git\"", origParts[1])
 		}
 		var err error
 		projectNumber, err = p.gcpAPI.GetProjectNumber(ctx, p.cfg.ProjectID)

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -1020,6 +1020,11 @@ const fullsendRepoSuffix = "/.fullsend"
 // parseConditionOrgs extracts GitHub org names from a WIF attribute condition.
 // Supports both the current org-scoped ("assertion.repository_owner == 'org'")
 // and legacy repo-scoped ("assertion.repository == 'org/.fullsend'") formats.
+//
+// The parser splits on single quotes and filters with githubOrgPattern, so it
+// assumes conditions contain only org names as quoted values. If conditions are
+// ever extended with additional CEL clauses containing non-org quoted values,
+// this parser must be updated to avoid false-positive extraction.
 func parseConditionOrgs(condition string) []string {
 	var orgs []string
 	for _, part := range strings.Split(condition, "'") {
@@ -1044,6 +1049,14 @@ type wifMergeResult struct {
 	allOrgs       []string
 }
 
+// ensureWIFPoolAndProvider creates or updates the WIF pool and provider,
+// merging the installing orgs with any existing orgs in the provider's
+// attribute condition.
+//
+// WARNING: read-modify-write without locking — concurrent installs
+// targeting the same WIF provider can race, causing one update to
+// overwrite the other. Run installs sequentially when sharing a WIF
+// provider, or accept that a lost update will be corrected on the next run.
 func (p *Provisioner) ensureWIFPoolAndProvider(ctx context.Context, installingOrgs []string) (*wifMergeResult, error) {
 	projectNumber, err := p.gcpAPI.GetProjectNumber(ctx, p.cfg.ProjectID)
 	if err != nil {
@@ -1058,8 +1071,13 @@ func (p *Provisioner) ensureWIFPoolAndProvider(ctx context.Context, installingOr
 	copy(allOrgs, installingOrgs)
 	existingProvider, getErr := p.gcpAPI.GetWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, p.cfg.WIFProvider)
 	if getErr != nil {
-		log.Printf("warning: could not read existing WIF provider for merge (proceeding with installing orgs only): %v", getErr)
-	} else if existingProvider != nil {
+		// A non-nil error means "unknown state" — proceeding would risk
+		// overwriting existing orgs (the exact clobber this helper prevents).
+		// Note: GetWIFProvider returns (nil, nil) for 404 (provider does not
+		// exist yet), so a non-nil error is always a real failure.
+		return nil, fmt.Errorf("reading existing WIF provider for merge: %w", getErr)
+	}
+	if existingProvider != nil {
 		existingOrgs := parseConditionOrgs(existingProvider.AttributeCondition)
 		merged := make(map[string]bool)
 		for _, org := range allOrgs {
@@ -1167,6 +1185,15 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 	var projectNumber string
 	if p.cfg.Repo != "" {
 		// Repo-scoped: dedicated provider per repo, no org merge.
+		// Each repo gets a unique provider ID (via BuildRepoProviderID),
+		// so no risk of clobbering another repo's WIF condition.
+		parts := strings.SplitN(p.cfg.Repo, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return "", fmt.Errorf("repo must be in owner/repo format, got %q", p.cfg.Repo)
+		}
+		if strings.ContainsAny(p.cfg.Repo, `'"`) {
+			return "", fmt.Errorf("invalid repo name %q: contains quotes", p.cfg.Repo)
+		}
 		var err error
 		projectNumber, err = p.gcpAPI.GetProjectNumber(ctx, p.cfg.ProjectID)
 		if err != nil {
@@ -1174,13 +1201,6 @@ func (p *Provisioner) ProvisionWIF(ctx context.Context) (wifProvider string, err
 		}
 		if err := p.gcpAPI.CreateWIFPool(ctx, projectNumber, p.cfg.WIFPoolName, "Fullsend GitHub OIDC Pool"); err != nil {
 			return "", fmt.Errorf("creating WIF pool: %w", err)
-		}
-		parts := strings.SplitN(p.cfg.Repo, "/", 2)
-		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			return "", fmt.Errorf("repo must be in owner/repo format, got %q", p.cfg.Repo)
-		}
-		if strings.ContainsAny(p.cfg.Repo, `'"`) {
-			return "", fmt.Errorf("invalid repo name %q: contains quotes", p.cfg.Repo)
 		}
 		p.cfg.WIFProvider = BuildRepoProviderID(parts[0], parts[1])
 		attrCondition := fmt.Sprintf("assertion.repository == '%s'", p.cfg.Repo)

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -1827,6 +1827,20 @@ func TestProvisionWIF_RepoScoped_LowercasesRepo(t *testing.T) {
 	assert.Contains(t, fake.projectIAMBindings[0].Member, "attribute.repository/acme/widget")
 }
 
+func TestProvisionWIF_RepoScoped_DotPrefixRepo(t *testing.T) {
+	fake := newFakeGCFClient()
+	p := NewProvisioner(Config{
+		ProjectID:  "my-project",
+		GitHubOrgs: []string{"nonflux"},
+		Repo:       "nonflux/.fullsend",
+	}, fake)
+
+	_, err := p.ProvisionWIF(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, "assertion.repository == 'nonflux/.fullsend'", fake.lastWIFProviderConfig.AttributeCondition)
+}
+
 func TestProvisionWIF_RepoScoped_DoesNotTouchSharedProvider(t *testing.T) {
 	fake := newFakeGCFClient()
 	fake.wifProvider = &WIFProviderInfo{
@@ -1871,9 +1885,9 @@ func TestProvisionWIF_RepoScoped_RejectsInvalidRepo(t *testing.T) {
 		{"quotes in repo", "owner's/repo", "must contain only"},
 		{"backslash in repo", `owner/repo\`, "must contain only"},
 		{"spaces in repo", "owner/my repo", "must contain only"},
-		{"leading dot in repo", "owner/.hidden", "must contain only"},
-		{"trailing dot in repo", "owner/repo.", "must contain only"},
-		{"leading dot in owner", ".owner/repo", "must contain only"},
+		{"dot as repo", "owner/.", "cannot be"},
+		{"dotdot as repo", "owner/..", "cannot be"},
+		{"dot as owner", "./repo", "cannot be"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -1825,6 +1825,7 @@ func TestProvisionWIF_RepoScoped_LowercasesRepo(t *testing.T) {
 
 	assert.Equal(t, "assertion.repository == 'acme/widget'", fake.lastWIFProviderConfig.AttributeCondition)
 	assert.Contains(t, fake.projectIAMBindings[0].Member, "attribute.repository/acme/widget")
+	assert.Equal(t, "Acme/Widget", p.cfg.Repo, "ProvisionWIF should not mutate p.cfg.Repo")
 }
 
 func TestProvisionWIF_RepoScoped_DotPrefixRepo(t *testing.T) {
@@ -1882,12 +1883,14 @@ func TestProvisionWIF_RepoScoped_RejectsInvalidRepo(t *testing.T) {
 		{"no slash", "just-a-name", "owner/repo format"},
 		{"empty owner", "/repo", "owner/repo format"},
 		{"empty repo", "owner/", "owner/repo format"},
-		{"quotes in repo", "owner's/repo", "must contain only"},
+		{"quotes in owner", "owner's/repo", "invalid repo owner"},
 		{"backslash in repo", `owner/repo\`, "must contain only"},
 		{"spaces in repo", "owner/my repo", "must contain only"},
+		{"underscore in owner", "_owner/repo", "invalid repo owner"},
+		{"dot in owner", "owner.name/repo", "invalid repo owner"},
 		{"dot as repo", "owner/.", "cannot be"},
 		{"dotdot as repo", "owner/..", "cannot be"},
-		{"dot as owner", "./repo", "cannot be"},
+		{"dot as owner", "./repo", "invalid repo owner"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -1812,6 +1812,21 @@ func TestProvisionWIF_RepoScoped(t *testing.T) {
 	assert.NotContains(t, fake.calls, "GetWIFProvider")
 }
 
+func TestProvisionWIF_RepoScoped_LowercasesRepo(t *testing.T) {
+	fake := newFakeGCFClient()
+	p := NewProvisioner(Config{
+		ProjectID:  "my-project",
+		GitHubOrgs: []string{"acme"},
+		Repo:       "Acme/Widget",
+	}, fake)
+
+	_, err := p.ProvisionWIF(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, "assertion.repository == 'acme/widget'", fake.lastWIFProviderConfig.AttributeCondition)
+	assert.Contains(t, fake.projectIAMBindings[0].Member, "attribute.repository/acme/widget")
+}
+
 func TestProvisionWIF_RepoScoped_DoesNotTouchSharedProvider(t *testing.T) {
 	fake := newFakeGCFClient()
 	fake.wifProvider = &WIFProviderInfo{
@@ -1856,6 +1871,9 @@ func TestProvisionWIF_RepoScoped_RejectsInvalidRepo(t *testing.T) {
 		{"quotes in repo", "owner's/repo", "must contain only"},
 		{"backslash in repo", `owner/repo\`, "must contain only"},
 		{"spaces in repo", "owner/my repo", "must contain only"},
+		{"leading dot in repo", "owner/.hidden", "must contain only"},
+		{"trailing dot in repo", "owner/repo.", "must contain only"},
+		{"leading dot in owner", ".owner/repo", "must contain only"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -1203,6 +1203,23 @@ func TestProvisioner_Provision_CreateWIFProviderError(t *testing.T) {
 	assert.Contains(t, err.Error(), "provider error")
 }
 
+func TestProvisioner_Provision_GetWIFProviderError_FailsFast(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.errs["GetWIFProvider"] = fmt.Errorf("transient error")
+
+	p := newTestProvisioner(Config{
+		ProjectID:         "test-project-id",
+		GitHubOrgs:        []string{"org"},
+		AgentPEMs:         singleRolePEMs(),
+		AgentAppIDs:       singleRoleAppIDs(),
+		FunctionSourceDir: fakeFunctionSourceDir(t),
+	}, fake)
+
+	_, err := p.Provision(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading existing WIF provider for merge")
+}
+
 func TestProvisioner_Provision_CreateSecretError(t *testing.T) {
 	fake := newFakeGCFClient()
 	fake.errs["GetSecret"] = ErrSecretNotFound
@@ -1836,7 +1853,9 @@ func TestProvisionWIF_RepoScoped_RejectsInvalidRepo(t *testing.T) {
 		{"no slash", "just-a-name", "owner/repo format"},
 		{"empty owner", "/repo", "owner/repo format"},
 		{"empty repo", "owner/", "owner/repo format"},
-		{"quotes in repo", "owner's/repo", "contains quotes"},
+		{"quotes in repo", "owner's/repo", "must contain only"},
+		{"backslash in repo", `owner/repo\`, "must contain only"},
+		{"spaces in repo", "owner/my repo", "must contain only"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -1866,6 +1866,27 @@ func TestProvisionWIF_OrgScoped_GetProviderError_StillProceeds(t *testing.T) {
 		fake.lastWIFProviderConfig.AttributeCondition)
 }
 
+func TestParseConditionOrgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		condition string
+		want      []string
+	}{
+		{"single org", "assertion.repository_owner == 'acme'", []string{"acme"}},
+		{"multiple orgs", "assertion.repository_owner in ['alpha', 'beta', 'gamma']", []string{"alpha", "beta", "gamma"}},
+		{"legacy repo-scoped", "assertion.repository == 'acme/.fullsend'", []string{"acme"}},
+		{"mixed case normalized", "assertion.repository_owner in ['AcMe', 'BETA']", []string{"acme", "beta"}},
+		{"empty condition", "", nil},
+		{"no quoted orgs", "assertion.repository_owner == true", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseConditionOrgs(tc.condition)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestBuildAttributeCondition(t *testing.T) {
 	t.Run("single org scopes to repository_owner", func(t *testing.T) {
 		got := buildAttributeCondition([]string{"myorg"})

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -1829,6 +1829,43 @@ func TestProvisionWIF_OrgScoped_Unchanged(t *testing.T) {
 	assert.Contains(t, fake.projectIAMBindings[0].Member, "attribute.repository/acme/.fullsend")
 }
 
+func TestProvisionWIF_OrgScoped_MergesExistingOrgs(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.wifProvider = &WIFProviderInfo{
+		AttributeCondition: "assertion.repository_owner in ['beta', 'gamma']",
+	}
+	p := NewProvisioner(Config{
+		ProjectID:  "my-project",
+		GitHubOrgs: []string{"acme"},
+	}, fake)
+
+	_, err := p.ProvisionWIF(context.Background())
+	require.NoError(t, err)
+
+	assert.Contains(t, fake.calls, "GetWIFProvider")
+	assert.Equal(t, "assertion.repository_owner in ['acme', 'beta', 'gamma']",
+		fake.lastWIFProviderConfig.AttributeCondition)
+
+	// IAM binding should only be for the installing org, not the merged ones.
+	require.Len(t, fake.projectIAMBindings, 1)
+	assert.Contains(t, fake.projectIAMBindings[0].Member, "attribute.repository/acme/.fullsend")
+}
+
+func TestProvisionWIF_OrgScoped_GetProviderError_StillProceeds(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.errs["GetWIFProvider"] = fmt.Errorf("transient error")
+	p := NewProvisioner(Config{
+		ProjectID:  "my-project",
+		GitHubOrgs: []string{"acme"},
+	}, fake)
+
+	_, err := p.ProvisionWIF(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, "assertion.repository_owner == 'acme'",
+		fake.lastWIFProviderConfig.AttributeCondition)
+}
+
 func TestBuildAttributeCondition(t *testing.T) {
 	t.Run("single org scopes to repository_owner", func(t *testing.T) {
 		got := buildAttributeCondition([]string{"myorg"})

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -384,8 +384,8 @@ func TestProvisioner_Provision_FullFlow(t *testing.T) {
 
 	expected := []string{
 		"GetFunction", // auto-routing check (no existing function → full deploy)
-		"GetProjectNumber",
 		"CreateServiceAccount",
+		"GetProjectNumber",
 		"CreateWIFPool",
 		"GetWIFProvider",
 		"CreateWIFProvider",

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -1842,6 +1842,19 @@ func TestProvisionWIF_RepoScoped_DotPrefixRepo(t *testing.T) {
 	assert.Equal(t, "assertion.repository == 'nonflux/.fullsend'", fake.lastWIFProviderConfig.AttributeCondition)
 }
 
+func TestProvisionWIF_RepoScoped_ErrorPreservesOriginalCase(t *testing.T) {
+	fake := newFakeGCFClient()
+	p := NewProvisioner(Config{
+		ProjectID:  "my-project",
+		GitHubOrgs: []string{"acme"},
+		Repo:       "Owner.Name/Repo",
+	}, fake)
+
+	_, err := p.ProvisionWIF(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Owner.Name", "error should show original casing, not lowercased")
+}
+
 func TestProvisionWIF_RepoScoped_DoesNotTouchSharedProvider(t *testing.T) {
 	fake := newFakeGCFClient()
 	fake.wifProvider = &WIFProviderInfo{
@@ -1891,6 +1904,8 @@ func TestProvisionWIF_RepoScoped_RejectsInvalidRepo(t *testing.T) {
 		{"dot as repo", "owner/.", "cannot be"},
 		{"dotdot as repo", "owner/..", "cannot be"},
 		{"dot as owner", "./repo", "invalid repo owner"},
+		{"double-hyphen in owner", "org--name/repo", "invalid repo owner"},
+		{"git suffix", "owner/repo.git", "cannot end with"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -1829,6 +1829,31 @@ func TestProvisionWIF_OrgScoped_Unchanged(t *testing.T) {
 	assert.Contains(t, fake.projectIAMBindings[0].Member, "attribute.repository/acme/.fullsend")
 }
 
+func TestProvisionWIF_RepoScoped_RejectsInvalidRepo(t *testing.T) {
+	tests := []struct {
+		name, repo, errContains string
+	}{
+		{"no slash", "just-a-name", "owner/repo format"},
+		{"empty owner", "/repo", "owner/repo format"},
+		{"empty repo", "owner/", "owner/repo format"},
+		{"quotes in repo", "owner's/repo", "contains quotes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := newFakeGCFClient()
+			p := NewProvisioner(Config{
+				ProjectID:  "my-project",
+				GitHubOrgs: []string{"acme"},
+				Repo:       tt.repo,
+			}, fake)
+			_, err := p.ProvisionWIF(context.Background())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errContains)
+			assert.NotContains(t, fake.calls, "GetProjectNumber")
+		})
+	}
+}
+
 func TestProvisionWIF_OrgScoped_MergesExistingOrgs(t *testing.T) {
 	fake := newFakeGCFClient()
 	fake.wifProvider = &WIFProviderInfo{
@@ -1851,7 +1876,7 @@ func TestProvisionWIF_OrgScoped_MergesExistingOrgs(t *testing.T) {
 	assert.Contains(t, fake.projectIAMBindings[0].Member, "attribute.repository/acme/.fullsend")
 }
 
-func TestProvisionWIF_OrgScoped_GetProviderError_StillProceeds(t *testing.T) {
+func TestProvisionWIF_OrgScoped_GetProviderError_FailsToPreventClobber(t *testing.T) {
 	fake := newFakeGCFClient()
 	fake.errs["GetWIFProvider"] = fmt.Errorf("transient error")
 	p := NewProvisioner(Config{
@@ -1860,10 +1885,8 @@ func TestProvisionWIF_OrgScoped_GetProviderError_StillProceeds(t *testing.T) {
 	}, fake)
 
 	_, err := p.ProvisionWIF(context.Background())
-	require.NoError(t, err)
-
-	assert.Equal(t, "assertion.repository_owner == 'acme'",
-		fake.lastWIFProviderConfig.AttributeCondition)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading existing WIF provider for merge")
 }
 
 func TestParseConditionOrgs(t *testing.T) {


### PR DESCRIPTION
## Summary

- `ProvisionWIF()` overwrote the WIF provider's `attributeCondition` with only the installing org, removing all other orgs. This caused STS 400 → mint 403 for every org not in the latest install run.
- Root cause: `ProvisionWIF()` (used by inference WIF and per-repo install paths) lacked the merge logic that `Provision()` already had.
- Adds the same read-existing → parse → union → write-merged pattern from `Provision()` into `ProvisionWIF()` via shared `ensureWIFPoolAndProvider` helper.
- Hardens repo name validation with allowlist regex, adds defensive lowercasing in the shared helper, and stops mutating `p.cfg.WIFProvider` in the repo-scoped path.
- Changes `GetWIFProvider` error handling from silent continue to fail-fast in both `Provision()` and `ProvisionWIF()` paths to prevent condition clobber on transient errors.

**Incident:** `fullsend-ai/fullsend` dispatch failed on PR #1111 ([run 26062774013](https://github.com/fullsend-ai/fullsend/actions/runs/26062774013)) because an earlier `fullsend install` for `konflux-ci` overwrote the WIF condition to only allow `konflux-ci`, blocking all other orgs (STS returned 400, mint returned 403). The WIF provider has been manually corrected.

## Test plan

- [x] All existing `TestProvisionWIF_*` tests pass
- [x] New `TestProvisionWIF_OrgScoped_MergesExistingOrgs` verifies merge behavior
- [x] New `TestProvisionWIF_OrgScoped_GetProviderError_FailsToPreventClobber` verifies fail-fast on transient errors
- [x] New `TestProvisioner_Provision_GetWIFProviderError_FailsFast` verifies fail-fast in Provision() path
- [x] New `TestProvisionWIF_RepoScoped_RejectsInvalidRepo` verifies allowlist validation (quotes, backslash, spaces)
- [x] New `TestParseConditionOrgs` verifies case normalization and format parsing
- [x] Full `go test ./...` passes