### PR TITLE
fix: raise mint maxRepos from 100 to 500

### DIFF
--- a/internal/dispatch/gcf/mintsrc/main.go.embed
+++ b/internal/dispatch/gcf/mintsrc/main.go.embed
@@ -475,7 +475,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(req.Repos) > maxRepos {
-		writeError(w, http.StatusBadRequest, "too many repos (max 500)")
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("too many repos (max %d)", maxRepos))
 		return
 	}
 	for _, repo := range req.Repos {

--- a/internal/dispatch/gcf/mintsrc/main.go.embed
+++ b/internal/dispatch/gcf/mintsrc/main.go.embed
@@ -226,7 +226,7 @@ var githubOrgPattern = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-z
 // GitHub allows repos starting with dot (e.g., .fullsend, .github).
 var repoNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_.][a-zA-Z0-9._-]{0,99}$`)
 
-const maxRepos = 100
+const maxRepos = 500
 
 // mintRequest is the JSON body sent by .fullsend agent workflows.
 type mintRequest struct {
@@ -475,7 +475,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(req.Repos) > maxRepos {
-		writeError(w, http.StatusBadRequest, "too many repos (max 100)")
+		writeError(w, http.StatusBadRequest, "too many repos (max 500)")
 		return
 	}
 	for _, repo := range req.Repos {

--- a/internal/mint/main.go
+++ b/internal/mint/main.go
@@ -475,7 +475,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(req.Repos) > maxRepos {
-		writeError(w, http.StatusBadRequest, "too many repos (max 500)")
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("too many repos (max %d)", maxRepos))
 		return
 	}
 	for _, repo := range req.Repos {

--- a/internal/mint/main.go
+++ b/internal/mint/main.go
@@ -226,7 +226,7 @@ var githubOrgPattern = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-z
 // GitHub allows repos starting with dot (e.g., .fullsend, .github).
 var repoNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_.][a-zA-Z0-9._-]{0,99}$`)
 
-const maxRepos = 100
+const maxRepos = 500
 
 // mintRequest is the JSON body sent by .fullsend agent workflows.
 type mintRequest struct {
@@ -475,7 +475,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(req.Repos) > maxRepos {
-		writeError(w, http.StatusBadRequest, "too many repos (max 100)")
+		writeError(w, http.StatusBadRequest, "too many repos (max 500)")
 		return
 	}
 	for _, repo := range req.Repos {


### PR DESCRIPTION
## Summary
- Raises the hard-coded `maxRepos` limit in the token mint from 100 to 500
- Orgs with >100 enrolled repos (e.g. konflux-ci with 127) get HTTP 400 on repo-maintenance token mints because all enrolled repos are passed in a single request
- GitHub's installation token API supports scoping to 500+ repos, so this is safe to raise
- Updates both `internal/mint/main.go` (source of truth) and `internal/dispatch/gcf/mintsrc/main.go.embed` (deployed copy)

## Test plan
- [x] `go test ./...` passes in `internal/mint/` — existing `TestHandler_TooManyRepos` now exercises 501 repos
- [ ] After merge + Cloud Function redeploy, re-run [konflux-ci repo-maintenance](https://github.com/konflux-ci/.fullsend/actions/workflows/repo-maintenance.yml) and confirm token mint succeeds

Triggered by: https://github.com/konflux-ci/.fullsend/actions/runs/26057898201/job/76610476449