### PR TITLE
fix: skip existing-PR check when --force is in comment body

### DIFF
--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -123,6 +123,7 @@ jobs:
           ISSUE_NUMBER: ${{ fromJSON(inputs.event_payload).issue.number }}
           REPO_FULL_NAME: ${{ inputs.source_repo }}
           GITHUB_ISSUE_URL: ${{ fromJSON(inputs.event_payload).issue.html_url }}
+          COMMENT_BODY: ${{ fromJSON(inputs.event_payload).comment.body }}
         run: bash scripts/pre-code.sh
 
       - name: Setup GCP and prepare credentials

--- a/internal/scaffold/fullsend-repo/scripts/pre-code-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-code-test.sh
@@ -86,11 +86,11 @@ run_test() {
     GH_TOKEN="fake-token"
   )
 
-  # Add extra env vars if provided.
+  # Add extra env vars if provided (read line-by-line to support values with spaces).
   if [[ -n "${extra_env}" ]]; then
-    for kv in ${extra_env}; do
-      env_cmd+=("${kv}")
-    done
+    while IFS= read -r kv; do
+      [[ -n "${kv}" ]] && env_cmd+=("${kv}")
+    done <<< "${extra_env}"
   fi
 
   local exit_code=0
@@ -139,9 +139,9 @@ run_test_stdout() {
   )
 
   if [[ -n "${extra_env}" ]]; then
-    for kv in ${extra_env}; do
-      env_cmd+=("${kv}")
-    done
+    while IFS= read -r kv; do
+      [[ -n "${kv}" ]] && env_cmd+=("${kv}")
+    done <<< "${extra_env}"
   fi
 
   local exit_code=0
@@ -199,11 +199,18 @@ run_test_stdout "bot-pr-does-not-block" \
   0
 
 # CODE_FORCE=true → should skip check even with human PR.
-run_test_stdout "force-override-skips-check" \
+run_test_stdout "force-override-code-force" \
   "99${TAB}human-dev${TAB}https://github.com/test-org/test-repo/pull/99" \
-  "CODE_FORCE=true" \
+  "Force override" \
   0 \
   "CODE_FORCE=true"
+
+# COMMENT_BODY contains --force → should also skip check.
+run_test_stdout "force-override-comment-body" \
+  "99${TAB}human-dev${TAB}https://github.com/test-org/test-repo/pull/99" \
+  "Force override" \
+  0 \
+  "COMMENT_BODY=/fs-code --force"
 
 # No GH_TOKEN → skips check entirely, exits 0.
 run_test_stdout "no-gh-token-skips-check" \

--- a/internal/scaffold/fullsend-repo/scripts/pre-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-code.sh
@@ -60,9 +60,9 @@ if [[ -z "${GH_TOKEN:-}" ]]; then
   exit 0
 fi
 
-# Allow override via CODE_FORCE (set when /fs-code --force is used).
-if [[ "${CODE_FORCE:-}" == "true" ]]; then
-  echo "CODE_FORCE=true — skipping existing-PR check"
+# Allow override when --force is in the trigger comment or CODE_FORCE is set.
+if [[ "${CODE_FORCE:-}" == "true" ]] || [[ "${COMMENT_BODY:-}" == *--force* ]]; then
+  echo "Force override — skipping existing-PR check"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- `pre-code.sh` was posting "use `/fs-code --force`" even when the user already triggered with `--force`, because the script only checked `CODE_FORCE=true` — and the workflow never set `COMMENT_BODY`, making that env var unreachable
- Now checks both `CODE_FORCE=true` and `COMMENT_BODY` containing `--force`; workflow passes `COMMENT_BODY` from the event payload
- Fixed a test harness bug where `for kv in ${extra_env}` word-split env values containing spaces, breaking the `COMMENT_BODY=/fs-code --force` test case

## Test plan

- [ ] `bash internal/scaffold/fullsend-repo/scripts/pre-code-test.sh` passes all 11 tests (including new `force-override-comment-body`)
- [ ] Trigger `/fs-code --force` on an issue with an existing human PR — confirm no "use --force" comment is posted

Closes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)