### PR TITLE
fix(skills): use repo-root-relative path for install-binary.sh

### DIFF
--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use when the user wants to tag a release, cut a release candidate, or ship a
   new version. Also use when asking about release process, versioning, or how
   GoReleaser is configured.
-allowed-tools: Read, Grep, Glob, AskUserQuestion, Bash(git tag:*), Bash(git log:*), Bash(git diff:*), Bash(git pull:*), Bash(git push:*), Bash(gh release:*), Bash(gh run:*), Bash(git checkout:*), Bash(bash scripts/install-binary.sh:*)
+allowed-tools: Read, Grep, Glob, AskUserQuestion, Bash(git tag:*), Bash(git log:*), Bash(git diff:*), Bash(git pull:*), Bash(git push:*), Bash(gh release:*), Bash(gh run:*), Bash(git checkout:*), Bash(bash skills/cutting-releases/scripts/install-binary.sh:*)
 ---
 
 # Cutting Releases
@@ -117,10 +117,11 @@ Check that the title, changelog, and binary assets look correct.
 ### 9. Install the binary locally
 
 Ask the user where to install (default: `~/.local/bin/`), then run
-[scripts/install-binary.sh](scripts/install-binary.sh):
+the install script. The script lives in the skill directory — always use
+the repo-root-relative path:
 
 ```bash
-bash scripts/install-binary.sh <tag> [install-dir]
+bash skills/cutting-releases/scripts/install-binary.sh <tag> [install-dir]
 ```
 
 The script downloads the release archive, verifies its SHA-256 checksum


### PR DESCRIPTION
Closes #1139

## Summary

- Fixed `allowed-tools` pattern: `scripts/install-binary.sh` → `skills/cutting-releases/scripts/install-binary.sh`
- Fixed step 9 prose and code block to use the same repo-root-relative path
- Removed the broken markdown link to a non-existent repo-root file

## Test plan

- [ ] Run `cutting-releases` skill and verify step 9 installs without a fallback `find` search

🤖 Generated with [Claude Code](https://claude.com/claude-code)