### PR TITLE
build(sandbox): add jq to base image

### DIFF
--- a/images/sandbox/Containerfile
+++ b/images/sandbox/Containerfile
@@ -3,6 +3,7 @@
 # Pre-installs all runtime dependencies needed by any fullsend agent:
 #   - Claude Code (official installer)
 #   - rsync (for safe repo write-back)
+#   - jq (JSON parsing in agent scripts and skills)
 #   - gitleaks (secret scanner, SHA256-verified)
 #   - pre-commit + gitlint (repo hook runner + commit message validator)
 #   - tirith (Rust CLI for terminal security scanning hooks)
@@ -32,9 +33,9 @@ USER root
 ARG TARGETARCH
 
 # ---------------------------------------------------------------------------
-# Install rsync (for safe repo write-back).
+# Install rsync (for safe repo write-back) and jq (JSON parsing in scripts).
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends rsync \
+    && apt-get install -y --no-install-recommends rsync jq \
     && rm -rf /var/lib/apt/lists/*
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `jq` to the base sandbox image alongside `rsync` in the existing `apt-get` block
- Without `jq`, agents fall back to `python3 -c "import json,sys; ..."` one-liners, wasting ~500–1000 tokens and 5–10 seconds per recovery sequence

## Test plan

- [ ] Sandbox image builds successfully (CI)
- [ ] `which jq` succeeds inside the sandbox at runtime
- [ ] Review agent run shows no `jq`-related error recovery in transcript

Closes #1126