### PR TITLE
fix(hack): report broken symlinks before exiting

### DIFF
--- a/hack/lint-broken-symlinks
+++ b/hack/lint-broken-symlinks
@@ -16,15 +16,21 @@ info() { echo "INFO: $1"; }
 
 cd "$REPO_ROOT"
 
+trap 'echo "lint-broken-symlinks: aborted unexpectedly at line $LINENO" >&2' ERR
+
 info "Checking for broken symlinks..."
 
 # Check only tracked symlinks (git mode 120000) to avoid false positives
 # from development artifacts in .venv/, bin/, etc.
 broken_symlinks=()
 while IFS= read -r symlink; do
-    if [[ ! -e "$symlink" ]]; then
-        target=$(readlink "$symlink")
-        broken_symlinks+=("$symlink -> $target")
+    if [[ -L "$symlink" ]]; then
+        if [[ ! -e "$symlink" ]]; then
+            target=$(readlink "$symlink" || echo "<unreadable>")
+            broken_symlinks+=("$symlink -> $target")
+        fi
+    else
+        broken_symlinks+=("$symlink (tracked as symlink but not a symlink on disk)")
     fi
 done < <(git ls-files -s | awk '$1 == "120000" {print $4}')
 


### PR DESCRIPTION
## Summary

- `set -e` caused silent exit when a tracked path had mode `120000` but wasn't a symlink on disk — `readlink` aborted before the report block ran
- Guard loop body with `[[ -L ]]` so non-symlink tracked paths get an explicit message
- Tolerate `readlink` failures with `|| echo "<unreadable>"`
- Add `ERR` trap so any unexpected abort still prints line number

## Reproducer

```bash
# Break a tracked symlink
ln -sfn /nonexistent/target .claude/skills

# Before fix: silent exit 1, no output beyond "INFO: Checking..."
# After fix:
$ hack/lint-broken-symlinks
INFO: Checking for broken symlinks...
========================
Broken symlinks found:
========================
ERROR: .claude/skills -> /nonexistent/target
========================
ERROR: 1 broken symlink(s) found

# Restore
ln -sfn ../skills .claude/skills
```

## Test plan

- [x] `bash hack/lint-broken-symlinks` passes on clean repo
- [x] Manually break a symlink — hook prints path + target before exiting 1

Closes #1106