### PR TITLE
fix(run): clarify skill scan log — blocked vs uploading

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -763,9 +763,9 @@ func bootstrapSandbox(sandboxName, repoDir, fullsendBinary string, h *harness.Ha
 					if h.FailModeClosed() {
 						return fmt.Errorf("skill %q blocked: critical injection findings in SKILL.md", skillPath)
 					}
-					fmt.Fprintf(os.Stderr, "WARNING: skill %q has critical injection findings (fail_mode: open)\n", skillPath)
+					fmt.Fprintf(os.Stderr, "WARNING: skill %q has critical injection findings (fail_mode: open) — uploading anyway\n", skillPath)
 				} else if len(result.Findings) > 0 {
-					fmt.Fprintf(os.Stderr, "WARNING: skill %q has %d injection finding(s)\n", skillPath, len(result.Findings))
+					fmt.Fprintf(os.Stderr, "WARNING: skill %q has %d non-critical injection finding(s) — not blocked (only critical findings block); uploading\n", skillPath, len(result.Findings))
 				}
 			}
 		}
@@ -774,6 +774,7 @@ func bootstrapSandbox(sandboxName, repoDir, fullsendBinary string, h *harness.Ha
 			fmt.Sprintf("%s/skills/", sandbox.SandboxClaudeConfig)); err != nil {
 			return fmt.Errorf("copying skill %q: %w", skillPath, err)
 		}
+		fmt.Fprintf(os.Stderr, "Skill %q: uploaded to sandbox\n", filepath.Base(skillPath))
 	}
 
 	// Scan plugin definitions for injection before copying into sandbox.


### PR DESCRIPTION
## Summary

- `WARNING: skill X has N injection finding(s)` gave no indication of what happened next — the skill could be blocked or uploaded and the log looked the same
- Only **critical** findings block a skill (when `fail_mode: closed`); high/medium/low findings just warn
- Adds the disposition to each message and a per-skill upload confirmation so future runs make the outcome unambiguous

## Before / after

**Non-critical finding (was):**
```
WARNING: skill "…/pr-review" has 1 injection finding(s)
```
**Non-critical finding (now):**
```
WARNING: skill "…/pr-review" has 1 non-critical injection finding(s) — not blocked (only critical findings block); uploading
Skill "pr-review": uploaded to sandbox
```

**Critical finding, fail_mode open (now):**
```
WARNING: skill "…/pr-review" has critical injection findings (fail_mode: open) — uploading anyway
Skill "pr-review": uploaded to sandbox
```

**Critical finding, fail_mode closed (unchanged — returns error, run aborts):**
```
Error: skill "…/pr-review" blocked: critical injection findings in SKILL.md
```

## Test plan

- [ ] Run with a skill that has a non-critical injection finding — confirm new message format
- [ ] Confirm `go vet` and `make lint` pass