### PR TITLE
feat(analyze-transcript): add cost estimate to summary output

### DIFF
--- a/skills/analyze-transcript/SKILL.md
+++ b/skills/analyze-transcript/SKILL.md
@@ -178,7 +178,7 @@ destination hosts, and HTTP URLs.
   check timestamps.
 - **Did the agent hit the timeout?** Check `summary` duration vs the harness
   `timeout_minutes`.
-- **Token cost?** `summary` shows input/output/cache token counts.
+- **Token cost?** `summary` shows input/output/cache token counts and a `Cost: ~$X.XXXX` line with per-component breakdown (input, output, cache-write, cache-read). Add `--json` to get a `cost_usd` key with `total` and per-component values. Cost is approximate (Anthropic list prices; actual Vertex AI billing may differ). Omitted for unrecognised models.
 - **Was a network request blocked?** `network <sandbox-log>` shows all denials
   at the top. Use `netsearch "DENIED"` for raw lines.
 - **What endpoints did the agent talk to?** `network <sandbox-log>` lists hosts

--- a/skills/analyze-transcript/analyze-transcript.py
+++ b/skills/analyze-transcript/analyze-transcript.py
@@ -104,6 +104,45 @@ def iter_messages(path, line_range=None):
             yield i, "meta", obj, obj
 
 
+# --- Pricing ---
+
+# Prices in USD per million tokens. Matched by substring against model ID.
+# Cache write = 1.25× input; cache read = 0.10× input (standard Anthropic rates).
+_PRICING = [
+    # (substring, input, output, cache_write, cache_read)
+    ("opus-4", 5.00, 25.00, 6.25, 0.50),
+    ("sonnet-4", 3.00, 15.00, 3.75, 0.30),
+    ("haiku-4", 0.80, 4.00, 1.00, 0.08),
+    ("opus-3-7", 3.00, 15.00, 3.75, 0.30),
+    ("opus-3", 15.00, 75.00, 18.75, 1.50),
+    ("sonnet-3", 3.00, 15.00, 3.75, 0.30),
+    ("haiku-3", 0.25, 1.25, 0.30, 0.03),
+]
+
+
+def _model_pricing(model):
+    """Return (input, output, cache_write, cache_read) per-million prices or None."""
+    if not model:
+        return None
+    m = model.lower()
+    for substr, *prices in _PRICING:
+        if substr in m:
+            return tuple(prices)
+    return None
+
+
+def _compute_cost(tokens, pricing):
+    """Return cost dict given token counts and per-million pricing tuple."""
+    inp_p, out_p, cw_p, cr_p = pricing
+    M = 1_000_000
+    return {
+        "input": tokens["input"] / M * inp_p,
+        "output": tokens["output"] / M * out_p,
+        "cache_write": tokens["cache_create"] / M * cw_p,
+        "cache_read": tokens["cache_read"] / M * cr_p,
+    }
+
+
 # --- Subcommands ---
 
 
@@ -166,21 +205,31 @@ def cmd_summary(args):
         except (ValueError, TypeError):
             pass
 
+    tokens = {
+        "input": total_input_tokens,
+        "output": total_output_tokens,
+        "cache_read": total_cache_read,
+        "cache_create": total_cache_create,
+    }
+
+    # Cost — use first recognised model; skip if unknown.
+    primary_model = sorted(models)[0] if models else None
+    pricing = _model_pricing(primary_model)
+    cost = _compute_cost(tokens, pricing) if pricing else None
+
     result = {
         "agent": agent_setting,
         "session_ids": sorted(session_ids),
         "models": sorted(models),
         "messages": dict(msg_counts),
-        "tokens": {
-            "input": total_input_tokens,
-            "output": total_output_tokens,
-            "cache_read": total_cache_read,
-            "cache_create": total_cache_create,
-        },
+        "tokens": tokens,
         "duration_seconds": duration,
         "tool_calls": dict(tool_counts.most_common()),
         "stop_reasons": dict(stop_reasons),
     }
+    if cost is not None:
+        result["cost_usd"] = {k: round(v, 6) for k, v in cost.items()}
+        result["cost_usd"]["total"] = round(sum(cost.values()), 6)
 
     if args.json_output:
         print(json.dumps(result, indent=2))
@@ -200,6 +249,16 @@ def cmd_summary(args):
         f"{total_cache_read} cache-read / "
         f"{total_cache_create} cache-create"
     )
+    if cost is not None:
+        total = sum(cost.values())
+        print(
+            f"Cost:       ~${total:.4f}  "
+            f"(in ${cost['input']:.4f} / "
+            f"out ${cost['output']:.4f} / "
+            f"cache-write ${cost['cache_write']:.4f} / "
+            f"cache-read ${cost['cache_read']:.4f})"
+            f"  [approx; Anthropic list prices, actual Vertex AI costs may differ]"
+        )
     print()
     if tool_counts:
         print("Tool calls:")

--- a/skills/analyze-transcript/analyze-transcript.py
+++ b/skills/analyze-transcript/analyze-transcript.py
@@ -113,10 +113,10 @@ _PRICING = [
     ("opus-4", 5.00, 25.00, 6.25, 0.50),
     ("sonnet-4", 3.00, 15.00, 3.75, 0.30),
     ("haiku-4", 0.80, 4.00, 1.00, 0.08),
-    ("opus-3-7", 3.00, 15.00, 3.75, 0.30),
-    ("opus-3", 15.00, 75.00, 18.75, 1.50),
-    ("sonnet-3", 3.00, 15.00, 3.75, 0.30),
-    ("haiku-3", 0.25, 1.25, 0.30, 0.03),
+    ("3-7-sonnet", 3.00, 15.00, 3.75, 0.30),
+    ("3-opus", 15.00, 75.00, 18.75, 1.50),
+    ("3-5-sonnet", 3.00, 15.00, 3.75, 0.30),
+    ("3-haiku", 0.25, 1.25, 0.30, 0.03),
 ]
 
 
@@ -158,6 +158,7 @@ def cmd_summary(args):
     total_cache_create = 0
     stop_reasons = Counter()
     agent_setting = None
+    model_tokens = {}  # model -> {input, output, cache_read, cache_create}
 
     for _i, role, msg, raw in iter_messages(args.file, args.line_range):
         if role == "meta":
@@ -183,10 +184,22 @@ def cmd_summary(args):
             if model:
                 models.add(model)
             usage = msg.get("usage", {})
-            total_input_tokens += usage.get("input_tokens", 0)
-            total_output_tokens += usage.get("output_tokens", 0)
-            total_cache_read += usage.get("cache_read_input_tokens", 0)
-            total_cache_create += usage.get("cache_creation_input_tokens", 0)
+            inp = usage.get("input_tokens", 0)
+            out = usage.get("output_tokens", 0)
+            cr = usage.get("cache_read_input_tokens", 0)
+            cc = usage.get("cache_creation_input_tokens", 0)
+            total_input_tokens += inp
+            total_output_tokens += out
+            total_cache_read += cr
+            total_cache_create += cc
+            if model:
+                mt = model_tokens.setdefault(
+                    model, {"input": 0, "output": 0, "cache_read": 0, "cache_create": 0}
+                )
+                mt["input"] += inp
+                mt["output"] += out
+                mt["cache_read"] += cr
+                mt["cache_create"] += cc
             sr = msg.get("stop_reason")
             if sr:
                 stop_reasons[sr] += 1
@@ -212,10 +225,19 @@ def cmd_summary(args):
         "cache_create": total_cache_create,
     }
 
-    # Cost — use first recognised model; skip if unknown.
-    primary_model = sorted(models)[0] if models else None
-    pricing = _model_pricing(primary_model)
-    cost = _compute_cost(tokens, pricing) if pricing else None
+    # Cost — sum per-model; skip models with no pricing entry.
+    cost = None
+    if model_tokens:
+        cost_acc = {"input": 0.0, "output": 0.0, "cache_write": 0.0, "cache_read": 0.0}
+        any_priced = False
+        for mdl, mt in model_tokens.items():
+            p = _model_pricing(mdl)
+            if p:
+                any_priced = True
+                mc = _compute_cost(mt, p)
+                for k in cost_acc:
+                    cost_acc[k] += mc[k]
+        cost = cost_acc if any_priced else None
 
     result = {
         "agent": agent_setting,


### PR DESCRIPTION
## Summary

- Adds a `Cost: ~$X.XXXX` line to `summary` output with per-component breakdown (input, output, cache-write, cache-read)
- Pricing table (`_PRICING`) covers Opus 4/3, Sonnet 4/3, Haiku 4/3 matched by model ID substring
- Output labelled approx since we run on Vertex AI and actual costs may differ from Anthropic list prices
- Cost breakdown also included in `--json` output under `cost_usd`

## Test plan

- [ ] Run `analyze-transcript summary <transcript.jsonl>` and confirm `Cost:` line appears with breakdown
- [ ] Run with `--json` and confirm `cost_usd` key is present with `total`
- [ ] Run against a transcript with an unrecognised model — confirm no `Cost:` line and no crash

Closes #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)