### PR TITLE
fix(dispatch): map fix stage to coder role in config check

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -14,27 +14,27 @@ on:
   workflow_call:
     inputs:
       event_action:
-        description: 'The event action (github.event.action) forwarded by the shim'
+        description: "The event action (github.event.action) forwarded by the shim"
         required: true
         type: string
       install_mode:
-        description: 'Installation mode: per-repo (default) or per-org'
+        description: "Installation mode: per-repo (default) or per-org"
         required: false
         type: string
-        default: 'per-repo'
+        default: "per-repo"
       mint_url:
-        description: 'Token mint URL for OIDC token exchange'
+        description: "Token mint URL for OIDC token exchange"
         required: true
         type: string
       gcp_region:
-        description: 'GCP region for Vertex AI'
+        description: "GCP region for Vertex AI"
         required: true
         type: string
       fullsend_version:
-        description: 'Fullsend CLI version to use'
+        description: "Fullsend CLI version to use"
         required: false
         type: string
-        default: 'latest'
+        default: "latest"
     secrets:
       FULLSEND_GCP_WIF_PROVIDER:
         required: false
@@ -261,7 +261,7 @@ jobs:
           fi
           STAGE_ROLE="$STAGE"
           case "$STAGE" in
-            code) STAGE_ROLE="coder" ;;
+            code|fix) STAGE_ROLE="coder" ;;
             retro|prioritize) STAGE_ROLE="fullsend" ;;
           esac
           ROLES=$(yq '.roles[]' .fullsend/config.yaml 2>/dev/null || echo "")
@@ -333,7 +333,6 @@ jobs:
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
 
-
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
 
   code:
@@ -353,7 +352,6 @@ jobs:
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
 
-
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
 
   review:
@@ -372,7 +370,6 @@ jobs:
       fullsend_version: ${{ inputs.fullsend_version }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
-
 
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
 
@@ -394,7 +391,6 @@ jobs:
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
 
-
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
 
   retro:
@@ -413,6 +409,5 @@ jobs:
       fullsend_version: ${{ inputs.fullsend_version }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
-
 
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}


### PR DESCRIPTION
## Summary

- The dispatch role gate checked for a `fix` entry in `.fullsend/config.yaml`, but `fix` is absent from `DefaultAgentRoles()` — so the fix agent was silently blocked on every default installation
- Added `fix` to the `code|fix) STAGE_ROLE="coder"` case, matching how `reusable-fix.yml` already mints a coder token (per ADR 0031)
- No config changes or new GitHub Apps required

Closes #1186
Related: #700

## Test plan

- [ ] Trigger `/fs-fix` on a repo whose `.fullsend/config.yaml` has default roles (no `fix` entry) — dispatch should route to fix stage instead of erroring
- [ ] Trigger `/fs-fix` on a repo that explicitly lists `fix` in roles — should still work
- [ ] Confirm `retro` and `prioritize` stage mappings are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)