### PR TITLE
refactor(#1148): join Claude command parts

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1097,34 +1097,38 @@ func buildClaudeCommand(agentName, model, repoDir string, pluginDirs []string, d
 	// Defense-in-depth: escape single quotes even though Validate() rejects them.
 	safe := strings.ReplaceAll(agentName, "'", "'\\''")
 
-	modelFlag := ""
-	if model != "" {
-		modelFlag = fmt.Sprintf("--model '%s' ", strings.ReplaceAll(model, "'", "'\\''"))
+	claudeParts := []string{
+		"claude",
+		"--print",
+		"--verbose",
+		"--output-format stream-json",
 	}
 
-	var pluginDirParts []string
-	for _, pd := range pluginDirs {
-		pluginDirParts = append(pluginDirParts, fmt.Sprintf("--plugin-dir '%s'", strings.ReplaceAll(pd, "'", "'\\''")))
-	}
-	pluginDirFlags := ""
-	if len(pluginDirParts) > 0 {
-		pluginDirFlags = strings.Join(pluginDirParts, " ") + " "
-	}
-
-	debugFlags := ""
 	if debug != "" {
-		debugFlags = fmt.Sprintf("--debug-file '%s/%s' ", sandbox.SandboxWorkspace, claudeDebugLog)
+		claudeParts = append(claudeParts, fmt.Sprintf("--debug-file '%s/%s'", sandbox.SandboxWorkspace, claudeDebugLog))
 		if debug != "*" {
-			debugFlags += fmt.Sprintf("--debug '%s' ", strings.ReplaceAll(debug, "'", "'\\''"))
+			claudeParts = append(claudeParts, fmt.Sprintf("--debug '%s'", strings.ReplaceAll(debug, "'", "'\\''")))
 		}
 	}
+
+	if model != "" {
+		claudeParts = append(claudeParts, fmt.Sprintf("--model '%s'", strings.ReplaceAll(model, "'", "'\\''")))
+	}
+
+	for _, pd := range pluginDirs {
+		claudeParts = append(claudeParts, fmt.Sprintf("--plugin-dir '%s'", strings.ReplaceAll(pd, "'", "'\\''")))
+	}
+	claudeParts = append(claudeParts,
+		fmt.Sprintf("--agent '%s'", safe),
+		"--dangerously-skip-permissions 'Run the agent task'",
+	)
 
 	return fmt.Sprintf(
 		// --verbose increases log output in the job log. If artifact upload is
 		// added to this workflow, consider whether verbose output should be
 		// redacted or made conditional via an env var.
-		"cd %s && . %s && claude --print --verbose --output-format stream-json %s%s%s--agent '%s' --dangerously-skip-permissions 'Run the agent task'",
-		repoDir, envFile, debugFlags, modelFlag, pluginDirFlags, safe,
+		"cd %s && . %s && %s",
+		repoDir, envFile, strings.Join(claudeParts, " "),
 	)
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -147,6 +147,26 @@ func TestBuildClaudeCommand_DebugEscapesQuotes(t *testing.T) {
 	assert.Contains(t, cmd, "--debug 'api'\\''hooks'")
 }
 
+func TestBuildClaudeCommand_UsesSingleSpacesAroundOptionalFlags(t *testing.T) {
+	cmd := buildClaudeCommand("agent", "sonnet", "/tmp/workspace/repo", []string{
+		"/tmp/claude-config/plugins/gopls-lsp",
+		"/tmp/claude-config/plugins/other-lsp",
+	}, "api,hooks")
+
+	assert.Contains(t, cmd, "--output-format stream-json --debug-file")
+	assert.Contains(t, cmd, "claude-debug.log' --debug 'api,hooks' --model 'sonnet'")
+	assert.Contains(t, cmd, "--model 'sonnet' --plugin-dir '/tmp/claude-config/plugins/gopls-lsp'")
+	assert.Contains(t, cmd, "--plugin-dir '/tmp/claude-config/plugins/other-lsp' --agent 'agent'")
+	assert.NotContains(t, cmd, "  ")
+}
+
+func TestBuildClaudeCommand_UsesSingleSpacesWithoutOptionalFlags(t *testing.T) {
+	cmd := buildClaudeCommand("agent", "", "/tmp/workspace/repo", nil, "")
+
+	assert.Contains(t, cmd, "--output-format stream-json --agent 'agent'")
+	assert.NotContains(t, cmd, "  ")
+}
+
 func TestBuildPluginConfigs_SinglePlugin(t *testing.T) {
 	dir := t.TempDir()
 	pluginDir := filepath.Join(dir, "gopls-lsp")


### PR DESCRIPTION
## Summary

- Build the Claude CLI invocation from explicit command parts joined with single spaces.
- Remove the convention where optional flag fragments have to carry trailing spaces.
- Add regression tests for all optional flags and no optional flags to catch missing or doubled separators around `--agent`.

Closes #1148

## Validation

- `go test ./internal/cli -run 'TestBuildClaudeCommand'`\n- `go test ./internal/cli`\n- `go vet ./internal/cli`\n- `go test ./...`\n- `git diff --check`\n- `git diff | gitleaks stdin --no-banner --redact --timeout 30`\n\nLint limitation: `make lint` failed locally because `pre-commit` is not installed on this host. I also tried `uv run --with pre-commit python -m pre_commit run`; it initialized hooks but failed before completing because the `lint-md-links` hook requires the `lychee` executable, which is not installed locally.\n