### PR TITLE
feat(e2e): add TOTP support for 2FA-enabled GitHub accounts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,6 +57,7 @@ jobs:
         env:
           E2E_SCREENSHOT_DIR: ${{ runner.temp }}/e2e-screenshots
           E2E_GITHUB_PASSWORD: ${{ secrets.E2E_GITHUB_PASSWORD }}
+          E2E_GITHUB_TOTP_SECRET: ${{ secrets.E2E_GITHUB_TOTP_SECRET }}
 
       - name: Upload debug screenshots
         if: always() && steps.secrets-check.outputs.available == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ The e2e tests require GitHub credentials. There are three ways to provide them:
 - **`E2E_GITHUB_PASSWORD` env var:** Set directly with the password.
 - **`E2E_GITHUB_PASSWORD_FILE` env var:** Set to a file path containing the password (used in devaipod environments where secrets are mounted as files).
 - **`E2E_GITHUB_SESSION_FILE` env var:** Set to a pre-exported Playwright session file (skips login).
+- **`E2E_GITHUB_TOTP_SECRET` env var:** Optional. The TOTP secret (base32) for the test account's 2FA. Required only when the test account has 2FA enabled — used during session export and sudo confirmation.
 
 If only `E2E_GITHUB_USERNAME` and a password source are available, `make e2e-test` will automatically generate a session file before running tests. See `make help` for all available targets.
 

--- a/docs/ADRs/0010-stored-session-for-e2e-browser-auth.md
+++ b/docs/ADRs/0010-stored-session-for-e2e-browser-auth.md
@@ -18,6 +18,8 @@ Date: 2026-04-03
 
 Accepted
 
+Extended by [ADR 0039](0039-totp-automation-for-e2e-2fa.md).
+
 ## Context
 
 The admin CLI e2e tests use Playwright to automate browser interactions with

--- a/docs/ADRs/0010-stored-session-for-e2e-browser-auth.md
+++ b/docs/ADRs/0010-stored-session-for-e2e-browser-auth.md
@@ -88,8 +88,8 @@ The e2e tests need both because:
   baked into the stored session).
 
 The `handleSudoIfPresent()` function detects the "Confirm access" page by
-title and enters the password automatically. It is called before PAT creation
-(both classic and fine-grained).
+title and enters either the password or a TOTP code (see [ADR 0039](0039-totp-automation-for-e2e-2fa.md)).
+It is called before PAT creation (both classic and fine-grained).
 
 **Local development:** When `E2E_GITHUB_SESSION_FILE` is not set but
 `E2E_GITHUB_USERNAME` and `E2E_GITHUB_PASSWORD` are, `make e2e-test`
@@ -133,12 +133,13 @@ it does expire, a developer runs `make e2e-upload-session` to refresh it.
 
 - Two repo secrets are required in CI: `E2E_GITHUB_SESSION` (base64-encoded
   storageState JSON for login bypass) and `E2E_GITHUB_PASSWORD` (for sudo
-  confirmation on sensitive pages).
+  confirmation on sensitive pages). A third secret, `E2E_GITHUB_TOTP_SECRET`,
+  is required when the test account has 2FA enabled (see [ADR 0039](0039-totp-automation-for-e2e-2fa.md)).
 - If the test account's password changes, the stored session must be
   re-exported (password change invalidates all sessions) and the
   `E2E_GITHUB_PASSWORD` secret must be updated.
-- If the test account enables 2FA, the session export must happen after the 2FA
-  step.
+- If the test account has 2FA enabled, set `E2E_GITHUB_TOTP_SECRET` so
+  `make e2e-export-session` and sudo confirmation can handle TOTP automatically.
 - The login function becomes a session-loading function -- simpler and more
   reliable.
 - Session refresh is `make e2e-upload-session`, expected to be needed at most

--- a/docs/ADRs/0039-totp-automation-for-e2e-2fa.md
+++ b/docs/ADRs/0039-totp-automation-for-e2e-2fa.md
@@ -1,0 +1,56 @@
+---
+title: "39. TOTP automation for e2e 2FA"
+status: Accepted
+relates_to:
+  - testing-agents
+topics:
+  - e2e
+  - ci
+  - authentication
+  - 2fa
+---
+
+# 39. TOTP automation for e2e 2FA
+
+Date: 2026-05-19
+
+## Status
+
+Accepted
+
+Extends [ADR 0010](0010-stored-session-for-e2e-browser-auth.md).
+
+## Context
+
+[ADR 0010](0010-stored-session-for-e2e-browser-auth.md) established stored
+Playwright sessions for e2e CI authentication. When that ADR was written, the
+test account did not have 2FA enabled. With 2FA on, two new authentication
+prompts appear that the existing infrastructure could not handle:
+
+1. A TOTP challenge during `make e2e-export-session` (local login).
+2. A TOTP challenge on sudo pages in CI (GitHub may present TOTP instead of
+   a password field for 2FA-enabled accounts).
+
+## Decision
+
+Automate TOTP entry in Playwright using a shared `e2e/internal/otp` package
+that wraps `pquerna/otp` to generate time-based codes. The TOTP secret is
+supplied via the `E2E_GITHUB_TOTP_SECRET` environment variable (base32-encoded).
+
+- `handleTOTPIfPresent()` in the login helpers detects TOTP form fields and
+  enters the current code. `handleSudoIfPresent()` now handles both password
+  and TOTP sudo prompts.
+- The `export-session` command detects and completes the 2FA prompt after
+  password login.
+- `E2E_GITHUB_TOTP_SECRET` is optional — omitting it preserves the existing
+  non-2FA flow.
+
+## Consequences
+
+- Three repo secrets are now required in CI when the test account has 2FA:
+  `E2E_GITHUB_SESSION`, `E2E_GITHUB_PASSWORD`, and `E2E_GITHUB_TOTP_SECRET`.
+- Session export and sudo confirmation work automatically for 2FA accounts.
+- The TOTP secret is a long-lived credential that must be protected like the
+  password.
+- If GitHub changes its TOTP form markup, the Playwright selectors will need
+  updating.

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -87,7 +87,7 @@ func setupE2ETest(t *testing.T) *e2eEnv {
 	// Generate a PAT for API access.
 	patNote := fmt.Sprintf("fullsend-e2e-%d", time.Now().Unix())
 	t.Logf("Creating PAT: %s", patNote)
-	token, err := createPAT(page, patNote, cfg.password, screenshotDir, t.Logf)
+	token, err := createPAT(page, patNote, cfg.password, cfg.totpSecret, screenshotDir, t.Logf)
 	require.NoError(t, err, "creating PAT")
 	t.Cleanup(func() {
 		t.Log("Deleting PAT...")

--- a/e2e/admin/browser.go
+++ b/e2e/admin/browser.go
@@ -56,6 +56,8 @@ func (b *PlaywrightBrowserOpener) Open(_ context.Context, url string) error {
 	case strings.Contains(pageURL, "/settings/apps/new"),
 		strings.Contains(pageURL, "/settings/apps/manifest"):
 		return b.handleCreateAppPage()
+	case strings.Contains(pageURL, "/installations/select_target"):
+		return b.handleSelectTargetPage()
 	case strings.Contains(pageURL, "/installations/new"):
 		return b.handleInstallAppPage()
 	default:
@@ -202,6 +204,29 @@ func (b *PlaywrightBrowserOpener) handleCreateAppPage() error {
 	}
 
 	return nil
+}
+
+// handleSelectTargetPage selects the target organization on GitHub's
+// "select installation target" page, then proceeds to the install page.
+func (b *PlaywrightBrowserOpener) handleSelectTargetPage() error {
+	b.logf("[browser] handleSelectTargetPage at URL: %s", b.page.URL())
+
+	orgLink := b.page.Locator(fmt.Sprintf("a:has-text('%s')", testOrg))
+	if err := orgLink.First().Click(playwright.LocatorClickOptions{
+		Timeout: playwright.Float(5000),
+	}); err != nil {
+		saveDebugScreenshot(b.page, b.screenshotDir, "browser-select-target-failed", b.logf)
+		return fmt.Errorf("selecting target org %s: %w", testOrg, err)
+	}
+
+	if err := b.page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
+		State: playwright.LoadStateDomcontentloaded,
+	}); err != nil {
+		return fmt.Errorf("waiting for install page after selecting org: %w", err)
+	}
+
+	b.logf("[browser] Selected org %s, now at: %s", testOrg, b.page.URL())
+	return b.handleInstallAppPage()
 }
 
 // handleInstallAppPage clicks "Install" on the GitHub App installation page.

--- a/e2e/admin/login.go
+++ b/e2e/admin/login.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/fullsend-ai/fullsend/e2e/internal/otp"
 	"github.com/playwright-community/playwright-go"
@@ -60,6 +59,18 @@ func handleSudoIfPresent(page playwright.Page, password, totpSecret, screenshotD
 		if err := passwordInput.Fill(password); err != nil {
 			return false, fmt.Errorf("filling sudo password: %w", err)
 		}
+	} else if passwordVisible && totpSecret != "" {
+		if handled, err := handleTOTPIfPresent(page, totpSecret, screenshotDir, logf); err != nil {
+			return false, fmt.Errorf("TOTP on sudo page (password field present but empty): %w", err)
+		} else if handled {
+			if err := waitForPageToLeave(page, "Confirm access", "Sudo"); err != nil {
+				saveDebugScreenshot(page, screenshotDir, "sudo-totp-still-on-page", logf)
+				return false, err
+			}
+			return true, nil
+		}
+		saveDebugScreenshot(page, screenshotDir, "sudo-password-not-set", logf)
+		return false, fmt.Errorf("sudo page shows password field but neither password nor TOTP succeeded")
 	} else if passwordVisible {
 		saveDebugScreenshot(page, screenshotDir, "sudo-password-not-set", logf)
 		return false, fmt.Errorf("sudo page shows password field but E2E_GITHUB_PASSWORD is not set")
@@ -69,6 +80,10 @@ func handleSudoIfPresent(page playwright.Page, password, totpSecret, screenshotD
 		} else if !handled {
 			saveDebugScreenshot(page, screenshotDir, "sudo-no-auth-method", logf)
 			return false, fmt.Errorf("sudo page has no visible password or TOTP field")
+		}
+		if err := waitForPageToLeave(page, "Confirm access", "Sudo"); err != nil {
+			saveDebugScreenshot(page, screenshotDir, "sudo-totp-still-on-page", logf)
+			return false, err
 		}
 		return true, nil
 	} else {
@@ -106,30 +121,22 @@ func handleTOTPIfPresent(page playwright.Page, totpSecret, screenshotDir string,
 	return handled, err
 }
 
-// waitForPageToLeave polls the page title until it no longer contains any
-// of the given substrings, or until the timeout (10s) is reached.
+// waitForPageToLeave waits until the page title no longer contains any of
+// the given substrings, or until the timeout (10s) is reached.
 func waitForPageToLeave(page playwright.Page, titleSubstrings ...string) error {
-	deadline := time.Now().Add(10 * time.Second)
-	for {
-		title, err := page.Title()
-		if err != nil {
-			return fmt.Errorf("checking page title: %w", err)
-		}
-		still := false
-		for _, sub := range titleSubstrings {
-			if strings.Contains(title, sub) {
-				still = true
-				break
-			}
-		}
-		if !still {
-			return nil
-		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("still on page after 10s (title: %s)", title)
-		}
-		time.Sleep(250 * time.Millisecond)
+	checks := make([]string, len(titleSubstrings))
+	for i, sub := range titleSubstrings {
+		checks[i] = fmt.Sprintf("!document.title.includes(%q)", sub)
 	}
+	jsExpr := "() => " + strings.Join(checks, " && ")
+	_, err := page.WaitForFunction(jsExpr, nil, playwright.PageWaitForFunctionOptions{
+		Timeout: playwright.Float(10000),
+	})
+	if err != nil {
+		title, _ := page.Title()
+		return fmt.Errorf("still on page after 10s (title: %s)", title)
+	}
+	return nil
 }
 
 // saveDebugScreenshot saves a screenshot to dir for debugging.

--- a/e2e/admin/login.go
+++ b/e2e/admin/login.go
@@ -59,6 +59,9 @@ func handleSudoIfPresent(page playwright.Page, password, totpSecret, screenshotD
 		if err := passwordInput.Fill(password); err != nil {
 			return false, fmt.Errorf("filling sudo password: %w", err)
 		}
+	} else if passwordVisible {
+		saveDebugScreenshot(page, screenshotDir, "sudo-password-not-set", logf)
+		return false, fmt.Errorf("sudo page shows password field but E2E_GITHUB_PASSWORD is not set")
 	} else if totpSecret != "" {
 		if handled, err := handleTOTPIfPresent(page, totpSecret, screenshotDir, logf); err != nil {
 			return false, fmt.Errorf("TOTP on sudo page: %w", err)
@@ -116,6 +119,7 @@ func handleTOTPIfPresent(page playwright.Page, totpSecret, screenshotDir string,
 	if err := totpInput.PressSequentially(code, playwright.LocatorPressSequentiallyOptions{
 		Delay: playwright.Float(50),
 	}); err != nil {
+		saveDebugScreenshot(page, screenshotDir, "totp-type-failed", logf)
 		return false, fmt.Errorf("typing TOTP code: %w", err)
 	}
 
@@ -124,10 +128,21 @@ func handleTOTPIfPresent(page playwright.Page, totpSecret, screenshotDir string,
 	if err := page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
 		State: playwright.LoadStateNetworkidle,
 	}); err != nil {
+		saveDebugScreenshot(page, screenshotDir, "totp-navigation-failed", logf)
 		return false, fmt.Errorf("waiting for post-TOTP navigation: %w", err)
 	}
 
-	logf("[totp] TOTP submission succeeded (URL: %s)", page.URL())
+	// Verify we actually left the TOTP/sudo page. If the code was wrong
+	// (e.g. expired at a period boundary), GitHub redisplays the form.
+	postURL := page.URL()
+	postTitle, _ := page.Title()
+	if strings.Contains(postURL, "/two-factor") || strings.Contains(postURL, "/2fa") ||
+		strings.Contains(postTitle, "Confirm access") || strings.Contains(postTitle, "Sudo") {
+		saveDebugScreenshot(page, screenshotDir, "totp-verification-failed", logf)
+		return false, fmt.Errorf("TOTP code was not accepted (still at %s, title: %s)", postURL, postTitle)
+	}
+
+	logf("[totp] TOTP submission succeeded (URL: %s)", postURL)
 	return true, nil
 }
 

--- a/e2e/admin/login.go
+++ b/e2e/admin/login.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fullsend-ai/fullsend/e2e/internal/otp"
 	"github.com/playwright-community/playwright-go"
 )
 
@@ -34,10 +35,11 @@ func verifyGitHubSession(page playwright.Page, screenshotDir string, logf func(s
 }
 
 // handleSudoIfPresent detects GitHub's "Confirm access" sudo page and
-// enters the password to proceed. GitHub requires sudo confirmation when
-// accessing sensitive settings pages (token management, app settings)
-// even with a valid session. Returns true if sudo was handled.
-func handleSudoIfPresent(page playwright.Page, password, screenshotDir string, logf func(string, ...any)) (bool, error) {
+// enters the password (or TOTP code if 2FA is enabled) to proceed.
+// GitHub requires sudo confirmation when accessing sensitive settings pages
+// (token management, app settings) even with a valid session.
+// Returns true if sudo was handled.
+func handleSudoIfPresent(page playwright.Page, password, totpSecret, screenshotDir string, logf func(string, ...any)) (bool, error) {
 	pageTitle, _ := page.Title()
 	if !strings.Contains(pageTitle, "Confirm access") && !strings.Contains(pageTitle, "Sudo") {
 		return false, nil
@@ -45,26 +47,32 @@ func handleSudoIfPresent(page playwright.Page, password, screenshotDir string, l
 
 	logf("[sudo] Detected sudo confirmation page (title: %s)", pageTitle)
 
-	if password == "" {
-		saveDebugScreenshot(page, screenshotDir, "sudo-no-password", logf)
-		return false, fmt.Errorf("sudo confirmation required but no password available — set E2E_GITHUB_PASSWORD")
-	}
-
-	// GitHub's sudo form uses #sudo_password for the password field.
+	// GitHub may show a password field or a TOTP field (or both with a toggle).
+	// Try password first, fall back to TOTP.
 	passwordInput := page.Locator("#sudo_password")
-	if err := passwordInput.WaitFor(playwright.LocatorWaitForOptions{
+	passwordVisible := passwordInput.WaitFor(playwright.LocatorWaitForOptions{
 		State:   playwright.WaitForSelectorStateVisible,
-		Timeout: playwright.Float(5000),
-	}); err != nil {
-		saveDebugScreenshot(page, screenshotDir, "sudo-password-field-missing", logf)
-		return false, fmt.Errorf("sudo password field not found: %w", err)
+		Timeout: playwright.Float(2000),
+	}) == nil
+
+	if passwordVisible && password != "" {
+		if err := passwordInput.Fill(password); err != nil {
+			return false, fmt.Errorf("filling sudo password: %w", err)
+		}
+	} else if totpSecret != "" {
+		if handled, err := handleTOTPIfPresent(page, totpSecret, screenshotDir, logf); err != nil {
+			return false, fmt.Errorf("TOTP on sudo page: %w", err)
+		} else if !handled {
+			saveDebugScreenshot(page, screenshotDir, "sudo-no-auth-method", logf)
+			return false, fmt.Errorf("sudo page has no visible password or TOTP field")
+		}
+		return true, nil
+	} else {
+		saveDebugScreenshot(page, screenshotDir, "sudo-no-credentials", logf)
+		return false, fmt.Errorf("sudo confirmation required but no password or TOTP secret available — set E2E_GITHUB_PASSWORD or E2E_GITHUB_TOTP_SECRET")
 	}
 
-	if err := passwordInput.Fill(password); err != nil {
-		return false, fmt.Errorf("filling sudo password: %w", err)
-	}
-
-	// Click the confirm button.
+	// Click the confirm button (password path).
 	confirmBtn := page.Locator("button[type='submit']:has-text('Confirm'), button[type='submit']:has-text('Confirm password'), button[type='submit']")
 	if err := confirmBtn.First().Click(playwright.LocatorClickOptions{
 		Timeout: playwright.Float(5000),
@@ -73,22 +81,72 @@ func handleSudoIfPresent(page playwright.Page, password, screenshotDir string, l
 		return false, fmt.Errorf("clicking sudo confirm button: %w", err)
 	}
 
-	// Wait for the page to navigate away from the sudo page.
-	if err := page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
-		State: playwright.LoadStateDomcontentloaded,
-	}); err != nil {
-		return false, fmt.Errorf("waiting for post-sudo navigation: %w", err)
-	}
-
-	// Verify we're past sudo.
-	newTitle, _ := page.Title()
-	if strings.Contains(newTitle, "Confirm access") || strings.Contains(newTitle, "Sudo") {
+	if err := waitForPageToLeave(page, "Confirm access", "Sudo"); err != nil {
 		saveDebugScreenshot(page, screenshotDir, "sudo-still-on-page", logf)
-		return false, fmt.Errorf("sudo confirmation failed — still on confirmation page (title: %s)", newTitle)
+		return false, err
 	}
 
 	logf("[sudo] Sudo confirmation succeeded")
 	return true, nil
+}
+
+// handleTOTPIfPresent detects a GitHub 2FA/TOTP input on the current page
+// and fills in a generated code. Works on both the post-login 2FA page
+// (/sessions/two-factor) and the sudo TOTP prompt. Returns true if a TOTP
+// form was found and submitted.
+func handleTOTPIfPresent(page playwright.Page, totpSecret, screenshotDir string, logf func(string, ...any)) (bool, error) {
+	// GitHub uses #app_totp for the TOTP input on both 2FA and sudo pages.
+	totpInput := page.Locator("#app_totp")
+	if err := totpInput.WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateVisible,
+		Timeout: playwright.Float(3000),
+	}); err != nil {
+		return false, nil
+	}
+
+	logf("[totp] Detected TOTP input on page (URL: %s)", page.URL())
+
+	code, err := otp.GenerateCode(totpSecret)
+	if err != nil {
+		return false, fmt.Errorf("generating TOTP code: %w", err)
+	}
+
+	// Use PressSequentially to simulate keystroke entry, which triggers
+	// GitHub's auto-submit after the 6th digit.
+	if err := totpInput.PressSequentially(code, playwright.LocatorPressSequentiallyOptions{
+		Delay: playwright.Float(50),
+	}); err != nil {
+		return false, fmt.Errorf("typing TOTP code: %w", err)
+	}
+
+	// GitHub's 2FA form auto-submits when 6 digits are entered.
+	// Wait for the page to navigate away.
+	if err := page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
+		State: playwright.LoadStateNetworkidle,
+	}); err != nil {
+		return false, fmt.Errorf("waiting for post-TOTP navigation: %w", err)
+	}
+
+	logf("[totp] TOTP submission succeeded (URL: %s)", page.URL())
+	return true, nil
+}
+
+// waitForPageToLeave waits for the page to navigate away from a page whose
+// title contains any of the given substrings.
+func waitForPageToLeave(page playwright.Page, titleSubstrings ...string) error {
+	if err := page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
+		State: playwright.LoadStateDomcontentloaded,
+	}); err != nil {
+		return fmt.Errorf("waiting for navigation: %w", err)
+	}
+
+	newTitle, _ := page.Title()
+	for _, sub := range titleSubstrings {
+		if strings.Contains(newTitle, sub) {
+			return fmt.Errorf("still on page (title: %s)", newTitle)
+		}
+	}
+	return nil
 }
 
 // saveDebugScreenshot saves a screenshot to dir for debugging.

--- a/e2e/admin/login.go
+++ b/e2e/admin/login.go
@@ -59,6 +59,35 @@ func handleSudoIfPresent(page playwright.Page, password, totpSecret, screenshotD
 		if err := passwordInput.Fill(password); err != nil {
 			return false, fmt.Errorf("filling sudo password: %w", err)
 		}
+
+		confirmBtn := page.Locator("button[type='submit']:has-text('Confirm'), button[type='submit']:has-text('Confirm password'), button[type='submit']")
+		if err := confirmBtn.First().Click(playwright.LocatorClickOptions{
+			Timeout: playwright.Float(5000),
+		}); err != nil {
+			saveDebugScreenshot(page, screenshotDir, "sudo-confirm-click-failed", logf)
+			return false, fmt.Errorf("clicking sudo confirm button: %w", err)
+		}
+
+		if err := waitForPageToLeave(page, "Confirm access", "Sudo"); err != nil {
+			if totpSecret != "" {
+				logf("[sudo] Password did not clear sudo page, falling back to TOTP")
+				if handled, totpErr := handleTOTPIfPresent(page, totpSecret, screenshotDir, logf); totpErr != nil {
+					return false, fmt.Errorf("TOTP fallback after password failed: %w", totpErr)
+				} else if handled {
+					if err := waitForPageToLeave(page, "Confirm access", "Sudo"); err != nil {
+						saveDebugScreenshot(page, screenshotDir, "sudo-totp-fallback-still-on-page", logf)
+						return false, err
+					}
+					logf("[sudo] Sudo confirmation succeeded via TOTP fallback")
+					return true, nil
+				}
+			}
+			saveDebugScreenshot(page, screenshotDir, "sudo-still-on-page", logf)
+			return false, err
+		}
+
+		logf("[sudo] Sudo confirmation succeeded via password")
+		return true, nil
 	} else if passwordVisible && totpSecret != "" {
 		if handled, err := handleTOTPIfPresent(page, totpSecret, screenshotDir, logf); err != nil {
 			return false, fmt.Errorf("TOTP on sudo page (password field present but empty): %w", err)
@@ -90,23 +119,6 @@ func handleSudoIfPresent(page playwright.Page, password, totpSecret, screenshotD
 		saveDebugScreenshot(page, screenshotDir, "sudo-no-credentials", logf)
 		return false, fmt.Errorf("sudo confirmation required but no password or TOTP secret available — set E2E_GITHUB_PASSWORD or E2E_GITHUB_TOTP_SECRET")
 	}
-
-	// Click the confirm button (password path).
-	confirmBtn := page.Locator("button[type='submit']:has-text('Confirm'), button[type='submit']:has-text('Confirm password'), button[type='submit']")
-	if err := confirmBtn.First().Click(playwright.LocatorClickOptions{
-		Timeout: playwright.Float(5000),
-	}); err != nil {
-		saveDebugScreenshot(page, screenshotDir, "sudo-confirm-click-failed", logf)
-		return false, fmt.Errorf("clicking sudo confirm button: %w", err)
-	}
-
-	if err := waitForPageToLeave(page, "Confirm access", "Sudo"); err != nil {
-		saveDebugScreenshot(page, screenshotDir, "sudo-still-on-page", logf)
-		return false, err
-	}
-
-	logf("[sudo] Sudo confirmation succeeded")
-	return true, nil
 }
 
 // handleTOTPIfPresent detects a GitHub 2FA/TOTP input on the current page

--- a/e2e/admin/login.go
+++ b/e2e/admin/login.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fullsend-ai/fullsend/e2e/internal/otp"
 	"github.com/playwright-community/playwright-go"
@@ -98,70 +99,37 @@ func handleSudoIfPresent(page playwright.Page, password, totpSecret, screenshotD
 // (/sessions/two-factor) and the sudo TOTP prompt. Returns true if a TOTP
 // form was found and submitted.
 func handleTOTPIfPresent(page playwright.Page, totpSecret, screenshotDir string, logf func(string, ...any)) (bool, error) {
-	// GitHub uses #app_totp for the TOTP input on both 2FA and sudo pages.
-	totpInput := page.Locator("#app_totp")
-	if err := totpInput.WaitFor(playwright.LocatorWaitForOptions{
-		State:   playwright.WaitForSelectorStateVisible,
-		Timeout: playwright.Float(3000),
-	}); err != nil {
-		return false, nil
-	}
-
-	logf("[totp] Detected TOTP input on page (URL: %s)", page.URL())
-
-	code, err := otp.GenerateCode(totpSecret)
+	handled, err := otp.EnterTOTPCode(page, totpSecret, logf)
 	if err != nil {
-		return false, fmt.Errorf("generating TOTP code: %w", err)
+		saveDebugScreenshot(page, screenshotDir, "totp-failed", logf)
 	}
-
-	// Use PressSequentially to simulate keystroke entry, which triggers
-	// GitHub's auto-submit after the 6th digit.
-	if err := totpInput.PressSequentially(code, playwright.LocatorPressSequentiallyOptions{
-		Delay: playwright.Float(50),
-	}); err != nil {
-		saveDebugScreenshot(page, screenshotDir, "totp-type-failed", logf)
-		return false, fmt.Errorf("typing TOTP code: %w", err)
-	}
-
-	// GitHub's 2FA form auto-submits when 6 digits are entered.
-	// Wait for the page to navigate away.
-	if err := page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
-		State: playwright.LoadStateNetworkidle,
-	}); err != nil {
-		saveDebugScreenshot(page, screenshotDir, "totp-navigation-failed", logf)
-		return false, fmt.Errorf("waiting for post-TOTP navigation: %w", err)
-	}
-
-	// Verify we actually left the TOTP/sudo page. If the code was wrong
-	// (e.g. expired at a period boundary), GitHub redisplays the form.
-	postURL := page.URL()
-	postTitle, _ := page.Title()
-	if strings.Contains(postURL, "/two-factor") || strings.Contains(postURL, "/2fa") ||
-		strings.Contains(postTitle, "Confirm access") || strings.Contains(postTitle, "Sudo") {
-		saveDebugScreenshot(page, screenshotDir, "totp-verification-failed", logf)
-		return false, fmt.Errorf("TOTP code was not accepted (still at %s, title: %s)", postURL, postTitle)
-	}
-
-	logf("[totp] TOTP submission succeeded (URL: %s)", postURL)
-	return true, nil
+	return handled, err
 }
 
-// waitForPageToLeave waits for the page to navigate away from a page whose
-// title contains any of the given substrings.
+// waitForPageToLeave polls the page title until it no longer contains any
+// of the given substrings, or until the timeout (10s) is reached.
 func waitForPageToLeave(page playwright.Page, titleSubstrings ...string) error {
-	if err := page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
-		State: playwright.LoadStateDomcontentloaded,
-	}); err != nil {
-		return fmt.Errorf("waiting for navigation: %w", err)
-	}
-
-	newTitle, _ := page.Title()
-	for _, sub := range titleSubstrings {
-		if strings.Contains(newTitle, sub) {
-			return fmt.Errorf("still on page (title: %s)", newTitle)
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		title, err := page.Title()
+		if err != nil {
+			return fmt.Errorf("checking page title: %w", err)
 		}
+		still := false
+		for _, sub := range titleSubstrings {
+			if strings.Contains(title, sub) {
+				still = true
+				break
+			}
+		}
+		if !still {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("still on page after 10s (title: %s)", title)
+		}
+		time.Sleep(250 * time.Millisecond)
 	}
-	return nil
 }
 
 // saveDebugScreenshot saves a screenshot to dir for debugging.

--- a/e2e/admin/pat.go
+++ b/e2e/admin/pat.go
@@ -20,7 +20,7 @@ var patScopes = []string{
 // createPAT creates a classic GitHub Personal Access Token via the browser.
 // The token is created with a 7-day expiry and the scopes needed for e2e tests.
 // Returns the token string.
-func createPAT(page playwright.Page, note, password, screenshotDir string, logf func(string, ...any)) (string, error) {
+func createPAT(page playwright.Page, note, password, totpSecret, screenshotDir string, logf func(string, ...any)) (string, error) {
 	url := "https://github.com/settings/tokens/new"
 	if _, err := page.Goto(url, playwright.PageGotoOptions{
 		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
@@ -39,7 +39,7 @@ func createPAT(page playwright.Page, note, password, screenshotDir string, logf 
 	}
 
 	// Handle sudo confirmation if GitHub requires re-authentication.
-	if handled, err := handleSudoIfPresent(page, password, screenshotDir, logf); err != nil {
+	if handled, err := handleSudoIfPresent(page, password, totpSecret, screenshotDir, logf); err != nil {
 		return "", fmt.Errorf("sudo confirmation for PAT creation: %w", err)
 	} else if handled {
 		// After sudo, we may need to re-navigate to the token page.

--- a/e2e/admin/testutil.go
+++ b/e2e/admin/testutil.go
@@ -44,6 +44,7 @@ var defaultRoles = []string{"fullsend", "triage", "coder", "review"}
 type envConfig struct {
 	sessionFile string
 	password    string
+	totpSecret  string
 	lockTimeout time.Duration
 }
 
@@ -62,6 +63,7 @@ func loadEnvConfig(t *testing.T) envConfig {
 	}
 
 	password := os.Getenv("E2E_GITHUB_PASSWORD")
+	totpSecret := os.Getenv("E2E_GITHUB_TOTP_SECRET")
 
 	lockTimeout := defaultLockTimeout
 	if v := os.Getenv("E2E_LOCK_TIMEOUT"); v != "" {
@@ -75,6 +77,7 @@ func loadEnvConfig(t *testing.T) envConfig {
 	return envConfig{
 		sessionFile: sessionFile,
 		password:    password,
+		totpSecret:  totpSecret,
 		lockTimeout: lockTimeout,
 	}
 }

--- a/e2e/cmd/export-session/main.go
+++ b/e2e/cmd/export-session/main.go
@@ -115,8 +115,8 @@ func main() {
 			log.Fatalf("generating TOTP code: %v", err)
 		}
 
-		// Use Type instead of Fill to simulate keystroke entry, which
-		// triggers GitHub's auto-submit after the 6th digit.
+		// Use PressSequentially instead of Fill to simulate keystroke
+		// entry, which triggers GitHub's auto-submit after the 6th digit.
 		if err := totpInput.PressSequentially(code, playwright.LocatorPressSequentiallyOptions{
 			Delay: playwright.Float(50),
 		}); err != nil {
@@ -125,7 +125,7 @@ func main() {
 
 		// GitHub's 2FA form auto-submits when 6 digits are entered.
 		// Wait for the URL to leave the 2FA page.
-		if err := page.WaitForURL("https://github.com/", playwright.PageWaitForURLOptions{
+		if err := page.WaitForURL("https://github.com/**", playwright.PageWaitForURLOptions{
 			Timeout: playwright.Float(15000),
 		}); err != nil {
 			log.Fatalf("waiting for post-2FA navigation: %v (url: %s)", err, page.URL())

--- a/e2e/cmd/export-session/main.go
+++ b/e2e/cmd/export-session/main.go
@@ -102,33 +102,12 @@ func main() {
 		}
 		fmt.Println("2FA page detected, entering TOTP code...")
 
-		totpInput := page.Locator("#app_totp")
-		if err := totpInput.WaitFor(playwright.LocatorWaitForOptions{
-			State:   playwright.WaitForSelectorStateVisible,
-			Timeout: playwright.Float(5000),
-		}); err != nil {
-			log.Fatalf("TOTP input not found on 2FA page: %v", err)
-		}
-
-		code, err := otp.GenerateCode(totpSecret)
+		handled, err := otp.EnterTOTPCode(page, totpSecret, log.Printf)
 		if err != nil {
-			log.Fatalf("generating TOTP code: %v", err)
+			log.Fatalf("TOTP submission failed: %v", err)
 		}
-
-		// Use PressSequentially instead of Fill to simulate keystroke
-		// entry, which triggers GitHub's auto-submit after the 6th digit.
-		if err := totpInput.PressSequentially(code, playwright.LocatorPressSequentiallyOptions{
-			Delay: playwright.Float(50),
-		}); err != nil {
-			log.Fatalf("typing TOTP code: %v", err)
-		}
-
-		// GitHub's 2FA form auto-submits when 6 digits are entered.
-		// Wait for the URL to leave the 2FA page.
-		if err := page.WaitForURL("https://github.com/**", playwright.PageWaitForURLOptions{
-			Timeout: playwright.Float(15000),
-		}); err != nil {
-			log.Fatalf("waiting for post-2FA navigation: %v (url: %s)", err, page.URL())
+		if !handled {
+			log.Fatalf("2FA page detected but TOTP input not found at %s", url)
 		}
 
 		url = page.URL()

--- a/e2e/cmd/export-session/main.go
+++ b/e2e/cmd/export-session/main.go
@@ -7,6 +7,9 @@
 //   - E2E_GITHUB_USERNAME: GitHub username
 //   - E2E_GITHUB_PASSWORD: GitHub password (use `pass` or similar)
 //
+// Optional environment variables:
+//   - E2E_GITHUB_TOTP_SECRET: Base32-encoded TOTP secret for 2FA accounts
+//
 // Output is written to E2E_GITHUB_SESSION_FILE (default: .playwright/session.json).
 package main
 
@@ -17,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fullsend-ai/fullsend/e2e/internal/otp"
 	"github.com/playwright-community/playwright-go"
 )
 
@@ -26,6 +30,7 @@ func main() {
 	if username == "" || password == "" {
 		log.Fatal("Set E2E_GITHUB_USERNAME and E2E_GITHUB_PASSWORD")
 	}
+	totpSecret := os.Getenv("E2E_GITHUB_TOTP_SECRET")
 
 	outFile := os.Getenv("E2E_GITHUB_SESSION_FILE")
 	if outFile == "" {
@@ -89,7 +94,46 @@ func main() {
 		log.Fatalf("post-login navigation: %v (url: %s)", err, page.URL())
 	}
 
+	// Handle 2FA if the account has TOTP enabled.
 	url := page.URL()
+	if strings.Contains(url, "/two-factor") || strings.Contains(url, "/2fa") {
+		if totpSecret == "" {
+			log.Fatalf("2FA page detected at %s but E2E_GITHUB_TOTP_SECRET is not set", url)
+		}
+		fmt.Println("2FA page detected, entering TOTP code...")
+
+		totpInput := page.Locator("#app_totp")
+		if err := totpInput.WaitFor(playwright.LocatorWaitForOptions{
+			State:   playwright.WaitForSelectorStateVisible,
+			Timeout: playwright.Float(5000),
+		}); err != nil {
+			log.Fatalf("TOTP input not found on 2FA page: %v", err)
+		}
+
+		code, err := otp.GenerateCode(totpSecret)
+		if err != nil {
+			log.Fatalf("generating TOTP code: %v", err)
+		}
+
+		// Use Type instead of Fill to simulate keystroke entry, which
+		// triggers GitHub's auto-submit after the 6th digit.
+		if err := totpInput.PressSequentially(code, playwright.LocatorPressSequentiallyOptions{
+			Delay: playwright.Float(50),
+		}); err != nil {
+			log.Fatalf("typing TOTP code: %v", err)
+		}
+
+		// GitHub's 2FA form auto-submits when 6 digits are entered.
+		// Wait for the URL to leave the 2FA page.
+		if err := page.WaitForURL("https://github.com/", playwright.PageWaitForURLOptions{
+			Timeout: playwright.Float(15000),
+		}); err != nil {
+			log.Fatalf("waiting for post-2FA navigation: %v (url: %s)", err, page.URL())
+		}
+
+		url = page.URL()
+	}
+
 	if strings.Contains(url, "/login") || strings.Contains(url, "/session") {
 		log.Fatalf("login failed, still at: %s", url)
 	}

--- a/e2e/internal/otp/otp.go
+++ b/e2e/internal/otp/otp.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GenerateCode produces a 6-digit TOTP code from a base32-encoded secret.
-// If the current time is within 4 seconds of a 30-second period boundary,
+// If the current time is within 5 seconds of a 30-second period boundary,
 // it sleeps until the next period to avoid generating a code that expires
 // before the recipient can validate it.
 func GenerateCode(secret string) (string, error) {
@@ -21,5 +21,6 @@ func GenerateCode(secret string) (string, error) {
 	if rem := time.Now().Second() % 30; rem >= 26 {
 		time.Sleep(time.Duration(30-rem+1) * time.Second)
 	}
-	return totp.GenerateCode(secret, time.Now())
+	now := time.Now()
+	return totp.GenerateCode(secret, now)
 }

--- a/e2e/internal/otp/otp.go
+++ b/e2e/internal/otp/otp.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GenerateCode produces a 6-digit TOTP code from a base32-encoded secret.
-// If the current time is within 5 seconds of a 30-second period boundary,
+// If the current time is within 4 seconds of a 30-second period boundary,
 // it sleeps until the next period to avoid generating a code that expires
 // before the recipient can validate it.
 func GenerateCode(secret string) (string, error) {

--- a/e2e/internal/otp/otp.go
+++ b/e2e/internal/otp/otp.go
@@ -1,0 +1,17 @@
+// Package otp generates TOTP codes for GitHub 2FA automation in e2e tests.
+package otp
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pquerna/otp/totp"
+)
+
+// GenerateCode produces a 6-digit TOTP code from a base32-encoded secret.
+func GenerateCode(secret string) (string, error) {
+	if secret == "" {
+		return "", fmt.Errorf("TOTP secret is empty")
+	}
+	return totp.GenerateCode(secret, time.Now())
+}

--- a/e2e/internal/otp/otp.go
+++ b/e2e/internal/otp/otp.go
@@ -9,9 +9,17 @@ import (
 )
 
 // GenerateCode produces a 6-digit TOTP code from a base32-encoded secret.
+// If the current time is within 4 seconds of a 30-second period boundary,
+// it sleeps until the next period to avoid generating a code that expires
+// before the recipient can validate it.
 func GenerateCode(secret string) (string, error) {
 	if secret == "" {
 		return "", fmt.Errorf("TOTP secret is empty")
+	}
+	// Avoid generating a code near a period boundary where it could expire
+	// during the ~300ms PressSequentially typing delay plus network round-trip.
+	if rem := time.Now().Second() % 30; rem >= 26 {
+		time.Sleep(time.Duration(30-rem+1) * time.Second)
 	}
 	return totp.GenerateCode(secret, time.Now())
 }

--- a/e2e/internal/otp/otp_test.go
+++ b/e2e/internal/otp/otp_test.go
@@ -1,0 +1,51 @@
+package otp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateCode(t *testing.T) {
+	// A valid base32-encoded TOTP secret (test-only).
+	const secret = "JBSWY3DPEHPK3PXP"
+
+	code, err := GenerateCode(secret)
+	require.NoError(t, err)
+
+	assert.Len(t, code, 6, "TOTP codes are 6 digits")
+
+	// The code we generate should validate against the same secret.
+	valid := totp.Validate(code, secret)
+	assert.True(t, valid, "generated code should validate against the secret")
+}
+
+func TestGenerateCodeRejectsEmpty(t *testing.T) {
+	_, err := GenerateCode("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TOTP secret")
+}
+
+func TestGenerateCodeRejectsInvalidBase32(t *testing.T) {
+	_, err := GenerateCode("not-valid-base32!!!")
+	require.Error(t, err)
+}
+
+func TestGenerateCodeDeterministic(t *testing.T) {
+	const secret = "JBSWY3DPEHPK3PXP"
+
+	// Two calls within the same 30s window should produce the same code.
+	code1, err := GenerateCode(secret)
+	require.NoError(t, err)
+
+	// Small sleep to stay in the same period (well under 30s).
+	time.Sleep(100 * time.Millisecond)
+
+	code2, err := GenerateCode(secret)
+	require.NoError(t, err)
+
+	assert.Equal(t, code1, code2, "codes generated in the same period should match")
+}

--- a/e2e/internal/otp/otp_test.go
+++ b/e2e/internal/otp/otp_test.go
@@ -2,7 +2,6 @@ package otp
 
 import (
 	"testing"
-	"time"
 
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
@@ -37,15 +36,19 @@ func TestGenerateCodeRejectsInvalidBase32(t *testing.T) {
 func TestGenerateCodeDeterministic(t *testing.T) {
 	const secret = "JBSWY3DPEHPK3PXP"
 
-	// Two calls within the same 30s window should produce the same code.
+	// Calling GenerateCode twice in quick succession should produce the
+	// same code, unless we happen to straddle a 30s TOTP window boundary.
+	// To avoid flakes, accept a match with either the first or second code.
 	code1, err := GenerateCode(secret)
 	require.NoError(t, err)
-
-	// Small sleep to stay in the same period (well under 30s).
-	time.Sleep(100 * time.Millisecond)
 
 	code2, err := GenerateCode(secret)
 	require.NoError(t, err)
 
-	assert.Equal(t, code1, code2, "codes generated in the same period should match")
+	if code1 != code2 {
+		// We straddled a window boundary. Verify the new code is valid
+		// (it should be the next period's code).
+		valid := totp.Validate(code2, secret)
+		assert.True(t, valid, "second code should still be a valid TOTP code")
+	}
 }

--- a/e2e/internal/otp/page.go
+++ b/e2e/internal/otp/page.go
@@ -49,7 +49,7 @@ func EnterTOTPCode(page playwright.Page, secret string, logf func(string, ...any
 		// GitHub's 2FA form auto-submits when 6 digits are entered.
 		// Wait for the page to navigate away.
 		if err := page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
-			State: playwright.LoadStateNetworkidle,
+			State: playwright.LoadStateDomcontentloaded,
 		}); err != nil {
 			return false, fmt.Errorf("waiting for post-TOTP navigation: %w", err)
 		}
@@ -64,8 +64,10 @@ func EnterTOTPCode(page playwright.Page, secret string, logf func(string, ...any
 		}
 
 		if attempt == 1 {
-			logf("[totp] First TOTP code not accepted, retrying with fresh code")
-			time.Sleep(2 * time.Second)
+			rem := time.Now().Second() % 30
+			wait := time.Duration(30-rem+1) * time.Second
+			logf("[totp] First TOTP code not accepted, waiting %s for next period", wait)
+			time.Sleep(wait)
 		}
 	}
 

--- a/e2e/internal/otp/page.go
+++ b/e2e/internal/otp/page.go
@@ -1,0 +1,75 @@
+package otp
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/playwright-community/playwright-go"
+)
+
+// EnterTOTPCode detects a GitHub TOTP input (#app_totp) on the current page,
+// generates a code from the given secret, and enters it via simulated
+// keystrokes (triggering GitHub's auto-submit). If the first code is rejected
+// (e.g. due to clock skew), it retries once with a fresh code. Returns true
+// if a TOTP form was found and submitted successfully. Returns (false, nil)
+// if no TOTP input is visible.
+func EnterTOTPCode(page playwright.Page, secret string, logf func(string, ...any)) (bool, error) {
+	totpInput := page.Locator("#app_totp")
+	if err := totpInput.WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateVisible,
+		Timeout: playwright.Float(3000),
+	}); err != nil {
+		return false, nil
+	}
+
+	logf("[totp] Detected TOTP input on page (URL: %s)", page.URL())
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		code, err := GenerateCode(secret)
+		if err != nil {
+			return false, fmt.Errorf("generating TOTP code: %w", err)
+		}
+
+		if attempt > 1 {
+			// Clear the input before retrying.
+			if err := totpInput.Fill(""); err != nil {
+				return false, fmt.Errorf("clearing TOTP input for retry: %w", err)
+			}
+		}
+
+		// Use PressSequentially to simulate keystroke entry, which triggers
+		// GitHub's auto-submit after the 6th digit.
+		if err := totpInput.PressSequentially(code, playwright.LocatorPressSequentiallyOptions{
+			Delay: playwright.Float(50),
+		}); err != nil {
+			return false, fmt.Errorf("typing TOTP code: %w", err)
+		}
+
+		// GitHub's 2FA form auto-submits when 6 digits are entered.
+		// Wait for the page to navigate away.
+		if err := page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
+			State: playwright.LoadStateNetworkidle,
+		}); err != nil {
+			return false, fmt.Errorf("waiting for post-TOTP navigation: %w", err)
+		}
+
+		// Verify we actually left the TOTP/sudo page.
+		postURL := page.URL()
+		postTitle, _ := page.Title()
+		if !strings.Contains(postURL, "/two-factor") && !strings.Contains(postURL, "/2fa") &&
+			!strings.Contains(postTitle, "Confirm access") && !strings.Contains(postTitle, "Sudo") {
+			logf("[totp] TOTP submission succeeded (URL: %s)", postURL)
+			return true, nil
+		}
+
+		if attempt == 1 {
+			logf("[totp] First TOTP code not accepted, retrying with fresh code")
+			time.Sleep(2 * time.Second)
+		}
+	}
+
+	postURL := page.URL()
+	postTitle, _ := page.Title()
+	return false, fmt.Errorf("TOTP code was not accepted after 2 attempts (still at %s, title: %s)", postURL, postTitle)
+}

--- a/e2e/internal/otp/page.go
+++ b/e2e/internal/otp/page.go
@@ -10,10 +10,11 @@ import (
 
 // EnterTOTPCode detects a GitHub TOTP input (#app_totp) on the current page,
 // generates a code from the given secret, and enters it via simulated
-// keystrokes (triggering GitHub's auto-submit). If the first code is rejected
-// (e.g. due to clock skew), it retries once with a fresh code. Returns true
-// if a TOTP form was found and submitted successfully. Returns (false, nil)
-// if no TOTP input is visible.
+// keystrokes. On the 2FA login page, GitHub auto-submits after 6 digits;
+// on sudo pages, the submit button is clicked explicitly. If the first code
+// is rejected, it retries once after waiting for the next TOTP period.
+// Returns true if a TOTP form was found and submitted successfully.
+// Returns (false, nil) if no TOTP input is visible.
 func EnterTOTPCode(page playwright.Page, secret string, logf func(string, ...any)) (bool, error) {
 	totpInput := page.Locator("#app_totp")
 	if err := totpInput.WaitFor(playwright.LocatorWaitForOptions{
@@ -38,16 +39,22 @@ func EnterTOTPCode(page playwright.Page, secret string, logf func(string, ...any
 			}
 		}
 
-		// Use PressSequentially to simulate keystroke entry, which triggers
-		// GitHub's auto-submit after the 6th digit.
 		if err := totpInput.PressSequentially(code, playwright.LocatorPressSequentiallyOptions{
 			Delay: playwright.Float(50),
 		}); err != nil {
 			return false, fmt.Errorf("typing TOTP code: %w", err)
 		}
 
-		// GitHub's 2FA form auto-submits when 6 digits are entered.
-		// Wait for the page to navigate away.
+		// The 2FA login page auto-submits after 6 digits, but the sudo
+		// confirmation page does not. Click submit if a button is visible.
+		submitBtn := page.Locator("button[type='submit']")
+		if visible, _ := submitBtn.First().IsVisible(); visible {
+			logf("[totp] Clicking submit button (sudo page)")
+			_ = submitBtn.First().Click(playwright.LocatorClickOptions{
+				Timeout: playwright.Float(3000),
+			})
+		}
+
 		if err := page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
 			State: playwright.LoadStateDomcontentloaded,
 		}); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/knights-analytics/hugot v0.7.1
 	github.com/playwright-community/playwright-go v0.5700.1
+	github.com/pquerna/otp v1.5.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.50.0
@@ -20,6 +21,7 @@ require (
 require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b h1:slYM766cy2nI3BwyR
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGWcpt8ov532z81sp/kMMUG485J2InIOyADM=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
@@ -96,6 +98,8 @@ github.com/playwright-community/playwright-go v0.5700.1/go.mod h1:MlSn1dZrx8rszb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
+github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
@@ -110,6 +114,7 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/streadway/quantile v0.0.0-20220407130108-4246515d968d h1:X4+kt6zM/OVO6gbJdAfJR60MGPsqCzbtXNnjoGqdfAs=
 github.com/streadway/quantile v0.0.0-20220407130108-4246515d968d/go.mod h1:lbP8tGiBjZ5YWIc2fzuRpTaz0b/53vT6PEs3QuAWzuU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=


### PR DESCRIPTION
## Summary

- Add TOTP/2FA support to e2e test infrastructure so the test account can have 2FA enabled
- New `e2e/internal/otp` package for shared TOTP code generation (wraps `pquerna/otp`)
- `handleTOTPIfPresent()` handles TOTP forms on both sudo and 2FA pages via Playwright
- `export-session` detects and completes 2FA after login (`PressSequentially` triggers GitHub's auto-submit)
- `E2E_GITHUB_TOTP_SECRET` wired through CI workflow, `envConfig`, and all call sites
- `handleSelectTargetPage()` added to handle GitHub's `/installations/select_target` redirect during app installation — discovered during 2FA CI testing when GitHub changed the installation flow to require org selection
- Password-path sudo confirmation now falls back to TOTP if password submission doesn't clear the page
- Verified working: `make e2e-export-session` and `make e2e-upload-session` both succeed with 2FA

## Why stored sessions are still needed

GitHub blocks password-based login from Actions runner IPs (Azure datacenter ranges). TOTP doesn't change this — the block happens at the `/login` form before reaching the 2FA prompt. The stored session bypasses login entirely. TOTP is needed for:
- `make e2e-export-session` (local login with 2FA to generate the session)
- Sudo confirmation during e2e runs (GitHub may present TOTP instead of password on sudo pages for 2FA accounts)

## Test plan

- [x] `make e2e-export-session` succeeds with 2FA
- [x] `make e2e-upload-session` succeeds (session uploaded to repo secret)
- [x] `go test ./e2e/internal/otp/ -v` — all unit tests pass
- [x] `go vet ./e2e/...` — clean
- [x] e2e package compiles with `-tags e2e`
- [ ] CI e2e run passes with new `E2E_GITHUB_TOTP_SECRET` secret (secret already set in repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Blocked by #1253