### PR TITLE
docs(#669): verify API contracts per code path in code skill

### DIFF
--- a/internal/scaffold/fullsend-repo/skills/code-implementation/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/code-implementation/SKILL.md
@@ -315,6 +315,10 @@ Before writing code, form a concrete plan:
       values rather than referencing constants, so a symbol-only search misses them.
    3. Evaluate each match — some may be intentional (e.g., testing the non-default
       case) while others are stale assumptions that need updating.
+9. **Verify API contracts per code path** — if the fix removes, empties,
+   or changes a parameter sent to an external API, check the API documentation or
+   test each code path that uses the function. Different operations
+   (e.g., approve vs request-changes) often have different required fields.
 
 When requirements are ambiguous, distinguish between "vague but actionable"
 (you can make a reasonable conservative interpretation) and "genuinely

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -373,6 +373,14 @@ func TestCodeAgentContent(t *testing.T) {
 	assert.Contains(t, s, "code-implementation")
 }
 
+func TestCodeImplementationSkillAPIContractGuidance(t *testing.T) {
+	content, err := FullsendRepoFile("skills/code-implementation/SKILL.md")
+	require.NoError(t, err)
+	s := string(content)
+	assert.Contains(t, s, "Verify API contracts per code path")
+	assert.Contains(t, s, "or changes a parameter sent to an external API")
+}
+
 func TestCodeWorkflowContent(t *testing.T) {
 	content, err := FullsendRepoFile(".github/workflows/code.yml")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Add step 8 planning guidance in the code-implementation skill so the code agent checks external API requirements for each code path before removing or emptying parameters. A scaffold regression test locks the guidance in place.

Closes #669

## Test plan

- [x] `make script-test`
- [x] `go test ./internal/scaffold/... -run TestCodeImplementationSkillContent` (or relevant scaffold tests)