### PR TITLE
fix(review): disable follow-up issue creation while PR is open

### DIFF
--- a/internal/cli/postreview.go
+++ b/internal/cli/postreview.go
@@ -384,99 +384,14 @@ type reviewFollowupIssue struct {
 	created bool
 }
 
-// postApprovedFollowUpIssues creates GitHub issues for actionable low/info
-// findings after an approval. Blocking and comment-only findings stay in the
-// review itself; this path only preserves non-blocking work that would
-// otherwise disappear after merge.
-func postApprovedFollowUpIssues(ctx context.Context, client forge.Client, owner, repo string, pr int, parsed ReviewResult, dryRun bool, maxFollowUpIssues int, printer *ui.Printer) error {
+// postApprovedFollowUpIssues is disabled pending #1137. Follow-up issues
+// should only be created after the PR merges, not while it is still open.
+func postApprovedFollowUpIssues(_ context.Context, _ forge.Client, _, _ string, _ int, parsed ReviewResult, _ bool, _ int, printer *ui.Printer) error {
 	if strings.ToLower(parsed.Action) != "approve" {
 		return nil
 	}
-	if err := validateMaxReviewFollowUpIssues(maxFollowUpIssues, "max follow-up issues"); err != nil {
-		return err
-	}
-
-	actionable := actionableApprovedFindings(parsed.Findings)
-	if len(actionable) == 0 {
-		return nil
-	}
-
-	if dryRun {
-		toCreate := min(len(actionable), maxFollowUpIssues)
-		skipped := len(actionable) - toCreate
-		if maxFollowUpIssues == 0 {
-			printer.StepInfo(fmt.Sprintf("Dry run — review follow-up issue creation disabled; would skip %d actionable finding(s)", len(actionable)))
-		} else if skipped > 0 {
-			printer.StepInfo(fmt.Sprintf("Dry run — would create up to %d review follow-up issue(s) and skip %d due to cap", toCreate, skipped))
-		} else {
-			printer.StepInfo(fmt.Sprintf("Dry run — would create %d review follow-up issue(s)", toCreate))
-		}
-		return nil
-	}
-
-	markers := make(map[string]ReviewFinding, len(actionable))
-	for _, finding := range actionable {
-		markers[reviewFollowupIssueMarker(owner, repo, finding)] = finding
-	}
-
-	printer.StepStart("Checking for existing review follow-up issues")
-	openIssues, err := client.ListOpenIssues(ctx, owner, repo, "type/chore")
-	if err != nil {
-		return fmt.Errorf("listing open issues for review follow-up duplicate detection: %w", err)
-	}
-	existingByMarker := map[string]forge.Issue{}
-	for _, issue := range openIssues {
-		for marker := range markers {
-			if strings.Contains(issue.Body, marker) {
-				if existing, ok := existingByMarker[marker]; ok {
-					printer.StepWarn(fmt.Sprintf("Duplicate review follow-up marker found in issues #%d and #%d; reusing #%d", existing.Number, issue.Number, existing.Number))
-					continue
-				}
-				existingByMarker[marker] = issue
-			}
-		}
-	}
-	printer.StepDone("Duplicate check complete")
-
-	results := make([]reviewFollowupIssue, 0, len(actionable))
-	createdCount := 0
-	skippedCount := 0
-	for _, finding := range actionable {
-		marker := reviewFollowupIssueMarker(owner, repo, finding)
-		if issue, ok := existingByMarker[marker]; ok {
-			issueCopy := issue
-			results = append(results, reviewFollowupIssue{
-				finding: finding,
-				issue:   &issueCopy,
-				created: false,
-			})
-			continue
-		}
-		if createdCount >= maxFollowUpIssues {
-			skippedCount++
-			continue
-		}
-
-		title := reviewFollowupIssueTitle(pr, finding)
-		body := reviewFollowupIssueBody(owner, repo, pr, finding, marker)
-		printer.StepStart("Creating review follow-up issue")
-		issue, err := client.CreateIssue(ctx, owner, repo, title, body, "type/chore")
-		if err != nil {
-			return fmt.Errorf("creating review follow-up issue for %s: %w", reviewFindingLocation(finding), err)
-		}
-		printer.StepDone(fmt.Sprintf("Created follow-up issue #%d", issue.Number))
-		results = append(results, reviewFollowupIssue{
-			finding: finding,
-			issue:   issue,
-			created: true,
-		})
-		createdCount++
-	}
-	if skippedCount > 0 {
-		printer.StepInfo(fmt.Sprintf("Review follow-up issue cap reached (%d); skipped %d actionable finding(s)", maxFollowUpIssues, skippedCount))
-	}
-
-	return postReviewFollowupSummary(ctx, client, owner, repo, pr, results, skippedCount, maxFollowUpIssues, printer)
+	printer.StepInfo("Review follow-up issue creation is temporarily disabled (#1137)")
+	return nil
 }
 
 func validateMaxReviewFollowUpIssues(value int, name string) error {

--- a/internal/cli/postreview.go
+++ b/internal/cli/postreview.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -19,22 +17,18 @@ import (
 )
 
 const reviewMarker = "<!-- fullsend:review-agent -->"
-const reviewFollowupSummaryMarker = "<!-- fullsend:review-follow-ups -->"
-const reviewFollowupIssueMarkerPrefix = "<!-- fullsend:review-follow-up:"
-const maxReviewFollowUpIssues = 3
 
 var hexSHARe = regexp.MustCompile(`^[0-9a-fA-F]{40}$|^[0-9a-fA-F]{64}$`)
 var reasonRe = regexp.MustCompile(`^[a-zA-Z0-9_-]*$`)
 
 func newPostReviewCmd() *cobra.Command {
 	var (
-		repo              string
-		pr                int
-		result            string
-		token             string
-		headSHA           string
-		dryRun            bool
-		maxFollowUpIssues int
+		repo    string
+		pr      int
+		result  string
+		token   string
+		headSHA string
+		dryRun  bool
 	)
 
 	cmd := &cobra.Command{
@@ -69,10 +63,6 @@ has moved, a stale-head failure is posted instead.`,
 			if pr <= 0 {
 				return fmt.Errorf("--pr must be a positive integer, got %d", pr)
 			}
-			if err := validateMaxReviewFollowUpIssues(maxFollowUpIssues, "--max-follow-up-issues"); err != nil {
-				return err
-			}
-
 			parts := strings.SplitN(repo, "/", 2)
 			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 				return fmt.Errorf("--repo must be in owner/repo format, got %q", repo)
@@ -132,7 +122,7 @@ has moved, a stale-head failure is posted instead.`,
 				return err
 			}
 
-			return postApprovedFollowUpIssues(cmd.Context(), client, owner, repoName, pr, parsed, dryRun, maxFollowUpIssues, printer)
+			return postApprovedFollowUpIssues(cmd.Context(), owner, repoName, pr, parsed, printer)
 		},
 	}
 
@@ -142,7 +132,6 @@ has moved, a stale-head failure is posted instead.`,
 	cmd.Flags().StringVar(&token, "token", "", "GitHub token (default: $GITHUB_TOKEN)")
 	cmd.Flags().StringVar(&headSHA, "head-sha", "", "expected PR HEAD SHA (skips review if HEAD has moved)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would be posted without making API calls")
-	cmd.Flags().IntVar(&maxFollowUpIssues, "max-follow-up-issues", maxReviewFollowUpIssues, "maximum number of review follow-up issues to create after an approval (0 disables creation; max 3)")
 	_ = cmd.MarkFlagRequired("repo")
 	_ = cmd.MarkFlagRequired("pr")
 
@@ -378,152 +367,14 @@ func formatFindingComment(f ReviewFinding) string {
 	return b.String()
 }
 
-type reviewFollowupIssue struct {
-	finding ReviewFinding
-	issue   *forge.Issue
-	created bool
-}
-
 // postApprovedFollowUpIssues is disabled pending #1137. Follow-up issues
 // should only be created after the PR merges, not while it is still open.
-func postApprovedFollowUpIssues(_ context.Context, _ forge.Client, _, _ string, _ int, parsed ReviewResult, _ bool, _ int, printer *ui.Printer) error {
+func postApprovedFollowUpIssues(_ context.Context, _, _ string, _ int, parsed ReviewResult, printer *ui.Printer) error {
 	if strings.ToLower(parsed.Action) != "approve" {
 		return nil
 	}
 	printer.StepInfo("Review follow-up issue creation is temporarily disabled (#1137)")
 	return nil
-}
-
-func validateMaxReviewFollowUpIssues(value int, name string) error {
-	if value < 0 || value > maxReviewFollowUpIssues {
-		return fmt.Errorf("%s must be between 0 and %d, got %d", name, maxReviewFollowUpIssues, value)
-	}
-	return nil
-}
-
-func actionableApprovedFindings(findings []ReviewFinding) []ReviewFinding {
-	actionable := make([]ReviewFinding, 0, len(findings))
-	for _, finding := range findings {
-		severity := strings.ToLower(finding.Severity)
-		if finding.Actionable && (severity == "low" || severity == "info") {
-			actionable = append(actionable, finding)
-		}
-	}
-	return actionable
-}
-
-func postReviewFollowupSummary(ctx context.Context, client forge.Client, owner, repo string, pr int, results []reviewFollowupIssue, skippedCount, maxFollowUpIssues int, printer *ui.Printer) error {
-	if len(results) == 0 && skippedCount == 0 {
-		return nil
-	}
-
-	var created []reviewFollowupIssue
-	var existing []reviewFollowupIssue
-	for _, result := range results {
-		if result.created {
-			created = append(created, result)
-		} else {
-			existing = append(existing, result)
-		}
-	}
-
-	var b strings.Builder
-	b.WriteString("## Review follow-ups\n\n")
-	if skippedCount > 0 {
-		if maxFollowUpIssues == 0 {
-			fmt.Fprintf(&b, "**Warning:** follow-up issue creation is disabled, so %d actionable non-blocking finding(s) were not filed.\n\n", skippedCount)
-		} else {
-			fmt.Fprintf(&b, "**Warning:** follow-up issue creation is capped at %d per review run; %d actionable non-blocking finding(s) were not filed.\n\n", maxFollowUpIssues, skippedCount)
-		}
-	}
-	if len(created) > 0 {
-		b.WriteString("Created follow-up issues for actionable non-blocking review findings:\n\n")
-		for _, result := range created {
-			fmt.Fprintf(&b, "- [#%d](%s) — %s\n", result.issue.Number, result.issue.URL, reviewFindingSummary(result.finding))
-		}
-	}
-	if len(existing) > 0 {
-		if len(created) > 0 {
-			b.WriteString("\n")
-		}
-		b.WriteString("Existing follow-up issues already track these findings:\n\n")
-		for _, result := range existing {
-			fmt.Fprintf(&b, "- [#%d](%s) — %s\n", result.issue.Number, result.issue.URL, reviewFindingSummary(result.finding))
-		}
-	}
-
-	cfg := sticky.Config{Marker: reviewFollowupSummaryMarker}
-	if _, err := sticky.Post(ctx, client, owner, repo, pr, b.String(), cfg, printer); err != nil {
-		return fmt.Errorf("posting review follow-up summary: %w", err)
-	}
-	return nil
-}
-
-func reviewFollowupIssueTitle(pr int, finding ReviewFinding) string {
-	summary := reviewFindingSummary(finding)
-	if summary == "" {
-		summary = "actionable review finding"
-	}
-	return fmt.Sprintf("Follow-up from PR #%d: %s", pr, truncate(summary, 88))
-}
-
-func reviewFollowupIssueBody(owner, repo string, pr int, finding ReviewFinding, marker string) string {
-	var b strings.Builder
-	b.WriteString(marker)
-	b.WriteString("\n\n")
-	b.WriteString("## Review follow-up\n\n")
-	fmt.Fprintf(&b, "- PR: https://github.com/%s/%s/pull/%d\n", owner, repo, pr)
-	fmt.Fprintf(&b, "- Severity: `%s`\n", finding.Severity)
-	fmt.Fprintf(&b, "- Category: `%s`\n", finding.Category)
-	fmt.Fprintf(&b, "- Location: `%s`\n", reviewFindingLocation(finding))
-	b.WriteString("\n## Finding\n\n")
-	b.WriteString(strings.TrimSpace(finding.Description))
-	if finding.Remediation != "" {
-		b.WriteString("\n\n## Suggested remediation\n\n")
-		b.WriteString(strings.TrimSpace(finding.Remediation))
-	}
-	b.WriteString("\n\n---\n")
-	b.WriteString("_Generated by the fullsend review agent from an approved PR. The PR was approved because this finding was non-blocking, but it was marked actionable so it is tracked separately._\n")
-	return b.String()
-}
-
-func reviewFollowupIssueMarker(owner, repo string, finding ReviewFinding) string {
-	hash := sha256.New()
-	fmt.Fprintf(hash, "%s/%s\n%s\n%s\n%s\n%d\n%s\n", owner, repo, strings.ToLower(finding.Severity), finding.Category, finding.File, finding.Line, compactWhitespace(finding.Description))
-	return reviewFollowupIssueMarkerPrefix + hex.EncodeToString(hash.Sum(nil)) + " -->"
-}
-
-func reviewFindingLocation(finding ReviewFinding) string {
-	if finding.Line > 0 {
-		return fmt.Sprintf("%s:%d", finding.File, finding.Line)
-	}
-	return finding.File
-}
-
-func reviewFindingSummary(finding ReviewFinding) string {
-	summary := compactWhitespace(finding.Description)
-	if summary != "" {
-		return summary
-	}
-	return compactWhitespace(finding.Category)
-}
-
-func compactWhitespace(s string) string {
-	return strings.Join(strings.Fields(s), " ")
-}
-
-func truncate(s string, max int) string {
-	runes := []rune(s)
-	if len(runes) <= max {
-		return s
-	}
-	if max <= 0 {
-		return ""
-	}
-	if max <= 3 {
-		return string(runes[:max])
-	}
-	return strings.TrimSpace(string(runes[:max-3])) + "..."
 }
 
 // dismissStaleRequestChanges dismisses the most recent CHANGES_REQUESTED

--- a/internal/cli/postreview_test.go
+++ b/internal/cli/postreview_test.go
@@ -829,7 +829,9 @@ func TestFormatFindingComment(t *testing.T) {
 	})
 }
 
-func TestPostApprovedFollowUpIssues_CreatesIssuesAndSummary(t *testing.T) {
+func TestPostApprovedFollowUpIssues_DisabledIsNoop(t *testing.T) {
+	// Issue creation is disabled (#1137). Verify the function is a no-op for
+	// approve actions with actionable findings.
 	fc := forge.NewFakeClient()
 	fc.AuthenticatedUser = "fullsend-review[bot]"
 	printer := ui.New(io.Discard)
@@ -842,7 +844,6 @@ func TestPostApprovedFollowUpIssues_CreatesIssuesAndSummary(t *testing.T) {
 				File:        "internal/service.go",
 				Line:        42,
 				Description: "Add coverage for the empty response path.",
-				Remediation: "Add a unit test that exercises an empty upstream response.",
 				Actionable:  true,
 			},
 		},
@@ -850,21 +851,8 @@ func TestPostApprovedFollowUpIssues_CreatesIssuesAndSummary(t *testing.T) {
 
 	err := postApprovedFollowUpIssues(context.Background(), fc, "acme", "repo", 9, parsed, false, maxReviewFollowUpIssues, printer)
 	require.NoError(t, err)
-
-	require.Len(t, fc.CreatedIssues, 1)
-	created := fc.CreatedIssues[0]
-	assert.Equal(t, "acme", created.Owner)
-	assert.Equal(t, "repo", created.Repo)
-	assert.Contains(t, created.Title, "Follow-up from PR #9")
-	assert.Contains(t, created.Body, "https://github.com/acme/repo/pull/9")
-	assert.Contains(t, created.Body, "internal/service.go:42")
-	assert.Contains(t, created.Body, reviewFollowupIssueMarkerPrefix)
-	assert.Equal(t, []string{"type/chore"}, created.Labels)
-
-	comments := fc.IssueComments["acme/repo/9"]
-	require.Len(t, comments, 1)
-	assert.Contains(t, comments[0].Body, "Created follow-up issues")
-	assert.Contains(t, comments[0].Body, "#1")
+	assert.Empty(t, fc.CreatedIssues)
+	assert.Empty(t, fc.IssueComments)
 }
 
 func TestPostApprovedFollowUpIssues_SkipsNonActionableFindings(t *testing.T) {
@@ -911,122 +899,6 @@ func TestPostApprovedFollowUpIssues_SkipsMediumFindings(t *testing.T) {
 	assert.Empty(t, fc.IssueComments)
 }
 
-func TestPostApprovedFollowUpIssues_UsesExistingDuplicate(t *testing.T) {
-	finding := ReviewFinding{
-		Severity:    "info",
-		Category:    "docs",
-		File:        "README.md",
-		Line:        7,
-		Description: "Document the new flag.",
-		Actionable:  true,
-	}
-	marker := reviewFollowupIssueMarker("acme", "repo", finding)
-	fc := forge.NewFakeClient()
-	fc.AuthenticatedUser = "fullsend-review[bot]"
-	fc.OpenIssues = map[string][]forge.Issue{
-		"acme/repo": {
-			{
-				Number: 12,
-				Title:  "Existing follow-up",
-				Body:   marker + "\n\nAlready tracked.",
-				URL:    "https://github.com/acme/repo/issues/12",
-				Labels: []string{"type/chore"},
-			},
-		},
-	}
-	printer := ui.New(io.Discard)
-	parsed := ReviewResult{Action: "approve", Findings: []ReviewFinding{finding}}
-
-	err := postApprovedFollowUpIssues(context.Background(), fc, "acme", "repo", 9, parsed, false, maxReviewFollowUpIssues, printer)
-	require.NoError(t, err)
-
-	assert.Empty(t, fc.CreatedIssues)
-	comments := fc.IssueComments["acme/repo/9"]
-	require.Len(t, comments, 1)
-	assert.Contains(t, comments[0].Body, "Existing follow-up issues")
-	assert.Contains(t, comments[0].Body, "#12")
-}
-
-func TestPostApprovedFollowUpIssues_DedupesAcrossPRs(t *testing.T) {
-	finding := ReviewFinding{
-		Severity:    "low",
-		Category:    "docs",
-		File:        "README.md",
-		Line:        7,
-		Description: "Document the new flag.",
-		Actionable:  true,
-	}
-	marker := reviewFollowupIssueMarker("acme", "repo", finding)
-	fc := forge.NewFakeClient()
-	fc.AuthenticatedUser = "fullsend-review[bot]"
-	fc.OpenIssues = map[string][]forge.Issue{
-		"acme/repo": {
-			{
-				Number: 12,
-				Title:  "Existing follow-up from earlier PR",
-				Body:   marker + "\n\nOriginally filed from PR #9.",
-				URL:    "https://github.com/acme/repo/issues/12",
-				Labels: []string{"type/chore"},
-			},
-		},
-	}
-	printer := ui.New(io.Discard)
-	parsed := ReviewResult{Action: "approve", Findings: []ReviewFinding{finding}}
-
-	err := postApprovedFollowUpIssues(context.Background(), fc, "acme", "repo", 10, parsed, false, maxReviewFollowUpIssues, printer)
-	require.NoError(t, err)
-
-	assert.Empty(t, fc.CreatedIssues)
-	comments := fc.IssueComments["acme/repo/10"]
-	require.Len(t, comments, 1)
-	assert.Contains(t, comments[0].Body, "Existing follow-up issues")
-	assert.Contains(t, comments[0].Body, "#12")
-}
-
-func TestPostApprovedFollowUpIssues_WarnsOnDuplicateMarkers(t *testing.T) {
-	finding := ReviewFinding{
-		Severity:    "low",
-		Category:    "docs",
-		File:        "README.md",
-		Line:        7,
-		Description: "Document the new flag.",
-		Actionable:  true,
-	}
-	marker := reviewFollowupIssueMarker("acme", "repo", finding)
-	fc := forge.NewFakeClient()
-	fc.AuthenticatedUser = "fullsend-review[bot]"
-	fc.OpenIssues = map[string][]forge.Issue{
-		"acme/repo": {
-			{
-				Number: 12,
-				Title:  "Existing follow-up",
-				Body:   marker + "\n\nAlready tracked.",
-				URL:    "https://github.com/acme/repo/issues/12",
-				Labels: []string{"type/chore"},
-			},
-			{
-				Number: 13,
-				Title:  "Duplicate follow-up",
-				Body:   marker + "\n\nManually duplicated.",
-				URL:    "https://github.com/acme/repo/issues/13",
-				Labels: []string{"type/chore"},
-			},
-		},
-	}
-	var out bytes.Buffer
-	printer := ui.New(&out)
-	parsed := ReviewResult{Action: "approve", Findings: []ReviewFinding{finding}}
-
-	err := postApprovedFollowUpIssues(context.Background(), fc, "acme", "repo", 10, parsed, false, maxReviewFollowUpIssues, printer)
-	require.NoError(t, err)
-
-	assert.Empty(t, fc.CreatedIssues)
-	comments := fc.IssueComments["acme/repo/10"]
-	require.Len(t, comments, 1)
-	assert.Contains(t, comments[0].Body, "#12")
-	assert.NotContains(t, comments[0].Body, "#13")
-	assert.Contains(t, out.String(), "Duplicate review follow-up marker found in issues #12 and #13; reusing #12")
-}
 
 func TestPostApprovedFollowUpIssues_DryRun(t *testing.T) {
 	fc := forge.NewFakeClient()
@@ -1050,122 +922,6 @@ func TestPostApprovedFollowUpIssues_DryRun(t *testing.T) {
 	assert.Empty(t, fc.IssueComments)
 }
 
-func TestPostApprovedFollowUpIssues_RespectsCreateCap(t *testing.T) {
-	fc := forge.NewFakeClient()
-	fc.AuthenticatedUser = "fullsend-review[bot]"
-	printer := ui.New(io.Discard)
-
-	findings := make([]ReviewFinding, 0, 5)
-	for i := 0; i < 5; i++ {
-		findings = append(findings, ReviewFinding{
-			Severity:    "low",
-			Category:    "docs",
-			File:        "README.md",
-			Line:        i + 1,
-			Description: fmt.Sprintf("Document behavior %d.", i+1),
-			Actionable:  true,
-		})
-	}
-	parsed := ReviewResult{Action: "approve", Findings: findings}
-
-	err := postApprovedFollowUpIssues(context.Background(), fc, "acme", "repo", 9, parsed, false, 2, printer)
-	require.NoError(t, err)
-
-	require.Len(t, fc.CreatedIssues, 2)
-	assert.Contains(t, fc.CreatedIssues[0].Body, "Document behavior 1.")
-	assert.Contains(t, fc.CreatedIssues[1].Body, "Document behavior 2.")
-
-	comments := fc.IssueComments["acme/repo/9"]
-	require.Len(t, comments, 1)
-	assert.Contains(t, comments[0].Body, "capped at 2")
-	assert.Contains(t, comments[0].Body, "3 actionable non-blocking finding(s) were not filed")
-}
-
-func TestPostApprovedFollowUpIssues_ExistingIssuesDoNotConsumeCreateCap(t *testing.T) {
-	existingFinding := ReviewFinding{
-		Severity:    "info",
-		Category:    "docs",
-		File:        "README.md",
-		Line:        7,
-		Description: "Document the existing flag.",
-		Actionable:  true,
-	}
-	marker := reviewFollowupIssueMarker("acme", "repo", existingFinding)
-
-	fc := forge.NewFakeClient()
-	fc.AuthenticatedUser = "fullsend-review[bot]"
-	fc.OpenIssues = map[string][]forge.Issue{
-		"acme/repo": {
-			{
-				Number: 12,
-				Title:  "Existing follow-up",
-				Body:   marker + "\n\nAlready tracked.",
-				URL:    "https://github.com/acme/repo/issues/12",
-				Labels: []string{"type/chore"},
-			},
-		},
-	}
-	printer := ui.New(io.Discard)
-	parsed := ReviewResult{
-		Action: "approve",
-		Findings: []ReviewFinding{
-			existingFinding,
-			{
-				Severity:    "low",
-				Category:    "docs",
-				File:        "README.md",
-				Line:        8,
-				Description: "Document the new flag.",
-				Actionable:  true,
-			},
-			{
-				Severity:    "low",
-				Category:    "docs",
-				File:        "README.md",
-				Line:        9,
-				Description: "Document another new flag.",
-				Actionable:  true,
-			},
-		},
-	}
-
-	err := postApprovedFollowUpIssues(context.Background(), fc, "acme", "repo", 9, parsed, false, 1, printer)
-	require.NoError(t, err)
-
-	require.Len(t, fc.CreatedIssues, 1)
-	assert.Contains(t, fc.CreatedIssues[0].Body, "Document the new flag.")
-
-	comments := fc.IssueComments["acme/repo/9"]
-	require.Len(t, comments, 1)
-	assert.Contains(t, comments[0].Body, "Existing follow-up issues")
-	assert.Contains(t, comments[0].Body, "#12")
-	assert.Contains(t, comments[0].Body, "capped at 1")
-	assert.Contains(t, comments[0].Body, "1 actionable non-blocking finding(s) were not filed")
-}
-
-func TestPostApprovedFollowUpIssues_ListOpenIssuesError(t *testing.T) {
-	fc := forge.NewFakeClient()
-	fc.Errors["ListOpenIssues"] = fmt.Errorf("boom")
-	printer := ui.New(io.Discard)
-	parsed := ReviewResult{
-		Action: "approve",
-		Findings: []ReviewFinding{
-			{
-				Severity:    "low",
-				Category:    "docs",
-				File:        "README.md",
-				Description: "Document the behavior.",
-				Actionable:  true,
-			},
-		},
-	}
-
-	err := postApprovedFollowUpIssues(context.Background(), fc, "acme", "repo", 9, parsed, false, maxReviewFollowUpIssues, printer)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate detection")
-	assert.Empty(t, fc.CreatedIssues)
-	assert.Empty(t, fc.IssueComments)
-}
 
 func TestReviewFollowupIssueMarkerGolden(t *testing.T) {
 	finding := ReviewFinding{

--- a/internal/cli/postreview_test.go
+++ b/internal/cli/postreview_test.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"testing"
-	"unicode/utf8"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -70,39 +68,6 @@ func TestParseReviewResult_Findings(t *testing.T) {
 	require.Len(t, result.Findings, 1)
 	assert.Equal(t, "low", result.Findings[0].Severity)
 	assert.True(t, result.Findings[0].Actionable)
-}
-
-func TestNewPostReviewCmd_MaxFollowUpIssuesDefault(t *testing.T) {
-	cmd := newPostReviewCmd()
-	flag := cmd.Flags().Lookup("max-follow-up-issues")
-	require.NotNil(t, flag)
-	assert.Equal(t, "3", flag.DefValue)
-}
-
-func TestValidateMaxReviewFollowUpIssues(t *testing.T) {
-	tests := []struct {
-		name    string
-		value   int
-		wantErr bool
-	}{
-		{name: "disabled", value: 0},
-		{name: "within cap", value: 2},
-		{name: "at cap", value: 3},
-		{name: "negative", value: -1, wantErr: true},
-		{name: "above cap", value: 4, wantErr: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateMaxReviewFollowUpIssues(tt.value, "--max-follow-up-issues")
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "between 0 and 3")
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
 }
 
 func TestReviewActionToEvent(t *testing.T) {
@@ -832,8 +797,6 @@ func TestFormatFindingComment(t *testing.T) {
 func TestPostApprovedFollowUpIssues_DisabledIsNoop(t *testing.T) {
 	// Issue creation is disabled (#1137). Verify the function is a no-op for
 	// approve actions with actionable findings.
-	fc := forge.NewFakeClient()
-	fc.AuthenticatedUser = "fullsend-review[bot]"
 	printer := ui.New(io.Discard)
 	parsed := ReviewResult{
 		Action: "approve",
@@ -849,106 +812,6 @@ func TestPostApprovedFollowUpIssues_DisabledIsNoop(t *testing.T) {
 		},
 	}
 
-	err := postApprovedFollowUpIssues(context.Background(), fc, "acme", "repo", 9, parsed, false, maxReviewFollowUpIssues, printer)
+	err := postApprovedFollowUpIssues(context.Background(), "acme", "repo", 9, parsed, printer)
 	require.NoError(t, err)
-	assert.Empty(t, fc.CreatedIssues)
-	assert.Empty(t, fc.IssueComments)
-}
-
-func TestPostApprovedFollowUpIssues_SkipsNonActionableFindings(t *testing.T) {
-	fc := forge.NewFakeClient()
-	printer := ui.New(io.Discard)
-	parsed := ReviewResult{
-		Action: "approve",
-		Findings: []ReviewFinding{
-			{
-				Severity:    "info",
-				Category:    "style",
-				File:        "README.md",
-				Description: "Nice-to-have wording improvement.",
-				Actionable:  false,
-			},
-		},
-	}
-
-	err := postApprovedFollowUpIssues(context.Background(), fc, "acme", "repo", 9, parsed, false, maxReviewFollowUpIssues, printer)
-	require.NoError(t, err)
-	assert.Empty(t, fc.CreatedIssues)
-	assert.Empty(t, fc.IssueComments)
-}
-
-func TestPostApprovedFollowUpIssues_SkipsMediumFindings(t *testing.T) {
-	fc := forge.NewFakeClient()
-	printer := ui.New(io.Discard)
-	parsed := ReviewResult{
-		Action: "approve",
-		Findings: []ReviewFinding{
-			{
-				Severity:    "medium",
-				Category:    "missing-test",
-				File:        "internal/service.go",
-				Description: "Medium findings should not be turned into approve follow-ups.",
-				Actionable:  true,
-			},
-		},
-	}
-
-	err := postApprovedFollowUpIssues(context.Background(), fc, "acme", "repo", 9, parsed, false, maxReviewFollowUpIssues, printer)
-	require.NoError(t, err)
-	assert.Empty(t, fc.CreatedIssues)
-	assert.Empty(t, fc.IssueComments)
-}
-
-
-func TestPostApprovedFollowUpIssues_DryRun(t *testing.T) {
-	fc := forge.NewFakeClient()
-	printer := ui.New(io.Discard)
-	parsed := ReviewResult{
-		Action: "approve",
-		Findings: []ReviewFinding{
-			{
-				Severity:    "low",
-				Category:    "docs",
-				File:        "README.md",
-				Description: "Document the behavior.",
-				Actionable:  true,
-			},
-		},
-	}
-
-	err := postApprovedFollowUpIssues(context.Background(), fc, "acme", "repo", 9, parsed, true, maxReviewFollowUpIssues, printer)
-	require.NoError(t, err)
-	assert.Empty(t, fc.CreatedIssues)
-	assert.Empty(t, fc.IssueComments)
-}
-
-
-func TestReviewFollowupIssueMarkerGolden(t *testing.T) {
-	finding := ReviewFinding{
-		Severity:    "low",
-		Category:    "docs",
-		File:        "README.md",
-		Line:        7,
-		Description: "Document the new flag.",
-		Actionable:  true,
-	}
-
-	assert.Equal(t,
-		"<!-- fullsend:review-follow-up:2dda9f082af27ccb771d0345fa8840f7f0ae71547ef1366c4bcfc87e48fdd20d -->",
-		reviewFollowupIssueMarker("acme", "repo", finding),
-	)
-}
-
-func TestCompactWhitespace(t *testing.T) {
-	assert.Equal(t, "one two three", compactWhitespace(" one\n\ttwo   three "))
-	assert.Equal(t, "", compactWhitespace(" \n\t "))
-}
-
-func TestTruncate(t *testing.T) {
-	assert.Equal(t, "", truncate("", 10))
-	assert.Equal(t, "", truncate("abcdef", 0))
-	assert.Equal(t, "ab", truncate("abcdef", 2))
-	assert.Equal(t, "ab...", truncate("abcdef", 5))
-	assert.Equal(t, "éé...", truncate("éééééé", 5))
-	assert.True(t, utf8.ValidString(truncate("abéé", 4)))
 }

--- a/internal/scaffold/fullsend-repo/agents/review.md
+++ b/internal/scaffold/fullsend-repo/agents/review.md
@@ -201,7 +201,7 @@ fields such as `outcome`, `summary`, `prior_review_sha`, or
 | `line`        | integer | no       | Line number (minimum 1)                       |
 | `description` | string  | yes      | Finding description (min 1 char)              |
 | `remediation` | string  | no       | Suggested fix                                 |
-| `actionable`  | boolean | no       | When true on low/info findings in an `approve` result, the post-script creates follow-up issues |
+| `actionable`  | boolean | no       | When true on low/info findings in an `approve` result, marks the finding for future follow-up issue creation (temporarily disabled; see #1137) |
 
 Schema validation failures trigger a harness retry iteration. The jq
 examples below show the exact JSON shape for each action.

--- a/internal/scaffold/fullsend-repo/skills/code-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/code-review/SKILL.md
@@ -197,7 +197,8 @@ Then determine the overall outcome:
 - **Low** or **info** findings only (no medium+) -> `approve` (attach
   findings as comments in the review body so the author sees them, but
   do not block the PR). Preserve concrete follow-up work in the structured
-  output with `actionable: true` so the post-script can create follow-up issues.
+  output with `actionable: true` (follow-up issue creation is temporarily
+  disabled pending #1137, but the field is retained for when it is re-enabled).
 - No findings -> `approve`
 - The approach is fundamentally wrong — wrong design, unauthorized
   change, or the PR should be closed/completely rethought -> `reject`.


### PR DESCRIPTION
## Summary

- Stubs out `postApprovedFollowUpIssues` as a no-op (logs a notice, returns immediately)
- Removes the creation/dedup/summary logic and the tests that covered it
- Adds one test verifying the function is inert for approve + actionable findings

## Why

Fixes #1137. Issues opened while a PR is still open cause three problems: line-number references become stale if the author pushes more commits, abandoned PRs leave orphaned issues, and re-reviews can duplicate the same finding. This is a temporary workaround; the proper deferred-until-merge implementation will follow.

## Test plan

- [ ] `go test ./internal/cli/...` passes
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)