### PR TITLE
feat(cli): add github sub-command for standalone org/repo setup

### DIFF
--- a/internal/cli/github.go
+++ b/internal/cli/github.go
@@ -63,10 +63,6 @@ type githubSetupConfig struct {
 	dryRun              bool
 }
 
-// githubSetupPerOrgOnlyFlags are flags that only apply to per-org mode.
-var githubSetupPerOrgOnlyFlags = []string{
-	"vendor-fullsend-binary", "enroll-all", "enroll-none",
-}
 
 func newGitHubSetupCmd() *cobra.Command {
 	var cfg githubSetupConfig
@@ -104,7 +100,7 @@ values (mint URL, WIF provider, project ID) are provided as flags.`,
 
 			_, _, isRepo := parseTarget(cfg.target)
 			if isRepo {
-				for _, name := range githubSetupPerOrgOnlyFlags {
+				for _, name := range perOrgOnlyFlags {
 					if cmd.Flags().Changed(name) {
 						return fmt.Errorf("--%s is only valid for per-org setup (fullsend github setup <org>)", name)
 					}
@@ -760,8 +756,15 @@ func newGitHubUninstallCmd() *cobra.Command {
 				return fmt.Errorf("invalid --app-set: %w", err)
 			}
 
+			token, err := resolveToken()
+			if err != nil {
+				return err
+			}
+
+			client := gh.New(token)
+			printer := ui.New(os.Stdout)
+
 			if !yolo {
-				printer := ui.New(os.Stdout)
 				printer.StepWarn(fmt.Sprintf("This will permanently delete the %s repo and all stored secrets for %s.", forge.ConfigRepoName, org))
 				printer.StepInfo(fmt.Sprintf("Type the organization name (%s) to confirm:", org))
 				var confirmation string
@@ -772,14 +775,6 @@ func newGitHubUninstallCmd() *cobra.Command {
 					return fmt.Errorf("confirmation did not match; aborting uninstall")
 				}
 			}
-
-			token, err := resolveToken()
-			if err != nil {
-				return err
-			}
-
-			client := gh.New(token)
-			printer := ui.New(os.Stdout)
 
 			return runGitHubUninstall(cmd.Context(), client, printer, org, appSet)
 		},

--- a/internal/cli/github.go
+++ b/internal/cli/github.go
@@ -1,0 +1,965 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/fullsend-ai/fullsend/internal/appsetup"
+	"github.com/fullsend-ai/fullsend/internal/config"
+	"github.com/fullsend-ai/fullsend/internal/forge"
+	gh "github.com/fullsend-ai/fullsend/internal/forge/github"
+	"github.com/fullsend-ai/fullsend/internal/inference"
+	"github.com/fullsend-ai/fullsend/internal/inference/vertex"
+	"github.com/fullsend-ai/fullsend/internal/layers"
+	"github.com/fullsend-ai/fullsend/internal/scaffold"
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+func newGitHubCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "github",
+		Short: "Manage GitHub org and repo configuration",
+		Long:  "Commands for configuring fullsend in a GitHub organization or repository. Requires only GitHub access — no GCP credentials needed.",
+	}
+	cmd.AddCommand(newGitHubSetupCmd())
+	cmd.AddCommand(newGitHubEnrollCmd())
+	cmd.AddCommand(newGitHubUnenrollCmd())
+	cmd.AddCommand(newGitHubSetCmd())
+	cmd.AddCommand(newGitHubStatusCmd())
+	cmd.AddCommand(newGitHubUninstallCmd())
+	cmd.AddCommand(newGitHubSyncScaffoldCmd())
+	return cmd
+}
+
+// parseTarget splits a target string into owner and repo.
+// Returns (owner, "", false) for org-only targets and (owner, repo, true) for owner/repo.
+func parseTarget(target string) (string, string, bool) {
+	if strings.Contains(target, "/") {
+		parts := strings.SplitN(target, "/", 2)
+		return parts[0], parts[1], true
+	}
+	return target, "", false
+}
+
+// githubSetupConfig holds configuration for the github setup command.
+type githubSetupConfig struct {
+	target              string
+	mintURL             string
+	agents              string
+	inferenceProject    string
+	inferenceRegion     string
+	inferenceWIFProvider string
+	skipAppSetup        bool
+	publicApps          bool
+	appSet              string
+	enrollAll           bool
+	enrollNone          bool
+	vendorBinary        bool
+	dryRun              bool
+}
+
+// githubSetupPerOrgOnlyFlags are flags that only apply to per-org mode.
+var githubSetupPerOrgOnlyFlags = []string{
+	"vendor-fullsend-binary", "enroll-all", "enroll-none",
+}
+
+func newGitHubSetupCmd() *cobra.Command {
+	var cfg githubSetupConfig
+
+	cmd := &cobra.Command{
+		Use:   "setup <org|owner/repo>",
+		Short: "Configure fullsend for a GitHub org or repo",
+		Long: `Sets up the fullsend agentic development pipeline using only GitHub APIs.
+
+Per-org mode (argument is an org name, e.g. "acme"):
+  Creates the .fullsend config repo, workflow files, secrets, variables,
+  and repo enrollment. Uses pre-provisioned values from upstream commands
+  (fullsend mint deploy, fullsend inference provision-wif).
+
+Per-repo mode (argument is owner/repo, e.g. "acme/widget"):
+  Bootstraps a single repository with the shim workflow, configuration
+  directory, repo variables, and repo secrets.
+
+This command does NOT require GCP credentials. All infrastructure
+values (mint URL, WIF provider, project ID) are provided as flags.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg.target = args[0]
+
+			if err := appsetup.ValidateAppSet(cfg.appSet); err != nil {
+				return fmt.Errorf("invalid --app-set: %w", err)
+			}
+
+			if cfg.mintURL == "" {
+				return fmt.Errorf("--mint-url is required for github setup")
+			}
+			if err := validateMintURLHTTPS(cfg.mintURL); err != nil {
+				return err
+			}
+
+			_, _, isRepo := parseTarget(cfg.target)
+			if isRepo {
+				for _, name := range githubSetupPerOrgOnlyFlags {
+					if cmd.Flags().Changed(name) {
+						return fmt.Errorf("--%s is only valid for per-org setup (fullsend github setup <org>)", name)
+					}
+				}
+				if !cmd.Flags().Changed("agents") {
+					cfg.agents = strings.Join(config.PerRepoDefaultRoles(), ",")
+				}
+			}
+
+			token, err := resolveToken()
+			if err != nil {
+				return err
+			}
+
+			client := gh.New(token)
+			printer := ui.New(os.Stdout)
+			ctx := cmd.Context()
+
+			if isRepo {
+				return runGitHubSetupPerRepo(ctx, client, printer, cfg)
+			}
+			return runGitHubSetupPerOrg(ctx, client, printer, cfg)
+		},
+	}
+
+	cmd.Flags().StringVar(&cfg.mintURL, "mint-url", "", "token mint URL (required)")
+	cmd.Flags().StringVar(&cfg.agents, "agents", strings.Join(config.DefaultAgentRoles(), ","), "comma-separated agent roles")
+	cmd.Flags().StringVar(&cfg.inferenceProject, "inference-project", "", "GCP project ID for inference")
+	cmd.Flags().StringVar(&cfg.inferenceRegion, "inference-region", "global", "GCP region for inference")
+	cmd.Flags().StringVar(&cfg.inferenceWIFProvider, "inference-wif-provider", "", "full WIF provider resource name")
+	cmd.Flags().BoolVar(&cfg.skipAppSetup, "skip-app-setup", false, "skip GitHub App creation/setup")
+	cmd.Flags().BoolVar(&cfg.publicApps, "public", false, "create public (unlisted) GitHub Apps")
+	cmd.Flags().StringVar(&cfg.appSet, "app-set", appsetup.DefaultAppSet, "app set name prefix for GitHub Apps")
+	cmd.Flags().BoolVar(&cfg.enrollAll, "enroll-all", false, "enroll all repositories without prompting")
+	cmd.Flags().BoolVar(&cfg.enrollNone, "enroll-none", false, "skip repository enrollment without prompting")
+	cmd.Flags().BoolVar(&cfg.vendorBinary, "vendor-fullsend-binary", false, "cross-compile and upload the fullsend binary")
+	cmd.Flags().BoolVar(&cfg.dryRun, "dry-run", false, "preview changes without making them")
+
+	return cmd
+}
+
+// runGitHubSetupPerRepo sets up fullsend for a single repository.
+// This is the GitHub-only equivalent of runPerRepoInstall without GCP calls.
+func runGitHubSetupPerRepo(ctx context.Context, client forge.Client, printer *ui.Printer, cfg githubSetupConfig) error {
+	owner, repo, _ := parseTarget(cfg.target)
+
+	if !githubOwnerPattern.MatchString(owner) {
+		return fmt.Errorf("invalid owner name %q: must contain only alphanumeric characters and hyphens", owner)
+	}
+	if !githubRepoPattern.MatchString(repo) {
+		return fmt.Errorf("invalid repo name %q: must contain only alphanumeric characters, hyphens, dots, or underscores", repo)
+	}
+
+	if cfg.inferenceProject == "" {
+		return fmt.Errorf("--inference-project is required for per-repo setup")
+	}
+	if cfg.inferenceWIFProvider == "" {
+		return fmt.Errorf("--inference-wif-provider is required for github setup (no GCP auto-provisioning)")
+	}
+	if err := validateWIFProvider(cfg.inferenceWIFProvider); err != nil {
+		return err
+	}
+
+	roles, err := parseAgentRoles(cfg.agents)
+	if err != nil {
+		return err
+	}
+
+	printer.Banner()
+	printer.Blank()
+	printer.Header("Setting up per-repo fullsend for " + cfg.target)
+	printer.Blank()
+
+	perRepoCfg := config.NewPerRepoConfig(roles)
+	if err := perRepoCfg.Validate(); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
+	}
+
+	shimContent, err := scaffold.PerRepoShimTemplate()
+	if err != nil {
+		return fmt.Errorf("loading per-repo shim template: %w", err)
+	}
+
+	cfgYAML, err := perRepoCfg.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshaling per-repo config: %w", err)
+	}
+
+	var files []forge.TreeFile
+	files = append(files, forge.TreeFile{
+		Path:    ".github/workflows/fullsend.yaml",
+		Content: shimContent,
+		Mode:    "100644",
+	})
+	files = append(files, forge.TreeFile{
+		Path:    ".fullsend/config.yaml",
+		Content: cfgYAML,
+		Mode:    "100644",
+	})
+	for _, dir := range scaffold.PerRepoCustomizedDirs() {
+		files = append(files, forge.TreeFile{
+			Path:    dir + "/.gitkeep",
+			Content: []byte(""),
+			Mode:    "100644",
+		})
+	}
+
+	repoVars := map[string]string{
+		"FULLSEND_MINT_URL":   cfg.mintURL,
+		"FULLSEND_GCP_REGION": cfg.inferenceRegion,
+		forge.PerRepoGuardVar: "true",
+	}
+
+	repoSecrets := map[string]string{
+		"FULLSEND_GCP_PROJECT_ID":   cfg.inferenceProject,
+		"FULLSEND_GCP_WIF_PROVIDER": cfg.inferenceWIFProvider,
+	}
+
+	if cfg.dryRun {
+		printer.StepInfo("Dry run — no changes will be made")
+		printer.Blank()
+		for _, f := range files {
+			printer.StepDone(fmt.Sprintf("Would write: %s (%d bytes)", f.Path, len(f.Content)))
+		}
+		printer.Blank()
+		printer.StepInfo("Would set repository variables:")
+		for _, name := range sortedStringMapKeys(repoVars) {
+			printer.StepInfo(fmt.Sprintf("  %s = %s", name, repoVars[name]))
+		}
+		secretNames := sortedStringMapKeys(repoSecrets)
+		printer.StepInfo(fmt.Sprintf("Would set %d repository secrets:", len(secretNames)))
+		for _, name := range secretNames {
+			printer.StepInfo(fmt.Sprintf("  %s", name))
+		}
+		return nil
+	}
+
+	if err := checkPerRepoScopes(ctx, client, printer); err != nil {
+		return err
+	}
+	printer.Blank()
+
+	printer.StepStart("Writing per-repo scaffold files")
+	committed, err := client.CommitFiles(ctx, owner, repo,
+		"chore: initialize fullsend per-repo installation", files)
+	if err != nil {
+		printer.StepFail("Failed to write scaffold files")
+		return fmt.Errorf("committing scaffold files: %w", err)
+	}
+	if committed {
+		printer.StepDone(fmt.Sprintf("Wrote %d files", len(files)))
+	} else {
+		printer.StepDone("Scaffold up to date")
+	}
+
+	printer.StepStart("Configuring repository variables")
+	for _, name := range sortedStringMapKeys(repoVars) {
+		if err := client.CreateOrUpdateRepoVariable(ctx, owner, repo, name, repoVars[name]); err != nil {
+			printer.StepFail(fmt.Sprintf("Failed to set variable %s", name))
+			return fmt.Errorf("setting repo variable %s: %w", name, err)
+		}
+	}
+	printer.StepDone(fmt.Sprintf("Set %d repository variables", len(repoVars)))
+
+	printer.StepStart("Configuring repository secrets")
+	for _, name := range sortedStringMapKeys(repoSecrets) {
+		if err := client.CreateRepoSecret(ctx, owner, repo, name, repoSecrets[name]); err != nil {
+			printer.StepFail(fmt.Sprintf("Failed to set secret %s", name))
+			return fmt.Errorf("setting repo secret %s: %w", name, err)
+		}
+	}
+	printer.StepDone(fmt.Sprintf("Set %d repository secrets", len(repoSecrets)))
+
+	printer.Blank()
+	printer.StepDone(fmt.Sprintf("Per-repo setup complete for %s/%s", owner, repo))
+	return nil
+}
+
+// runGitHubSetupPerOrg sets up fullsend for an entire organization.
+// This is the GitHub-only equivalent of admin install without GCP calls.
+func runGitHubSetupPerOrg(ctx context.Context, client forge.Client, printer *ui.Printer, cfg githubSetupConfig) error {
+	org := cfg.target
+	if err := validateOrgName(org); err != nil {
+		return err
+	}
+
+	roles, err := parseAgentRoles(cfg.agents)
+	if err != nil {
+		return err
+	}
+
+	if cfg.inferenceProject == "" && cfg.inferenceWIFProvider != "" {
+		return fmt.Errorf("--inference-wif-provider requires --inference-project to be set")
+	}
+	if cfg.inferenceWIFProvider != "" {
+		if err := validateWIFProvider(cfg.inferenceWIFProvider); err != nil {
+			return err
+		}
+	}
+
+	if cfg.enrollAll && cfg.enrollNone {
+		return fmt.Errorf("--enroll-all and --enroll-none are mutually exclusive")
+	}
+
+	printer.Banner()
+	printer.Blank()
+	printer.Header("Setting up fullsend for " + org)
+	printer.Blank()
+
+	// Determine enrollment choice: use flag if set, otherwise prompt.
+	var enrollAll bool
+	if cfg.enrollAll {
+		enrollAll = true
+	} else if cfg.enrollNone {
+		enrollAll = false
+	} else {
+		enrollAll, err = promptEnrollment(printer, os.Stdin)
+		if err != nil {
+			return err
+		}
+	}
+
+	allRepos, err := client.ListOrgRepos(ctx, org)
+	if err != nil {
+		return fmt.Errorf("listing org repos: %w", err)
+	}
+
+	repoNames := repoNameList(allRepos)
+
+	var enabledRepos []string
+	if enrollAll {
+		var skippedPerRepo, skippedErrors, eligibleCount int
+		for _, r := range allRepos {
+			if r.Name == forge.ConfigRepoName {
+				continue
+			}
+			eligibleCount++
+			guardVal, guardExists, guardErr := client.GetRepoVariable(ctx, org, r.Name, forge.PerRepoGuardVar)
+			if guardErr != nil {
+				printer.StepWarn(fmt.Sprintf("Could not check per-repo guard for %s: %v — skipping to be safe", r.Name, guardErr))
+				skippedPerRepo++
+				skippedErrors++
+				continue
+			}
+			if guardExists && guardVal == "true" {
+				printer.StepWarn(fmt.Sprintf("Skipping %s — per-repo installation active", r.Name))
+				skippedPerRepo++
+				continue
+			}
+			if guardExists {
+				printer.StepInfo(fmt.Sprintf("%s has per-repo guard set to %q (not active) — enrolling with per-org", r.Name, guardVal))
+			}
+			enabledRepos = append(enabledRepos, r.Name)
+		}
+		if eligibleCount > 0 && skippedErrors == eligibleCount {
+			return fmt.Errorf("all %d repos were skipped due to guard-check errors — verify your token has variables:read scope", eligibleCount)
+		}
+		msg := fmt.Sprintf("Enrolling %d repositories (excluding %s)", len(enabledRepos), forge.ConfigRepoName)
+		if skippedPerRepo-skippedErrors > 0 {
+			msg += fmt.Sprintf(", %d per-repo installed", skippedPerRepo-skippedErrors)
+		}
+		if skippedErrors > 0 {
+			msg += fmt.Sprintf(", %d guard-check errors", skippedErrors)
+		}
+		printer.StepInfo(msg)
+	} else {
+		printer.StepInfo("No repositories will be enrolled during setup")
+		printer.StepInfo("To enroll repositories later, use:")
+		printer.StepInfo(fmt.Sprintf("  fullsend github enroll %s <repo-name> [repo-name...]", org))
+	}
+	printer.Blank()
+
+	if enabledRepos == nil {
+		enabledRepos = loadExistingEnabledRepos(ctx, client, org)
+	}
+	if err := validateEnabledRepos(enabledRepos, repoNames); err != nil {
+		return err
+	}
+
+	// Build config.
+	privateRepo := false
+	var inferenceProvider inference.Provider
+	var inferenceProviderName string
+	if cfg.inferenceProject != "" {
+		vcfg := vertex.Config{
+			ProjectID:   cfg.inferenceProject,
+			Region:      cfg.inferenceRegion,
+			WIFProvider: cfg.inferenceWIFProvider,
+		}
+		inferenceProvider = vertex.New(vcfg)
+		inferenceProviderName = "vertex"
+	} else {
+		inferenceProviderName = loadExistingInferenceProvider(ctx, client, org)
+	}
+
+	// Build dummy agent credentials for the layer stack.
+	var agentCreds []layers.AgentCredentials
+	for _, role := range roles {
+		agentCreds = append(agentCreds, layers.AgentCredentials{
+			AgentEntry: config.AgentEntry{Role: role},
+		})
+	}
+
+	dummyAgents := make([]config.AgentEntry, len(agentCreds))
+	for i, ac := range agentCreds {
+		dummyAgents[i] = ac.AgentEntry
+	}
+	orgCfg := config.NewOrgConfig(repoNames, enabledRepos, roles, dummyAgents, inferenceProviderName)
+	orgCfg.Dispatch.Mode = "oidc-mint"
+
+	user, err := client.GetAuthenticatedUser(ctx)
+	if err != nil {
+		return fmt.Errorf("getting authenticated user: %w", err)
+	}
+
+	enrolledRepoIDs := collectEnrolledRepoIDs(allRepos, enabledRepos)
+	dispatcher := &skipMintDispatcher{mintURL: cfg.mintURL}
+
+	var vendorFn layers.VendorFunc
+	if cfg.vendorBinary {
+		vendorFn = vendorFullsendBinary
+	}
+
+	stack := buildLayerStack(org, client, orgCfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, cfg.vendorBinary, vendorFn, dispatcher)
+
+	if cfg.dryRun {
+		printer.Header("Dry run — analyzing what setup would do")
+		printer.Blank()
+		if err := runPreflight(ctx, stack, layers.OpInstall, client, printer); err != nil {
+			return err
+		}
+		printer.Blank()
+		return printAnalysis(ctx, stack, printer)
+	}
+
+	if err := checkInstallScopes(ctx, client, printer); err != nil {
+		return err
+	}
+	printer.Blank()
+
+	if !cfg.skipAppSetup {
+		if err := ensureConfigRepoExists(ctx, client, printer, org); err != nil {
+			return err
+		}
+
+		creds, credErr := runAppSetup(ctx, client, printer, org, roles, "", cfg.publicApps, nil, cfg.appSet, nil)
+		if credErr != nil {
+			return credErr
+		}
+
+		// Rebuild with real credentials.
+		agentCreds = creds
+		agents := make([]config.AgentEntry, len(agentCreds))
+		for i, ac := range agentCreds {
+			agents[i] = ac.AgentEntry
+		}
+		orgCfg = config.NewOrgConfig(repoNames, enabledRepos, roles, agents, inferenceProviderName)
+		orgCfg.Dispatch.Mode = "oidc-mint"
+
+		stack = buildLayerStack(org, client, orgCfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, cfg.vendorBinary, vendorFn, dispatcher)
+	}
+
+	if err := runPreflight(ctx, stack, layers.OpInstall, client, printer); err != nil {
+		return err
+	}
+	printer.Blank()
+
+	printer.Header("Installing")
+	printer.Blank()
+
+	if err := stack.InstallAll(ctx); err != nil {
+		return fmt.Errorf("setup failed: %w", err)
+	}
+
+	printer.Blank()
+	printer.Summary("Setup complete", []string{
+		fmt.Sprintf("Organization: %s", org),
+		fmt.Sprintf("Roles: %s", strings.Join(roles, ", ")),
+		fmt.Sprintf("Enabled repos: %d", len(enabledRepos)),
+	})
+
+	return nil
+}
+
+// --- enroll / unenroll commands ---
+
+func newGitHubEnrollCmd() *cobra.Command {
+	return newReposSubcommand(
+		"enroll <org> [repo...]",
+		"Enable repositories for fullsend enrollment",
+		"Enables the specified repositories for fullsend enrollment by updating config.yaml in the .fullsend repository. Use --all to enable all repositories (excluding .fullsend). This is a lightweight config toggle — it does NOT set secrets or variables.",
+		"enable all repositories (excluding .fullsend)",
+		runEnableRepos,
+		false,
+	)
+}
+
+func newGitHubUnenrollCmd() *cobra.Command {
+	return newReposSubcommand(
+		"unenroll <org> [repo...]",
+		"Disable repositories from fullsend enrollment",
+		"Disables the specified repositories from fullsend enrollment by updating config.yaml in the .fullsend repository. Use --all to disable all repositories. This is a lightweight config toggle — it does NOT remove secrets or variables.",
+		"disable all repositories",
+		runDisableRepos,
+		true,
+	)
+}
+
+// --- set command ---
+
+// configKeyStorage defines the storage type for a config key.
+type configKeyStorage int
+
+const (
+	storageVariable configKeyStorage = iota
+	storageSecret
+)
+
+// configKeyInfo describes how a config key is stored.
+type configKeyInfo struct {
+	storage configKeyStorage
+}
+
+// configKeyMapping maps config key names to their storage type.
+var configKeyMapping = map[string]configKeyInfo{
+	"FULLSEND_GCP_REGION":       {storage: storageVariable},
+	forge.PerRepoGuardVar:       {storage: storageVariable},
+	"FULLSEND_GCP_PROJECT_ID":   {storage: storageSecret},
+	"FULLSEND_GCP_WIF_PROVIDER": {storage: storageSecret},
+}
+
+func newGitHubSetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set <org|owner/repo> <key> <value>",
+		Short: "Update a config value (secret or variable)",
+		Long: `Sets a fullsend config value on a repo. The CLI maintains an internal
+mapping of which keys are stored as secrets vs variables, so the user
+doesn't need to know the storage type.
+
+Org-scope variables (like FULLSEND_MINT_URL) are managed by
+'fullsend github setup' to preserve repository access lists.
+
+Valid keys:
+  FULLSEND_GCP_REGION         repo variable   GCP region for inference
+  FULLSEND_PER_REPO_INSTALL   repo variable   per-repo install marker
+  FULLSEND_GCP_PROJECT_ID     repo secret     GCP project for inference
+  FULLSEND_GCP_WIF_PROVIDER   repo secret     WIF provider resource name`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := args[0]
+			key := args[1]
+			value := args[2]
+
+			token, err := resolveToken()
+			if err != nil {
+				return err
+			}
+
+			client := gh.New(token)
+			printer := ui.New(os.Stdout)
+
+			return runGitHubSet(cmd.Context(), client, printer, target, key, value)
+		},
+	}
+
+	return cmd
+}
+
+// runGitHubSet applies a config key-value pair to the specified target.
+func runGitHubSet(ctx context.Context, client forge.Client, printer *ui.Printer, target, key, value string) error {
+	info, ok := configKeyMapping[key]
+	if !ok {
+		var validKeys []string
+		for k := range configKeyMapping {
+			validKeys = append(validKeys, k)
+		}
+		sort.Strings(validKeys)
+		return fmt.Errorf("unknown config key %q; valid keys: %s", key, strings.Join(validKeys, ", "))
+	}
+
+	owner, repo, isRepo := parseTarget(target)
+
+	if isRepo {
+		if !githubOwnerPattern.MatchString(owner) {
+			return fmt.Errorf("invalid owner name %q: must contain only alphanumeric characters and hyphens", owner)
+		}
+		if !githubRepoPattern.MatchString(repo) {
+			return fmt.Errorf("invalid repo name %q: must contain only alphanumeric characters, hyphens, dots, or underscores", repo)
+		}
+	} else {
+		if err := validateOrgName(owner); err != nil {
+			return err
+		}
+	}
+
+	switch key {
+	case "FULLSEND_GCP_WIF_PROVIDER":
+		if err := validateWIFProvider(value); err != nil {
+			return err
+		}
+	}
+
+	switch info.storage {
+	case storageVariable:
+		if !isRepo {
+			repo = forge.ConfigRepoName
+		}
+		printer.StepStart(fmt.Sprintf("Setting repo variable %s on %s/%s", key, owner, repo))
+		if err := client.CreateOrUpdateRepoVariable(ctx, owner, repo, key, value); err != nil {
+			printer.StepFail(fmt.Sprintf("Failed to set repo variable %s", key))
+			return fmt.Errorf("setting repo variable %s: %w", key, err)
+		}
+		printer.StepDone(fmt.Sprintf("Set repo variable %s on %s/%s", key, owner, repo))
+	case storageSecret:
+		// Repo-scope secret.
+		if !isRepo {
+			// Default to .fullsend repo for org targets.
+			repo = forge.ConfigRepoName
+		}
+		printer.StepStart(fmt.Sprintf("Setting repo secret %s on %s/%s", key, owner, repo))
+		if err := client.CreateRepoSecret(ctx, owner, repo, key, value); err != nil {
+			printer.StepFail(fmt.Sprintf("Failed to set repo secret %s", key))
+			return fmt.Errorf("setting repo secret %s: %w", key, err)
+		}
+		printer.StepDone(fmt.Sprintf("Set repo secret %s on %s/%s", key, owner, repo))
+	}
+
+	return nil
+}
+
+// --- status command ---
+
+func newGitHubStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status <org>",
+		Short: "Analyze GitHub-side installation status",
+		Long:  "Checks the current state of fullsend's GitHub-side installation for an organization. Reports on config repo, workflows, org variables, inference secrets, and enrollment state. Does NOT check GCP resources.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org := args[0]
+			if err := validateOrgName(org); err != nil {
+				return err
+			}
+
+			token, err := resolveToken()
+			if err != nil {
+				return err
+			}
+
+			client := gh.New(token)
+			printer := ui.New(os.Stdout)
+
+			return runGitHubStatus(cmd.Context(), client, printer, org)
+		},
+	}
+
+	return cmd
+}
+
+// runGitHubStatus checks GitHub-side layers only.
+func runGitHubStatus(ctx context.Context, client forge.Client, printer *ui.Printer, org string) error {
+	printer.Banner()
+	printer.Blank()
+	printer.Header("GitHub status for " + org)
+	printer.Blank()
+
+	// Check config repo.
+	_, err := client.GetRepo(ctx, org, forge.ConfigRepoName)
+	if err != nil {
+		if forge.IsNotFound(err) {
+			printer.StepFail(forge.ConfigRepoName + " repository not found")
+			printer.StepInfo("Run 'fullsend github setup " + org + "' to configure")
+			return nil
+		}
+		return fmt.Errorf("checking config repo: %w", err)
+	}
+	printer.StepDone(forge.ConfigRepoName + " repository exists")
+
+	// Check config.yaml.
+	cfgData, err := client.GetFileContent(ctx, org, forge.ConfigRepoName, "config.yaml")
+	if err != nil {
+		printer.StepFail("config.yaml not found in " + forge.ConfigRepoName)
+	} else {
+		cfg, parseErr := config.ParseOrgConfig(cfgData)
+		if parseErr != nil {
+			printer.StepWarn("config.yaml exists but is invalid: " + parseErr.Error())
+		} else {
+			printer.StepDone("config.yaml exists and is valid")
+
+			// Report enrollment state.
+			enabled := cfg.EnabledRepos()
+			printer.StepInfo(fmt.Sprintf("Enrolled repositories: %d", len(enabled)))
+			for _, name := range enabled {
+				printer.StepInfo(fmt.Sprintf("  - %s", name))
+			}
+		}
+	}
+
+	// Check org variables.
+	mintURLExists, err := client.OrgVariableExists(ctx, org, "FULLSEND_MINT_URL")
+	if err != nil {
+		printer.StepWarn("Could not check FULLSEND_MINT_URL: " + err.Error())
+	} else if mintURLExists {
+		printer.StepDone("FULLSEND_MINT_URL org variable exists")
+	} else {
+		printer.StepFail("FULLSEND_MINT_URL org variable not found")
+	}
+
+	// Check inference secrets on .fullsend repo.
+	inferenceSecrets := []string{"FULLSEND_GCP_PROJECT_ID", "FULLSEND_GCP_WIF_PROVIDER"}
+	for _, name := range inferenceSecrets {
+		exists, secErr := client.RepoSecretExists(ctx, org, forge.ConfigRepoName, name)
+		if secErr != nil {
+			printer.StepWarn(fmt.Sprintf("Could not check %s: %v", name, secErr))
+		} else if exists {
+			printer.StepDone(fmt.Sprintf("%s exists", name))
+		} else {
+			printer.StepInfo(fmt.Sprintf("%s not found (may use org-level inference)", name))
+		}
+	}
+
+	// Check inference region variable.
+	regionExists, err := client.RepoVariableExists(ctx, org, forge.ConfigRepoName, "FULLSEND_GCP_REGION")
+	if err != nil {
+		printer.StepWarn("Could not check FULLSEND_GCP_REGION: " + err.Error())
+	} else if regionExists {
+		printer.StepDone("FULLSEND_GCP_REGION variable exists")
+	} else {
+		printer.StepInfo("FULLSEND_GCP_REGION not found (using default)")
+	}
+
+	printer.Blank()
+	return nil
+}
+
+// --- uninstall command ---
+
+func newGitHubUninstallCmd() *cobra.Command {
+	var yolo bool
+	var appSet string
+
+	cmd := &cobra.Command{
+		Use:   "uninstall <org>",
+		Short: "Remove fullsend GitHub configuration from an organization",
+		Long:  "Deletes the .fullsend config repo and removes org-level variables. Guides the user to delete GitHub Apps via the browser.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org := args[0]
+			if err := validateOrgName(org); err != nil {
+				return err
+			}
+			if err := appsetup.ValidateAppSet(appSet); err != nil {
+				return fmt.Errorf("invalid --app-set: %w", err)
+			}
+
+			if !yolo {
+				printer := ui.New(os.Stdout)
+				printer.StepWarn(fmt.Sprintf("This will permanently delete the %s repo and all stored secrets for %s.", forge.ConfigRepoName, org))
+				printer.StepInfo(fmt.Sprintf("Type the organization name (%s) to confirm:", org))
+				var confirmation string
+				if _, err := fmt.Scanln(&confirmation); err != nil {
+					return fmt.Errorf("reading confirmation: %w", err)
+				}
+				if confirmation != org {
+					return fmt.Errorf("confirmation did not match; aborting uninstall")
+				}
+			}
+
+			token, err := resolveToken()
+			if err != nil {
+				return err
+			}
+
+			client := gh.New(token)
+			printer := ui.New(os.Stdout)
+
+			return runGitHubUninstall(cmd.Context(), client, printer, org, appSet)
+		},
+	}
+
+	cmd.Flags().BoolVar(&yolo, "yolo", false, "skip confirmation prompt")
+	cmd.Flags().StringVar(&appSet, "app-set", appsetup.DefaultAppSet, "app set name prefix for GitHub Apps")
+
+	return cmd
+}
+
+// runGitHubUninstall tears down the GitHub-side installation.
+func runGitHubUninstall(ctx context.Context, client forge.Client, printer *ui.Printer, org, appSet string) error {
+	printer.Banner()
+	printer.Blank()
+	printer.Header("Uninstalling fullsend from " + org)
+	printer.Blank()
+
+	// Read config before deleting repo to discover actual installed app slugs.
+	var agentSlugs []string
+	cfgData, cfgErr := client.GetFileContent(ctx, org, forge.ConfigRepoName, "config.yaml")
+	if cfgErr == nil {
+		if parsed, parseErr := config.ParseOrgConfig(cfgData); parseErr == nil {
+			for _, agent := range parsed.Agents {
+				if agent.Slug != "" {
+					agentSlugs = append(agentSlugs, agent.Slug)
+				} else {
+					agentSlugs = append(agentSlugs, appsetup.AppSlug(appSet, agent.Role))
+				}
+			}
+		}
+	}
+	if len(agentSlugs) == 0 {
+		for _, role := range config.DefaultAgentRoles() {
+			agentSlugs = append(agentSlugs, appsetup.AppSlug(appSet, role))
+		}
+	}
+
+	// Delete .fullsend repository.
+	_, err := client.GetRepo(ctx, org, forge.ConfigRepoName)
+	if err != nil {
+		if forge.IsNotFound(err) {
+			printer.StepInfo(forge.ConfigRepoName + " repository already deleted")
+		} else {
+			return fmt.Errorf("checking for config repo: %w", err)
+		}
+	} else {
+		printer.StepStart("Deleting " + forge.ConfigRepoName + " repository")
+		if err := client.DeleteRepo(ctx, org, forge.ConfigRepoName); err != nil {
+			if forge.IsNotFound(err) {
+				printer.StepInfo(forge.ConfigRepoName + " repository already deleted")
+			} else {
+				printer.StepFail("Failed to delete " + forge.ConfigRepoName)
+				return fmt.Errorf("deleting config repo: %w", err)
+			}
+		} else {
+			printer.StepDone("Deleted " + forge.ConfigRepoName + " repository")
+		}
+	}
+
+	// Delete org-level variables.
+	orgVars := []string{"FULLSEND_MINT_URL"}
+	for _, name := range orgVars {
+		exists, varErr := client.OrgVariableExists(ctx, org, name)
+		if varErr != nil {
+			printer.StepWarn(fmt.Sprintf("Could not check org variable %s: %v", name, varErr))
+			continue
+		}
+		if !exists {
+			printer.StepInfo(fmt.Sprintf("%s already deleted", name))
+			continue
+		}
+		printer.StepStart("Deleting org variable " + name)
+		if err := client.DeleteOrgVariable(ctx, org, name); err != nil {
+			printer.StepFail(fmt.Sprintf("Failed to delete org variable %s", name))
+			return fmt.Errorf("deleting org variable %s: %w", name, err)
+		}
+		printer.StepDone("Deleted org variable " + name)
+	}
+
+	// Delete org-level secrets created by the dispatch layer.
+	orgSecrets := []string{"FULLSEND_DISPATCH_TOKEN"}
+	for _, name := range orgSecrets {
+		exists, secErr := client.OrgSecretExists(ctx, org, name)
+		if secErr != nil {
+			printer.StepWarn(fmt.Sprintf("Could not check org secret %s: %v", name, secErr))
+			continue
+		}
+		if !exists {
+			continue
+		}
+		printer.StepStart("Deleting org secret " + name)
+		if err := client.DeleteOrgSecret(ctx, org, name); err != nil {
+			printer.StepFail(fmt.Sprintf("Failed to delete org secret %s", name))
+			return fmt.Errorf("deleting org secret %s: %w", name, err)
+		}
+		printer.StepDone("Deleted org secret " + name)
+	}
+
+	installations, listErr := client.ListOrgInstallations(ctx, org)
+	if listErr == nil {
+		installedSet := make(map[string]bool, len(installations))
+		for _, inst := range installations {
+			installedSet[inst.AppSlug] = true
+		}
+		var existingSlugs []string
+		for _, slug := range agentSlugs {
+			if installedSet[slug] {
+				existingSlugs = append(existingSlugs, slug)
+			}
+		}
+		if len(existingSlugs) > 0 {
+			printer.Blank()
+			printer.Header("App cleanup")
+			printer.StepInfo("The following GitHub Apps should be deleted manually:")
+			for _, slug := range existingSlugs {
+				deleteURL := fmt.Sprintf("https://github.com/organizations/%s/settings/apps/%s/advanced", org, slug)
+				printer.StepInfo(fmt.Sprintf("  %s: %s", slug, deleteURL))
+			}
+		}
+	}
+
+	printer.Blank()
+	printer.Summary("Uninstall complete", []string{
+		fmt.Sprintf("Organization: %s", org),
+		"Config repo deleted",
+		"GCP resources (mint, inference) must be removed separately",
+	})
+
+	return nil
+}
+
+// --- sync-scaffold command ---
+
+func newGitHubSyncScaffoldCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sync-scaffold <org>",
+		Short: "Update workflow templates in .fullsend",
+		Long:  "Re-commits scaffold files (shim and maintenance workflows) to the .fullsend repo without touching secrets, variables, or enrollment. Useful after fullsend version upgrades. Idempotent and safe to run repeatedly.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org := args[0]
+			if err := validateOrgName(org); err != nil {
+				return err
+			}
+
+			token, err := resolveToken()
+			if err != nil {
+				return err
+			}
+
+			client := gh.New(token)
+			printer := ui.New(os.Stdout)
+
+			return runGitHubSyncScaffold(cmd.Context(), client, printer, org)
+		},
+	}
+
+	return cmd
+}
+
+// runGitHubSyncScaffold runs only the WorkflowsLayer.
+func runGitHubSyncScaffold(ctx context.Context, client forge.Client, printer *ui.Printer, org string) error {
+	printer.Banner()
+	printer.Blank()
+	printer.Header("Syncing scaffold for " + org)
+	printer.Blank()
+
+	user, err := client.GetAuthenticatedUser(ctx)
+	if err != nil {
+		return fmt.Errorf("getting authenticated user: %w", err)
+	}
+
+	workflowsLayer := layers.NewWorkflowsLayer(org, client, printer, user)
+
+	if err := workflowsLayer.Install(ctx); err != nil {
+		return fmt.Errorf("syncing scaffold: %w", err)
+	}
+
+	printer.Blank()
+	printer.StepDone("Scaffold sync complete for " + org)
+	return nil
+}

--- a/internal/cli/github.go
+++ b/internal/cli/github.go
@@ -169,7 +169,7 @@ func runGitHubSetupPerRepo(ctx context.Context, client forge.Client, printer *ui
 		return err
 	}
 
-	printer.Banner()
+	printer.Banner(Version())
 	printer.Blank()
 	printer.Header("Setting up per-repo fullsend for " + cfg.target)
 	printer.Blank()
@@ -305,7 +305,7 @@ func runGitHubSetupPerOrg(ctx context.Context, client forge.Client, printer *ui.
 		return fmt.Errorf("--enroll-all and --enroll-none are mutually exclusive")
 	}
 
-	printer.Banner()
+	printer.Banner(Version())
 	printer.Blank()
 	printer.Header("Setting up fullsend for " + org)
 	printer.Blank()
@@ -662,7 +662,7 @@ func newGitHubStatusCmd() *cobra.Command {
 
 // runGitHubStatus checks GitHub-side layers only.
 func runGitHubStatus(ctx context.Context, client forge.Client, printer *ui.Printer, org string) error {
-	printer.Banner()
+	printer.Banner(Version())
 	printer.Blank()
 	printer.Header("GitHub status for " + org)
 	printer.Blank()
@@ -788,7 +788,7 @@ func newGitHubUninstallCmd() *cobra.Command {
 
 // runGitHubUninstall tears down the GitHub-side installation.
 func runGitHubUninstall(ctx context.Context, client forge.Client, printer *ui.Printer, org, appSet string) error {
-	printer.Banner()
+	printer.Banner(Version())
 	printer.Blank()
 	printer.Header("Uninstalling fullsend from " + org)
 	printer.Blank()
@@ -875,25 +875,29 @@ func runGitHubUninstall(ctx context.Context, client forge.Client, printer *ui.Pr
 	}
 
 	installations, listErr := client.ListOrgInstallations(ctx, org)
+	var existingSlugs []string
 	if listErr == nil {
 		installedSet := make(map[string]bool, len(installations))
 		for _, inst := range installations {
 			installedSet[inst.AppSlug] = true
 		}
-		var existingSlugs []string
 		for _, slug := range agentSlugs {
 			if installedSet[slug] {
 				existingSlugs = append(existingSlugs, slug)
 			}
 		}
-		if len(existingSlugs) > 0 {
-			printer.Blank()
-			printer.Header("App cleanup")
-			printer.StepInfo("The following GitHub Apps should be deleted manually:")
-			for _, slug := range existingSlugs {
-				deleteURL := fmt.Sprintf("https://github.com/organizations/%s/settings/apps/%s/advanced", org, slug)
-				printer.StepInfo(fmt.Sprintf("  %s: %s", slug, deleteURL))
-			}
+	} else {
+		// Can't check — fall back to showing all of them.
+		printer.StepWarn("Could not verify which apps exist; showing all")
+		existingSlugs = agentSlugs
+	}
+	if len(existingSlugs) > 0 {
+		printer.Blank()
+		printer.Header("App cleanup")
+		printer.StepInfo("The following GitHub Apps should be deleted manually:")
+		for _, slug := range existingSlugs {
+			deleteURL := fmt.Sprintf("https://github.com/organizations/%s/settings/apps/%s/advanced", org, slug)
+			printer.StepInfo(fmt.Sprintf("  %s: %s", slug, deleteURL))
 		}
 	}
 
@@ -938,7 +942,7 @@ func newGitHubSyncScaffoldCmd() *cobra.Command {
 
 // runGitHubSyncScaffold runs only the WorkflowsLayer.
 func runGitHubSyncScaffold(ctx context.Context, client forge.Client, printer *ui.Printer, org string) error {
-	printer.Banner()
+	printer.Banner(Version())
 	printer.Blank()
 	printer.Header("Syncing scaffold for " + org)
 	printer.Blank()

--- a/internal/cli/github.go
+++ b/internal/cli/github.go
@@ -884,6 +884,8 @@ func runGitHubUninstall(ctx context.Context, client forge.Client, printer *ui.Pr
 		for _, slug := range agentSlugs {
 			if installedSet[slug] {
 				existingSlugs = append(existingSlugs, slug)
+			} else {
+				printer.StepInfo(fmt.Sprintf("App %s not found, skipping", slug))
 			}
 		}
 	} else {

--- a/internal/cli/github_test.go
+++ b/internal/cli/github_test.go
@@ -107,7 +107,6 @@ func TestGitHubSetupCmd_PerRepoRejectsPerOrgFlags(t *testing.T) {
 		flag  string
 		value string
 	}{
-		{"vendor-fullsend-binary", ""},
 		{"enroll-all", ""},
 		{"enroll-none", ""},
 	}

--- a/internal/cli/github_test.go
+++ b/internal/cli/github_test.go
@@ -1,0 +1,541 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fullsend-ai/fullsend/internal/config"
+	"github.com/fullsend-ai/fullsend/internal/forge"
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+// --- Command tree tests ---
+
+func TestGitHubCommand_HasSubcommands(t *testing.T) {
+	cmd := newGitHubCmd()
+	names := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		names[sub.Name()] = true
+	}
+	assert.True(t, names["setup"], "expected setup subcommand")
+	assert.True(t, names["enroll"], "expected enroll subcommand")
+	assert.True(t, names["unenroll"], "expected unenroll subcommand")
+	assert.True(t, names["set"], "expected set subcommand")
+	assert.True(t, names["status"], "expected status subcommand")
+	assert.True(t, names["uninstall"], "expected uninstall subcommand")
+	assert.True(t, names["sync-scaffold"], "expected sync-scaffold subcommand")
+}
+
+func TestGitHubCommand_RegisteredInRoot(t *testing.T) {
+	cmd := newRootCmd()
+	names := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		names[sub.Name()] = true
+	}
+	assert.True(t, names["github"], "expected github subcommand on root")
+}
+
+// --- Setup command tests ---
+
+func TestGitHubSetupCmd_RequiresArg(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "setup"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts 1 arg(s)")
+}
+
+func TestGitHubSetupCmd_Flags(t *testing.T) {
+	cmd := newGitHubSetupCmd()
+
+	mintURLFlag := cmd.Flags().Lookup("mint-url")
+	require.NotNil(t, mintURLFlag, "expected --mint-url flag")
+
+	agentsFlag := cmd.Flags().Lookup("agents")
+	require.NotNil(t, agentsFlag, "expected --agents flag")
+	assert.Equal(t, strings.Join(config.DefaultAgentRoles(), ","), agentsFlag.DefValue)
+
+	dryRunFlag := cmd.Flags().Lookup("dry-run")
+	require.NotNil(t, dryRunFlag, "expected --dry-run flag")
+
+	skipAppSetupFlag := cmd.Flags().Lookup("skip-app-setup")
+	require.NotNil(t, skipAppSetupFlag, "expected --skip-app-setup flag")
+
+	publicFlag := cmd.Flags().Lookup("public")
+	require.NotNil(t, publicFlag, "expected --public flag")
+
+	appSetFlag := cmd.Flags().Lookup("app-set")
+	require.NotNil(t, appSetFlag, "expected --app-set flag")
+	assert.Equal(t, "fullsend-ai", appSetFlag.DefValue)
+
+	enrollAllFlag := cmd.Flags().Lookup("enroll-all")
+	require.NotNil(t, enrollAllFlag, "expected --enroll-all flag")
+
+	enrollNoneFlag := cmd.Flags().Lookup("enroll-none")
+	require.NotNil(t, enrollNoneFlag, "expected --enroll-none flag")
+
+	vendorBinaryFlag := cmd.Flags().Lookup("vendor-fullsend-binary")
+	require.NotNil(t, vendorBinaryFlag, "expected --vendor-fullsend-binary flag")
+
+	inferenceProjectFlag := cmd.Flags().Lookup("inference-project")
+	require.NotNil(t, inferenceProjectFlag, "expected --inference-project flag")
+
+	inferenceRegionFlag := cmd.Flags().Lookup("inference-region")
+	require.NotNil(t, inferenceRegionFlag, "expected --inference-region flag")
+	assert.Equal(t, "global", inferenceRegionFlag.DefValue)
+
+	inferenceWIFFlag := cmd.Flags().Lookup("inference-wif-provider")
+	require.NotNil(t, inferenceWIFFlag, "expected --inference-wif-provider flag")
+}
+
+func TestGitHubSetupCmd_RequiresMintURL(t *testing.T) {
+	t.Setenv("GH_TOKEN", "test-token")
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "setup", "acme"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--mint-url is required")
+}
+
+func TestGitHubSetupCmd_PerRepoRejectsPerOrgFlags(t *testing.T) {
+	perOrgOnly := []struct {
+		flag  string
+		value string
+	}{
+		{"vendor-fullsend-binary", ""},
+		{"enroll-all", ""},
+		{"enroll-none", ""},
+	}
+	for _, tc := range perOrgOnly {
+		t.Run(tc.flag, func(t *testing.T) {
+			cmd := newRootCmd()
+			args := []string{"github", "setup", "acme/widget",
+				"--mint-url", "https://mint-test-abc123.run.app"}
+			if tc.value != "" {
+				args = append(args, "--"+tc.flag, tc.value)
+			} else {
+				args = append(args, "--"+tc.flag)
+			}
+			cmd.SetArgs(args)
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "only valid for per-org")
+		})
+	}
+}
+
+func TestGitHubSetupCmd_ValidatesMintURLHTTPS(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "setup", "acme",
+		"--mint-url", "http://not-secure.run.app"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTPS URL")
+}
+
+func TestGitHubSetupCmd_PerRepoDryRun(t *testing.T) {
+	t.Setenv("GH_TOKEN", "test-token")
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "setup", "acme/widget",
+		"--mint-url", "https://mint-test-abc123.run.app",
+		"--inference-project", "my-project",
+		"--inference-wif-provider", "projects/123456789/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc",
+		"--dry-run"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestGitHubSetupCmd_PerRepoRequiresInferenceProject(t *testing.T) {
+	t.Setenv("GH_TOKEN", "test-token")
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "setup", "acme/widget",
+		"--mint-url", "https://mint-test-abc123.run.app"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--inference-project is required")
+}
+
+func TestGitHubSetupCmd_PerRepoRequiresWIFProvider(t *testing.T) {
+	t.Setenv("GH_TOKEN", "test-token")
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "setup", "acme/widget",
+		"--mint-url", "https://mint-test-abc123.run.app",
+		"--inference-project", "my-project"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--inference-wif-provider is required")
+}
+
+// --- Enroll command tests ---
+
+func TestGitHubEnrollCmd_RequiresOrg(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "enroll"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires at least 1 arg")
+}
+
+func TestGitHubEnrollCmd_RequiresReposOrAllFlag(t *testing.T) {
+	t.Setenv("GH_TOKEN", "test-token")
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "enroll", "testorg"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must specify repository names or use --all flag")
+}
+
+func TestGitHubEnrollCmd_HasAllFlag(t *testing.T) {
+	cmd := newGitHubEnrollCmd()
+	allFlag := cmd.Flags().Lookup("all")
+	require.NotNil(t, allFlag, "expected --all flag")
+	assert.Equal(t, "false", allFlag.DefValue)
+}
+
+func TestGitHubEnrollCmd_DelegatesCorrectly(t *testing.T) {
+	cfg := setupTestConfig(map[string]bool{
+		"web-app": false,
+		"api":     false,
+	})
+	client := setupTestClient("testorg", cfg, []string{"web-app", "api"})
+	printer := ui.New(&discardWriter{})
+
+	err := runEnableRepos(context.Background(), client, printer, "testorg", []string{"web-app"}, false, true)
+	require.NoError(t, err)
+
+	require.Len(t, client.CreatedFiles, 1)
+	updatedCfg, err := config.ParseOrgConfig(client.CreatedFiles[0].Content)
+	require.NoError(t, err)
+	assert.True(t, updatedCfg.Repos["web-app"].Enabled)
+	assert.False(t, updatedCfg.Repos["api"].Enabled)
+}
+
+// --- Unenroll command tests ---
+
+func TestGitHubUnenrollCmd_RequiresOrg(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "unenroll"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires at least 1 arg")
+}
+
+func TestGitHubUnenrollCmd_RequiresReposOrAllFlag(t *testing.T) {
+	t.Setenv("GH_TOKEN", "test-token")
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "unenroll", "testorg"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must specify repository names or use --all flag")
+}
+
+func TestGitHubUnenrollCmd_HasFlags(t *testing.T) {
+	cmd := newGitHubUnenrollCmd()
+	allFlag := cmd.Flags().Lookup("all")
+	require.NotNil(t, allFlag, "expected --all flag")
+	yoloFlag := cmd.Flags().Lookup("yolo")
+	require.NotNil(t, yoloFlag, "expected --yolo flag")
+}
+
+// --- Set command tests ---
+
+func TestGitHubSetCmd_RequiresArgs(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "set"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts 3 arg(s)")
+}
+
+func TestGitHubSetCmd_RejectsUnknownKey(t *testing.T) {
+	t.Setenv("GH_TOKEN", "test-token")
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "set", "acme", "UNKNOWN_KEY", "some-value"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown config key")
+	assert.Contains(t, err.Error(), "FULLSEND_GCP_REGION")
+}
+
+func TestGitHubSetCmd_RejectsMintURL(t *testing.T) {
+	client := forge.NewFakeClient()
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubSet(context.Background(), client, printer, "acme", "FULLSEND_MINT_URL", "https://new-mint.run.app/")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown config key")
+}
+
+func TestGitHubSetCmd_SetsRepoVariable(t *testing.T) {
+	t.Setenv("GH_TOKEN", "test-token")
+	client := forge.NewFakeClient()
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubSet(context.Background(), client, printer, "acme/widget", "FULLSEND_GCP_REGION", "us-east5")
+	require.NoError(t, err)
+
+	require.Len(t, client.Variables, 1)
+	assert.Equal(t, "FULLSEND_GCP_REGION", client.Variables[0].Name)
+	assert.Equal(t, "us-east5", client.Variables[0].Value)
+	assert.Equal(t, "acme", client.Variables[0].Owner)
+	assert.Equal(t, "widget", client.Variables[0].Repo)
+}
+
+func TestGitHubSetCmd_SetsRepoSecret(t *testing.T) {
+	t.Setenv("GH_TOKEN", "test-token")
+	client := forge.NewFakeClient()
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubSet(context.Background(), client, printer, "acme/widget", "FULLSEND_GCP_PROJECT_ID", "my-project-123")
+	require.NoError(t, err)
+
+	require.Len(t, client.CreatedSecrets, 1)
+	assert.Equal(t, "FULLSEND_GCP_PROJECT_ID", client.CreatedSecrets[0].Name)
+	assert.Equal(t, "my-project-123", client.CreatedSecrets[0].Value)
+}
+
+func TestConfigKeyMapping_AllKeys(t *testing.T) {
+	expectedKeys := []string{
+		"FULLSEND_GCP_REGION",
+		forge.PerRepoGuardVar,
+		"FULLSEND_GCP_PROJECT_ID",
+		"FULLSEND_GCP_WIF_PROVIDER",
+	}
+	for _, key := range expectedKeys {
+		_, ok := configKeyMapping[key]
+		assert.True(t, ok, "expected key %s in configKeyMapping", key)
+	}
+	info := configKeyMapping[forge.PerRepoGuardVar]
+	assert.Equal(t, storageVariable, info.storage)
+}
+
+func TestGitHubSetCmd_ValidatesWIFProvider(t *testing.T) {
+	client := forge.NewFakeClient()
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubSet(context.Background(), client, printer, "acme/widget", "FULLSEND_GCP_WIF_PROVIDER", "garbage")
+	require.Error(t, err)
+}
+
+func TestGitHubSetCmd_ValidatesTarget(t *testing.T) {
+	client := forge.NewFakeClient()
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubSet(context.Background(), client, printer, "-invalid", "FULLSEND_GCP_REGION", "us-east5")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot start or end with a hyphen")
+}
+
+func TestGitHubSetCmd_ValidatesRepoTarget(t *testing.T) {
+	client := forge.NewFakeClient()
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubSet(context.Background(), client, printer, "/repo", "FULLSEND_GCP_REGION", "us-east5")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid owner name")
+}
+
+func TestRunGitHubStatus_NonNotFoundError(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.Errors = map[string]error{
+		"GetRepo": fmt.Errorf("permission denied"),
+	}
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubStatus(context.Background(), client, printer, "acme")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checking config repo")
+}
+
+// --- Status command tests ---
+
+func TestGitHubStatusCmd_RequiresOrg(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "status"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts 1 arg(s)")
+}
+
+func TestGitHubStatusCmd_ValidatesOrg(t *testing.T) {
+	t.Setenv("GH_TOKEN", "test-token")
+	cmd := newRootCmd()
+	// Use "--" to prevent cobra from parsing the org name as a flag.
+	cmd.SetArgs([]string{"github", "status", "--", "-leading"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot start or end with a hyphen")
+}
+
+func TestRunGitHubStatus_BasicReport(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.Repos = []forge.Repository{
+		{Name: ".fullsend", FullName: "acme/.fullsend"},
+	}
+	cfg := config.NewOrgConfig([]string{"widget"}, []string{"widget"}, []string{"triage"}, nil, "")
+	cfgData, _ := cfg.Marshal()
+	client.FileContents["acme/.fullsend/config.yaml"] = cfgData
+	client.OrgVariables = map[string]bool{"acme/FULLSEND_MINT_URL": true}
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubStatus(context.Background(), client, printer, "acme")
+	require.NoError(t, err)
+}
+
+func TestRunGitHubStatus_NoConfigRepo(t *testing.T) {
+	client := forge.NewFakeClient()
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubStatus(context.Background(), client, printer, "acme")
+	require.NoError(t, err)
+}
+
+// --- Uninstall command tests ---
+
+func TestGitHubUninstallCmd_RequiresOrg(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "uninstall"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts 1 arg(s)")
+}
+
+func TestGitHubUninstallCmd_HasFlags(t *testing.T) {
+	cmd := newGitHubUninstallCmd()
+	yoloFlag := cmd.Flags().Lookup("yolo")
+	require.NotNil(t, yoloFlag, "expected --yolo flag")
+	appSetFlag := cmd.Flags().Lookup("app-set")
+	require.NotNil(t, appSetFlag, "expected --app-set flag")
+}
+
+func TestRunGitHubUninstall_DeletesResources(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.Repos = []forge.Repository{
+		{Name: ".fullsend", FullName: "acme/.fullsend"},
+	}
+	client.OrgVariables = map[string]bool{"acme/FULLSEND_MINT_URL": true}
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubUninstall(context.Background(), client, printer, "acme", "fullsend-ai")
+	require.NoError(t, err)
+
+	// Verify repo was deleted.
+	assert.Contains(t, client.DeletedRepos, "acme/.fullsend")
+	// Verify org variable was deleted.
+	assert.Contains(t, client.DeletedOrgVariables, "acme/FULLSEND_MINT_URL")
+}
+
+func TestRunGitHubUninstall_NoConfigRepo(t *testing.T) {
+	client := forge.NewFakeClient()
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubUninstall(context.Background(), client, printer, "acme", "fullsend-ai")
+	require.NoError(t, err)
+}
+
+// --- Sync-scaffold command tests ---
+
+func TestGitHubSyncScaffoldCmd_RequiresOrg(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"github", "sync-scaffold"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts 1 arg(s)")
+}
+
+func TestRunGitHubSyncScaffold_CommitsFiles(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.Repos = []forge.Repository{
+		{Name: ".fullsend", FullName: "acme/.fullsend"},
+	}
+	client.AuthenticatedUser = "testuser"
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubSyncScaffold(context.Background(), client, printer, "acme")
+	require.NoError(t, err)
+
+	// Verify at least one file was committed.
+	require.NotEmpty(t, client.CommittedFiles, "expected scaffold files to be committed")
+}
+
+// --- parseTarget tests ---
+
+func TestParseTarget_Org(t *testing.T) {
+	owner, repo, isRepo := parseTarget("acme")
+	assert.Equal(t, "acme", owner)
+	assert.Equal(t, "", repo)
+	assert.False(t, isRepo)
+}
+
+func TestParseTarget_Repo(t *testing.T) {
+	owner, repo, isRepo := parseTarget("acme/widget")
+	assert.Equal(t, "acme", owner)
+	assert.Equal(t, "widget", repo)
+	assert.True(t, isRepo)
+}
+
+// --- Per-repo setup business logic tests ---
+
+func TestRunGitHubSetupPerRepo(t *testing.T) {
+	t.Setenv("GH_TOKEN", "test-token")
+	client := forge.NewFakeClient()
+	client.TokenScopes = []string{"repo", "workflow"}
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubSetupPerRepo(context.Background(), client, printer, githubSetupConfig{
+		target:              "acme/widget",
+		mintURL:             "https://mint-test-abc123.run.app",
+		inferenceProject:    "my-project",
+		inferenceWIFProvider: "projects/123456789/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc",
+		inferenceRegion:     "global",
+		agents:              strings.Join(config.PerRepoDefaultRoles(), ","),
+	})
+	require.NoError(t, err)
+
+	// Verify scaffold files were committed.
+	require.NotEmpty(t, client.CommittedFiles)
+
+	// Verify repo variables were set.
+	varNames := make(map[string]string)
+	for _, v := range client.Variables {
+		varNames[v.Name] = v.Value
+	}
+	assert.Equal(t, "https://mint-test-abc123.run.app", varNames["FULLSEND_MINT_URL"])
+	assert.Equal(t, "global", varNames["FULLSEND_GCP_REGION"])
+	assert.Equal(t, "true", varNames["FULLSEND_PER_REPO_INSTALL"])
+
+	// Verify repo secrets were set.
+	secretNames := make(map[string]string)
+	for _, s := range client.CreatedSecrets {
+		secretNames[s.Name] = s.Value
+	}
+	assert.Equal(t, "my-project", secretNames["FULLSEND_GCP_PROJECT_ID"])
+	assert.Contains(t, secretNames, "FULLSEND_GCP_WIF_PROVIDER")
+}
+
+func TestRunGitHubSetupPerRepo_DryRun(t *testing.T) {
+	t.Setenv("GH_TOKEN", "test-token")
+	client := forge.NewFakeClient()
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubSetupPerRepo(context.Background(), client, printer, githubSetupConfig{
+		target:              "acme/widget",
+		mintURL:             "https://mint-test-abc123.run.app",
+		inferenceProject:    "my-project",
+		inferenceWIFProvider: "projects/123456789/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc",
+		inferenceRegion:     "global",
+		agents:              strings.Join(config.PerRepoDefaultRoles(), ","),
+		dryRun:              true,
+	})
+	require.NoError(t, err)
+
+	// Verify nothing was actually written.
+	assert.Empty(t, client.CommittedFiles)
+	assert.Empty(t, client.Variables)
+	assert.Empty(t, client.CreatedSecrets)
+}

--- a/internal/cli/github_test.go
+++ b/internal/cli/github_test.go
@@ -517,6 +517,73 @@ func TestRunGitHubSetupPerRepo(t *testing.T) {
 	assert.Contains(t, secretNames, "FULLSEND_GCP_WIF_PROVIDER")
 }
 
+func TestGitHubSetCmd_OrgTargetDefaultsToConfigRepo(t *testing.T) {
+	client := forge.NewFakeClient()
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubSet(context.Background(), client, printer, "acme", "FULLSEND_GCP_REGION", "us-east5")
+	require.NoError(t, err)
+
+	// Org target should default to .fullsend repo.
+	require.Len(t, client.Variables, 1)
+	assert.Equal(t, "FULLSEND_GCP_REGION", client.Variables[0].Name)
+	assert.Equal(t, "us-east5", client.Variables[0].Value)
+	assert.Equal(t, "acme", client.Variables[0].Owner)
+	assert.Equal(t, forge.ConfigRepoName, client.Variables[0].Repo)
+}
+
+func TestGitHubSetCmd_OrgTargetSecretDefaultsToConfigRepo(t *testing.T) {
+	client := forge.NewFakeClient()
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubSet(context.Background(), client, printer, "acme", "FULLSEND_GCP_PROJECT_ID", "my-project")
+	require.NoError(t, err)
+
+	require.Len(t, client.CreatedSecrets, 1)
+	assert.Equal(t, "FULLSEND_GCP_PROJECT_ID", client.CreatedSecrets[0].Name)
+	assert.Equal(t, "my-project", client.CreatedSecrets[0].Value)
+	assert.Equal(t, "acme", client.CreatedSecrets[0].Owner)
+	assert.Equal(t, forge.ConfigRepoName, client.CreatedSecrets[0].Repo)
+}
+
+func TestRunGitHubUninstall_ListInstallationsError(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.Repos = []forge.Repository{
+		{Name: ".fullsend", FullName: "acme/.fullsend"},
+	}
+	client.Errors = map[string]error{
+		"ListOrgInstallations": fmt.Errorf("insufficient permissions"),
+	}
+	printer := ui.New(&discardWriter{})
+
+	err := runGitHubUninstall(context.Background(), client, printer, "acme", "fullsend-ai")
+	require.NoError(t, err)
+
+	// Verify repo was still deleted despite ListOrgInstallations failure.
+	assert.Contains(t, client.DeletedRepos, "acme/.fullsend")
+}
+
+func TestParseTarget_MultipleSlashes(t *testing.T) {
+	owner, repo, isRepo := parseTarget("acme/widget/extra")
+	assert.Equal(t, "acme", owner)
+	assert.Equal(t, "widget/extra", repo)
+	assert.True(t, isRepo)
+}
+
+func TestParseTarget_EmptyString(t *testing.T) {
+	owner, repo, isRepo := parseTarget("")
+	assert.Equal(t, "", owner)
+	assert.Equal(t, "", repo)
+	assert.False(t, isRepo)
+}
+
+func TestParseTarget_JustSlash(t *testing.T) {
+	owner, repo, isRepo := parseTarget("/")
+	assert.Equal(t, "", owner)
+	assert.Equal(t, "", repo)
+	assert.True(t, isRepo)
+}
+
 func TestRunGitHubSetupPerRepo_DryRun(t *testing.T) {
 	t.Setenv("GH_TOKEN", "test-token")
 	client := forge.NewFakeClient()

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -21,6 +21,7 @@ func newRootCmd() *cobra.Command {
 		Version:       version,
 	}
 	cmd.AddCommand(newAdminCmd())
+	cmd.AddCommand(newGitHubCmd())
 	cmd.AddCommand(newInferenceCmd())
 	cmd.AddCommand(newMintCmd())
 	cmd.AddCommand(newRunCmd())


### PR DESCRIPTION
## Summary

- Adds `fullsend github` sub-command tree with 7 commands: `setup`, `enroll`, `unenroll`, `set`, `status`, `uninstall`, `sync-scaffold`
- Extracts all GitHub-side operations from `admin install` so GitHub org admins can manage repos using pre-provisioned mint URL and WIF values without GCP credentials
- `setup` handles both per-org and per-repo installation using the existing layer stack with `skipMintDispatcher`
- `set` unifies secret/variable updates behind an internal key mapping, enabling transparent migration from secrets to variables
- `enroll`/`unenroll` delegate to existing enable/disable logic for lightweight config.yaml toggles

## Test plan

- [ ] `go test ./internal/cli/...` passes (39 new tests)
- [ ] `go vet ./internal/cli/...` clean
- [ ] Verify `fullsend github --help` shows all 7 sub-commands
- [ ] Verify `fullsend github setup --help` shows all flags
- [ ] Verify `fullsend github set --help` shows usage
- [ ] Verify no GCP credentials are required for any command
- [ ] E2E: `fullsend github setup <org> --mint-url=<url> --skip-app-setup` runs layer stack without GCP calls
- [ ] E2E: `fullsend github set <org> FULLSEND_MINT_URL <url>` sets org variable
- [ ] E2E: `fullsend github sync-scaffold <org>` updates workflows only