### PR TITLE
fix(admin): show CLI version in banner

### DIFF
--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -309,7 +309,7 @@ Inference authentication:
 			printer := ui.New(os.Stdout)
 			ctx := cmd.Context()
 
-			printer.Banner()
+			printer.Banner(Version())
 			printer.Blank()
 			printer.Header("Installing fullsend for " + org)
 			printer.Blank()
@@ -603,7 +603,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 	client := gh.New(token)
 	printer := ui.New(os.Stdout)
 
-	printer.Banner()
+	printer.Banner(Version())
 	printer.Blank()
 	printer.Header("Installing per-repo fullsend for " + repoFullName)
 	printer.Blank()
@@ -1048,7 +1048,7 @@ func newUninstallCmd() *cobra.Command {
 			printer := ui.New(os.Stdout)
 			ctx := cmd.Context()
 
-			printer.Banner()
+			printer.Banner(Version())
 			printer.Blank()
 			printer.Header("Uninstalling fullsend from " + org)
 			printer.Blank()
@@ -1096,7 +1096,7 @@ func newAnalyzeCmd() *cobra.Command {
 			printer := ui.New(os.Stdout)
 			ctx := cmd.Context()
 
-			printer.Banner()
+			printer.Banner(Version())
 			printer.Blank()
 			printer.Header("Analyzing fullsend installation for " + org)
 			printer.Blank()
@@ -2077,7 +2077,7 @@ func newDisableReposCmd() *cobra.Command {
 // The yolo parameter is accepted for signature compatibility with reposRunFunc but is unused
 // since enable has no destructive operations that require confirmation.
 func runEnableRepos(ctx context.Context, client forge.Client, printer *ui.Printer, org string, repos []string, all bool, yolo bool) error {
-	printer.Banner()
+	printer.Banner(Version())
 	printer.Blank()
 	printer.Header("Enabling repositories for " + org)
 	printer.Blank()
@@ -2190,7 +2190,7 @@ func runEnableRepos(ctx context.Context, client forge.Client, printer *ui.Printe
 
 // runDisableRepos disables the specified repositories from fullsend enrollment.
 func runDisableRepos(ctx context.Context, client forge.Client, printer *ui.Printer, org string, repos []string, all bool, yolo bool) error {
-	printer.Banner()
+	printer.Banner(Version())
 	printer.Blank()
 	printer.Header("Disabling repositories for " + org)
 	printer.Blank()

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -77,7 +77,7 @@ func newRunCmd() *cobra.Command {
 }
 
 func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary string, envFiles []string, noPostScript bool, debug string, printer *ui.Printer) (runErr error) {
-	printer.Banner()
+	printer.Banner(Version())
 	printer.Blank()
 	printer.Header("Running agent: " + agentName)
 	printer.Blank()

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -32,10 +32,14 @@ func New(w io.Writer) *Printer {
 }
 
 // Banner prints the fullsend brand banner with tagline.
-func (p *Printer) Banner() {
+func (p *Printer) Banner(version string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	brand := lipgloss.NewStyle().Bold(true).Foreground(ColorBrand).Render("fullsend")
+	brandText := "fullsend"
+	if version != "" {
+		brandText += " " + version
+	}
+	brand := lipgloss.NewStyle().Bold(true).Foreground(ColorBrand).Render(brandText)
 	fmt.Fprintf(p.w, "\u26a1 %s\n", brand)
 	tagline := lipgloss.NewStyle().Foreground(ColorMuted).Render("Autonomous agentic development for GitHub organizations")
 	fmt.Fprintf(p.w, "  %s\n", tagline)

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -10,9 +10,19 @@ import (
 func TestBanner(t *testing.T) {
 	var buf bytes.Buffer
 	p := New(&buf)
-	p.Banner()
+	p.Banner("v1.2.3")
 	out := buf.String()
 	assert.Contains(t, out, "fullsend")
+	assert.Contains(t, out, "v1.2.3")
+}
+
+func TestBannerIncludesDevVersion(t *testing.T) {
+	var buf bytes.Buffer
+	p := New(&buf)
+	p.Banner("dev")
+	out := buf.String()
+	assert.Contains(t, out, "fullsend")
+	assert.Contains(t, out, "dev")
 }
 
 func TestHeader(t *testing.T) {


### PR DESCRIPTION
## Summary
- include the CLI version on the fullsend banner line
- pass cli.Version() from CLI call sites instead of coupling the UI package to cli
- cover release-style and dev banner values in ui tests

Fixes #1249

## Validation
- go test ./internal/ui ./internal/cli
- GH_TOKEN= GITHUB_TOKEN= go test ./...