### PR TITLE
fix(cli): join Claude command args

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1152,38 +1152,43 @@ func refreshOIDCToken(ctx context.Context, sandboxName, oidcURL, oidcAuth string
 func buildClaudeCommand(agentName, model, repoDir string, pluginDirs []string, debug string) string {
 	envFile := sandbox.SandboxWorkspace + "/.env"
 
-	// Defense-in-depth: escape single quotes even though Validate() rejects them.
-	safe := strings.ReplaceAll(agentName, "'", "'\\''")
-
-	modelFlag := ""
-	if model != "" {
-		modelFlag = fmt.Sprintf("--model '%s' ", strings.ReplaceAll(model, "'", "'\\''"))
+	claudeParts := []string{
+		"claude",
+		"--print",
+		"--verbose",
+		"--output-format",
+		"stream-json",
 	}
 
-	var pluginDirParts []string
-	for _, pd := range pluginDirs {
-		pluginDirParts = append(pluginDirParts, fmt.Sprintf("--plugin-dir '%s'", strings.ReplaceAll(pd, "'", "'\\''")))
-	}
-	pluginDirFlags := ""
-	if len(pluginDirParts) > 0 {
-		pluginDirFlags = strings.Join(pluginDirParts, " ") + " "
-	}
-
-	debugFlags := ""
 	if debug != "" {
-		debugFlags = fmt.Sprintf("--debug-file '%s/%s' ", sandbox.SandboxWorkspace, claudeDebugLog)
+		claudeParts = append(claudeParts, "--debug-file", shellSingleQuote(sandbox.SandboxWorkspace+"/"+claudeDebugLog))
 		if debug != "*" {
-			debugFlags += fmt.Sprintf("--debug '%s' ", strings.ReplaceAll(debug, "'", "'\\''"))
+			claudeParts = append(claudeParts, "--debug", shellSingleQuote(debug))
 		}
 	}
+	if model != "" {
+		claudeParts = append(claudeParts, "--model", shellSingleQuote(model))
+	}
+	for _, pd := range pluginDirs {
+		claudeParts = append(claudeParts, "--plugin-dir", shellSingleQuote(pd))
+	}
+	claudeParts = append(
+		claudeParts,
+		"--agent", shellSingleQuote(agentName),
+		"--dangerously-skip-permissions", shellSingleQuote("Run the agent task"),
+	)
 
 	return fmt.Sprintf(
 		// --verbose increases log output in the job log. If artifact upload is
 		// added to this workflow, consider whether verbose output should be
 		// redacted or made conditional via an env var.
-		"cd %s && . %s && claude --print --verbose --output-format stream-json %s%s%s--agent '%s' --dangerously-skip-permissions 'Run the agent task'",
-		repoDir, envFile, debugFlags, modelFlag, pluginDirFlags, safe,
+		"cd %s && . %s && %s",
+		repoDir, envFile, strings.Join(claudeParts, " "),
 	)
+}
+
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 // buildScanContextCommand builds the command to run `fullsend scan context`

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -147,6 +147,17 @@ func TestBuildClaudeCommand_DebugEscapesQuotes(t *testing.T) {
 	assert.Contains(t, cmd, "--debug 'api'\\''hooks'")
 }
 
+func TestBuildClaudeCommand_AllOptionalFlagsHaveSingleSeparators(t *testing.T) {
+	cmd := buildClaudeCommand("agent", "sonnet", "/tmp/workspace/repo", []string{
+		"/tmp/claude-config/plugins/gopls-lsp",
+		"/tmp/claude-config/plugins/other-lsp",
+	}, "api,hooks")
+
+	assert.Contains(t, cmd, "--output-format stream-json --debug-file '/tmp/workspace/claude-debug.log' --debug 'api,hooks' --model 'sonnet' --plugin-dir '/tmp/claude-config/plugins/gopls-lsp' --plugin-dir '/tmp/claude-config/plugins/other-lsp' --agent 'agent'")
+	assert.NotContains(t, cmd, "  ")
+	assert.NotContains(t, cmd, "log--agent")
+}
+
 func TestBuildPluginConfigs_SinglePlugin(t *testing.T) {
 	dir := t.TempDir()
 	pluginDir := filepath.Join(dir, "gopls-lsp")


### PR DESCRIPTION
Fixes #1148.

## What changed
- Build the Claude invocation from a `[]string` and `strings.Join` instead of optional flag fragments that carry trailing spaces.
- Added `shellSingleQuote` so every optional value is quoted the same way.
- Added coverage for all optional flags together, verifying the command has single separators and does not concatenate `--debug-file` into `--agent`.

## Validation
- `go test ./internal/cli -run TestBuildClaudeCommand -count=1`
- `go test ./internal/cli ./internal/ui -count=1`
- `GH_TOKEN= GITHUB_TOKEN= go test ./...`
- `git diff --check`