### PR TITLE
feat: add sandbox creation failure tolerance

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -241,7 +241,7 @@ runs:
       run: |
         IMAGE="${FULLSEND_SANDBOX_IMAGE:-ghcr.io/fullsend-ai/fullsend-code:latest}"
         echo "Pre-pulling sandbox image: ${IMAGE}"
-        podman pull "${IMAGE}" || echo "::warning::Image pre-pull failed; sandbox create will pull on demand"
+        timeout 300 podman pull -- "${IMAGE}" || echo "::warning::Image pre-pull failed; sandbox create will pull on demand"
 
     - name: Install validation dependencies
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -236,6 +236,13 @@ runs:
         openshell gateway add http://127.0.0.1:8080 --local --name local
         openshell gateway select local
 
+    - name: Pre-pull sandbox image
+      shell: bash
+      run: |
+        IMAGE="${FULLSEND_SANDBOX_IMAGE:-ghcr.io/fullsend-ai/fullsend-code:latest}"
+        echo "Pre-pulling sandbox image: ${IMAGE}"
+        podman pull "${IMAGE}" || echo "::warning::Image pre-pull failed; sandbox create will pull on demand"
+
     - name: Install validation dependencies
       shell: bash
       run: pip install --quiet "jsonschema>=4.18.0"

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -248,7 +248,7 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary str
 	printer.StepStart("Creating sandbox: " + sandboxName)
 
 	readyTimeout := time.Duration(h.SandboxTimeoutSeconds) * time.Second
-	if err := sandbox.CreateWithRetry(sandboxName, h.Providers, h.Image, h.Policy, 3, readyTimeout); err != nil {
+	if err := sandbox.CreateWithRetry(sandboxName, h.Providers, h.Image, h.Policy, sandbox.DefaultMaxCreateAttempts, readyTimeout); err != nil {
 		printer.StepFail("Failed to create sandbox")
 		return fmt.Errorf("creating sandbox: %w", err)
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -247,7 +247,8 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary str
 	createStart := time.Now()
 	printer.StepStart("Creating sandbox: " + sandboxName)
 
-	if err := sandbox.Create(sandboxName, h.Providers, h.Image, h.Policy); err != nil {
+	readyTimeout := time.Duration(h.SandboxTimeoutSeconds) * time.Second
+	if err := sandbox.CreateWithRetry(sandboxName, h.Providers, h.Image, h.Policy, 3, readyTimeout); err != nil {
 		printer.StepFail("Failed to create sandbox")
 		return fmt.Errorf("creating sandbox: %w", err)
 	}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -249,8 +249,8 @@ func (h *Harness) Validate() error {
 	if h.TimeoutMinutes < 0 {
 		return fmt.Errorf("timeout_minutes must be non-negative, got %d", h.TimeoutMinutes)
 	}
-	if h.SandboxTimeoutSeconds < 0 {
-		return fmt.Errorf("sandbox_timeout_seconds must be non-negative, got %d", h.SandboxTimeoutSeconds)
+	if h.SandboxTimeoutSeconds < 0 || h.SandboxTimeoutSeconds > 600 {
+		return fmt.Errorf("sandbox_timeout_seconds must be between 0 and 600, got %d", h.SandboxTimeoutSeconds)
 	}
 	for i, hf := range h.HostFiles {
 		if hf.Src == "" {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -203,9 +203,9 @@ type Harness struct {
 	AgentInput     string            `yaml:"agent_input,omitempty"`
 	ValidationLoop *ValidationLoop   `yaml:"validation_loop,omitempty"`
 	RunnerEnv      map[string]string `yaml:"runner_env,omitempty"`
-	TimeoutMinutes        int               `yaml:"timeout_minutes,omitempty"`
-	SandboxTimeoutSeconds int               `yaml:"sandbox_timeout_seconds,omitempty"`
-	Security              *SecurityConfig   `yaml:"security,omitempty"`
+	TimeoutMinutes        int             `yaml:"timeout_minutes,omitempty"`
+	SandboxTimeoutSeconds int             `yaml:"sandbox_timeout_seconds,omitempty"`
+	Security              *SecurityConfig `yaml:"security,omitempty"`
 }
 
 // Load reads a harness YAML file from path, unmarshals it, and validates it.
@@ -249,8 +249,8 @@ func (h *Harness) Validate() error {
 	if h.TimeoutMinutes < 0 {
 		return fmt.Errorf("timeout_minutes must be non-negative, got %d", h.TimeoutMinutes)
 	}
-	if h.SandboxTimeoutSeconds < 0 || h.SandboxTimeoutSeconds > 600 {
-		return fmt.Errorf("sandbox_timeout_seconds must be between 0 and 600, got %d", h.SandboxTimeoutSeconds)
+	if h.SandboxTimeoutSeconds != 0 && (h.SandboxTimeoutSeconds < 30 || h.SandboxTimeoutSeconds > 600) {
+		return fmt.Errorf("sandbox_timeout_seconds must be 0 (default) or between 30 and 600, got %d", h.SandboxTimeoutSeconds)
 	}
 	for i, hf := range h.HostFiles {
 		if hf.Src == "" {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -203,8 +203,9 @@ type Harness struct {
 	AgentInput     string            `yaml:"agent_input,omitempty"`
 	ValidationLoop *ValidationLoop   `yaml:"validation_loop,omitempty"`
 	RunnerEnv      map[string]string `yaml:"runner_env,omitempty"`
-	TimeoutMinutes int               `yaml:"timeout_minutes,omitempty"`
-	Security       *SecurityConfig   `yaml:"security,omitempty"`
+	TimeoutMinutes        int               `yaml:"timeout_minutes,omitempty"`
+	SandboxTimeoutSeconds int               `yaml:"sandbox_timeout_seconds,omitempty"`
+	Security              *SecurityConfig   `yaml:"security,omitempty"`
 }
 
 // Load reads a harness YAML file from path, unmarshals it, and validates it.
@@ -247,6 +248,9 @@ func (h *Harness) Validate() error {
 	}
 	if h.TimeoutMinutes < 0 {
 		return fmt.Errorf("timeout_minutes must be non-negative, got %d", h.TimeoutMinutes)
+	}
+	if h.SandboxTimeoutSeconds < 0 {
+		return fmt.Errorf("sandbox_timeout_seconds must be non-negative, got %d", h.SandboxTimeoutSeconds)
 	}
 	for i, hf := range h.HostFiles {
 		if hf.Src == "" {

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -494,7 +494,19 @@ func TestValidate_NegativeSandboxTimeout(t *testing.T) {
 	h := &Harness{Agent: "agents/test.md", SandboxTimeoutSeconds: -1}
 	err := h.Validate()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "sandbox_timeout_seconds must be non-negative")
+	assert.Contains(t, err.Error(), "sandbox_timeout_seconds must be between 0 and 600")
+}
+
+func TestValidate_SandboxTimeoutTooLarge(t *testing.T) {
+	h := &Harness{Agent: "agents/test.md", SandboxTimeoutSeconds: 601}
+	err := h.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sandbox_timeout_seconds must be between 0 and 600")
+}
+
+func TestValidate_SandboxTimeoutAtMax(t *testing.T) {
+	h := &Harness{Agent: "agents/test.md", SandboxTimeoutSeconds: 600}
+	require.NoError(t, h.Validate())
 }
 
 func TestValidate_ZeroSandboxTimeout(t *testing.T) {

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -494,14 +494,26 @@ func TestValidate_NegativeSandboxTimeout(t *testing.T) {
 	h := &Harness{Agent: "agents/test.md", SandboxTimeoutSeconds: -1}
 	err := h.Validate()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "sandbox_timeout_seconds must be between 0 and 600")
+	assert.Contains(t, err.Error(), "sandbox_timeout_seconds must be 0 (default) or between 30 and 600")
+}
+
+func TestValidate_SandboxTimeoutTooSmall(t *testing.T) {
+	h := &Harness{Agent: "agents/test.md", SandboxTimeoutSeconds: 10}
+	err := h.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sandbox_timeout_seconds must be 0 (default) or between 30 and 600")
 }
 
 func TestValidate_SandboxTimeoutTooLarge(t *testing.T) {
 	h := &Harness{Agent: "agents/test.md", SandboxTimeoutSeconds: 601}
 	err := h.Validate()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "sandbox_timeout_seconds must be between 0 and 600")
+	assert.Contains(t, err.Error(), "sandbox_timeout_seconds must be 0 (default) or between 30 and 600")
+}
+
+func TestValidate_SandboxTimeoutAtMin(t *testing.T) {
+	h := &Harness{Agent: "agents/test.md", SandboxTimeoutSeconds: 30}
+	require.NoError(t, h.Validate())
 }
 
 func TestValidate_SandboxTimeoutAtMax(t *testing.T) {

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -490,6 +490,37 @@ func TestValidate_NegativeTimeout(t *testing.T) {
 	assert.Contains(t, err.Error(), "timeout_minutes must be non-negative")
 }
 
+func TestValidate_NegativeSandboxTimeout(t *testing.T) {
+	h := &Harness{Agent: "agents/test.md", SandboxTimeoutSeconds: -1}
+	err := h.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sandbox_timeout_seconds must be non-negative")
+}
+
+func TestValidate_ZeroSandboxTimeout(t *testing.T) {
+	h := &Harness{Agent: "agents/test.md", SandboxTimeoutSeconds: 0}
+	require.NoError(t, h.Validate())
+}
+
+func TestValidate_PositiveSandboxTimeout(t *testing.T) {
+	h := &Harness{Agent: "agents/test.md", SandboxTimeoutSeconds: 180}
+	require.NoError(t, h.Validate())
+}
+
+func TestLoad_SandboxTimeoutField(t *testing.T) {
+	content := `
+agent: agents/test.md
+sandbox_timeout_seconds: 180
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	h, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, 180, h.SandboxTimeoutSeconds)
+}
+
 func TestLoad_ModelField(t *testing.T) {
 	content := `
 agent: agents/test.md

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -18,12 +18,13 @@ const (
 	// SandboxClaudeConfig is the Claude config directory inside the sandbox.
 	SandboxClaudeConfig = "/tmp/claude-config" //nolint:gosec // not a credential
 
-	createTimeout   = 130 * time.Second
 	readyTimeout    = 120 * time.Second
 	readyPoll       = 2 * time.Second
+	readyCtxBuffer  = 10 * time.Second
+	maxReadyTimeout = 600 * time.Second
 	transferTimeout = 5 * time.Minute
 
-	defaultMaxCreateAttempts = 3
+	DefaultMaxCreateAttempts = 3
 	retryInitialBackoff      = 5 * time.Second
 	retryMaxBackoff          = 15 * time.Second
 )
@@ -157,21 +158,24 @@ func CheckGateway() error {
 // explicit override (from harness config) > FULLSEND_SANDBOX_READY_TIMEOUT
 // env var > package default.
 func effectiveReadyTimeout(override time.Duration) time.Duration {
+	t := readyTimeout
 	if override > 0 {
-		return override
-	}
-	if envVal := os.Getenv("FULLSEND_SANDBOX_READY_TIMEOUT"); envVal != "" {
+		t = override
+	} else if envVal := os.Getenv("FULLSEND_SANDBOX_READY_TIMEOUT"); envVal != "" {
 		if d, err := time.ParseDuration(envVal); err == nil && d > 0 {
-			return d
+			t = d
 		}
 	}
-	return readyTimeout
+	if t > maxReadyTimeout {
+		t = maxReadyTimeout
+	}
+	return t
 }
 
 // Create creates a persistent OpenShell sandbox and waits for it to be ready,
 // retrying up to defaultMaxCreateAttempts times with exponential backoff.
 func Create(name string, providers []string, image, policy string) error {
-	return CreateWithRetry(name, providers, image, policy, defaultMaxCreateAttempts, 0)
+	return CreateWithRetry(name, providers, image, policy, DefaultMaxCreateAttempts, 0)
 }
 
 // CreateWithRetry creates a sandbox, retrying up to maxAttempts times with
@@ -179,6 +183,10 @@ func Create(name string, providers []string, image, policy string) error {
 // deleted to avoid name conflicts. If readyTimeoutOverride is positive, it
 // overrides the default ready timeout.
 func CreateWithRetry(name string, providers []string, image, policy string, maxAttempts int, readyTimeoutOverride time.Duration) error {
+	if maxAttempts < 1 {
+		return fmt.Errorf("maxAttempts must be >= 1, got %d", maxAttempts)
+	}
+
 	timeout := effectiveReadyTimeout(readyTimeoutOverride)
 
 	var lastErr error
@@ -188,19 +196,24 @@ func CreateWithRetry(name string, providers []string, image, policy string, maxA
 			return nil
 		}
 
-		// Clean up failed sandbox before retry.
-		_ = Delete(name)
+		if delErr := Delete(name); delErr != nil {
+			fmt.Fprintf(os.Stderr, "  Warning: cleanup of sandbox %s failed: %v\n", name, delErr)
+		}
 
 		if attempt < maxAttempts {
-			backoff := retryInitialBackoff * time.Duration(1<<uint(attempt-1))
+			shift := uint(attempt - 1)
+			if shift > 30 {
+				shift = 30
+			}
+			backoff := retryInitialBackoff * time.Duration(1<<shift)
 			if backoff > retryMaxBackoff {
 				backoff = retryMaxBackoff
 			}
-			fmt.Fprintf(os.Stderr, "  Sandbox creation attempt %d/%d failed, retrying in %s...\n", attempt, maxAttempts, backoff)
+			fmt.Fprintf(os.Stderr, "  Sandbox creation attempt %d/%d failed (%v), retrying in %s...\n", attempt, maxAttempts, lastErr, backoff)
 			time.Sleep(backoff)
 		}
 	}
-	return lastErr
+	return fmt.Errorf("sandbox creation failed after %d attempts: %w", maxAttempts, lastErr)
 }
 
 // createOnce creates a persistent OpenShell sandbox and waits for it to be
@@ -208,8 +221,7 @@ func CreateWithRetry(name string, providers []string, image, policy string, maxA
 // is non-empty, it is passed as --from to start the sandbox from a container
 // image. If policy is non-empty, it is applied at creation time via --policy.
 func createOnce(name string, providers []string, image, policy string, timeout time.Duration) error {
-	ctxTimeout := timeout + 10*time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout+readyCtxBuffer)
 	defer cancel()
 
 	args := []string{
@@ -237,7 +249,7 @@ func createOnce(name string, providers []string, image, policy string, timeout t
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {
-		check := exec.Command("openshell", "sandbox", "get", name)
+		check := exec.CommandContext(ctx, "openshell", "sandbox", "get", name)
 		if checkErr := check.Run(); checkErr != nil {
 			return fmt.Errorf("sandbox create failed: %s", string(out))
 		}
@@ -247,7 +259,7 @@ func createOnce(name string, providers []string, image, policy string, timeout t
 	deadline := time.Now().Add(timeout)
 	var lastOutput, lastStderr string
 	for time.Now().Before(deadline) {
-		check := exec.Command("openshell", "sandbox", "get", name)
+		check := exec.CommandContext(ctx, "openshell", "sandbox", "get", name)
 		var stdoutBuf, stderrBuf strings.Builder
 		check.Stdout = &stdoutBuf
 		check.Stderr = &stderrBuf

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -172,8 +172,9 @@ func effectiveReadyTimeout(override time.Duration) time.Duration {
 	return t
 }
 
-// Create creates a persistent OpenShell sandbox and waits for it to be ready,
-// retrying up to defaultMaxCreateAttempts times with exponential backoff.
+// Create creates a persistent OpenShell sandbox and waits for it to be ready.
+// It retries up to DefaultMaxCreateAttempts times with exponential backoff,
+// deleting the failed sandbox between attempts.
 func Create(name string, providers []string, image, policy string) error {
 	return CreateWithRetry(name, providers, image, policy, DefaultMaxCreateAttempts, 0)
 }

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -18,10 +18,14 @@ const (
 	// SandboxClaudeConfig is the Claude config directory inside the sandbox.
 	SandboxClaudeConfig = "/tmp/claude-config" //nolint:gosec // not a credential
 
-	createTimeout   = 65 * time.Second
-	readyTimeout    = 60 * time.Second
+	createTimeout   = 130 * time.Second
+	readyTimeout    = 120 * time.Second
 	readyPoll       = 2 * time.Second
 	transferTimeout = 5 * time.Minute
+
+	defaultMaxCreateAttempts = 3
+	retryInitialBackoff      = 5 * time.Second
+	retryMaxBackoff          = 15 * time.Second
 )
 
 func sanitizeDownload(localDir string) error {
@@ -149,12 +153,63 @@ func CheckGateway() error {
 	return nil
 }
 
-// Create creates a persistent OpenShell sandbox and waits for it to be ready.
-// If providers are given, they are passed as --provider flags. If image is
-// non-empty, it is passed as --from to start the sandbox from a container image.
-// If policy is non-empty, it is applied at creation time via --policy.
+// effectiveReadyTimeout returns the sandbox ready timeout to use. Priority:
+// explicit override (from harness config) > FULLSEND_SANDBOX_READY_TIMEOUT
+// env var > package default.
+func effectiveReadyTimeout(override time.Duration) time.Duration {
+	if override > 0 {
+		return override
+	}
+	if envVal := os.Getenv("FULLSEND_SANDBOX_READY_TIMEOUT"); envVal != "" {
+		if d, err := time.ParseDuration(envVal); err == nil && d > 0 {
+			return d
+		}
+	}
+	return readyTimeout
+}
+
+// Create creates a persistent OpenShell sandbox and waits for it to be ready,
+// retrying up to defaultMaxCreateAttempts times with exponential backoff.
 func Create(name string, providers []string, image, policy string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), createTimeout)
+	return CreateWithRetry(name, providers, image, policy, defaultMaxCreateAttempts, 0)
+}
+
+// CreateWithRetry creates a sandbox, retrying up to maxAttempts times with
+// exponential backoff on failure. Between attempts the failed sandbox is
+// deleted to avoid name conflicts. If readyTimeoutOverride is positive, it
+// overrides the default ready timeout.
+func CreateWithRetry(name string, providers []string, image, policy string, maxAttempts int, readyTimeoutOverride time.Duration) error {
+	timeout := effectiveReadyTimeout(readyTimeoutOverride)
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		lastErr = createOnce(name, providers, image, policy, timeout)
+		if lastErr == nil {
+			return nil
+		}
+
+		// Clean up failed sandbox before retry.
+		_ = Delete(name)
+
+		if attempt < maxAttempts {
+			backoff := retryInitialBackoff * time.Duration(1<<uint(attempt-1))
+			if backoff > retryMaxBackoff {
+				backoff = retryMaxBackoff
+			}
+			fmt.Fprintf(os.Stderr, "  Sandbox creation attempt %d/%d failed, retrying in %s...\n", attempt, maxAttempts, backoff)
+			time.Sleep(backoff)
+		}
+	}
+	return lastErr
+}
+
+// createOnce creates a persistent OpenShell sandbox and waits for it to be
+// ready. If providers are given, they are passed as --provider flags. If image
+// is non-empty, it is passed as --from to start the sandbox from a container
+// image. If policy is non-empty, it is applied at creation time via --policy.
+func createOnce(name string, providers []string, image, policy string, timeout time.Duration) error {
+	ctxTimeout := timeout + 10*time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
 	args := []string{
@@ -189,7 +244,7 @@ func Create(name string, providers []string, image, policy string) error {
 	}
 
 	// Wait for sandbox to be fully ready (image pull can take a while).
-	deadline := time.Now().Add(readyTimeout)
+	deadline := time.Now().Add(timeout)
 	var lastOutput, lastStderr string
 	for time.Now().Before(deadline) {
 		check := exec.Command("openshell", "sandbox", "get", name)
@@ -212,7 +267,7 @@ func Create(name string, providers []string, image, policy string) error {
 	containerLogs := collectPodmanLogs(name)
 
 	return fmt.Errorf("sandbox %q not ready after %s\nstdout: %s\nstderr: %s\nsupervisor logs: %s\ngateway logs: %s\ncontainer logs: %s",
-		name, readyTimeout, lastOutput, lastStderr, supervisorLogs, gatewayLogs, containerLogs)
+		name, timeout, lastOutput, lastStderr, supervisorLogs, gatewayLogs, containerLogs)
 }
 
 // Delete deletes a sandbox, returning any error for the caller to log.

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -352,6 +352,30 @@ func TestCreateWithRetry_OpenshellNotInPath(t *testing.T) {
 
 	err := CreateWithRetry("test-sandbox", nil, "", "", 1, 0)
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "sandbox creation failed after 1 attempts")
+}
+
+func TestCreateWithRetry_ZeroAttempts(t *testing.T) {
+	err := CreateWithRetry("test-sandbox", nil, "", "", 0, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "maxAttempts must be >= 1")
+}
+
+func TestCreateWithRetry_NegativeAttempts(t *testing.T) {
+	err := CreateWithRetry("test-sandbox", nil, "", "", -1, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "maxAttempts must be >= 1")
+}
+
+func TestEffectiveReadyTimeout_CappedAtMax(t *testing.T) {
+	got := effectiveReadyTimeout(999 * time.Second)
+	assert.Equal(t, maxReadyTimeout, got)
+}
+
+func TestEffectiveReadyTimeout_EnvVarCappedAtMax(t *testing.T) {
+	t.Setenv("FULLSEND_SANDBOX_READY_TIMEOUT", "1h")
+	got := effectiveReadyTimeout(0)
+	assert.Equal(t, maxReadyTimeout, got)
 }
 
 func TestUploadDir_OpenshellNotInPath(t *testing.T) {

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -312,6 +312,48 @@ func TestSanitizeDownload_EmptyDir(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestEffectiveReadyTimeout_Default(t *testing.T) {
+	t.Setenv("FULLSEND_SANDBOX_READY_TIMEOUT", "")
+	got := effectiveReadyTimeout(0)
+	assert.Equal(t, readyTimeout, got)
+}
+
+func TestEffectiveReadyTimeout_Override(t *testing.T) {
+	got := effectiveReadyTimeout(90 * time.Second)
+	assert.Equal(t, 90*time.Second, got)
+}
+
+func TestEffectiveReadyTimeout_EnvVar(t *testing.T) {
+	t.Setenv("FULLSEND_SANDBOX_READY_TIMEOUT", "180s")
+	got := effectiveReadyTimeout(0)
+	assert.Equal(t, 180*time.Second, got)
+}
+
+func TestEffectiveReadyTimeout_OverrideTakesPrecedenceOverEnv(t *testing.T) {
+	t.Setenv("FULLSEND_SANDBOX_READY_TIMEOUT", "180s")
+	got := effectiveReadyTimeout(90 * time.Second)
+	assert.Equal(t, 90*time.Second, got)
+}
+
+func TestEffectiveReadyTimeout_InvalidEnvVar(t *testing.T) {
+	t.Setenv("FULLSEND_SANDBOX_READY_TIMEOUT", "not-a-duration")
+	got := effectiveReadyTimeout(0)
+	assert.Equal(t, readyTimeout, got)
+}
+
+func TestEffectiveReadyTimeout_NegativeEnvVar(t *testing.T) {
+	t.Setenv("FULLSEND_SANDBOX_READY_TIMEOUT", "-30s")
+	got := effectiveReadyTimeout(0)
+	assert.Equal(t, readyTimeout, got)
+}
+
+func TestCreateWithRetry_OpenshellNotInPath(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	err := CreateWithRetry("test-sandbox", nil, "", "", 1, 0)
+	assert.Error(t, err)
+}
+
 func TestUploadDir_OpenshellNotInPath(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("PATH", "")


### PR DESCRIPTION
## Summary

- **Pre-pull sandbox image** in `action.yml` before `fullsend run` — moves image pull time out of the sandbox ready timeout window
- **Add `CreateWithRetry`** with exponential backoff (3 attempts, 5-15s delay) and cleanup between attempts — a single transient failure no longer kills the run
- **Increase default `readyTimeout`** from 60s to 120s — gives cold image pulls more headroom
- **Add `sandbox_timeout_seconds`** harness config field — per-agent tuning without env vars
- **Add `FULLSEND_SANDBOX_READY_TIMEOUT`** env var override — operator tuning without code changes

Fixes #1298

## Test plan

- [x] `effectiveReadyTimeout` unit tests: default, override, env var, precedence, invalid/negative env, capped at max
- [x] `CreateWithRetry` error path tests (openshell not in PATH, zero/negative maxAttempts)
- [x] `SandboxTimeoutSeconds` harness validation tests: negative rejected, >600 rejected, zero/positive/600 accepted
- [x] `SandboxTimeoutSeconds` YAML load round-trip test
- [x] `make go-test` passes
- [x] `make go-vet` passes
- [x] `make lint` passes
- [ ] Re-run agentshed/seshi PR #51 failed job to verify fix in CI