### PR TITLE
fix: use plain comments for interactive triage actions

### DIFF
--- a/internal/scaffold/fullsend-repo/scripts/post-triage-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-triage-test.sh
@@ -125,6 +125,10 @@ run_test_stdout() {
 
 # --- Test cases ---
 
+run_test "insufficient-uses-plain-comment" \
+  '{"action":"insufficient","reasoning":"missing repro","clarity_scores":{"symptom":0.6,"cause":0.3,"reproduction":0.1,"impact":0.5,"overall":0.39},"comment":"Could you share the exact steps to reproduce this?"}' \
+  "gh issue comment 42 --repo test-org/test-repo --body-file -"
+
 run_test "insufficient-posts-comment-and-labels" \
   '{"action":"insufficient","reasoning":"missing repro","clarity_scores":{"symptom":0.6,"cause":0.3,"reproduction":0.1,"impact":0.5,"overall":0.39},"comment":"Could you share the exact steps to reproduce this?"}' \
   "gh api repos/test-org/test-repo/issues/42/labels -f labels[]=needs-info --silent"

--- a/internal/scaffold/fullsend-repo/scripts/post-triage.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-triage.sh
@@ -235,11 +235,14 @@ fi
 # --- Post comment ---
 
 echo "Posting comment..."
-if [[ "${ACTION}" == "blocked" ]]; then
-  # Blocked uses plain gh issue comment (no marker-based upsert).
-  printf '%s' "${COMMENT}" | gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" --body-file -
-else
+if [[ "${ACTION}" == "sufficient" ]]; then
+  # Summaries use sticky comments — there's one logical summary per issue and
+  # updating it in-place avoids flooding. See #602.
   printf '%s' "${COMMENT}" | fullsend post-comment --repo "${REPO}" --number "${ISSUE_NUMBER}" --marker "<!-- fullsend:triage-agent -->" --token "${GH_TOKEN}" --result -
+else
+  # Interactive comments (needs-info questions, blocked notices, duplicates)
+  # post as new comments so the conversation reads chronologically.
+  printf '%s' "${COMMENT}" | gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" --body-file -
 fi
 
 # --- Post-action: close duplicate issues ---


### PR DESCRIPTION
## Summary

- Only the `sufficient` action uses sticky `post-comment` now (triage summaries update in place)
- Interactive actions (`insufficient`, `blocked`, `duplicate`) post as regular `gh issue comment` so the conversation reads chronologically
- Added test case `insufficient-uses-plain-comment` to assert the new behavior

Closes #602

## Test plan

- [x] `post-triage-test.sh` — all 35 tests pass
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)