### PR TITLE
fix: validate inline review comment lines against diff hunks

### DIFF
--- a/internal/cli/postreview.go
+++ b/internal/cli/postreview.go
@@ -336,8 +336,10 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 // or line number are omitted — they remain in the sticky comment body.
 // When diffHunks is non-nil, findings referencing files outside the PR
 // diff or lines outside any diff hunk are omitted to avoid GitHub 422
-// errors. Returns the comments and counts of findings dropped for each
-// reason (file not in diff, line not in any hunk).
+// errors. Files with empty hunk lists (binary files, truncated patches)
+// skip line-level filtering — the file is known to be in the diff but
+// hunk coverage is unavailable. Returns the comments and counts of
+// findings dropped for each reason (file not in diff, line not in hunk).
 func findingsToReviewComments(findings []ReviewFinding, diffHunks map[string][][2]int) ([]forge.ReviewComment, int, int) {
 	var comments []forge.ReviewComment
 	var fileFiltered, lineFiltered int
@@ -351,7 +353,7 @@ func findingsToReviewComments(findings []ReviewFinding, diffHunks map[string][][
 				fileFiltered++
 				continue
 			}
-			if !lineInHunks(f.Line, hunks) {
+			if len(hunks) > 0 && !lineInHunks(f.Line, hunks) {
 				lineFiltered++
 				continue
 			}
@@ -386,6 +388,9 @@ func formatFindingComment(f ReviewFinding) string {
 func parseDiffLineRanges(patch string) [][2]int {
 	var ranges [][2]int
 	for _, line := range strings.Split(patch, "\n") {
+		if !strings.HasPrefix(line, "@@") {
+			continue
+		}
 		m := hunkHeaderRe.FindStringSubmatch(line)
 		if m == nil {
 			continue

--- a/internal/cli/postreview.go
+++ b/internal/cli/postreview.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -20,6 +21,7 @@ const reviewMarker = "<!-- fullsend:review-agent -->"
 
 var hexSHARe = regexp.MustCompile(`^[0-9a-fA-F]{40}$|^[0-9a-fA-F]{64}$`)
 var reasonRe = regexp.MustCompile(`^[a-zA-Z0-9_-]*$`)
+var hunkHeaderRe = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
 
 func newPostReviewCmd() *cobra.Command {
 	var (
@@ -289,22 +291,25 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 		return nil
 	}
 
-	var diffFiles map[string]bool
-	if prFiles, err := client.ListPullRequestFiles(ctx, owner, repo, pr); err != nil {
+	var diffHunks map[string][][2]int
+	if fileDiffs, err := client.ListPullRequestFileDiffs(ctx, owner, repo, pr); err != nil {
 		printer.StepInfo(fmt.Sprintf("Could not list PR files (%v), inline comments may be rejected", err))
-	} else if len(prFiles) == 0 {
+	} else if len(fileDiffs) == 0 {
 		printer.StepInfo("PR file list is empty, inline comments disabled")
 	} else {
-		diffFiles = make(map[string]bool, len(prFiles))
-		for _, f := range prFiles {
-			diffFiles[f] = true
+		diffHunks = make(map[string][][2]int, len(fileDiffs))
+		for _, f := range fileDiffs {
+			diffHunks[f.Path] = parseDiffLineRanges(f.Patch)
 		}
 	}
 
-	inlineComments, diffFiltered := findingsToReviewComments(findings, diffFiles)
+	inlineComments, fileFiltered, lineFiltered := findingsToReviewComments(findings, diffHunks)
 
-	if diffFiltered > 0 {
-		printer.StepWarn(fmt.Sprintf("%d finding(s) omitted: file not in PR diff", diffFiltered))
+	if fileFiltered > 0 {
+		printer.StepWarn(fmt.Sprintf("%d finding(s) omitted: file not in PR diff", fileFiltered))
+	}
+	if lineFiltered > 0 {
+		printer.StepWarn(fmt.Sprintf("%d finding(s) omitted: line not in any diff hunk", lineFiltered))
 	}
 
 	var reviewBody string
@@ -329,20 +334,27 @@ func submitFormalReview(ctx context.Context, client forge.Client, owner, repo st
 // findingsToReviewComments converts review findings with file and line
 // locations into inline review comments. Findings without a file path
 // or line number are omitted — they remain in the sticky comment body.
-// When diffFiles is non-nil, findings referencing files outside the PR
-// diff are also omitted to avoid GitHub 422 errors.
-// Returns the comments and the count of findings dropped because their
-// file was not in the diff.
-func findingsToReviewComments(findings []ReviewFinding, diffFiles map[string]bool) ([]forge.ReviewComment, int) {
+// When diffHunks is non-nil, findings referencing files outside the PR
+// diff or lines outside any diff hunk are omitted to avoid GitHub 422
+// errors. Returns the comments and counts of findings dropped for each
+// reason (file not in diff, line not in any hunk).
+func findingsToReviewComments(findings []ReviewFinding, diffHunks map[string][][2]int) ([]forge.ReviewComment, int, int) {
 	var comments []forge.ReviewComment
-	var diffFiltered int
+	var fileFiltered, lineFiltered int
 	for _, f := range findings {
 		if f.File == "" || f.Line <= 0 {
 			continue
 		}
-		if diffFiles != nil && !diffFiles[f.File] {
-			diffFiltered++
-			continue
+		if diffHunks != nil {
+			hunks, fileInDiff := diffHunks[f.File]
+			if !fileInDiff {
+				fileFiltered++
+				continue
+			}
+			if !lineInHunks(f.Line, hunks) {
+				lineFiltered++
+				continue
+			}
 		}
 		comments = append(comments, forge.ReviewComment{
 			Path: f.File,
@@ -350,7 +362,7 @@ func findingsToReviewComments(findings []ReviewFinding, diffFiles map[string]boo
 			Body: formatFindingComment(f),
 		})
 	}
-	return comments, diffFiltered
+	return comments, fileFiltered, lineFiltered
 }
 
 // formatFindingComment renders a single review finding as a Markdown
@@ -365,6 +377,40 @@ func formatFindingComment(f ReviewFinding) string {
 		b.WriteString(strings.TrimSpace(f.Remediation))
 	}
 	return b.String()
+}
+
+// parseDiffLineRanges extracts new-file line ranges from unified diff
+// hunk headers. Each returned [2]int is an inclusive [start, end] range
+// of lines on the right (new) side of the diff that can receive inline
+// comments.
+func parseDiffLineRanges(patch string) [][2]int {
+	var ranges [][2]int
+	for _, line := range strings.Split(patch, "\n") {
+		m := hunkHeaderRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		start, _ := strconv.Atoi(m[1])
+		size := 1
+		if m[2] != "" {
+			size, _ = strconv.Atoi(m[2])
+		}
+		if size == 0 {
+			continue
+		}
+		ranges = append(ranges, [2]int{start, start + size - 1})
+	}
+	return ranges
+}
+
+// lineInHunks returns true if line falls within any of the given ranges.
+func lineInHunks(line int, hunks [][2]int) bool {
+	for _, h := range hunks {
+		if line >= h[0] && line <= h[1] {
+			return true
+		}
+	}
+	return false
 }
 
 // postApprovedFollowUpIssues is disabled pending #1137. Follow-up issues

--- a/internal/cli/postreview_test.go
+++ b/internal/cli/postreview_test.go
@@ -761,6 +761,29 @@ func TestFindingsToReviewComments_FiltersByDiffHunks(t *testing.T) {
 	assert.Equal(t, 3, comments[1].Line)
 }
 
+func TestFindingsToReviewComments_EmptyPatchSkipsLineFiltering(t *testing.T) {
+	findings := []ReviewFinding{
+		{File: "binary.png", Line: 1, Severity: "high", Category: "bug", Description: "On binary file"},
+		{File: "large.go", Line: 999, Severity: "medium", Category: "style", Description: "On truncated-patch file"},
+		{File: "changed.go", Line: 10, Severity: "low", Category: "bug", Description: "In hunk"},
+		{File: "changed.go", Line: 50, Severity: "info", Category: "docs", Description: "Outside hunk"},
+	}
+	diffHunks := map[string][][2]int{
+		"binary.png": nil,
+		"large.go":   nil,
+		"changed.go": {{5, 15}},
+	}
+
+	comments, fileFiltered, lineFiltered := findingsToReviewComments(findings, diffHunks)
+	assert.Equal(t, 0, fileFiltered)
+	assert.Equal(t, 1, lineFiltered, "only the out-of-hunk finding on changed.go should be filtered")
+	require.Len(t, comments, 3)
+	assert.Equal(t, "binary.png", comments[0].Path)
+	assert.Equal(t, "large.go", comments[1].Path)
+	assert.Equal(t, "changed.go", comments[2].Path)
+	assert.Equal(t, 10, comments[2].Line)
+}
+
 func TestSubmitFormalReview_FiltersByPRFileDiffs(t *testing.T) {
 	fc := forge.NewFakeClient()
 	fc.AuthenticatedUser = "fullsend-bot"

--- a/internal/cli/postreview_test.go
+++ b/internal/cli/postreview_test.go
@@ -664,6 +664,57 @@ func TestSubmitFormalReview_SkipsFindingsWithoutLocation(t *testing.T) {
 	assert.Equal(t, "internal/service.go", fc.CreatedReviews[0].Comments[0].Path)
 }
 
+func TestParseDiffLineRanges(t *testing.T) {
+	tests := []struct {
+		name   string
+		patch  string
+		expect [][2]int
+	}{
+		{
+			name:   "single hunk",
+			patch:  "@@ -10,5 +12,7 @@ func foo() {",
+			expect: [][2]int{{12, 18}},
+		},
+		{
+			name:   "multiple hunks",
+			patch:  "@@ -1,3 +1,4 @@ header\n context\n+added\n@@ -20,5 +21,3 @@ other",
+			expect: [][2]int{{1, 4}, {21, 23}},
+		},
+		{
+			name:   "new file single hunk",
+			patch:  "@@ -0,0 +1,50 @@",
+			expect: [][2]int{{1, 50}},
+		},
+		{
+			name:   "deletion only hunk size 0",
+			patch:  "@@ -5,3 +5,0 @@ removed",
+			expect: nil,
+		},
+		{
+			name:   "omitted size defaults to 1",
+			patch:  "@@ -1 +1 @@",
+			expect: [][2]int{{1, 1}},
+		},
+		{
+			name:   "empty patch",
+			patch:  "",
+			expect: nil,
+		},
+		{
+			name:   "mixed hunks with deletion",
+			patch:  "@@ -1,3 +1,5 @@ first\n context\n@@ -10,4 +12,0 @@ deleted\n@@ -20,2 +18,3 @@ third",
+			expect: [][2]int{{1, 5}, {18, 20}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDiffLineRanges(tt.patch)
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}
+
 func TestFindingsToReviewComments(t *testing.T) {
 	findings := []ReviewFinding{
 		{File: "a.go", Line: 10, Severity: "high", Category: "bug", Description: "Desc A"},
@@ -672,8 +723,9 @@ func TestFindingsToReviewComments(t *testing.T) {
 		{File: "c.go", Line: 20, Severity: "critical", Category: "security", Description: "Desc C", Remediation: "Fix it"},
 	}
 
-	comments, filtered := findingsToReviewComments(findings, nil)
-	assert.Equal(t, 0, filtered)
+	comments, fileFiltered, lineFiltered := findingsToReviewComments(findings, nil)
+	assert.Equal(t, 0, fileFiltered)
+	assert.Equal(t, 0, lineFiltered)
 	require.Len(t, comments, 2)
 
 	assert.Equal(t, "a.go", comments[0].Path)
@@ -687,52 +739,61 @@ func TestFindingsToReviewComments(t *testing.T) {
 	assert.Contains(t, comments[1].Body, "Fix it")
 }
 
-func TestFindingsToReviewComments_FiltersByDiffFiles(t *testing.T) {
+func TestFindingsToReviewComments_FiltersByDiffHunks(t *testing.T) {
 	findings := []ReviewFinding{
-		{File: "changed.go", Line: 10, Severity: "high", Category: "bug", Description: "In diff"},
+		{File: "changed.go", Line: 10, Severity: "high", Category: "bug", Description: "In hunk"},
+		{File: "changed.go", Line: 50, Severity: "low", Category: "style", Description: "Outside hunk"},
 		{File: "not-changed.go", Line: 5, Severity: "low", Category: "docs", Description: "Not in diff"},
-		{File: "also-changed.go", Line: 20, Severity: "medium", Category: "style", Description: "Also in diff"},
+		{File: "also-changed.go", Line: 3, Severity: "medium", Category: "style", Description: "In hunk"},
 	}
-	diffFiles := map[string]bool{
-		"changed.go":      true,
-		"also-changed.go": true,
+	diffHunks := map[string][][2]int{
+		"changed.go":      {{5, 15}},
+		"also-changed.go": {{1, 10}},
 	}
 
-	comments, filtered := findingsToReviewComments(findings, diffFiles)
-	assert.Equal(t, 1, filtered)
+	comments, fileFiltered, lineFiltered := findingsToReviewComments(findings, diffHunks)
+	assert.Equal(t, 1, fileFiltered)
+	assert.Equal(t, 1, lineFiltered)
 	require.Len(t, comments, 2)
 	assert.Equal(t, "changed.go", comments[0].Path)
+	assert.Equal(t, 10, comments[0].Line)
 	assert.Equal(t, "also-changed.go", comments[1].Path)
+	assert.Equal(t, 3, comments[1].Line)
 }
 
-func TestSubmitFormalReview_FiltersByPRFiles(t *testing.T) {
+func TestSubmitFormalReview_FiltersByPRFileDiffs(t *testing.T) {
 	fc := forge.NewFakeClient()
 	fc.AuthenticatedUser = "fullsend-bot"
-	fc.PRFiles = map[string][]string{
-		"acme/repo/1": {"changed.go", "also-changed.go"},
+	fc.PRFileDiffs = map[string][]forge.PullRequestFileDiff{
+		"acme/repo/1": {
+			{Path: "changed.go", Patch: "@@ -5,10 +5,12 @@ func main() {"},
+			{Path: "also-changed.go", Patch: "@@ -1,5 +1,25 @@ package foo"},
+		},
 	}
 	var out bytes.Buffer
 	printer := ui.New(&out)
 
 	findings := []ReviewFinding{
-		{File: "changed.go", Line: 10, Severity: "high", Category: "bug", Description: "In diff"},
-		{File: "not-in-diff.go", Line: 5, Severity: "medium", Category: "style", Description: "Should be filtered"},
-		{File: "also-changed.go", Line: 20, Severity: "low", Category: "docs", Description: "Also in diff"},
+		{File: "changed.go", Line: 10, Severity: "high", Category: "bug", Description: "In hunk"},
+		{File: "changed.go", Line: 50, Severity: "low", Category: "style", Description: "Outside hunk"},
+		{File: "not-in-diff.go", Line: 5, Severity: "medium", Category: "style", Description: "File not in diff"},
+		{File: "also-changed.go", Line: 20, Severity: "low", Category: "docs", Description: "In hunk"},
 	}
 
 	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "request-changes", "", "", findings, false, printer)
 	require.NoError(t, err)
 	require.Len(t, fc.CreatedReviews, 1)
-	require.Len(t, fc.CreatedReviews[0].Comments, 2, "finding on not-in-diff.go should be filtered out")
+	require.Len(t, fc.CreatedReviews[0].Comments, 2, "file-filtered and line-filtered findings should be omitted")
 	assert.Equal(t, "changed.go", fc.CreatedReviews[0].Comments[0].Path)
 	assert.Equal(t, "also-changed.go", fc.CreatedReviews[0].Comments[1].Path)
 	assert.Contains(t, out.String(), "1 finding(s) omitted: file not in PR diff")
+	assert.Contains(t, out.String(), "1 finding(s) omitted: line not in any diff hunk")
 }
 
-func TestSubmitFormalReview_ListPRFilesErrorFallsBack(t *testing.T) {
+func TestSubmitFormalReview_ListPRFileDiffsErrorFallsBack(t *testing.T) {
 	fc := forge.NewFakeClient()
 	fc.AuthenticatedUser = "fullsend-bot"
-	fc.Errors["ListPullRequestFiles"] = fmt.Errorf("API rate limited")
+	fc.Errors["ListPullRequestFileDiffs"] = fmt.Errorf("API rate limited")
 	printer := ui.New(io.Discard)
 
 	findings := []ReviewFinding{
@@ -742,14 +803,14 @@ func TestSubmitFormalReview_ListPRFilesErrorFallsBack(t *testing.T) {
 	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "request-changes", "", "", findings, false, printer)
 	require.NoError(t, err)
 	require.Len(t, fc.CreatedReviews, 1)
-	require.Len(t, fc.CreatedReviews[0].Comments, 1, "all comments should pass through when ListPullRequestFiles fails")
+	require.Len(t, fc.CreatedReviews[0].Comments, 1, "all comments should pass through when ListPullRequestFileDiffs fails")
 	assert.Equal(t, "any-file.go", fc.CreatedReviews[0].Comments[0].Path)
 }
 
-func TestSubmitFormalReview_EmptyPRFileListFallsBack(t *testing.T) {
+func TestSubmitFormalReview_EmptyPRFileDiffListFallsBack(t *testing.T) {
 	fc := forge.NewFakeClient()
 	fc.AuthenticatedUser = "fullsend-bot"
-	fc.PRFiles = map[string][]string{
+	fc.PRFileDiffs = map[string][]forge.PullRequestFileDiff{
 		"acme/repo/1": {},
 	}
 	var out bytes.Buffer
@@ -762,7 +823,6 @@ func TestSubmitFormalReview_EmptyPRFileListFallsBack(t *testing.T) {
 	err := submitFormalReview(context.Background(), fc, "acme", "repo", 1, "request-changes", "", "", findings, false, printer)
 	require.NoError(t, err)
 	require.Len(t, fc.CreatedReviews, 1)
-	// When PR file list is empty, filtering is disabled — all comments pass through unfiltered.
 	require.Len(t, fc.CreatedReviews[0].Comments, 1, "comments pass through unfiltered when PR file list is empty")
 	assert.Contains(t, out.String(), "PR file list is empty")
 }

--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -139,6 +139,9 @@ type FakeClient struct {
 	// Pull request files for ListPullRequestFiles.
 	PRFiles map[string][]string // key: "owner/repo/number"
 
+	// Pull request file diffs for ListPullRequestFileDiffs.
+	PRFileDiffs map[string][]PullRequestFileDiff // key: "owner/repo/number"
+
 	// Pull request reviews for ListPullRequestReviews.
 	PRReviews map[string][]PullRequestReview // key: "owner/repo/number"
 
@@ -812,6 +815,21 @@ func (f *FakeClient) ListPullRequestFiles(_ context.Context, owner, repo string,
 	if f.PRFiles != nil {
 		key := fmt.Sprintf("%s/%s/%d", owner, repo, number)
 		if files, ok := f.PRFiles[key]; ok {
+			return files, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *FakeClient) ListPullRequestFileDiffs(_ context.Context, owner, repo string, number int) ([]PullRequestFileDiff, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e := f.err("ListPullRequestFileDiffs"); e != nil {
+		return nil, e
+	}
+	if f.PRFileDiffs != nil {
+		key := fmt.Sprintf("%s/%s/%d", owner, repo, number)
+		if files, ok := f.PRFileDiffs[key]; ok {
 			return files, nil
 		}
 	}

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -91,7 +91,8 @@ type ReviewComment struct {
 }
 
 // PullRequestFileDiff represents a file changed in a pull request along
-// with its unified diff patch. The patch may be empty for binary files.
+// with its unified diff patch. The patch may be empty for binary files,
+// rename-only changes, or when GitHub truncates large diffs.
 type PullRequestFileDiff struct {
 	Path  string
 	Patch string

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -90,6 +90,13 @@ type ReviewComment struct {
 	Body string // comment body (Markdown)
 }
 
+// PullRequestFileDiff represents a file changed in a pull request along
+// with its unified diff patch. The patch may be empty for binary files.
+type PullRequestFileDiff struct {
+	Path  string
+	Patch string
+}
+
 // Installation represents an app installation on an org.
 type Installation struct {
 	ID          int
@@ -214,6 +221,10 @@ type Client interface {
 	// ListPullRequestFiles returns the relative file paths changed by a pull
 	// request. On GitHub, the API caps results at 3000 files total.
 	ListPullRequestFiles(ctx context.Context, owner, repo string, number int) ([]string, error)
+	// ListPullRequestFileDiffs returns the files changed by a pull request
+	// along with their unified diff patches. Use this when you need to
+	// determine which lines are within diff hunks (e.g. for inline comments).
+	ListPullRequestFileDiffs(ctx context.Context, owner, repo string, number int) ([]PullRequestFileDiff, error)
 
 	// Pull request review operations.
 	// commitSHA, when non-empty, pins the review to a specific commit.

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -1463,6 +1463,36 @@ func (c *LiveClient) ListPullRequestFiles(ctx context.Context, owner, repo strin
 	return files, nil
 }
 
+// ListPullRequestFileDiffs returns the files changed by a pull request
+// along with their unified diff patches. Same API endpoint as
+// ListPullRequestFiles but also extracts the patch field.
+func (c *LiveClient) ListPullRequestFileDiffs(ctx context.Context, owner, repo string, number int) ([]forge.PullRequestFileDiff, error) {
+	var files []forge.PullRequestFileDiff
+	for page := 1; page <= 100; page++ {
+		resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/pulls/%d/files?per_page=100&page=%d", owner, repo, number, page))
+		if err != nil {
+			return nil, fmt.Errorf("list pull request file diffs page %d: %w", page, err)
+		}
+		var raw []struct {
+			Filename string `json:"filename"`
+			Patch    string `json:"patch"`
+		}
+		if err := decodeJSON(resp, &raw); err != nil {
+			return nil, fmt.Errorf("decoding pull request file diffs page %d: %w", page, err)
+		}
+		for _, f := range raw {
+			files = append(files, forge.PullRequestFileDiff{
+				Path:  f.Filename,
+				Patch: f.Patch,
+			})
+		}
+		if len(raw) < 100 {
+			break
+		}
+	}
+	return files, nil
+}
+
 // CreatePullRequestReview submits a formal review on a pull request.
 // The event must be one of: APPROVE, REQUEST_CHANGES, COMMENT.
 // When commitSHA is non-empty it is sent as commit_id, pinning the

--- a/internal/forge/github/github_comment_test.go
+++ b/internal/forge/github/github_comment_test.go
@@ -477,6 +477,34 @@ func TestCreatePullRequestReview_WithInlineComments(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestListPullRequestFileDiffs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/repos/owner/repo/pulls/5/files", r.URL.Path)
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"filename": "main.go",
+				"patch":    "@@ -10,5 +10,7 @@ func main() {\n context\n+added line",
+			},
+			{
+				"filename": "binary.png",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	files, err := client.ListPullRequestFileDiffs(context.Background(), "owner", "repo", 5)
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+	assert.Equal(t, "main.go", files[0].Path)
+	assert.Contains(t, files[0].Patch, "@@ -10,5 +10,7 @@")
+	assert.Equal(t, "binary.png", files[1].Path)
+	assert.Empty(t, files[1].Patch)
+}
+
 func TestListPullRequestReviews(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)


### PR DESCRIPTION
## Summary

- Fixes GitHub 422 errors when the review agent places inline comments on lines outside diff hunks. Previously only file-level validation was done; now line-level validation against parsed hunk headers prevents the 422.
- Adds `ListPullRequestFileDiffs` to the forge interface to return unified diff patches alongside file paths
- Adds `parseDiffLineRanges` to extract valid new-side line ranges from `@@ -a,b +c,d @@` hunk headers
- Updates `findingsToReviewComments` to filter by both file presence and line-in-hunk, with separate warning counts

## Test plan

- [x] `TestParseDiffLineRanges` — single hunk, multiple hunks, new file, deletion-only, omitted size, empty patch, mixed
- [x] `TestFindingsToReviewComments` — no filtering when diffHunks is nil
- [x] `TestFindingsToReviewComments_FiltersByDiffHunks` — file not in diff, line outside hunk, line inside hunk
- [x] `TestSubmitFormalReview_FiltersByPRFileDiffs` — end-to-end with fake client and patches
- [x] `TestSubmitFormalReview_ListPRFileDiffsErrorFallsBack` — graceful fallback on API error
- [x] `TestSubmitFormalReview_EmptyPRFileDiffListFallsBack` — graceful fallback on empty list
- [x] `TestListPullRequestFileDiffs` — GitHub client correctly extracts path and patch
- [x] `go test ./internal/cli/... ./internal/forge/...` all pass
- [x] `go vet` clean