### PR TITLE
fix(skills): satisfy ty check in analyze-transcript

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@
 # Then `cd` into this repo; `node`, `npm`, and `go` come from mise.
 [tools]
 node = "22"
-go = "1.25.8"
+go = "1.26.0"
 
 [env]
 _.file = ".env.local"

--- a/skills/analyze-transcript/analyze-transcript.py
+++ b/skills/analyze-transcript/analyze-transcript.py
@@ -8,6 +8,7 @@ import signal
 import sys
 from collections import Counter
 from datetime import datetime
+from typing import TypedDict
 
 # Prevent BrokenPipeError when output is piped through head/tail.
 signal.signal(signal.SIGPIPE, signal.SIG_DFL)
@@ -243,8 +244,13 @@ def cmd_conversation(args):
                         print()
 
 
+class ToolStats(TypedDict):
+    count: int
+    lines: list[int]
+
+
 def cmd_tools(args):
-    tool_data = {}
+    tool_data: dict[str, ToolStats] = {}
 
     for i, role, msg, _raw in iter_messages(args.file, args.line_range):
         if role != "assistant":


### PR DESCRIPTION
## Summary

- Add a `ToolStats` `TypedDict` and annotate `tool_data` in `cmd_tools` so `ty` can infer `count` and `lines` types (fixes four diagnostics that fail `make test` / pre-commit `ty check` on current main with recent `ty` releases).
- Bump mise Go pin from `1.25.8` to `1.26.0` to match `go.mod`, avoiding `compile: version "go1.26.0" does not match go tool version "go1.25.8"` when `GOTOOLCHAIN=auto` is set in the Makefile.

No existing open PR addressed these failures.

## Test plan

- [x] `make test` (after `mise trust`, `mise install`, and `uv pip install --system jsonschema` per CI)
- [ ] CI `lint.yml` on this PR


Made with [Cursor](https://cursor.com)