### PR TITLE
fix: restore setup-agent-env.sh copy in prioritize scaffold workflow

### DIFF
--- a/internal/scaffold/fullsend-repo/.github/workflows/prioritize.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/prioritize.yml
@@ -40,31 +40,20 @@ jobs:
           ref: v0
           path: .defaults
           sparse-checkout: |
-            internal/scaffold/fullsend-repo/agents/
-            internal/scaffold/fullsend-repo/skills/
-            internal/scaffold/fullsend-repo/schemas/
-            internal/scaffold/fullsend-repo/harness/
-            internal/scaffold/fullsend-repo/plugins/
-            internal/scaffold/fullsend-repo/policies/
-            internal/scaffold/fullsend-repo/scripts/
-            internal/scaffold/fullsend-repo/env/
-            .github/scripts/
+            internal/scaffold/fullsend-repo/
 
       - name: Prepare workspace (upstream defaults + org overrides)
         run: |
           set -euo pipefail
-          for dir in agents skills schemas harness plugins policies scripts env; do
-            src=".defaults/internal/scaffold/fullsend-repo/${dir}"
-            if [[ -d "${src}" ]]; then
+          SRC=".defaults/internal/scaffold/fullsend-repo"
+          LAYERED_DIRS="agents skills schemas harness plugins policies scripts env"
+          for dir in ${LAYERED_DIRS}; do
+            if [[ -d "${SRC}/${dir}" ]]; then
               mkdir -p "${dir}"
-              cp -r "${src}/." "${dir}/"
+              cp -r "${SRC}/${dir}/." "${dir}/"
             fi
           done
-          if [[ -d ".defaults/.github/scripts" ]]; then
-            mkdir -p .github/scripts
-            cp -r ".defaults/.github/scripts/." .github/scripts/
-          fi
-          for dir in agents skills schemas harness plugins policies scripts env; do
+          for dir in ${LAYERED_DIRS}; do
             if [[ -d "customized/${dir}" ]]; then
               find "customized/${dir}" -type f ! -name '.gitkeep' -print0 \
                 | while IFS= read -r -d '' f; do
@@ -74,6 +63,8 @@ jobs:
                   done
             fi
           done
+          mkdir -p .github/scripts
+          cp "${SRC}/.github/scripts/setup-agent-env.sh" .github/scripts/setup-agent-env.sh
           rm -rf .defaults
 
       - name: Validate enrollment and extract repo metadata

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -700,6 +700,8 @@ func TestPrioritizeWorkflowContent(t *testing.T) {
 	assert.Contains(t, s, "event_payload")
 	assert.Contains(t, s, "FULLSEND_PROJECT_NUMBER")
 	assert.Contains(t, s, "setup-agent-env.sh")
+	assert.Contains(t, s, `cp "${SRC}/.github/scripts/setup-agent-env.sh"`)
+	assert.NotContains(t, s, ".defaults/.github/scripts")
 	assert.Contains(t, s, "agent: prioritize")
 	assert.Contains(t, s, "concurrency:")
 	assert.Contains(t, s, "fullsend-prioritize")


### PR DESCRIPTION
## Summary

- Fixes Prioritize workflow template so workspace prep copies `setup-agent-env.sh` from `internal/scaffold/fullsend-repo/.github/scripts/` (the script’s real location), not the non-existent repo-root `.github/scripts/` path.
- Aligns `internal/scaffold/fullsend-repo/.github/workflows/prioritize.yml` with `gh-classify.yml`, `scribe.yml`, and the reusable agent workflows: broad sparse-checkout of `internal/scaffold/fullsend-repo/`, `SRC` + `LAYERED_DIRS` pattern, and explicit `cp "${SRC}/.github/scripts/setup-agent-env.sh"`.
- Adds scaffold test assertions to prevent regressing to `.defaults/.github/scripts`.

Pairs with [fullsend-ai/.fullsend#77](https://github.com/fullsend-ai/.fullsend/pull/77) (runtime fix in the config repo). After both merge, orgs that sync from scaffold get the corrected template; `.fullsend` gets immediate relief without waiting for a `v0` tag bump for the script itself (it already exists at the scaffold path on `@v0`).

## Test plan

- [x] `go test ./internal/scaffold/ -run TestPrioritizeWorkflowContent`
- [ ] After merge: scaffold sync / installer picks up updated `prioritize.yml` for new installs
- [ ] With `.fullsend#77` merged: re-run Prioritize workflow and confirm **Setup agent environment** succeeds

Made with [Cursor](https://cursor.com)