### PR TITLE
fix(#1408): debounce retro workflow to make concurrency group effective

### DIFF
--- a/internal/scaffold/fullsend-repo/.github/workflows/retro.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/retro.yml
@@ -25,7 +25,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  debounce:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - run: sleep 60
+
   retro:
+    needs: debounce
     uses: fullsend-ai/fullsend/.github/workflows/reusable-retro.yml@v0
     with:
       event_type: ${{ inputs.event_type }}


### PR DESCRIPTION
## Summary

- Adds a 60-second `debounce` job before the `retro` job in the scaffold's `retro.yml`
- Multiple dispatches for the same PR close (from burst webhook deliveries or shim retries) all start simultaneously; the sleep keeps each run active long enough for the existing `cancel-in-progress: true` concurrency group to cancel stale ones — only the last run survives and proceeds to the actual retro
- No API calls, no TOCTOU races — pure GitHub Actions concurrency semantics

## How it works

```
dispatch 1 → retro starts → sleeping 60s
dispatch 2 → retro starts → cancels dispatch 1's run (cancel-in-progress: true)
dispatch 3 → retro starts → cancels dispatch 2's run
...
dispatch N → retro starts → sleeps 60s uninterrupted → retro job runs
```

## Trade-offs

- Adds 1 minute of runner time per retro run (~$0.008/retro at standard ubuntu-latest pricing)
- Effective when dispatches arrive within the 60-second window; longer gaps (> 60 s between sequential shim executions) may still produce occasional duplicates, mitigated by the pre-existing concurrency group canceling any still-running retro

## Relation to prior work

Supersedes #1412, which implemented the alternative (pre-dispatch API dedup check in `dispatch.yml`). This PR implements the **preferred** approach from #1408: concurrency group in `retro.yml` with `cancel-in-progress: true`, made effective via debounce.

Closes #1408

## Test plan

- [ ] Merge a PR in an enrolled repo and verify only one retro run completes
- [ ] Monitor next 10 PR merges for duplicate retro runs within 5-minute window

🤖 Generated with [Claude Code](https://claude.com/claude-code)