### PR TITLE
fix(#1467): add dedup research step to retro agent before proposing

### DIFF
--- a/internal/scaffold/fullsend-repo/agents/retro.md
+++ b/internal/scaffold/fullsend-repo/agents/retro.md
@@ -29,7 +29,7 @@ You are an analyst, not a fixer. Your job is to:
 
 1. **Explore** — Reconstruct what happened across the full workflow graph (triage, code, review, fix agents and human interactions).
 2. **Analyze** — Evaluate what could go better, considering the optimization goals below.
-3. **Propose** — Write structured improvement proposals with clear validation criteria.
+3. **Propose** — Write structured improvement proposals with clear validation criteria. Before including any proposal, verify no open issue already covers it (see the `retro-analysis` skill's "Before proposing" section).
 
 You do NOT implement fixes, push code, or modify configuration. You propose changes and let existing agent and human workflows handle implementation.
 
@@ -54,6 +54,7 @@ Use the `retro-analysis` skill for detailed workflow tracing recipes.
 - "Gather all review comments on PR #N and categorize them by source (agent vs human) and type (approval, change request, comment)"
 - "Check the last 10 retro proposals in this repo for recurring patterns"
 - "Read the harness config and agent definition for the code agent and summarize its setup"
+- "Search `<target_repo>` for open issues related to `<topic>`. Return title, number, and URL for each result."
 
 Go deep. Follow threads. If you notice a pattern, investigate whether it occurs on other PRs too.
 

--- a/internal/scaffold/fullsend-repo/skills/retro-analysis/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/retro-analysis/SKILL.md
@@ -96,6 +96,33 @@ After subagents return their findings, use your main context to:
 3. Form hypotheses about root causes
 4. Decide what changes to propose and where
 
+## Before proposing: check for existing issues
+
+**This step is mandatory.** Before including any proposal in your output, verify that no open issue already covers the same improvement. The retro agent is the primary source of systemic proposals — without this check, repeated runs produce duplicate issues that waste human triage time.
+
+For each candidate proposal, dispatch a subagent:
+
+> "Search `<target_repo>` for open GitHub issues related to `<topic keywords>`. Return the title, number, URL, and a one-sentence description of each result. I need to know whether any of them already propose the same change I'm considering: `<proposed_change_summary>`."
+
+The subagent should run:
+
+```bash
+# Broad keyword search across title and body
+gh api \
+  "search/issues?q=<topic+keywords>+repo:<target_repo>+is:issue+is:open&per_page=20" \
+  --jq '.items[] | {number: .number, title: .title, url: .html_url, body: .body}'
+```
+
+Use multiple searches with different keyword combinations if the first returns no results — the same idea can be filed under different titles.
+
+**Evaluation criteria** (apply these yourself, not the subagent):
+
+- **Skip the proposal** if an existing open issue proposes the same or a substantially overlapping change. Reference the existing issue in your summary instead.
+- **Skip the proposal** if a recently closed issue addressed the same problem (closed in the last 90 days) — the fix may already be in flight.
+- **Include the proposal** only if you are confident no existing issue covers it, or if your proposal meaningfully refines an existing one in a way that warrants a new issue.
+
+When skipping, note the duplicate in your `summary` field so the human understands what was filtered and why.
+
 ## Localization guidance
 
 When deciding where a proposed change belongs:


### PR DESCRIPTION
## Summary

- Adds a mandatory "Before proposing: check for existing issues" section to `retro-analysis/SKILL.md` with a `gh api search/issues` recipe and clear skip/include criteria
- Updates `retro.md` to reference the dedup check in the Propose step and adds an issue-search example to the subagent dispatch list

## Test plan

- [ ] Trigger a retro run on a PR where related issues already exist and verify the agent skips duplicates and notes them in the summary
- [ ] Verify retro agent still files new issues when no duplicates exist
- [ ] Check `gh issue list --author 'fullsend-ai-retro[bot]' --label duplicate --state closed` rate drops below 10% over the next 2 weeks (per #1467 validation criteria)

Closes #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)