### PR TITLE
fix(ci): raise gitlint title-max-length from 72 to 100

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           echo "${PR_TITLE}" > /tmp/pr-title.txt
-          uvx --from gitlint gitlint --config .gitlint --ignore B6 --msg-filename /tmp/pr-title.txt
+          uvx --from gitlint-core gitlint --config .gitlint --ignore B6 --msg-filename /tmp/pr-title.txt
 
       - name: Lint commits
         if: github.event_name != 'pull_request'
@@ -76,7 +76,7 @@ jobs:
           FAILED=false
           for sha in $(git rev-list --no-merges "${RANGE}"); do
             git log --format='%s' -1 "${sha}" > /tmp/commit-msg.txt
-            if ! uvx --from gitlint gitlint --config .gitlint --ignore B6 --msg-filename /tmp/commit-msg.txt; then
+            if ! uvx --from gitlint-core gitlint --config .gitlint --ignore B6 --msg-filename /tmp/commit-msg.txt; then
               echo "::error::Commit ${sha} does not follow Conventional Commits format"
               FAILED=true
             fi

--- a/.gitlint
+++ b/.gitlint
@@ -2,6 +2,9 @@
 # Enable conventional commits title check
 contrib=CT1
 
+[title-max-length]
+line-length=100
+
 # Conventional commit types allowed in this repo.
 # Matches the types documented in CONTRIBUTING.md and parsed by
 # GoReleaser for release notes.


### PR DESCRIPTION
## Summary
- Raises the gitlint `T1` title-max-length from the default 72 to 100 characters — fixes commit-lint failures in the merge queue and push events caused by conventional commit subjects exceeding 72 chars
- Switches `uvx --from gitlint` to `uvx --from gitlint-core` to suppress the "executable not provided by package" warnings

## Test plan
- [x] Verified the offending 76-char commit message passes with the new config
- [x] `make lint` passes