### PR TITLE
chore: add .fullsend-cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ web/admin/dist
 .dev.vars
 .wrangler
 .worktrees/
+.fullsend-cache/
 __pycache__/
 *.pyc
 .venv/


### PR DESCRIPTION
## Summary

- Adds `.fullsend-cache/` to root `.gitignore` to prevent cache artifacts from being committed
- Part of ADR-0038 Phase 1 implementation (PR 6 in the [implementation plan](docs/plans/universal-harness-access-implementation.md))

## Test plan

- [x] `make lint` passes
- [ ] Verify `.fullsend-cache/` directories are excluded from git tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)