### PR TITLE
feat: add schema extensions for remote resource allowlists

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,13 +43,14 @@ type RepoConfig struct {
 
 // OrgConfig is the top-level configuration for a fullsend organization.
 type OrgConfig struct {
-	Version    string                `yaml:"version"`
-	KillSwitch bool                  `yaml:"kill_switch,omitempty"`
-	Dispatch   DispatchConfig        `yaml:"dispatch"`
-	Inference  InferenceConfig       `yaml:"inference,omitempty"`
-	Defaults   RepoDefaults          `yaml:"defaults"`
-	Agents     []AgentEntry          `yaml:"agents"`
-	Repos      map[string]RepoConfig `yaml:"repos"`
+	Version                string                `yaml:"version"`
+	KillSwitch             bool                  `yaml:"kill_switch,omitempty"`
+	Dispatch               DispatchConfig        `yaml:"dispatch"`
+	Inference              InferenceConfig       `yaml:"inference,omitempty"`
+	Defaults               RepoDefaults          `yaml:"defaults"`
+	Agents                 []AgentEntry          `yaml:"agents"`
+	Repos                  map[string]RepoConfig `yaml:"repos"`
+	AllowedRemoteResources []string              `yaml:"allowed_remote_resources,omitempty"`
 }
 
 // ValidRoles returns the set of recognized agent roles.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -664,3 +664,78 @@ func TestPerRepoConfig_RoundTrip(t *testing.T) {
 	assert.Equal(t, original.Roles, parsed.Roles)
 	assert.Equal(t, original.KillSwitch, parsed.KillSwitch)
 }
+
+// --- AllowedRemoteResources tests ---
+
+func TestOrgConfig_AllowedRemoteResources(t *testing.T) {
+	t.Run("parse YAML with allowed_remote_resources", func(t *testing.T) {
+		yamlData := `
+version: "1"
+dispatch:
+  platform: github-actions
+defaults:
+  roles:
+    - fullsend
+  max_implementation_retries: 2
+agents: []
+repos: {}
+allowed_remote_resources:
+  - https://example.com/skills/
+  - https://cdn.example.com/policies/
+`
+		cfg, err := ParseOrgConfig([]byte(yamlData))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"https://example.com/skills/", "https://cdn.example.com/policies/"}, cfg.AllowedRemoteResources)
+	})
+
+	t.Run("parse YAML without allowed_remote_resources", func(t *testing.T) {
+		yamlData := `
+version: "1"
+dispatch:
+  platform: github-actions
+defaults:
+  roles:
+    - fullsend
+  max_implementation_retries: 2
+agents: []
+repos: {}
+`
+		cfg, err := ParseOrgConfig([]byte(yamlData))
+		require.NoError(t, err)
+		assert.Empty(t, cfg.AllowedRemoteResources)
+	})
+
+	t.Run("marshal with field", func(t *testing.T) {
+		cfg := &OrgConfig{
+			Version:  "1",
+			Dispatch: DispatchConfig{Platform: "github-actions"},
+			Defaults: RepoDefaults{
+				Roles:                    []string{"fullsend"},
+				MaxImplementationRetries: 2,
+			},
+			Agents:                 []AgentEntry{},
+			Repos:                  map[string]RepoConfig{},
+			AllowedRemoteResources: []string{"https://example.com/skills/"},
+		}
+		data, err := cfg.Marshal()
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "allowed_remote_resources:")
+		assert.Contains(t, string(data), "https://example.com/skills/")
+	})
+
+	t.Run("marshal without field omits key", func(t *testing.T) {
+		cfg := &OrgConfig{
+			Version:  "1",
+			Dispatch: DispatchConfig{Platform: "github-actions"},
+			Defaults: RepoDefaults{
+				Roles:                    []string{"fullsend"},
+				MaxImplementationRetries: 2,
+			},
+			Agents: []AgentEntry{},
+			Repos:  map[string]RepoConfig{},
+		}
+		data, err := cfg.Marshal()
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "allowed_remote_resources")
+	})
+}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -2,7 +2,9 @@ package harness
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -203,10 +205,11 @@ type Harness struct {
 	PostScript     string            `yaml:"post_script,omitempty"`
 	AgentInput     string            `yaml:"agent_input,omitempty"`
 	ValidationLoop *ValidationLoop   `yaml:"validation_loop,omitempty"`
-	RunnerEnv      map[string]string `yaml:"runner_env,omitempty"`
-	TimeoutMinutes        int             `yaml:"timeout_minutes,omitempty"`
-	SandboxTimeoutSeconds int             `yaml:"sandbox_timeout_seconds,omitempty"`
-	Security              *SecurityConfig `yaml:"security,omitempty"`
+	RunnerEnv              map[string]string `yaml:"runner_env,omitempty"`
+	TimeoutMinutes         int               `yaml:"timeout_minutes,omitempty"`
+	SandboxTimeoutSeconds  int               `yaml:"sandbox_timeout_seconds,omitempty"`
+	Security               *SecurityConfig   `yaml:"security,omitempty"`
+	AllowedRemoteResources []string          `yaml:"allowed_remote_resources,omitempty"`
 }
 
 // Load reads a harness YAML file from path, unmarshals it, and validates it.
@@ -267,6 +270,11 @@ func (h *Harness) Validate() error {
 	if err := h.validateSecurity(); err != nil {
 		return err
 	}
+	if err := h.ValidateResourceTypes(); err != nil {
+		return err
+	}
+	// ValidateAllowedRemoteResources requires the org allowlist and is called
+	// by the integration layer, not here.
 	return nil
 }
 
@@ -317,6 +325,7 @@ func (h *Harness) validateSecurity() error {
 // ResolveRelativeTo resolves all relative paths in the harness against baseDir.
 // Relative paths that resolve outside baseDir are rejected to prevent directory
 // traversal (e.g. ../../etc/shadow). Absolute paths and ${VAR} paths are allowed.
+// TODO(PR 7): skip URL-valued fields (agent, policy, skills[]) via IsURL().
 func (h *Harness) ResolveRelativeTo(baseDir string) error {
 	cleanBase := filepath.Clean(baseDir) + string(filepath.Separator)
 
@@ -489,4 +498,163 @@ func (h *Harness) Scripts() []string {
 		scripts = append(scripts, h.ValidationLoop.Script)
 	}
 	return scripts
+}
+
+// ValidateAllowedRemoteResources checks that each entry in AllowedRemoteResources
+// is a valid HTTPS URL ending with "/" and is covered by at least one entry in the
+// org-level allowlist. Org allowlist entries are also validated: each must be a
+// valid HTTPS URL ending with "/" and must not contain double-encoded sequences.
+func (h *Harness) ValidateAllowedRemoteResources(orgAllowlist []string) error {
+	for i, orgEntry := range orgAllowlist {
+		if !IsURL(orgEntry) {
+			return fmt.Errorf("org allowlist[%d]: %q is not a valid HTTPS URL", i, orgEntry)
+		}
+		if !strings.HasSuffix(orgEntry, "/") {
+			return fmt.Errorf("org allowlist[%d]: %q must end with /", i, orgEntry)
+		}
+		if strings.Contains(strings.ToLower(orgEntry), "%25") {
+			return fmt.Errorf("org allowlist[%d]: %q contains double-encoded sequence", i, orgEntry)
+		}
+	}
+	for i, entry := range h.AllowedRemoteResources {
+		if !IsURL(entry) {
+			return fmt.Errorf("allowed_remote_resources[%d]: %q is not a valid HTTPS URL", i, entry)
+		}
+		if !strings.HasSuffix(entry, "/") {
+			return fmt.Errorf("allowed_remote_resources[%d]: %q must end with /", i, entry)
+		}
+		if strings.Contains(strings.ToLower(entry), "%25") {
+			return fmt.Errorf("allowed_remote_resources[%d]: %q contains double-encoded sequence", i, entry)
+		}
+		normEntry, entryOK := normalizeURLPath(strings.ToLower(entry))
+		if !entryOK {
+			return fmt.Errorf("allowed_remote_resources[%d]: %q cannot be normalized", i, entry)
+		}
+		covered := false
+		for _, orgEntry := range orgAllowlist {
+			normOrg, orgOK := normalizeURLPath(strings.ToLower(orgEntry))
+			if !orgOK {
+				continue
+			}
+			if strings.HasPrefix(normEntry, normOrg) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			return fmt.Errorf("allowed_remote_resources[%d]: %q is not covered by the org allowlist", i, entry)
+		}
+	}
+	return nil
+}
+
+// ValidateResourceTypes checks that executable fields (pre_script, post_script,
+// validation_loop.script, host_files[].src, api_servers[].script) are local paths
+// and not URLs, and that declarative fields (agent, policy, skills[]) that are URLs
+// include an integrity hash (#sha256=...).
+func (h *Harness) ValidateResourceTypes() error {
+	// Executable fields must be local paths, not URLs.
+	execFields := []struct {
+		name  string
+		value string
+	}{
+		{"pre_script", h.PreScript},
+		{"post_script", h.PostScript},
+		{"agent_input", h.AgentInput},
+	}
+	for _, f := range execFields {
+		if f.value != "" && IsURL(f.value) {
+			return fmt.Errorf("%s must be a local path, not a URL", f.name)
+		}
+	}
+	if h.ValidationLoop != nil && h.ValidationLoop.Script != "" && IsURL(h.ValidationLoop.Script) {
+		return fmt.Errorf("validation_loop.script must be a local path, not a URL")
+	}
+	for i, hf := range h.HostFiles {
+		if IsURL(hf.Src) {
+			return fmt.Errorf("host_files[%d].src must be a local path, not a URL", i)
+		}
+	}
+	for i, as := range h.APIServers {
+		if IsURL(as.Script) {
+			return fmt.Errorf("api_servers[%d].script must be a local path, not a URL", i)
+		}
+	}
+
+	// Declarative fields: if a URL, must include integrity hash.
+	declFields := []struct {
+		name  string
+		value string
+	}{
+		{"agent", h.Agent},
+		{"policy", h.Policy},
+	}
+	for _, f := range declFields {
+		if f.value != "" && IsURL(f.value) {
+			if _, _, hasHash := ParseIntegrityHash(f.value); !hasHash {
+				return fmt.Errorf("%s URL must include #sha256=... integrity hash", f.name)
+			}
+		}
+	}
+	for i, s := range h.Skills {
+		if IsURL(s) {
+			if _, _, hasHash := ParseIntegrityHash(s); !hasHash {
+				return fmt.Errorf("skills[%d] URL must include #sha256=... integrity hash", i)
+			}
+		}
+	}
+
+	return nil
+}
+
+// MatchesAllowedPrefix reports whether rawURL starts with any entry in
+// AllowedRemoteResources (case-insensitive). The URL path is percent-decoded
+// and normalized (resolving ".." and "." segments) before prefix matching to
+// prevent path-traversal bypasses via both literal and encoded dot segments.
+// Returns false if the URL contains "%25" (double-encoded percent sign) or
+// cannot be parsed.
+func (h *Harness) MatchesAllowedPrefix(rawURL string) bool {
+	lower := strings.ToLower(rawURL)
+	if strings.Contains(lower, "%25") {
+		return false
+	}
+	normalized, ok := normalizeURLPath(lower)
+	if !ok {
+		return false
+	}
+	for _, prefix := range h.AllowedRemoteResources {
+		normPrefix, prefixOK := normalizeURLPath(strings.ToLower(prefix))
+		if !prefixOK {
+			continue
+		}
+		if strings.HasPrefix(normalized, normPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeURLPath parses a URL, percent-decodes and cleans its path, and
+// returns the reconstructed URL string. Returns false if parsing fails.
+func normalizeURLPath(rawURL string) (string, bool) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", false
+	}
+	unescaped, err := url.PathUnescape(parsed.Path)
+	if err != nil {
+		return "", false
+	}
+	if strings.ContainsRune(unescaped, '\\') {
+		return "", false
+	}
+	rawPath := parsed.Path
+	parsed.Path = path.Clean(unescaped)
+	parsed.RawPath = ""
+	if parsed.Path == "." {
+		parsed.Path = "/"
+	} else if strings.HasSuffix(rawPath, "/") && !strings.HasSuffix(parsed.Path, "/") {
+		parsed.Path += "/"
+	}
+	return parsed.String(), true
 }

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -662,3 +662,325 @@ func TestValidateFilesExist_SkipsOptionalPaths(t *testing.T) {
 	// Should not error — optional host files may not exist until runtime.
 	require.NoError(t, h.ValidateFilesExist())
 }
+
+// --- AllowedRemoteResources tests ---
+
+func TestHarness_AllowedRemoteResources_Parse(t *testing.T) {
+	t.Run("with allowed_remote_resources", func(t *testing.T) {
+		content := `
+agent: agents/test.md
+allowed_remote_resources:
+  - https://example.com/skills/
+  - https://cdn.example.com/policies/
+`
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+		h, err := Load(path)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"https://example.com/skills/", "https://cdn.example.com/policies/"}, h.AllowedRemoteResources)
+	})
+
+	t.Run("without allowed_remote_resources", func(t *testing.T) {
+		content := `
+agent: agents/test.md
+`
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+		h, err := Load(path)
+		require.NoError(t, err)
+		assert.Empty(t, h.AllowedRemoteResources)
+	})
+}
+
+func TestValidateAllowedRemoteResources(t *testing.T) {
+	t.Run("valid entries with matching org allowlist", func(t *testing.T) {
+		h := &Harness{
+			Agent: "agents/test.md",
+			AllowedRemoteResources: []string{
+				"https://example.com/skills/",
+				"https://cdn.example.com/policies/",
+			},
+		}
+		orgAllowlist := []string{
+			"https://example.com/",
+			"https://cdn.example.com/policies/",
+		}
+		require.NoError(t, h.ValidateAllowedRemoteResources(orgAllowlist))
+	})
+
+	t.Run("non-HTTPS entry", func(t *testing.T) {
+		h := &Harness{
+			Agent: "agents/test.md",
+			AllowedRemoteResources: []string{
+				"http://example.com/skills/",
+			},
+		}
+		err := h.ValidateAllowedRemoteResources([]string{"http://example.com/"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a valid HTTPS URL")
+	})
+
+	t.Run("missing trailing slash", func(t *testing.T) {
+		h := &Harness{
+			Agent: "agents/test.md",
+			AllowedRemoteResources: []string{
+				"https://example.com/skills",
+			},
+		}
+		err := h.ValidateAllowedRemoteResources([]string{"https://example.com/"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must end with /")
+	})
+
+	t.Run("entry not covered by org allowlist", func(t *testing.T) {
+		h := &Harness{
+			Agent: "agents/test.md",
+			AllowedRemoteResources: []string{
+				"https://evil.com/skills/",
+			},
+		}
+		err := h.ValidateAllowedRemoteResources([]string{"https://example.com/"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not covered by the org allowlist")
+	})
+
+	t.Run("org entry without trailing slash", func(t *testing.T) {
+		h := &Harness{
+			Agent: "agents/test.md",
+			AllowedRemoteResources: []string{
+				"https://example.com/skills/",
+			},
+		}
+		err := h.ValidateAllowedRemoteResources([]string{"https://example.com"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "org allowlist")
+		assert.Contains(t, err.Error(), "must end with /")
+	})
+
+	t.Run("org entry non-HTTPS", func(t *testing.T) {
+		h := &Harness{
+			Agent: "agents/test.md",
+			AllowedRemoteResources: []string{
+				"https://example.com/skills/",
+			},
+		}
+		err := h.ValidateAllowedRemoteResources([]string{"http://example.com/"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "org allowlist")
+		assert.Contains(t, err.Error(), "not a valid HTTPS URL")
+	})
+
+	t.Run("org entry with double encoding", func(t *testing.T) {
+		h := &Harness{
+			Agent: "agents/test.md",
+			AllowedRemoteResources: []string{
+				"https://example.com/skills/",
+			},
+		}
+		err := h.ValidateAllowedRemoteResources([]string{"https://example.com/%252f/"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "double-encoded")
+	})
+
+	t.Run("harness entry with double encoding", func(t *testing.T) {
+		h := &Harness{
+			Agent: "agents/test.md",
+			AllowedRemoteResources: []string{
+				"https://example.com/%252fskills/",
+			},
+		}
+		err := h.ValidateAllowedRemoteResources([]string{"https://example.com/"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "double-encoded")
+	})
+
+	t.Run("org entry without trailing slash enables domain confusion", func(t *testing.T) {
+		h := &Harness{
+			Agent: "agents/test.md",
+			AllowedRemoteResources: []string{
+				"https://example.com.evil.com/",
+			},
+		}
+		err := h.ValidateAllowedRemoteResources([]string{"https://example.com/"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not covered by the org allowlist")
+	})
+
+	t.Run("percent-encoded traversal not covered", func(t *testing.T) {
+		h := &Harness{
+			Agent: "agents/test.md",
+			AllowedRemoteResources: []string{
+				"https://example.com/skills/%2e%2e/evil/",
+			},
+		}
+		err := h.ValidateAllowedRemoteResources([]string{"https://example.com/skills/"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not covered by the org allowlist")
+	})
+}
+
+func TestValidateResourceTypes(t *testing.T) {
+	t.Run("URL in pre_script", func(t *testing.T) {
+		h := &Harness{
+			Agent:     "agents/test.md",
+			PreScript: "https://example.com/scripts/pre.sh",
+		}
+		err := h.ValidateResourceTypes()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a local path")
+	})
+
+	t.Run("URL in post_script", func(t *testing.T) {
+		h := &Harness{
+			Agent:      "agents/test.md",
+			PostScript: "https://example.com/scripts/post.sh",
+		}
+		err := h.ValidateResourceTypes()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a local path")
+	})
+
+	t.Run("URL in agent without hash", func(t *testing.T) {
+		h := &Harness{
+			Agent: "https://example.com/agents/test.md",
+		}
+		err := h.ValidateResourceTypes()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "integrity hash")
+	})
+
+	t.Run("URL in agent with valid hash", func(t *testing.T) {
+		h := &Harness{
+			Agent: "https://example.com/agents/test.md#sha256=abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+		}
+		require.NoError(t, h.ValidateResourceTypes())
+	})
+
+	t.Run("all-local harness", func(t *testing.T) {
+		h := &Harness{
+			Agent:      "agents/test.md",
+			Policy:     "policies/readonly.yaml",
+			Skills:     []string{"skills/summarize"},
+			PreScript:  "scripts/pre.sh",
+			PostScript: "scripts/post.sh",
+			HostFiles:  []HostFile{{Src: "/etc/ssl/certs/ca.crt", Dest: "/tmp/ca.crt"}},
+			APIServers: []APIServer{{Name: "api", Script: "scripts/api.sh", Port: 8080}},
+			ValidationLoop: &ValidationLoop{
+				Script:        "scripts/validate.sh",
+				MaxIterations: 1,
+			},
+		}
+		require.NoError(t, h.ValidateResourceTypes())
+	})
+
+	t.Run("URL in skills without hash", func(t *testing.T) {
+		h := &Harness{
+			Agent:  "agents/test.md",
+			Skills: []string{"https://example.com/skills/summarize.md"},
+		}
+		err := h.ValidateResourceTypes()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "integrity hash")
+	})
+
+	t.Run("URL in validation_loop.script", func(t *testing.T) {
+		h := &Harness{
+			Agent: "agents/test.md",
+			ValidationLoop: &ValidationLoop{
+				Script:        "https://example.com/scripts/validate.sh",
+				MaxIterations: 1,
+			},
+		}
+		err := h.ValidateResourceTypes()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a local path")
+	})
+
+	t.Run("URL in host_files src", func(t *testing.T) {
+		h := &Harness{
+			Agent: "agents/test.md",
+			HostFiles: []HostFile{
+				{Src: "https://example.com/file.txt", Dest: "/tmp/file.txt"},
+			},
+		}
+		err := h.ValidateResourceTypes()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a local path")
+	})
+
+	t.Run("URL in api_servers script", func(t *testing.T) {
+		h := &Harness{
+			Agent: "agents/test.md",
+			APIServers: []APIServer{
+				{Name: "api", Script: "https://example.com/api.sh", Port: 8080},
+			},
+		}
+		err := h.ValidateResourceTypes()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a local path")
+	})
+
+	t.Run("URL in agent_input", func(t *testing.T) {
+		h := &Harness{
+			Agent:      "agents/test.md",
+			AgentInput: "https://example.com/input.txt",
+		}
+		err := h.ValidateResourceTypes()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "agent_input must be a local path")
+	})
+}
+
+func TestMatchesAllowedPrefix(t *testing.T) {
+	h := &Harness{
+		Agent: "agents/test.md",
+		AllowedRemoteResources: []string{
+			"https://example.com/skills/",
+			"https://cdn.example.com/policies/",
+		},
+	}
+
+	t.Run("matching URL", func(t *testing.T) {
+		assert.True(t, h.MatchesAllowedPrefix("https://example.com/skills/summarize.md"))
+	})
+
+	t.Run("non-matching URL", func(t *testing.T) {
+		assert.False(t, h.MatchesAllowedPrefix("https://evil.com/skills/summarize.md"))
+	})
+
+	t.Run("double-encoded URL", func(t *testing.T) {
+		assert.False(t, h.MatchesAllowedPrefix("https://example.com/skills/%2561gent.md"))
+	})
+
+	t.Run("case-insensitive match", func(t *testing.T) {
+		assert.True(t, h.MatchesAllowedPrefix("https://EXAMPLE.COM/skills/summarize.md"))
+	})
+
+	t.Run("path traversal rejected", func(t *testing.T) {
+		assert.False(t, h.MatchesAllowedPrefix("https://example.com/skills/../evil/payload"))
+	})
+
+	t.Run("dot segment in matching path", func(t *testing.T) {
+		assert.True(t, h.MatchesAllowedPrefix("https://example.com/skills/./summarize.md"))
+	})
+
+	t.Run("percent-encoded traversal rejected", func(t *testing.T) {
+		assert.False(t, h.MatchesAllowedPrefix("https://example.com/skills/%2e%2e/evil/payload"))
+	})
+
+	t.Run("percent-encoded dot segment in matching path", func(t *testing.T) {
+		assert.True(t, h.MatchesAllowedPrefix("https://example.com/skills/%2e/summarize.md"))
+	})
+
+	t.Run("backslash traversal rejected", func(t *testing.T) {
+		assert.False(t, h.MatchesAllowedPrefix(`https://example.com/skills\..\secret`))
+	})
+
+	t.Run("trailing slash from query not path", func(t *testing.T) {
+		assert.False(t, h.MatchesAllowedPrefix("https://evil.com/path?ref=v1/"))
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `AllowedRemoteResources []string` field to both `Harness` and `OrgConfig` structs (backward-compatible, `omitempty`)
- Adds `ValidateAllowedRemoteResources(orgAllowlist)` — validates entries are HTTPS URLs with trailing `/`, covered by org allowlist
- Adds `ValidateResourceTypes()` — rejects URLs in executable fields (`pre_script`, `post_script`, etc.), requires `#sha256=...` integrity hashes on declarative URL fields (`agent`, `policy`, `skills[]`)
- Adds `MatchesAllowedPrefix(rawURL)` — case-insensitive prefix match with `%25` double-encoding rejection
- Part of ADR-0038 Phase 1 implementation (PR 5 in the [implementation plan](docs/plans/universal-harness-access-implementation.md))

## Test plan

- [x] `go test ./internal/harness/ ./internal/config/` — all 93 tests pass
- [x] `go vet` — clean
- [x] Backward compatibility: existing harnesses without `allowed_remote_resources` parse and validate identically
- [x] 17 new harness test cases + 4 new config test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)