### PR TITLE
fix(reusable-fix): propagate gh pr view failures in eligibility check

### DIFF
--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -247,8 +247,8 @@ jobs:
         run: |
           if [[ "${TRIGGER_SOURCE}" =~ \[bot\]$ ]]; then
             PR_INFO=$(gh pr view "${PR_NUM}" --repo "${SOURCE_REPO}" \
-              --json labels,author --jq '{labels: [.labels[].name], author: .author.login}' 2>/dev/null \
-              || echo '{"labels":[],"author":""}')
+              --json labels,author --jq '{labels: [.labels[].name], author: .author.login}') \
+              || { echo "::error::Failed to fetch PR info for #${PR_NUM}"; exit 1; }
 
             HAS_NO_FIX=$(echo "${PR_INFO}" | jq -r '.labels | any(. == "fullsend-no-fix")')
             if [[ "${HAS_NO_FIX}" == "true" ]]; then


### PR DESCRIPTION
## Summary

- `gh pr view` in the "Check fix eligibility" step was called with `2>/dev/null || echo '{"labels":[],"author":""}'`, silently swallowing API failures
- A failed call returned empty author/labels, causing the step to exit 1 with a misleading "Human-authored PR without fullsend-fix label" message instead of exposing the real error
- Removes the silent fallback; failure now emits `::error::` and exits 1 explicitly

Closes #1564

## Test plan

- [ ] Verify the eligibility step passes normally on a bot-triggered PR with expected labels
- [ ] Simulate a `gh pr view` failure (e.g. revoke token) and confirm the job fails with `::error::Failed to fetch PR info` rather than the misleading "human-authored" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)