### PR TITLE
fix(triage): accumulate prior analysis on re-runs

### DIFF
--- a/docs/agents/triage.md
+++ b/docs/agents/triage.md
@@ -23,7 +23,7 @@ The agent runs in a read-only sandbox. It cannot modify issues, push code, or in
 | `/fs-triage` | Issue comment | Runs triage on the issue |
 
 The `/fs-triage` command does not accept arguments — it re-evaluates the issue
-from scratch using current content and comments.
+using current content, comments, and any prior triage analysis.
 
 Triage also runs automatically when a new issue is opened, when an issue is
 edited, and when someone comments on an issue labeled `needs-info` (to

--- a/docs/guides/user/bugfix-workflow.md
+++ b/docs/guides/user/bugfix-workflow.md
@@ -107,7 +107,7 @@ The triage agent:
 4. **Produces a test artifact.** When possible, writes a failing test case aligned with the repo's test framework.
 5. **Hands off.** Labels `ready-to-code` with a summary comment.
 
-**If triage gets it wrong:** Add a comment with the missing information, or edit the issue body. Edits to the title or body trigger triage automatically. You can also use `/fs-triage` to force a fresh run — this clears all previous labels and starts from scratch.
+**If triage gets it wrong:** Add a comment with the missing information, or edit the issue body. Edits to the title or body trigger triage automatically. You can also use `/fs-triage` to force a fresh run — this clears previous triage labels and re-evaluates, building on any prior triage analysis rather than discarding it.
 
 ### Stage 2: Code
 

--- a/internal/scaffold/fullsend-repo/agents/triage.md
+++ b/internal/scaffold/fullsend-repo/agents/triage.md
@@ -76,6 +76,17 @@ gh pr view BLOCKING_URL --json state,title,body,comments,labels,mergedAt
 
 Use `gh issue view` for `/issues/` URLs and `gh pr view` for `/pull/` URLs. Review the blocker's state, recent comments, and labels to determine whether the dependency has been resolved, is making progress, or remains stalled. If the blocker has been closed or merged, the block may be resolved — proceed with a fresh assessment.
 
+### 2d. Review prior triage analysis
+
+Check whether this issue has already been triaged. Look through the comments you fetched in Step 1 for a prior triage comment — it will contain `<!-- fullsend:triage-agent -->` in its body, or be posted by a user whose login ends in `-triage[bot]`.
+
+If a prior triage comment exists, **accumulate — do not replace:**
+
+- **Preserve all previously identified problems.** Treat every cause documented in the prior analysis as an established finding. Do not silently drop any of them. If you believe a previously identified cause is no longer valid (e.g., already fixed, confirmed misdiagnosis), document this explicitly in `reasoning` — a cause removed without explanation is a regression in analysis quality.
+- **Incorporate human-identified problems.** When an issue author or contributor adds a comment that says "the real issue is X", "you also missed Y", or otherwise points to a problem not in the prior analysis, treat it with the same evidentiary weight as a clear error message. If you cannot independently verify the claim, include it as a hypothesis — do not omit it.
+- **Your new analysis must be a superset** of the prior analysis. Identified problems accumulate across triage runs; the count of documented problems can only go up, not down (unless a cause is explicitly refuted with reasoning).
+- **Re-triaging is about incorporating new information**, not restarting from scratch. If a human comment triggered this re-run, focus your analysis on what that comment changes or adds. Then confirm all previously documented problems are still represented.
+
 ## Step 3: Assess information sufficiency
 
 Use this phased approach to evaluate the issue:


### PR DESCRIPTION
## Summary

- Adds Step 2d to `agents/triage.md` instructing triage to locate its own prior sticky comment (`<!-- fullsend:triage-agent -->`) before producing a new result
- Enforces a superset rule: identified problems accumulate across re-runs and cannot be silently dropped
- Human comments pointing to missed problems are explicitly weighted as strong evidence (same as an error message), not ignored

Closes #1491.

## Test plan

- [ ] Triage an issue, add a comment identifying a second root cause, re-trigger triage — verify the new analysis includes both causes
- [ ] Verify re-triage `reasoning` field explains any cause removed from the prior analysis (regression guard)
- [ ] Verify triage on a fresh issue (no prior comment) behaves identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)