### PR TITLE
fix(cli): open correct uninstall URL and wait for user confirmation

### DIFF
--- a/docs/guides/getting-started/installation.md
+++ b/docs/guides/getting-started/installation.md
@@ -361,6 +361,8 @@ fullsend admin uninstall "$ORG_NAME"
 
 The uninstall preflight will prompt you to add the `delete_repo` scope if it is missing.
 
+After removing the config repo and secrets, the CLI opens a browser tab for each installed fullsend GitHub App. Click **Uninstall** on the page, then press **Enter** in the terminal to continue to the next app. Once all apps have been processed, the CLI re-checks the org's installations and reports whether each app was successfully removed.
+
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--yolo` | `false` | Skip the confirmation prompt |

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -1739,6 +1739,7 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 				}
 			}
 		} else {
+			printer.StepWarn(fmt.Sprintf("Could not verify which apps are installed for %s. Assuming all apps are installed.", org))
 			existingSlugs = agentSlugs
 		}
 

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -118,9 +118,9 @@ type skipMintDispatcher struct {
 	mintURL string
 }
 
-func (d *skipMintDispatcher) Name() string                        { return "skip-mint-check" }
-func (d *skipMintDispatcher) OrgSecretNames() []string            { return nil }
-func (d *skipMintDispatcher) OrgVariableNames() []string          { return []string{"FULLSEND_MINT_URL"} }
+func (d *skipMintDispatcher) Name() string               { return "skip-mint-check" }
+func (d *skipMintDispatcher) OrgSecretNames() []string   { return nil }
+func (d *skipMintDispatcher) OrgVariableNames() []string { return []string{"FULLSEND_MINT_URL"} }
 func (d *skipMintDispatcher) StoreAgentPEM(context.Context, string, string, []byte) error {
 	return nil
 }
@@ -129,23 +129,23 @@ func (d *skipMintDispatcher) Provision(context.Context) (map[string]string, erro
 }
 
 type perRepoInstallConfig struct {
-	RepoFullName        string
-	Agents              string
-	MintURL             string
-	InferenceRegion     string
-	InferenceProject    string
+	RepoFullName         string
+	Agents               string
+	MintURL              string
+	InferenceRegion      string
+	InferenceProject     string
 	InferenceWIFProvider string
-	MintProject         string
-	MintRegion          string
-	DryRun              bool
-	SkipAppSetup        bool
-	PublicApps          bool
-	MintProvider        string
-	MintSourceDir       string
-	MintSkipDeploy      bool
-	SkipMintCheck       bool
-	AppSet              string
-	VendorBinary        bool
+	MintProject          string
+	MintRegion           string
+	DryRun               bool
+	SkipAppSetup         bool
+	PublicApps           bool
+	MintProvider         string
+	MintSourceDir        string
+	MintSkipDeploy       bool
+	SkipMintCheck        bool
+	AppSet               string
+	VendorBinary         bool
 }
 
 // wifProviderPattern validates the full WIF provider resource name format
@@ -283,23 +283,23 @@ Inference authentication:
 					perRepoMintProject = inferenceProject
 				}
 				return runPerRepoInstall(cmd.Context(), perRepoInstallConfig{
-					RepoFullName:        arg,
-					Agents:              perRepoAgents,
-					MintURL:             mintURL,
-					InferenceRegion:     inferenceRegion,
-					InferenceProject:    inferenceProject,
+					RepoFullName:         arg,
+					Agents:               perRepoAgents,
+					MintURL:              mintURL,
+					InferenceRegion:      inferenceRegion,
+					InferenceProject:     inferenceProject,
 					InferenceWIFProvider: inferenceWIFProvider,
-					MintProject:         perRepoMintProject,
-					MintRegion:          mintRegion,
-					DryRun:              dryRun,
-					SkipAppSetup:        skipAppSetup,
-					PublicApps:          publicApps,
-					MintProvider:        mintProvider,
-					MintSourceDir:       mintSourceDir,
-					MintSkipDeploy:      mintSkipDeploy,
-					SkipMintCheck:       skipMintCheck,
-					AppSet:              appSet,
-					VendorBinary:        vendorBinary,
+					MintProject:          perRepoMintProject,
+					MintRegion:           mintRegion,
+					DryRun:               dryRun,
+					SkipAppSetup:         skipAppSetup,
+					PublicApps:           publicApps,
+					MintProvider:         mintProvider,
+					MintSourceDir:        mintSourceDir,
+					MintSkipDeploy:       mintSkipDeploy,
+					SkipMintCheck:        skipMintCheck,
+					AppSet:               appSet,
+					VendorBinary:         vendorBinary,
 				})
 			}
 
@@ -1720,6 +1720,7 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 
 	printer.Blank()
 
+	printer.Header("App uninstall")
 	// Check which apps actually exist before opening browser pages.
 	// We open the org's installation settings page (/organizations/{org}/settings/installations/{id})
 	// rather than the app's own /advanced page, because the /advanced delete button is only
@@ -1748,7 +1749,7 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 		}
 
 		if len(existingSlugs) > 0 {
-			printer.Header("App cleanup")
+
 			printer.StepInfo("Opening browser for each app installation that needs to be removed.")
 			printer.StepInfo("Click 'Uninstall' on each page. Press Enter here after each one to continue.")
 			printer.Blank()

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -1720,7 +1720,6 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 
 	printer.Blank()
 
-	printer.Header("App uninstall")
 	// Check which apps actually exist before opening browser pages.
 	// We open the org's installation settings page (/organizations/{org}/settings/installations/{id})
 	// rather than the app's own /advanced page, because the /advanced delete button is only
@@ -1729,27 +1728,23 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 	if len(agentSlugs) > 0 {
 		// Find which slugs correspond to real installed apps.
 		var existingSlugs []string
-		installationIDs := make(map[string]int)
-		installations, listErr := client.ListOrgInstallations(ctx, org)
+		appIDs := make(map[string]int)
+		appInstallations, listErr := client.ListOrgInstallations(ctx, org)
 		if listErr == nil {
-			for _, inst := range installations {
-				installationIDs[inst.AppSlug] = inst.ID
+			for _, inst := range appInstallations {
+				appIDs[inst.AppSlug] = inst.ID
 			}
 			for _, slug := range agentSlugs {
-				if _, ok := installationIDs[slug]; ok {
+				if _, ok := appIDs[slug]; ok {
 					existingSlugs = append(existingSlugs, slug)
-				} else {
-					printer.StepInfo(fmt.Sprintf("App %s not found, skipping", slug))
 				}
 			}
 		} else {
-			// Can't check — fall back to opening all of them.
-			printer.StepWarn("Could not verify which apps exist; opening all")
 			existingSlugs = agentSlugs
 		}
 
 		if len(existingSlugs) > 0 {
-
+			printer.Header("App uninstall")
 			printer.StepInfo("Opening browser for each app installation that needs to be removed.")
 			printer.StepInfo("Click 'Uninstall' on each page. Press Enter here after each one to continue.")
 			printer.Blank()
@@ -1757,7 +1752,7 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 			stdinReader := bufio.NewReader(stdin)
 			for _, slug := range existingSlugs {
 				var uninstallURL string
-				if id := installationIDs[slug]; id != 0 {
+				if id := appIDs[slug]; id != 0 {
 					uninstallURL = fmt.Sprintf("https://github.com/organizations/%s/settings/installations/%d", org, id)
 				} else {
 					uninstallURL = fmt.Sprintf("https://github.com/organizations/%s/settings/installations", org)
@@ -1773,12 +1768,32 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 				if _, err := stdinReader.ReadString('\n'); err != nil && !errors.Is(err, io.EOF) {
 					return fmt.Errorf("reading confirmation: %w", err)
 				}
-				printer.StepDone(fmt.Sprintf("%s uninstalled", slug))
 			}
 			printer.Blank()
+
+			printer.StepStart("Verifying if apps were removed")
+			freshInstalls, verifyErr := client.ListOrgInstallations(ctx, org)
+			if verifyErr != nil {
+				printer.StepWarn(fmt.Sprintf("Could not get installations for org %s: %v", org, verifyErr))
+			} else {
+				stillInstalledSlugs := []string{}
+				for _, slug := range existingSlugs {
+					for _, inst := range freshInstalls {
+						if inst.AppSlug == slug {
+							stillInstalledSlugs = append(stillInstalledSlugs, inst.AppSlug)
+						}
+					}
+				}
+
+				if len(stillInstalledSlugs) != 0 {
+					printer.StepWarn(fmt.Sprintf("Some fullsend apps are still installed — uninstall manually at: %s", fmt.Sprintf("https://github.com/organizations/%s/settings/installations", org)))
+				} else {
+					printer.StepDone("Apps were uninstalled")
+				}
+			}
 		} else if listErr == nil {
 			printer.StepWarn("No fullsend apps found installed in this organization.")
-			printer.StepInfo("If apps were created under a custom --app-set prefix, re-run with that prefix.")
+			printer.StepWarn("If apps were created under a custom --app-set prefix, re-run with that prefix.")
 		}
 	}
 

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -1134,7 +1134,7 @@ func newUninstallCmd() *cobra.Command {
 			if os.Getenv("CI") != "" {
 				browser = appsetup.NopBrowser{}
 			}
-			return runUninstall(ctx, client, printer, org, appSet, browser)
+			return runUninstall(ctx, client, printer, org, appSet, browser, os.Stdin)
 		},
 	}
 
@@ -1631,7 +1631,7 @@ func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, o
 }
 
 // runUninstall tears down the fullsend installation.
-func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer, org, appSet string, browser appsetup.BrowserOpener) error {
+func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer, org, appSet string, browser appsetup.BrowserOpener, stdin io.Reader) error {
 	// Try to load agent slugs from existing config. If the .fullsend repo
 	// is already gone (e.g., previous partial uninstall), fall back to the
 	// default naming convention so we can still guide the user to delete
@@ -1750,9 +1750,10 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 		if len(existingSlugs) > 0 {
 			printer.Header("App cleanup")
 			printer.StepInfo("Opening browser for each app installation that needs to be removed.")
-			printer.StepInfo("Click 'Uninstall' on each page, then return here.")
+			printer.StepInfo("Click 'Uninstall' on each page. Press Enter here after each one to continue.")
 			printer.Blank()
 
+			stdinReader := bufio.NewReader(stdin)
 			for _, slug := range existingSlugs {
 				var uninstallURL string
 				if id := installationIDs[slug]; id != 0 {
@@ -1765,8 +1766,13 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 					printer.StepWarn(fmt.Sprintf("Could not open browser: %v", err))
 					printer.StepInfo(fmt.Sprintf("  Uninstall manually at: %s", uninstallURL))
 				} else {
-					printer.StepDone(fmt.Sprintf("Opened %s — %s", slug, deleteURL))
+					printer.StepDone(fmt.Sprintf("Opened %s — %s", slug, uninstallURL))
 				}
+				printer.StepInfo(fmt.Sprintf("Press Enter once %s is uninstalled...", slug))
+				if _, err := stdinReader.ReadString('\n'); err != nil && !errors.Is(err, io.EOF) {
+					return fmt.Errorf("reading confirmation: %w", err)
+				}
+				printer.StepDone(fmt.Sprintf("%s uninstalled", slug))
 			}
 			printer.Blank()
 		} else if listErr == nil {

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -1721,23 +1721,21 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 	printer.Blank()
 
 	// Check which apps actually exist before opening browser pages.
-	// GitHub App uninstallation via API (DELETE /app/installations/{id}) requires
-	// JWT auth from the app's own private key, not a PAT. Since we authenticate
-	// with a PAT, we open the browser to the app's advanced settings page instead.
-	// The correct URL for org-scoped apps is /organizations/{org}/settings/apps/{slug}/advanced
-	// (the /advanced suffix is required to see the delete button; /settings/apps/{slug}
-	// alone is for user-scoped apps and will 404 for org-scoped ones).
+	// We open the org's installation settings page (/organizations/{org}/settings/installations/{id})
+	// rather than the app's own /advanced page, because the /advanced delete button is only
+	// accessible to the app owner. Users who installed a third-party app are org admins, not
+	// app owners, so they must uninstall via the installation settings page instead.
 	if len(agentSlugs) > 0 {
 		// Find which slugs correspond to real installed apps.
 		var existingSlugs []string
+		installationIDs := make(map[string]int)
 		installations, listErr := client.ListOrgInstallations(ctx, org)
 		if listErr == nil {
-			installedSet := make(map[string]bool, len(installations))
 			for _, inst := range installations {
-				installedSet[inst.AppSlug] = true
+				installationIDs[inst.AppSlug] = inst.ID
 			}
 			for _, slug := range agentSlugs {
-				if installedSet[slug] {
+				if _, ok := installationIDs[slug]; ok {
 					existingSlugs = append(existingSlugs, slug)
 				} else {
 					printer.StepInfo(fmt.Sprintf("App %s not found, skipping", slug))
@@ -1751,16 +1749,21 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 
 		if len(existingSlugs) > 0 {
 			printer.Header("App cleanup")
-			printer.StepInfo("Opening browser for each app that needs to be deleted.")
-			printer.StepInfo("Click 'Delete GitHub App' on each page, then return here.")
+			printer.StepInfo("Opening browser for each app installation that needs to be removed.")
+			printer.StepInfo("Click 'Uninstall' on each page, then return here.")
 			printer.Blank()
 
 			for _, slug := range existingSlugs {
-				deleteURL := fmt.Sprintf("https://github.com/organizations/%s/settings/apps/%s/advanced", org, slug)
-				printer.StepStart(fmt.Sprintf("Opening %s settings...", slug))
-				if err := browser.Open(ctx, deleteURL); err != nil {
+				var uninstallURL string
+				if id := installationIDs[slug]; id != 0 {
+					uninstallURL = fmt.Sprintf("https://github.com/organizations/%s/settings/installations/%d", org, id)
+				} else {
+					uninstallURL = fmt.Sprintf("https://github.com/organizations/%s/settings/installations", org)
+				}
+				printer.StepStart(fmt.Sprintf("Opening %s installation settings...", slug))
+				if err := browser.Open(ctx, uninstallURL); err != nil {
 					printer.StepWarn(fmt.Sprintf("Could not open browser: %v", err))
-					printer.StepInfo(fmt.Sprintf("  Delete manually at: %s", deleteURL))
+					printer.StepInfo(fmt.Sprintf("  Uninstall manually at: %s", uninstallURL))
 				} else {
 					printer.StepDone(fmt.Sprintf("Opened %s — %s", slug, deleteURL))
 				}

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -22,12 +22,12 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/config"
 	"github.com/fullsend-ai/fullsend/internal/dispatch"
 	"github.com/fullsend-ai/fullsend/internal/dispatch/gcf"
-	"github.com/fullsend-ai/fullsend/internal/mintcore"
 	"github.com/fullsend-ai/fullsend/internal/forge"
 	gh "github.com/fullsend-ai/fullsend/internal/forge/github"
 	"github.com/fullsend-ai/fullsend/internal/inference"
 	"github.com/fullsend-ai/fullsend/internal/inference/vertex"
 	"github.com/fullsend-ai/fullsend/internal/layers"
+	"github.com/fullsend-ai/fullsend/internal/mintcore"
 	"github.com/fullsend-ai/fullsend/internal/scaffold"
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
@@ -105,7 +105,6 @@ var githubOwnerPattern = regexp.MustCompile(`^[a-zA-Z0-9](-?[a-zA-Z0-9])*$`)
 // githubRepoPattern matches valid GitHub repository names
 // (alphanumeric, hyphens, dots, and underscores).
 var githubRepoPattern = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`)
-
 
 // perOrgOnlyFlags are flags that only apply to per-org mode.
 var perOrgOnlyFlags = []string{

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -1605,10 +1605,10 @@ func TestInstallCmd_PerRepoAcceptsValidWIFProvider(t *testing.T) {
 
 func TestFilterSlugsByAppSet(t *testing.T) {
 	tests := []struct {
-		name string
+		name   string
 		appSet string
-		slugs map[string]string
-		want  map[string]string
+		slugs  map[string]string
+		want   map[string]string
 	}{
 		{
 			name:   "matching app-set preserved",

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -1672,7 +1672,7 @@ func TestRunUninstall_LegacySlugsIncludedWhenConfigUnavailable(t *testing.T) {
 	var buf strings.Builder
 	printer := ui.New(&buf)
 
-	err := runUninstall(context.Background(), client, printer, "test-org", "fullsend-ai", appsetup.NopBrowser{})
+	err := runUninstall(context.Background(), client, printer, "test-org", "fullsend-ai", appsetup.NopBrowser{}, strings.NewReader(""))
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -1695,7 +1695,7 @@ func TestRunUninstall_WarnsWhenNoAppsFound(t *testing.T) {
 	var buf strings.Builder
 	printer := ui.New(&buf)
 
-	err := runUninstall(context.Background(), client, printer, "test-org", "fullsend-ai", appsetup.NopBrowser{})
+	err := runUninstall(context.Background(), client, printer, "test-org", "fullsend-ai", appsetup.NopBrowser{}, strings.NewReader(""))
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -1716,7 +1716,7 @@ func TestRunUninstall_LegacySlugsSkippedWhenAppSetMatchesLegacy(t *testing.T) {
 	var buf strings.Builder
 	printer := ui.New(&buf)
 
-	err := runUninstall(context.Background(), client, printer, "test-org", "fullsend", appsetup.NopBrowser{})
+	err := runUninstall(context.Background(), client, printer, "test-org", "fullsend", appsetup.NopBrowser{}, strings.NewReader(""))
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -1742,13 +1742,13 @@ func TestRunUninstall_DedupsSlugsAcrossAppSets(t *testing.T) {
 
 	// Use "fullsend" which matches a legacy prefix — without dedup,
 	// each slug would appear twice.
-	err := runUninstall(context.Background(), client, printer, "test-org", "fullsend", appsetup.NopBrowser{})
+	err := runUninstall(context.Background(), client, printer, "test-org", "fullsend", appsetup.NopBrowser{}, strings.NewReader(""))
 	require.NoError(t, err)
 
 	output := buf.String()
-	// Each slug should appear in the "Opening ... settings" line exactly once.
-	assert.Equal(t, 1, strings.Count(output, "Opening fullsend-coder settings"))
-	assert.Equal(t, 1, strings.Count(output, "Opening fullsend-triage settings"))
+	// Each slug should appear in the "Opening ... installation settings" line exactly once.
+	assert.Equal(t, 1, strings.Count(output, "Opening fullsend-coder installation settings"))
+	assert.Equal(t, 1, strings.Count(output, "Opening fullsend-triage installation settings"))
 }
 
 func TestRunUninstall_NopBrowserSkipsBrowserOpen(t *testing.T) {
@@ -1763,13 +1763,13 @@ func TestRunUninstall_NopBrowserSkipsBrowserOpen(t *testing.T) {
 	var buf strings.Builder
 	printer := ui.New(&buf)
 
-	err := runUninstall(context.Background(), client, printer, "test-org", "fullsend-ai", appsetup.NopBrowser{})
+	err := runUninstall(context.Background(), client, printer, "test-org", "fullsend-ai", appsetup.NopBrowser{}, strings.NewReader(""))
 	require.NoError(t, err)
 
 	output := buf.String()
 	// NopBrowser.Open returns nil, so the success path runs.
 	assert.Contains(t, output, "Opened fullsend-ai-coder")
-	assert.Contains(t, output, "fullsend-ai-coder/advanced")
+	assert.Contains(t, output, "settings/installations/1")
 	assert.NotContains(t, output, "Could not open browser")
 }
 


### PR DESCRIPTION
## Summary

- Open `/organizations/{org}/settings/installations/{id}` instead of `/organizations/{org}/settings/apps/{slug}/advanced` — the `/advanced` page requires app owner access; org admins installing a third-party app need the installation settings page (#1490 item 2)
- After opening each app's installation page, prompt the user to press Enter to confirm the app was uninstalled before continuing, so the command no longer exits immediately with a misleading success message (#323 / #1490 item 5)
- Rename "App cleanup" section header to "App uninstall"

Relates to #1490
Closes #323

## Test plan

- [x] Run `fullsend admin uninstall <org>` against an org with fullsend installed as a third-party app
- [x] Verify browser opens to `/settings/installations/{id}` (not `/settings/apps/.../advanced`)
- [x] Verify command pauses and waits for Enter after each app page is opened
- [ ] Verify fallback to `/settings/installations` list when installation ID is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)