### PR TITLE
feat(cli): tee stream-json output to iteration artifact

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -28,8 +28,8 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/envfile"
 	"github.com/fullsend-ai/fullsend/internal/fetch"
 	"github.com/fullsend-ai/fullsend/internal/harness"
-	agentruntime "github.com/fullsend-ai/fullsend/internal/runtime"
 	"github.com/fullsend-ai/fullsend/internal/resolve"
+	agentruntime "github.com/fullsend-ai/fullsend/internal/runtime"
 	"github.com/fullsend-ai/fullsend/internal/sandbox"
 	"github.com/fullsend-ai/fullsend/internal/scaffold"
 	"github.com/fullsend-ai/fullsend/internal/security"
@@ -604,6 +604,7 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 			PluginDirs:    pluginDirs,
 			Debug:         debug,
 			Timeout:       timeout,
+			OutputPath:    filepath.Join(iterDir, "output.jsonl"),
 		}, printer, agentStart, &metrics)
 		close(heartbeatDone)
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1037,6 +1037,21 @@ func envToList(env map[string]string) []string {
 	return list
 }
 
+// openTeeReader wraps r in an io.TeeReader that copies to the file at
+// outputPath, returning the reader and a closer. If outputPath is empty or
+// the file cannot be created, r is returned unchanged and the warn is logged.
+func openTeeReader(r io.Reader, outputPath string, printer *ui.Printer) (io.Reader, func()) {
+	if outputPath == "" {
+		return r, func() {}
+	}
+	f, err := os.Create(outputPath)
+	if err != nil {
+		printer.StepWarn("Failed to create claude-output.jsonl: " + err.Error())
+		return r, func() {}
+	}
+	return io.TeeReader(r, f), func() { f.Close() }
+}
+
 var heartbeatInterval = 30 * time.Second
 
 func runHeartbeat(printer *ui.Printer, start time.Time, timeout time.Duration, done <-chan struct{}) {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -932,3 +932,78 @@ func TestValidationFailMessage_TrimsOutput(t *testing.T) {
 	msg := validationFailMessage([]byte("  some output\n"), fmt.Errorf("exit status 1"))
 	assert.Equal(t, "some output", msg)
 }
+
+func TestOpenTeeReader_EmptyPath(t *testing.T) {
+	src := strings.NewReader("hello")
+	printer := ui.New(io.Discard)
+
+	r, close := openTeeReader(src, "", printer)
+	defer close()
+
+	// r should be the original reader — no file created
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(got))
+}
+
+func TestOpenTeeReader_WritesToFile(t *testing.T) {
+	content := "line1\nline2\n"
+	src := strings.NewReader(content)
+	printer := ui.New(io.Discard)
+
+	outPath := filepath.Join(t.TempDir(), "out.jsonl")
+	r, close := openTeeReader(src, outPath, printer)
+	defer close()
+
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(got))
+
+	close() // flush before reading file
+	fileData, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(fileData))
+}
+
+func TestOpenTeeReader_CreateFailFallsBackToSource(t *testing.T) {
+	content := "data"
+	src := strings.NewReader(content)
+
+	var warnBuf bytes.Buffer
+	printer := ui.New(&warnBuf)
+
+	// Unwritable path — directory that doesn't exist
+	r, close := openTeeReader(src, "/nonexistent-dir/out.jsonl", printer)
+	defer close()
+
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(got), "source stream still readable after create failure")
+	assert.Contains(t, warnBuf.String(), "Failed to create claude-output.jsonl")
+}
+
+func TestOpenTeeReader_FileCompleteOnParserError(t *testing.T) {
+	// Simulate: progressParser reads part of stream, then errors; caller drains
+	// remainder via io.Copy(io.Discard, r). File should contain all bytes.
+	content := "part1\npart2\n"
+	src := strings.NewReader(content)
+	printer := ui.New(io.Discard)
+
+	outPath := filepath.Join(t.TempDir(), "out.jsonl")
+	r, closeFile := openTeeReader(src, outPath, printer)
+
+	// Simulate parser reading only first 6 bytes then returning an error
+	firstPart := make([]byte, 6)
+	_, err := io.ReadFull(r, firstPart)
+	require.NoError(t, err)
+
+	// Simulate drain of remaining bytes (as runAgentWithProgress does on parse error)
+	_, err = io.Copy(io.Discard, r)
+	require.NoError(t, err)
+
+	closeFile()
+
+	fileData, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(fileData), "file should contain all bytes including post-error drain")
+}

--- a/internal/runtime/claude.go
+++ b/internal/runtime/claude.go
@@ -87,10 +87,21 @@ func (ClaudeRuntime) Run(params RunParams, printer *ui.Printer, start time.Time,
 	}
 	defer cancel()
 
-	if parseErr := progressParser(stdout, printer, start, metrics); parseErr != nil {
+	var r io.Reader = stdout
+	if params.OutputPath != "" {
+		f, ferr := os.Create(params.OutputPath)
+		if ferr != nil {
+			printer.StepWarn(fmt.Sprintf("Failed to create %s: ", params.OutputPath) + ferr.Error())
+		} else {
+			defer f.Close()
+			r = io.TeeReader(stdout, f)
+		}
+	}
+
+	if parseErr := progressParser(r, printer, start, metrics); parseErr != nil {
 		fmt.Fprintf(os.Stderr, "  progress parser: %v\n", sanitizeOutput(parseErr.Error()))
 		cancel()
-		io.Copy(io.Discard, stdout)
+		io.Copy(io.Discard, r)
 	}
 
 	waitErr := execCmd.Wait()
@@ -218,6 +229,7 @@ func buildRunCommand(params RunParams) string {
 // Claude Code reads two settings.json files in the sandbox:
 //   - {CLAUDE_CONFIG_DIR}/settings.json — plugin marketplace state (bootstrapPlugins)
 //   - {SandboxWorkspace}/.claude/settings.json — security Pre/PostToolUse hooks (here)
+//
 // Keep these paths separate; merging them would mix plugin config with hook wiring.
 func installClaudeHooks(sandboxName string, hooks security.ClaudeSandboxHooks) error {
 	hooksDir := sandbox.SandboxWorkspace + "/.claude/hooks"

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -21,6 +21,7 @@ type RunParams struct {
 	PluginDirs    []string
 	Debug         string
 	Timeout       time.Duration
+	OutputPath    string // if set, tee stream-json stdout to this file
 }
 
 // TranscriptError holds extracted error information from a runtime transcript.


### PR DESCRIPTION
## Summary

- Tees `claude --output-format stream-json` stdout to `iteration-N/claude-output.jsonl` in the run artifact alongside existing transcripts and output files
- Preserves job-log streaming — no change to visible output
- Falls back gracefully (warn, no tee) if the file cannot be created

## Why

The stream-json NDJSON contains exact token usage (input, output, cache-write, cache-read) on the `result` event. Without this file, `analyze-transcript` approximates costs from a pricing table. With it, tooling gets exact counts directly from the run.

Closes #1228

## Test plan

- [ ] Run `fullsend run triage` locally and confirm `iteration-1/claude-output.jsonl` appears in the run dir
- [ ] Verify the file contains valid NDJSON with `result` events including token usage fields
- [ ] Confirm job-log streaming output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)