### PR TITLE
feat(cli): add --keep-sandbox flag to fullsend run

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -53,6 +53,7 @@ func newRunCmd() *cobra.Command {
 	var noPostScript bool
 	var debugFilter string
 	var offline bool
+	var keepSandbox bool
 
 	cmd := &cobra.Command{
 		Use:   "run <agent-name>",
@@ -62,7 +63,7 @@ func newRunCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agentName := args[0]
 			printer := ui.New(os.Stdout)
-			return runAgent(cmd.Context(), agentName, fullsendDir, outputBase, targetRepo, fullsendBinary, envFiles, noPostScript, debugFilter, offline, printer)
+			return runAgent(cmd.Context(), agentName, fullsendDir, outputBase, targetRepo, fullsendBinary, envFiles, noPostScript, debugFilter, offline, printer, keepSandbox)
 		},
 	}
 
@@ -72,6 +73,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&fullsendBinary, "fullsend-binary", "", "path to a Linux fullsend binary to copy into the sandbox (default: current executable)")
 	cmd.Flags().StringArrayVar(&envFiles, "env-file", nil, "load environment variables from a dotenv file (repeatable)")
 	cmd.Flags().BoolVar(&noPostScript, "no-post-script", false, "skip post-script execution (agent still runs full inference)")
+	cmd.Flags().BoolVar(&keepSandbox, "keep-sandbox", false, "skip sandbox deletion after the run (useful for post-failure inspection)")
 	cmd.Flags().StringVar(&debugFilter, "debug", "", `enable Claude Code debug logging with optional category filter (e.g. "api,hooks")`)
 	cmd.Flags().Lookup("debug").NoOptDefVal = "*"
 	cmd.Flags().BoolVar(&offline, "offline", false, "reject network fetches; only use cached remote resources")
@@ -81,7 +83,7 @@ func newRunCmd() *cobra.Command {
 	return cmd
 }
 
-func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRepo, fullsendBinary string, envFiles []string, noPostScript bool, debug string, offline bool, printer *ui.Printer) (runErr error) {
+func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRepo, fullsendBinary string, envFiles []string, noPostScript bool, debug string, offline bool, printer *ui.Printer, keepSandbox bool) (runErr error) {
 	printer.Banner(Version())
 	printer.Blank()
 	printer.Header("Running agent: " + agentName)
@@ -365,6 +367,12 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	defer func() {
 		// Collect OpenShell logs before sandbox deletion for post-mortem debugging.
 		collectOpenshellLogs(sandboxName, runDir, printer)
+
+		if keepSandbox {
+			printer.StepWarn(fmt.Sprintf("Sandbox kept (--keep-sandbox): %s", sandboxName))
+			printer.StepInfo(fmt.Sprintf("openshell sandbox exec --name %s -- sh", sandboxName))
+			return
+		}
 
 		cleanupStart := time.Now()
 		printer.StepStart("Cleaning up sandbox")


### PR DESCRIPTION
## Summary

- Adds `--keep-sandbox` flag to `fullsend run`
- When set, skips sandbox deletion at end of run regardless of success or failure
- Prints the sandbox name and the exact `openshell sandbox exec` command to drop into a shell

## Why

Post-failure sandbox inspection currently requires re-running with extra instrumentation. This flag lets developers exec directly into the sandbox after a failure to check uploaded files, env contents, or reproduce commands manually.

Closes #1594

## Test plan

- [ ] Run `fullsend run triage --keep-sandbox` and confirm sandbox is not deleted
- [ ] Confirm printed `openshell sandbox exec` command drops into a shell in the sandbox
- [ ] Run without flag and confirm sandbox is still deleted normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)