### PR TITLE
fix(e2e): retry lock verification read to handle auto_init race

### DIFF
--- a/e2e/admin/lock.go
+++ b/e2e/admin/lock.go
@@ -148,15 +148,30 @@ func tryCreateLock(ctx context.Context, client forge.Client, org, runID string, 
 	}
 
 	// Verify we actually got the lock (handle race between two creators).
-	content, err := client.GetFileContent(ctx, org, lockRepo, "README.md")
-	if err != nil {
-		return false, fmt.Errorf("verifying lock: %w", err)
-	}
-	if strings.TrimSpace(string(content)) == runID {
-		logf("[e2e-lock] Lock acquired (run: %s)", truncateUUID(runID))
-		return true, nil
+	// Retry the read because GitHub's auto_init may serve stale default
+	// README content ("# e2e-lock") briefly after CreateOrUpdateFile succeeds.
+	for i := range 5 {
+		if i > 0 {
+			select {
+			case <-time.After(time.Duration(i+1) * time.Second):
+			case <-ctx.Done():
+				return false, ctx.Err()
+			}
+		}
+		content, err := client.GetFileContent(ctx, org, lockRepo, "README.md")
+		if err != nil {
+			return false, fmt.Errorf("verifying lock: %w", err)
+		}
+		holder := strings.TrimSpace(string(content))
+		if holder == runID {
+			logf("[e2e-lock] Lock acquired (run: %s)", truncateUUID(runID))
+			return true, nil
+		}
+		logf("[e2e-lock] Verification read %d/5: got %q, expected %s (auto_init race?)", i+1, truncateUUID(holder), truncateUUID(runID))
 	}
 
+	// After retries, still not our content — genuinely lost the race.
+	content, _ := client.GetFileContent(ctx, org, lockRepo, "README.md")
 	logf("[e2e-lock] Lost lock race for %s/%s (holder: %s)", org, lockRepo, truncateUUID(strings.TrimSpace(string(content))))
 	return false, nil
 }


### PR DESCRIPTION
## Summary

- GitHub's `auto_init` creates a default README.md asynchronously when a repo is created
- Our `CreateOrUpdateFile` overwrites it, but the verification read can briefly return the stale auto-init content (`# e2e-lock`) instead of our run ID
- This caused `tryCreateLock` to think it lost the lock race when it had actually won
- Now retries the verification read up to 5 times with linear backoff, logging each mismatch

Depends on #1612 — based on `fix/e2e-lock-debug`.

## Test plan

- [x] `go test -tags e2e ./e2e/admin/ -run TestAcquire` passes
- [x] `make go-test` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)