### PR TITLE
feat(cli): watch repo-maintenance workflow after enable/disable repos

### DIFF
--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -225,25 +225,36 @@ func TestAdminInstallUninstall(t *testing.T) {
 
 // mergeEnrollmentPR finds and merges the enrollment PR for test-repo so the
 // shim workflow is active on the default branch.
+// The install CLI waits for repo-maintenance to complete, so the PR should
+// already exist. A few retries handle GitHub eventual consistency.
 func mergeEnrollmentPR(t *testing.T, env *e2eEnv) {
 	t.Helper()
 	ctx := context.Background()
 
-	prs, err := env.client.ListRepoPullRequests(ctx, env.org, testRepo)
-	require.NoError(t, err, "listing PRs for %s", testRepo)
-
 	var enrollmentPR *forge.ChangeProposal
-	for _, pr := range prs {
-		if strings.Contains(pr.Title, "fullsend") {
-			cp := pr
-			enrollmentPR = &cp
+	for attempt := range 5 {
+		if attempt > 0 {
+			time.Sleep(3 * time.Second)
+		}
+		prs, err := env.client.ListRepoPullRequests(ctx, env.org, testRepo)
+		require.NoError(t, err, "listing PRs for %s", testRepo)
+
+		for _, pr := range prs {
+			if strings.Contains(pr.Title, "fullsend") {
+				cp := pr
+				enrollmentPR = &cp
+				break
+			}
+		}
+		if enrollmentPR != nil {
 			break
 		}
+		t.Logf("Attempt %d: enrollment PR not yet visible", attempt+1)
 	}
 	require.NotNil(t, enrollmentPR, "enrollment PR should exist for %s", testRepo)
 
 	t.Logf("Merging enrollment PR #%d: %s", enrollmentPR.Number, enrollmentPR.URL)
-	err = env.client.MergeChangeProposal(ctx, env.org, testRepo, enrollmentPR.Number)
+	err := env.client.MergeChangeProposal(ctx, env.org, testRepo, enrollmentPR.Number)
 	require.NoError(t, err, "merging enrollment PR")
 
 	time.Sleep(5 * time.Second)
@@ -566,17 +577,20 @@ func runUnenrollmentTest(t *testing.T, env *e2eEnv) {
 	t.Helper()
 	ctx := context.Background()
 
-	// Disable the test repo via CLI (updates config.yaml). The push to
-	// config.yaml on main triggers repo-maintenance, which creates the
-	// removal PR.
-	runCLI(t, env.binary, env.token,
+	// Disable the test repo via CLI (updates config.yaml). The CLI now
+	// watches the repo-maintenance workflow to completion before returning,
+	// so the removal PR should already exist when this returns.
+	output := runCLI(t, env.binary, env.token,
 		"admin", "disable", "repos", env.org, testRepo, "--yolo")
+	t.Logf("Disable repos output:\n%s", output)
 
-	// Wait for the removal PR to be created by repo-maintenance.
-	t.Log("Waiting for removal PR...")
+	// The CLI waited for repo-maintenance, so the removal PR should exist.
+	// A few retries handle GitHub eventual consistency.
 	var removalPR *forge.ChangeProposal
-	for attempt := 0; attempt < 24; attempt++ {
-		time.Sleep(5 * time.Second)
+	for attempt := range 5 {
+		if attempt > 0 {
+			time.Sleep(3 * time.Second)
+		}
 		prs, err := env.client.ListRepoPullRequests(ctx, env.org, testRepo)
 		if err != nil {
 			t.Logf("Attempt %d: error listing PRs: %v", attempt+1, err)
@@ -592,7 +606,7 @@ func runUnenrollmentTest(t *testing.T, env *e2eEnv) {
 		if removalPR != nil {
 			break
 		}
-		t.Logf("Attempt %d: removal PR not yet created", attempt+1)
+		t.Logf("Attempt %d: removal PR not yet visible", attempt+1)
 	}
 	require.NotNil(t, removalPR, "removal PR should exist for %s", testRepo)
 	t.Logf("Found removal PR #%d: %s", removalPR.Number, removalPR.URL)

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -2244,6 +2245,8 @@ func runEnableRepos(ctx context.Context, client forge.Client, printer *ui.Printe
 		}
 	}
 
+	var dispatchTime time.Time
+
 	if changed == 0 {
 		printer.StepInfo("All specified repositories are already enabled")
 	} else {
@@ -2251,7 +2254,9 @@ func runEnableRepos(ctx context.Context, client forge.Client, printer *ui.Printe
 
 		// Save updated config.
 		commitMsg := fmt.Sprintf("chore: enable %d repositories for fullsend enrollment", changed)
-		if err := saveRepoConfig(ctx, client, printer, org, cfg, commitMsg); err != nil {
+		var err error
+		dispatchTime, err = saveRepoConfig(ctx, client, printer, org, cfg, commitMsg)
+		if err != nil {
 			return err
 		}
 	}
@@ -2271,8 +2276,11 @@ func runEnableRepos(ctx context.Context, client forge.Client, printer *ui.Printe
 	printer.Summary("Repositories enabled", []string{
 		fmt.Sprintf("Organization: %s", org),
 		fmt.Sprintf("Enabled: %d repositories", changed),
-		"The repo-maintenance workflow will create enrollment PRs",
 	})
+
+	if !dispatchTime.IsZero() {
+		awaitRepoMaintenance(ctx, client, printer, org, dispatchTime)
+	}
 
 	return nil
 }
@@ -2412,7 +2420,8 @@ func runDisableRepos(ctx context.Context, client forge.Client, printer *ui.Print
 
 	// Save updated config.
 	commitMsg := fmt.Sprintf("chore: disable %d repositories from fullsend enrollment", changed)
-	if err := saveRepoConfig(ctx, client, printer, org, cfg, commitMsg); err != nil {
+	dispatchTime, err := saveRepoConfig(ctx, client, printer, org, cfg, commitMsg)
+	if err != nil {
 		return err
 	}
 
@@ -2430,8 +2439,11 @@ func runDisableRepos(ctx context.Context, client forge.Client, printer *ui.Print
 	printer.Summary("Repositories disabled", []string{
 		fmt.Sprintf("Organization: %s", org),
 		fmt.Sprintf("Disabled: %d repositories", changed),
-		"The repo-maintenance workflow will create unenrollment PRs",
 	})
+
+	if !dispatchTime.IsZero() {
+		awaitRepoMaintenance(ctx, client, printer, org, dispatchTime)
+	}
 
 	return nil
 }
@@ -2479,12 +2491,15 @@ func loadRepoConfig(ctx context.Context, client forge.Client, printer *ui.Printe
 }
 
 // saveRepoConfig marshals and commits the updated config, then triggers the repo-maintenance workflow.
-func saveRepoConfig(ctx context.Context, client forge.Client, printer *ui.Printer, org string, cfg *config.OrgConfig, commitMsg string) error {
+// saveRepoConfig marshals the config, commits it, and dispatches the
+// repo-maintenance workflow. It returns the dispatch time so callers can
+// watch the resulting workflow run. A zero time means the dispatch failed.
+func saveRepoConfig(ctx context.Context, client forge.Client, printer *ui.Printer, org string, cfg *config.OrgConfig, commitMsg string) (time.Time, error) {
 	// Marshal updated config.
 	updatedConfigData, err := cfg.Marshal()
 	if err != nil {
 		printer.StepFail("Failed to marshal config.yaml")
-		return fmt.Errorf("marshaling config.yaml: %w", err)
+		return time.Time{}, fmt.Errorf("marshaling config.yaml: %w", err)
 	}
 
 	// Commit and push changes.
@@ -2492,21 +2507,95 @@ func saveRepoConfig(ctx context.Context, client forge.Client, printer *ui.Printe
 	if err := client.CreateOrUpdateFile(ctx, org, forge.ConfigRepoName, "config.yaml", commitMsg, updatedConfigData); err != nil {
 		printer.StepFail("Failed to commit changes")
 		printer.StepInfo("Hint: verify your token has 'repo' scope with: gh auth refresh -s repo")
-		return fmt.Errorf("committing config.yaml: %w", err)
+		return time.Time{}, fmt.Errorf("committing config.yaml: %w", err)
 	}
 	printer.StepDone("Changes committed to .fullsend")
 
 	// Trigger repo-maintenance workflow.
+	dispatchTime := time.Now().UTC().Add(-30 * time.Second)
 	printer.StepStart("Triggering repo-maintenance workflow")
 	if err := client.DispatchWorkflow(ctx, org, forge.ConfigRepoName, "repo-maintenance.yml", "main", nil); err != nil {
 		printer.StepWarn(fmt.Sprintf("Failed to trigger repo-maintenance: %v", err))
 		printer.StepInfo("Hint: verify your token has 'workflow' scope with: gh auth refresh -s workflow")
 		printer.StepInfo("Changes committed successfully, but you may need to manually trigger the workflow")
-	} else {
-		printer.StepDone("Triggered repo-maintenance workflow")
+		return time.Time{}, nil
+	}
+	printer.StepDone("Triggered repo-maintenance workflow")
+
+	return dispatchTime, nil
+}
+
+// awaitRepoMaintenance watches the repo-maintenance workflow run triggered by a
+// config.yaml push, waits for it to complete, and prints any PR URLs from its
+// annotations.
+func awaitRepoMaintenance(ctx context.Context, client forge.Client, printer *ui.Printer, org string, dispatchTime time.Time) {
+	awaitRepoMaintenanceWithInterval(ctx, client, printer, org, dispatchTime, 5*time.Second, 36)
+}
+
+func awaitRepoMaintenanceWithInterval(ctx context.Context, client forge.Client, printer *ui.Printer, org string, dispatchTime time.Time, pollInterval time.Duration, maxAttempts int) {
+	printer.Blank()
+	printer.StepStart("Watching repo-maintenance workflow")
+
+	// Poll for a workflow run created after dispatchTime.
+	var run *forge.WorkflowRun
+	for attempt := range maxAttempts {
+		select {
+		case <-ctx.Done():
+			printer.StepWarn("context cancelled while waiting for workflow")
+			return
+		case <-time.After(pollInterval):
+		}
+
+		runs, err := client.ListWorkflowRuns(ctx, org, forge.ConfigRepoName, "repo-maintenance.yml")
+		if err != nil {
+			printer.StepInfo(fmt.Sprintf("waiting for workflow run (attempt %d)...", attempt+1))
+			continue
+		}
+
+		for i := range runs {
+			r := &runs[i]
+			runTime, parseErr := time.Parse(time.RFC3339, r.CreatedAt)
+			if parseErr != nil {
+				continue
+			}
+			if runTime.Before(dispatchTime) {
+				continue
+			}
+			if r.Status == "completed" {
+				run = r
+				break
+			}
+			printer.StepInfo(fmt.Sprintf("workflow run: %s (%s)", r.HTMLURL, r.Status))
+			break // found our run, keep waiting
+		}
+		if run != nil {
+			break
+		}
 	}
 
-	return nil
+	if run == nil {
+		printer.StepWarn("timed out waiting for repo-maintenance workflow")
+		printer.StepInfo("check the repo-maintenance workflow in .fullsend for results")
+		return
+	}
+
+	if run.Conclusion == "success" {
+		printer.StepDone("repo-maintenance completed successfully")
+	} else {
+		printer.StepWarn(fmt.Sprintf("repo-maintenance completed with conclusion: %s", run.Conclusion))
+	}
+	printer.StepInfo(fmt.Sprintf("workflow run: %s", run.HTMLURL))
+
+	// Harvest PR URLs from workflow annotations (::notice:: commands).
+	annotations, err := client.GetWorkflowRunAnnotations(ctx, org, forge.ConfigRepoName, run.ID)
+	if err != nil {
+		return
+	}
+	for _, a := range annotations {
+		if a.Level == "notice" {
+			printer.StepInfo(a.Message)
+		}
+	}
 }
 
 // checkPerRepoScopes verifies the token has sufficient permissions for per-repo install.

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -584,6 +586,9 @@ func setupTestClient(org string, cfg *config.OrgConfig, orgRepos []string) *forg
 		cfgData, _ := cfg.Marshal()
 		client.FileContents[org+"/.fullsend/config.yaml"] = cfgData
 	}
+	// Fail the workflow dispatch so unit tests skip awaitRepoMaintenance
+	// (which would poll for 3 minutes against an empty fake).
+	client.Errors["DispatchWorkflow"] = fmt.Errorf("fake: dispatch not configured")
 	return client
 }
 
@@ -800,9 +805,7 @@ func TestRunEnableRepos_VariableSyncErrorDoesNotBlockEnable(t *testing.T) {
 		}
 	}
 	client.OrgVariables = map[string]bool{"testorg/FULLSEND_MINT_URL": true}
-	client.Errors = map[string]error{
-		"SetOrgVariableRepos": fmt.Errorf("API rate limit exceeded"),
-	}
+	client.Errors["SetOrgVariableRepos"] = fmt.Errorf("API rate limit exceeded")
 
 	printer := ui.New(&discardWriter{})
 
@@ -1768,6 +1771,86 @@ func TestRunUninstall_NopBrowserSkipsBrowserOpen(t *testing.T) {
 	assert.Contains(t, output, "Opened fullsend-ai-coder")
 	assert.Contains(t, output, "fullsend-ai-coder/advanced")
 	assert.NotContains(t, output, "Could not open browser")
+}
+
+func TestAwaitRepoMaintenance_Success(t *testing.T) {
+	client := forge.NewFakeClient()
+	dispatchTime := time.Now().UTC().Add(-10 * time.Second)
+	client.WorkflowRuns["testorg/.fullsend/repo-maintenance.yml"] = &forge.WorkflowRun{
+		ID:         42,
+		Status:     "completed",
+		Conclusion: "success",
+		HTMLURL:    "https://github.com/testorg/.fullsend/actions/runs/42",
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	client.Annotations = []forge.Annotation{
+		{Level: "notice", Message: "Enrollment PR: https://github.com/testorg/web-app/pull/1"},
+		{Level: "warning", Message: "some warning"},
+		{Level: "notice", Message: "Enrollment PR: https://github.com/testorg/api/pull/2"},
+	}
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+
+	awaitRepoMaintenanceWithInterval(context.Background(), client, printer, "testorg", dispatchTime, 1*time.Millisecond, 2)
+
+	output := buf.String()
+	assert.Contains(t, output, "repo-maintenance completed successfully")
+	assert.Contains(t, output, "https://github.com/testorg/.fullsend/actions/runs/42")
+	assert.Contains(t, output, "Enrollment PR: https://github.com/testorg/web-app/pull/1")
+	assert.Contains(t, output, "Enrollment PR: https://github.com/testorg/api/pull/2")
+	// Warnings from annotations should not be printed (only notices).
+	assert.NotContains(t, output, "some warning")
+}
+
+func TestAwaitRepoMaintenance_Timeout(t *testing.T) {
+	client := forge.NewFakeClient()
+	dispatchTime := time.Now().UTC().Add(-10 * time.Second)
+	// No workflow runs configured — will timeout.
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+
+	awaitRepoMaintenanceWithInterval(context.Background(), client, printer, "testorg", dispatchTime, 1*time.Millisecond, 2)
+
+	output := buf.String()
+	assert.Contains(t, output, "timed out waiting for repo-maintenance workflow")
+}
+
+func TestAwaitRepoMaintenance_Failure(t *testing.T) {
+	client := forge.NewFakeClient()
+	dispatchTime := time.Now().UTC().Add(-10 * time.Second)
+	client.WorkflowRuns["testorg/.fullsend/repo-maintenance.yml"] = &forge.WorkflowRun{
+		ID:         43,
+		Status:     "completed",
+		Conclusion: "failure",
+		HTMLURL:    "https://github.com/testorg/.fullsend/actions/runs/43",
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+
+	awaitRepoMaintenanceWithInterval(context.Background(), client, printer, "testorg", dispatchTime, 1*time.Millisecond, 2)
+
+	output := buf.String()
+	assert.Contains(t, output, "repo-maintenance completed with conclusion: failure")
+}
+
+func TestAwaitRepoMaintenance_ContextCancelled(t *testing.T) {
+	client := forge.NewFakeClient()
+	dispatchTime := time.Now().UTC().Add(-10 * time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+
+	awaitRepoMaintenanceWithInterval(ctx, client, printer, "testorg", dispatchTime, 1*time.Millisecond, 36)
+
+	output := buf.String()
+	assert.Contains(t, output, "context cancelled while waiting for workflow")
 }
 
 func TestInstallCmd_SkipMintCheckStillValidatesWIFProvider(t *testing.T) {

--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -146,6 +146,9 @@ type FakeClient struct {
 	// Pull request reviews for ListPullRequestReviews.
 	PRReviews map[string][]PullRequestReview // key: "owner/repo/number"
 
+	// Annotations for GetWorkflowRunAnnotations.
+	Annotations []Annotation
+
 	// Call recorders
 	CreatedRepos        []Repository
 	CreatedFiles        []FileRecord
@@ -935,6 +938,15 @@ func (f *FakeClient) GetWorkflowRunLogs(_ context.Context, _, _ string, _ int) (
 		return "", e
 	}
 	return "[fake workflow logs]", nil
+}
+
+func (f *FakeClient) GetWorkflowRunAnnotations(_ context.Context, _, _ string, _ int) ([]Annotation, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e := f.err("GetWorkflowRunAnnotations"); e != nil {
+		return nil, e
+	}
+	return f.Annotations, nil
 }
 
 func (f *FakeClient) ListOrgInstallations(_ context.Context, _ string) ([]Installation, error) {

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -52,6 +52,13 @@ type WorkflowRun struct {
 	CreatedAt  string
 }
 
+// Annotation represents a check-run annotation (e.g. from ::notice:: or
+// ::warning:: workflow commands).
+type Annotation struct {
+	Level   string // "notice", "warning", "failure"
+	Message string
+}
+
 // Issue represents a forge issue.
 type Issue struct {
 	Number int
@@ -249,6 +256,10 @@ type Client interface {
 	// GetWorkflowRunLogs downloads the logs for a workflow run as plain text.
 	// On GitHub, this fetches job logs for each job in the run.
 	GetWorkflowRunLogs(ctx context.Context, owner, repo string, runID int) (string, error)
+
+	// GetWorkflowRunAnnotations returns annotations (::notice::, ::warning::,
+	// etc.) from all jobs in a workflow run.
+	GetWorkflowRunAnnotations(ctx context.Context, owner, repo string, runID int) ([]Annotation, error)
 
 	// App installation operations
 	ListOrgInstallations(ctx context.Context, org string) ([]Installation, error)

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -1747,6 +1747,47 @@ func (c *LiveClient) GetWorkflowRunLogs(ctx context.Context, owner, repo string,
 	return buf.String(), nil
 }
 
+// GetWorkflowRunAnnotations returns annotations from all jobs in a workflow run.
+// GitHub workflow commands (::notice::, ::warning::) produce check-run
+// annotations that are accessible via the check-runs API.
+func (c *LiveClient) GetWorkflowRunAnnotations(ctx context.Context, owner, repo string, runID int) ([]forge.Annotation, error) {
+	// List jobs for this run.
+	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/actions/runs/%d/jobs", owner, repo, runID))
+	if err != nil {
+		return nil, fmt.Errorf("list jobs for run %d: %w", runID, err)
+	}
+	var jobsResult struct {
+		Jobs []struct {
+			ID int `json:"id"`
+		} `json:"jobs"`
+	}
+	if err := decodeJSON(resp, &jobsResult); err != nil {
+		return nil, fmt.Errorf("decode jobs: %w", err)
+	}
+
+	var annotations []forge.Annotation
+	for _, job := range jobsResult.Jobs {
+		resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/check-runs/%d/annotations", owner, repo, job.ID))
+		if err != nil {
+			continue // best-effort
+		}
+		var anns []struct {
+			Level   string `json:"annotation_level"`
+			Message string `json:"message"`
+		}
+		if err := decodeJSON(resp, &anns); err != nil {
+			continue
+		}
+		for _, a := range anns {
+			annotations = append(annotations, forge.Annotation{
+				Level:   a.Level,
+				Message: a.Message,
+			})
+		}
+	}
+	return annotations, nil
+}
+
 // ListOrgInstallations lists app installations for an organization.
 func (c *LiveClient) ListOrgInstallations(ctx context.Context, org string) ([]forge.Installation, error) {
 	resp, err := c.get(ctx, fmt.Sprintf("/orgs/%s/installations?per_page=100", org))


### PR DESCRIPTION
## Summary

- After `fullsend admin enable/disable repos` updates config.yaml, the CLI now watches the repo-maintenance workflow run to completion and prints PR URLs from its `::notice::` annotations
- Adds `GetWorkflowRunAnnotations` to the forge interface (harvests check-run annotations via GitHub API)
- Simplifies e2e test polling loops — since the CLI waits for the workflow, the test no longer needs to poll for 2 minutes

> **Depends on #1612** (`fix/e2e-lock-debug`) — base branch set accordingly.

## Test plan

- [x] Unit tests for `awaitRepoMaintenance` (success, timeout, failure, context cancellation)
- [x] Existing enable/disable unit tests pass (dispatch error injected to skip await)
- [x] `make go-test` and `make lint` pass
- [x] E2E test validates the full flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)