### PR TITLE
docs: add role-based setup guide and update CLI docs

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -8,7 +8,9 @@ Structure decided in [ADR 0023](../ADRs/0023-user-documentation-structure.md).
 
 Guides for org administrators who install, configure, and manage fullsend.
 
-- [Installing fullsend](admin/installation.md) — Set up fullsend in a GitHub organization from scratch (see [#328](https://github.com/fullsend-ai/fullsend/pull/328))
+- [Installing fullsend](admin/installation.md) — All-in-one setup for a GitHub organization (GCP + GitHub)
+- [Setting up with pre-provisioned infrastructure](admin/github-setup.md) — GitHub-only setup when GCP infrastructure is already provisioned
+- [Infrastructure reference](admin/infrastructure-reference.md) — Token mint, WIF, and secrets deployment details
 - [Enabling fullsend on private repositories](admin/private-repositories.md) — Additional guardrails and configuration for private repos
 
 ## User guides
@@ -23,3 +25,4 @@ Guides for developers working in repositories where fullsend is active.
 Guides for contributors developing and testing fullsend itself.
 
 - [Local development](dev/local-dev.md) — Run fullsend agents locally on macOS and Linux (amd64 + arm64)
+- [CLI internals](dev/cli-internals.md) — Command structure, installation pipeline, and sandbox runtime

--- a/docs/guides/admin/github-setup.md
+++ b/docs/guides/admin/github-setup.md
@@ -1,0 +1,253 @@
+# Setting up fullsend with pre-provisioned infrastructure
+
+This guide walks through configuring fullsend in a GitHub organization or repository when the GCP infrastructure (token mint and inference WIF) has already been provisioned by a GCP administrator. No GCP credentials are required.
+
+For the all-in-one setup that provisions both GCP and GitHub in a single command, see [Installing fullsend](installation.md).
+
+## Prerequisites
+
+- **GitHub access** — the required permission level depends on the setup mode:
+  - **Per-org mode** (`fullsend github setup <org>`) requires **GitHub organization owner** access. The command creates org-level variables (`FULLSEND_MINT_URL`), creates the `.fullsend` config repo, and (unless `--skip-app-setup` is passed) creates or installs GitHub Apps — all of which require the `admin:org` OAuth scope.
+  - **Per-repo mode** (`fullsend github setup <owner/repo>`) requires **repo admin** access only. It writes secrets and variables to the target repo and does not create or install GitHub Apps. Only the `repo` and `workflow` OAuth scopes are needed. However, an **org owner** must [pre-install the GitHub Apps](#default-fullsend-ai-app-set-installation-urls) on the org before agents can function — the token mint requires an app installation to generate tokens.
+- **GitHub CLI** (`gh`) authenticated — the installer runs a preflight check and tells you which scopes are missing. When prompted, run the `gh auth refresh -s <scopes>` command it suggests.
+- **fullsend CLI** — download the latest binary from [GitHub Releases](https://github.com/fullsend-ai/fullsend/releases)
+- **From your Mint service provider admin** (currently GCP-managed; other providers planned):
+  - Token mint URL (`--mint-url`) — the HTTPS endpoint of the deployed mint Cloud Function
+- **From your Inference provider admin** (currently GCP Agent Platform, formerly Vertex AI; other providers planned):
+  - GCP project ID (`--inference-project`) — the project where Agent Platform is enabled (e.g., `my-gcp-project`)
+  - WIF provider resource name (`--inference-wif-provider`) — the full resource path, e.g., `projects/123456789/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc` (note: the leading number is the GCP **project number**, not the project ID string; your GCP admin can find it with `gcloud projects describe <project-id> --format='value(projectNumber)'`)
+  - GCP region for inference (`--inference-region`, defaults to `global`)
+
+> **Note:** You do NOT need GCP project access, `gcloud` authentication, or any IAM roles. All GCP infrastructure values are provided as flags.
+
+## Roles and responsibilities
+
+fullsend separates infrastructure management into distinct roles. A single person can hold multiple roles, but the CLI supports splitting them across teams:
+
+| Role | Commands | Access Required | Provisions |
+|------|----------|-----------------|------------|
+| **GCP Admin (Mint)**\* | `fullsend mint deploy`, `mint enroll`, `mint unenroll`, `mint status` | GCP project with Cloud Functions, Secret Manager, IAM | Token mint Cloud Function, PEM secrets |
+| **GCP Admin (Inference)** | `fullsend inference provision`, `inference status` | GCP project with IAM, Agent Platform enabled | WIF pool/provider, IAM bindings for Agent Platform |
+| **GitHub Maintainer (org)** | `fullsend github setup <org>`, `github enroll`, `github unenroll`, `github set`, `github status`, `github uninstall`, `github sync-scaffold` | GitHub org owner (`admin:org` scope) | GitHub Apps, config repo, org variables, workflows, enrollment |
+| **GitHub Maintainer (repo)** | `fullsend github setup <owner/repo>`, `github set` | GitHub repo admin (`repo` + `workflow` scopes) | Repo-level secrets, variables, shim workflow |
+| **Full Admin** | `fullsend admin install` | GCP + GitHub | Everything above in one command |
+
+\*The mint is fully self-hostable, but most users currently use the mint service hosted by the fullsend team for convenience. Work is in progress to offer this as a secure, trusted public service — reducing the need for per-org `mint enroll` operations and GCP-side management.
+
+The typical workflow: a GCP admin runs `mint deploy` (one-time), `mint enroll` (once per new org or repo), and `inference provision`, then hands off the mint URL and WIF provider resource name to a GitHub maintainer who runs `github setup`. For users of the fullsend-hosted mint, `mint deploy` is already done — only `mint enroll` is needed for new orgs or repos (planned to be eliminated in a future release).
+
+**Ordering flexibility:** GCP operations (`mint deploy`, `mint enroll`, `inference provision`) are pure GCP — they do not interact with GitHub and do not require the GitHub Apps to be installed. `mint enroll` copies app IDs from the mint's existing configuration (defaulting to `--source-org=fullsend-ai`), not from the target org's GitHub installations. The GitHub Apps must be installed on the target org before **agents can run**, but the timing relative to GCP setup is flexible:
+
+- **Per-org mode** — `github setup <org>` handles app installation interactively (opens a browser for each role), so a single org owner can run it without pre-installing apps.
+- **Per-org with `--skip-app-setup`** — an org owner must [pre-install the apps](#default-fullsend-ai-app-set-installation-urls) before running setup.
+- **Per-repo mode** — an org owner must [pre-install the apps](#default-fullsend-ai-app-set-installation-urls) before a repo admin runs `github setup <owner/repo>`.
+
+### Default `fullsend-ai` app set installation URLs
+
+When using the default app set, an **org owner** installs each app from these URLs. The org owner approves which repositories the app can access during installation.
+
+| Role | Installation URL |
+|------|-----------------|
+| fullsend | <https://github.com/apps/fullsend-ai-fullsend/installations/new> |
+| triage | <https://github.com/apps/fullsend-ai-triage/installations/new> |
+| coder | <https://github.com/apps/fullsend-ai-coder/installations/new> |
+| review | <https://github.com/apps/fullsend-ai-review/installations/new> |
+| retro | <https://github.com/apps/fullsend-ai-retro/installations/new> |
+| prioritize | <https://github.com/apps/fullsend-ai-prioritize/installations/new> |
+
+> **Tip:** To verify apps are installed, run `gh api /orgs/{org}/installations --jq '.installations[].app_slug'`.
+
+## Per-org setup
+
+Per-org mode creates a `.fullsend` config repository, deploys reusable workflows, configures secrets and variables, and enrolls repositories:
+
+```bash
+fullsend github setup acme-corp \
+  --mint-url=<MINT_URL> \
+  --inference-project=my-gcp-project \
+  --inference-wif-provider=projects/123456789/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc \
+  --inference-region=global
+```
+
+Unless `--skip-app-setup` is passed, the command opens a browser for each agent role to create or install GitHub Apps (see [GitHub App setup](#github-app-setup) below), then prompts you to select repositories for enrollment.
+
+### GitHub App setup
+
+Per-org setup includes a GitHub App setup phase that runs automatically unless `--skip-app-setup` is passed. Understanding this phase is important for choosing the right workflow.
+
+**What happens during app setup:**
+
+1. For each agent role (e.g., `triage`, `coder`, `review`), the CLI checks whether a GitHub App matching the naming convention (`{app-set}-{role}`, e.g., `fullsend-ai-triage`) is already installed on the org.
+2. If an app is already installed and its private key secret exists, the CLI reuses it.
+3. If no matching app is found, the CLI checks whether the app exists globally (e.g., a public app owned by another org). If found, it opens a browser to install the existing app on your org.
+4. If no app exists at all, the CLI runs the [manifest flow](https://docs.github.com/en/apps/creating-github-apps/setting-up-a-github-app/creating-a-github-app-from-a-manifest) — it opens a browser to `https://github.com/organizations/{org}/settings/apps/new` to create a new GitHub App.
+
+**Permission requirements for app setup:**
+
+- **Creating a new GitHub App** (manifest flow) requires **GitHub organization owner** access. Only org owners can create apps in an organization's developer settings.
+- **Installing an existing app** (e.g., a public app like `fullsend-ai-triage`) on an org also requires org owner access, or the org must have an [app installation approval policy](https://docs.github.com/en/organizations/managing-programmatic-access-to-your-organization/limiting-oauth-app-and-github-app-access-requests) that allows members to request installations.
+
+**The default `fullsend-ai` app set:**
+
+The default `--app-set` value is `fullsend-ai`, which corresponds to public GitHub Apps owned by the `fullsend-ai` organization (e.g., `fullsend-ai-triage`, `fullsend-ai-coder`, `fullsend-ai-review`). When using this default, the CLI detects these existing public apps and installs them on your org rather than creating new ones. An org owner must approve the installation.
+
+**When to use `--skip-app-setup`:**
+
+Pass `--skip-app-setup` when the GitHub Apps are already installed on the org — for example, when an org owner has already installed the `fullsend-ai` apps or completed a previous `github setup` run that handled app creation. With this flag, the CLI skips all app-related steps (no browser windows, no manifest flow, no installation prompts) and proceeds directly to configuring the config repo, org variables, secrets, and enrollment.
+
+```bash
+# Org owner has already installed fullsend-ai apps on acme-corp
+fullsend github setup acme-corp \
+  --mint-url=<MINT_URL> \
+  --inference-project=my-gcp-project \
+  --inference-wif-provider=projects/123456789/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc \
+  --skip-app-setup
+```
+
+> **Note:** Even with `--skip-app-setup`, per-org setup still requires the `admin:org` OAuth scope because it creates org-level variables. Repo admins without org-level access should use [per-repo mode](#per-repo-setup) instead.
+
+### Setup flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--mint-url` | Yes | — | Token mint Cloud Function URL (HTTPS) |
+| `--agents` | No | `fullsend,triage,coder,review,retro,prioritize` | Comma-separated agent roles to configure (per-repo omits `fullsend`) |
+| `--inference-project` | Yes (per-org: optional on re-run) | — | GCP project ID where Agent Platform is enabled |
+| `--inference-region` | No | `global` | GCP region for Agent Platform inference |
+| `--inference-wif-provider` | Yes (per-org: optional on re-run) | — | Full WIF provider resource name (see [Prerequisites](#prerequisites) for format) |
+| `--skip-app-setup` | No | `false` | Skip GitHub App creation/installation (use when apps are already installed; see [GitHub App setup](#github-app-setup)) |
+| `--public` | No | `false` | Create public (unlisted) GitHub Apps (for multi-org sharing) |
+| `--app-set` | No | `fullsend-ai` | App set name prefix for GitHub Apps |
+| `--enroll-all` | No | `false` | Enroll all repositories without prompting (per-org only) |
+| `--enroll-none` | No | `false` | Skip enrollment without prompting (per-org only) |
+| `--vendor-fullsend-binary` | No | `false` | Build and upload the fullsend binary to the config repo for local dev testing (e.g., macOS with a Podman Linux VM) |
+| `--dry-run` | No | `false` | Preview changes without making them |
+
+## Per-repo setup
+
+Per-repo mode bootstraps a single repository with a `.fullsend/` directory, shim workflow, and repo-level secrets:
+
+```bash
+fullsend github setup acme-corp/my-service \
+  --mint-url=<MINT_URL> \
+  --inference-project=my-gcp-project \
+  --inference-wif-provider=projects/123456789/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc
+```
+
+Per-repo mode differs from per-org in these ways:
+- `--inference-project` and `--inference-wif-provider` are required (optional for per-org)
+- Secrets and variables are written to the target repo (not a `.fullsend` config repo)
+- The `fullsend` meta-role is excluded from the default agent set
+- `--enroll-all` and `--enroll-none` flags are not available
+- No config repo is created
+- No GitHub App creation or installation — per-repo mode does not manage apps
+
+### Repo admin without org access
+
+If you are a repo admin but **not** an org owner, per-repo mode is your setup path. The CLI itself only needs `repo` and `workflow` scopes, but the agent pipeline requires the GitHub Apps to be installed on your org **before** agents can function. The token mint exchanges OIDC tokens for GitHub App installation tokens — if the app isn't installed, the mint returns an error and the agent workflow fails.
+
+**Prerequisites for repo admins:**
+
+1. An **org owner** must have [installed the GitHub Apps](#default-fullsend-ai-app-set-installation-urls) on the org (or on your specific repos)
+2. A **GCP admin** has deployed the token mint and provisioned WIF infrastructure
+3. You have received the mint URL, inference project, and WIF provider values
+
+Once the apps are installed, run [per-repo setup](#per-repo-setup) for each repository you manage. This writes the shim workflow, config directory, repo variables, and repo secrets to the target repo. No org-level changes are made and no GitHub App interaction occurs.
+
+After setup, agents activate once the GitHub Apps have access to the repo. If the apps are installed org-wide, no further action is needed. If installed on specific repos only, ask your org owner to add your repo to each app's installation.
+
+## Merging enrollment PRs
+
+After setup, each enrolled repository will have an open PR adding the agent workflow files. Review and merge these PRs to activate agents. See the "Merge enrollment PRs" section of the [installation guide](installation.md) for details.
+
+## Day-2 operations
+
+### Enrolling and unenrolling repositories
+
+Add or remove repositories from agent enrollment after initial setup:
+
+```bash
+# Enable specific repos
+fullsend github enroll acme-corp repo-a repo-b
+
+# Enable all repos (excluding .fullsend)
+fullsend github enroll acme-corp --all
+
+# Disable specific repos
+fullsend github unenroll acme-corp repo-a repo-b
+
+# Disable all repos (--yolo skips the confirmation prompt)
+fullsend github unenroll acme-corp --all --yolo
+```
+
+### Updating configuration values
+
+Update individual secrets or variables without re-running full setup:
+
+```bash
+# Update a value for an org (writes to the .fullsend config repo)
+fullsend github set acme-corp FULLSEND_GCP_REGION us-east5
+
+# Update a value for a specific repo
+fullsend github set acme-corp/my-service FULLSEND_GCP_PROJECT_ID new-gcp-project
+```
+
+| Key | Storage Type | Description | Example value |
+|-----|-------------|-------------|---------------|
+| `FULLSEND_GCP_REGION` | Repo variable | GCP region for Agent Platform inference | `global` |
+| `FULLSEND_PER_REPO_INSTALL` | Repo variable | Set to `true` for per-repo installations (auto-set by installer) | `true` |
+| `FULLSEND_GCP_PROJECT_ID` | Repo secret | GCP project ID where Agent Platform is enabled | `my-gcp-project` |
+| `FULLSEND_GCP_WIF_PROVIDER` | Repo secret | Full WIF provider resource name for OIDC authentication | `projects/123456789/locations/global/...` |
+
+For org targets, values are written to the `.fullsend` config repo. For `owner/repo` targets, values are written directly to that repo.
+
+### Syncing workflow templates
+
+Update the workflow files in the `.fullsend` config repo to match the current fullsend binary version:
+
+```bash
+fullsend github sync-scaffold acme-corp
+```
+
+Run this after upgrading the fullsend CLI to pick up workflow template changes.
+
+### Checking status
+
+Inspect the GitHub-side installation state:
+
+```bash
+fullsend github status acme-corp
+```
+
+Reports on: config repo presence, workflow files, org variables, inference secrets, and enrollment state. Does not check GCP resources.
+
+## Uninstalling
+
+Remove fullsend GitHub configuration from an organization:
+
+```bash
+fullsend github uninstall acme-corp
+```
+
+This removes the `.fullsend` config repo, org variables (`FULLSEND_MINT_URL`), and org secrets (`FULLSEND_DISPATCH_TOKEN`). It also lists any installed GitHub Apps and provides links for manual deletion. Add `--yolo` to skip the confirmation prompt.
+
+> **Note:** `github uninstall` only removes GitHub-side configuration. GCP resources (mint, WIF, PEM secrets) are managed separately via `fullsend mint unenroll` and `fullsend inference` commands by the GCP administrator.
+
+## Relationship to admin install
+
+`fullsend admin install` performs all setup — GCP and GitHub — in a single command. The standalone subcommands decompose the same pipeline:
+
+```
+fullsend admin install <org>
+  ├── mint deploy + mint enroll      → fullsend mint deploy + fullsend mint enroll <org>
+  ├── inference provision            → fullsend inference provision <org>
+  └── github setup                   → fullsend github setup <org> --mint-url=... --inference-wif-provider=...
+```
+
+Use `admin install` when one person has both GCP and GitHub access. Use the standalone commands when responsibilities are split across teams.
+
+## See Also
+
+- [Installing fullsend](installation.md) — All-in-one setup (GCP + GitHub)
+- [Infrastructure Reference](infrastructure-reference.md) — Token mint, WIF, and secrets details
+- [CLI Internals](../dev/cli-internals.md) — Command structure and implementation details

--- a/docs/guides/admin/infrastructure-reference.md
+++ b/docs/guides/admin/infrastructure-reference.md
@@ -4,6 +4,8 @@ This guide provides implementation details for fullsend's infrastructure compone
 
 ## Token Mint (OIDC) — GCF Cloud Function
 
+> Managed by: `fullsend mint deploy`, `fullsend mint enroll`, `fullsend mint unenroll`, `fullsend mint status`
+
 The mint is a GCP Cloud Function that exchanges GitHub OIDC tokens for scoped GitHub App installation tokens. This eliminates long-lived PATs from the system.
 
 ### Mint Architecture
@@ -102,9 +104,11 @@ A single mint instance can serve multiple orgs:
 
 ---
 
-## Inference — Vertex AI with Workload Identity Federation
+## Inference — Agent Platform with Workload Identity Federation
 
-Inference authentication uses GCP Workload Identity Federation (WIF) to allow GitHub Actions to authenticate to Vertex AI without service account keys.
+> Managed by: `fullsend inference provision`, `fullsend inference status`
+
+Inference authentication uses GCP Workload Identity Federation (WIF) to allow GitHub Actions to authenticate to Agent Platform without service account keys.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -140,7 +144,7 @@ Inference authentication uses GCP Workload Identity Federation (WIF) to allow Gi
 │             │                                               │
 │             ▼                                               │
 │  ┌─────────────────────────────────┐                        │
-│  │ Vertex AI API                   │                        │
+│  │ Agent Platform API              │                        │
 │  │                                 │                        │
 │  │ Project: FULLSEND_GCP_PROJECT_ID│                        │
 │  │ Region:  FULLSEND_GCP_REGION    │                        │
@@ -167,6 +171,8 @@ During installation, the GCF provisioner creates:
 ---
 
 ## GitHub Secrets & Variables Deployment
+
+> Individual values can be updated with `fullsend github set <target> <key> <value>`. See [Setting up with pre-provisioned infrastructure](github-setup.md) for the full GitHub management guide.
 
 Secrets and variables are deployed at different scopes depending on the installation mode.
 
@@ -244,9 +250,9 @@ The GCF provisioner handles full GCP infrastructure deployment:
 │  └─────────┬─────────┘                                          │
 │            ▼                                                    │
 │  ┌───────────────────┐                                          │
-│  │ Grant Vertex AI   │ roles/aiplatform.user                    │
-│  │ access to         │ on the inference project                 │
-│  │ federated IDs     │                                          │
+│  │ Grant Agent       │ roles/aiplatform.user                    │
+│  │ Platform access   │ on the inference project                 │
+│  │ to federated IDs  │                                          │
 │  └─────────┬─────────┘                                          │
 │            ▼                                                    │
 │  ┌───────────────────┐                                          │
@@ -284,5 +290,6 @@ The GCF provisioner avoids redundant Cloud Function deployments by computing a S
 
 ## See Also
 
-- [Installation Guide](installation.md) - Step-by-step setup instructions
-- [Local Development](../dev/local-dev.md) - Developer setup
+- [Installation Guide](installation.md) — All-in-one setup instructions
+- [Setting up with pre-provisioned infrastructure](github-setup.md) — GitHub-only setup guide
+- [Local Development](../dev/local-dev.md) — Developer setup

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -2,6 +2,8 @@
 
 This guide walks through installing fullsend in a GitHub organization and enrolling your first repository.
 
+> **GitHub-only setup:** If your GCP admin has already deployed the token mint and inference infrastructure, you do not need GCP access. See [Setting up with pre-provisioned infrastructure](github-setup.md) for the GitHub-only path using `fullsend github setup`.
+
 ## Prerequisites
 
 - **GitHub organization** with admin access
@@ -326,6 +328,8 @@ Per-repo mode installs fullsend for a single repository without requiring an org
 
 When a platform operator has pre-provisioned shared public GitHub Apps and a token mint, you only need to provide a GCP project for inference. This is the simplest installation path — no Apps to create, no mint to deploy, no PEM management.
 
+> **Tip:** For GitHub-only setup without GCP access, use `fullsend github setup` instead of `admin install`. See [Setting up with pre-provisioned infrastructure](github-setup.md).
+
 > This section documents the **SaaS installation profile** defined in [ADR 0033 §6](../../ADRs/0033-per-repo-installation-mode.md#6-credential-models). If you are reusing apps from your own prior per-org installation, see [Reusing existing infrastructure](#reusing-existing-infrastructure) instead.
 
 **Prerequisites:**
@@ -492,9 +496,35 @@ fullsend admin uninstall "$ORG_NAME" --app-set "$ORG_NAME"
 
 ---
 
+## Standalone commands
+
+The `admin install` command performs all setup in a single invocation. For organizations that separate GCP and GitHub responsibilities across teams, fullsend provides standalone commands that decompose the same pipeline:
+
+| Role | Command | What it does |
+|------|---------|-------------|
+| GCP Admin (Mint) | `fullsend mint deploy` | Deploy the token mint Cloud Function |
+| GCP Admin (Mint) | `fullsend mint enroll <org\|owner/repo>` | Register an org or repo in the mint, store PEMs |
+| GCP Admin (Mint) | `fullsend mint unenroll <org\|owner/repo>` | Remove an org or repo from the mint |
+| GCP Admin (Mint) | `fullsend mint status` | Inspect mint state and PEM health |
+| GCP Admin (Inference) | `fullsend inference provision <org\|owner/repo>` | Create WIF pool/provider for Agent Platform |
+| GCP Admin (Inference) | `fullsend inference status <org\|owner/repo>` | Check WIF health, print config values |
+| GitHub Maintainer | `fullsend github setup <org\|owner/repo>` | Configure GitHub org or repo (no GCP needed) |
+| GitHub Maintainer | `fullsend github enroll <org> [repo...]` | Add repositories to agent enrollment |
+| GitHub Maintainer | `fullsend github unenroll <org> [repo...]` | Remove repositories from agent enrollment |
+| GitHub Maintainer | `fullsend github set <org\|owner/repo> <key> <value>` | Update a single config value (secret or variable) |
+| GitHub Maintainer | `fullsend github status <org>` | Analyze GitHub-side installation state |
+| GitHub Maintainer | `fullsend github sync-scaffold <org>` | Update workflow templates to current CLI version |
+| GitHub Maintainer | `fullsend github uninstall <org>` | Remove GitHub configuration (org-level only) |
+
+See [Setting up with pre-provisioned infrastructure](github-setup.md) for the complete GitHub maintainer guide.
+
+---
+
 ## Advanced: pre-configure WIF
 
-The installer auto-provisions WIF infrastructure, but you can create it manually if you need custom pool names, attribute conditions, or want to share a provider across tools.
+The installer auto-provisions WIF infrastructure. For most cases, `fullsend inference provision <org>` handles this automatically and prints the WIF provider resource name to pass to `admin install --inference-wif-provider` or `github setup --inference-wif-provider`.
+
+If you need custom pool names, attribute conditions, or want to share a provider across tools, you can create WIF manually:
 
 **Create a Workload Identity Pool and OIDC Provider:**
 
@@ -544,3 +574,10 @@ fullsend admin install "$ORG_NAME" \
 ```
 
 > **Note:** IAM policy bindings may take several minutes to propagate. If agent workflows fail with a permission error immediately after setup, wait a few minutes and retry.
+
+## See Also
+
+- [Setting up with pre-provisioned infrastructure](github-setup.md) — GitHub-only setup when GCP is already provisioned
+- [Infrastructure Reference](infrastructure-reference.md) — Token mint, WIF, and secrets deployment details
+- [Enabling fullsend on private repositories](private-repositories.md) — Additional guardrails for private repos
+- [CLI Internals](../dev/cli-internals.md) — Command structure and implementation details

--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -6,23 +6,51 @@ This guide provides implementation details for fullsend CLI internals: command s
 
 ```
 fullsend
-├── admin
-│   ├── install     # Per-org or per-repo infrastructure setup
-│   ├── uninstall   # Tear down infrastructure (reverse layer order)
-│   ├── analyze     # Health check: inspect installed state
+├── admin                                    # All-in-one setup (GCP + GitHub)
+│   ├── install      <org|owner/repo>        # Full infrastructure setup
+│   ├── uninstall    <org>                   # Tear down (reverse layer order)
+│   ├── analyze      <org>                   # Health check installed state
 │   ├── enable
-│   │   └── repos   # Enable agent on repos (per-org mode)
+│   │   └── repos    <org> [repo...]         # Enable agent on repos
 │   └── disable
-│       └── repos   # Disable agent on repos (per-org mode)
-├── run             # Execute an agent in a sandbox
-├── scan            # Run security scanner on input/output
-│   ├── input       # Scan event payload for prompt injection
-│   ├── output      # Scan agent output for secrets
-│   ├── context     # Scan context files for injection
-│   └── url         # Validate URLs for SSRF
-├── post-review     # Post PR review comments to GitHub
-└── post-comment    # Post issue/PR comments to GitHub
+│       └── repos    <org> [repo...]         # Disable agent on repos
+├── mint                                     # GCP: token mint management
+│   ├── deploy                               # Deploy/update mint Cloud Function
+│   ├── enroll       <org|owner/repo>        # Register org/repo in mint
+│   ├── unenroll     <org|owner/repo>        # Remove org/repo from mint
+│   └── status       [org]                   # Inspect mint state and PEM health
+├── inference                                # GCP: inference WIF management
+│   ├── provision    <org|owner/repo>        # Create WIF pool/provider for Agent Platform
+│   └── status       <org|owner/repo>        # Check WIF health, print config
+├── github                                   # GitHub-only configuration
+│   ├── setup        <org|owner/repo>        # Configure fullsend (no GCP needed)
+│   ├── enroll       <org> [repo...]         # Enable repos for agent workflows
+│   ├── unenroll     <org> [repo...]         # Disable repos from agent workflows
+│   ├── set          <target> <key> <value>  # Update a config value
+│   ├── status       <org>                   # Analyze GitHub-side state
+│   ├── uninstall    <org>                   # Remove fullsend GitHub configuration
+│   └── sync-scaffold <org>                  # Update workflow templates
+├── run                                      # Execute an agent in a sandbox
+├── scan                                     # Run security scanner on input/output
+│   ├── input                                # Scan event payload for prompt injection
+│   ├── output                               # Scan agent output for leaked secrets
+│   ├── context                              # Scan context files for prompt injection
+│   └── url                                  # Validate URLs against SSRF attacks
+├── post-review                              # Post PR review comments to GitHub
+└── post-comment                             # Post issue/PR comments to GitHub
 ```
+
+### Command Decomposition
+
+The `admin install` command performs all setup in a single invocation. The `mint`, `inference`, and `github` subcommands break this into role-specific operations for organizations that separate GCP and GitHub responsibilities:
+
+| `admin install` Phase | Standalone Command | Required Access |
+|-----------------------|--------------------|-----------------|
+| Phases 1-3: Mint provisioning | `fullsend mint deploy` + `fullsend mint enroll` | GCP project (mint) |
+| Phase 4: WIF provisioning | `fullsend inference provision` | GCP project (inference) |
+| Phases 5-7: GitHub setup + enrollment | `fullsend github setup` | GitHub only |
+
+The typical handoff: a GCP admin runs `mint deploy` and `inference provision`, then passes the mint URL and WIF provider resource name to a GitHub maintainer who runs `github setup --mint-url=... --inference-wif-provider=...`. See [Setting up with pre-provisioned infrastructure](../admin/github-setup.md).
 
 ### Token Resolution Chain
 
@@ -448,6 +476,9 @@ var executableFiles = map[string]struct{}{
 |------|-------|---------|
 | `internal/cli/root.go` | ~34 | CLI entry point, command registration |
 | `internal/cli/admin.go` | ~2415 | Install/uninstall/analyze/enable/disable |
+| `internal/cli/mint.go` | ~1022 | Mint deploy/enroll/unenroll/status |
+| `internal/cli/inference.go` | ~408 | Inference WIF provision/status |
+| `internal/cli/github.go` | ~966 | GitHub setup/set/status/uninstall/sync-scaffold/enroll/unenroll |
 | `internal/cli/run.go` | ~1923 | Agent execution lifecycle |
 | `internal/mint/main.go` | ~906 | GCF token mint service |
 | `internal/dispatch/gcf/provisioner.go` | ~1350 | GCP infrastructure provisioner |
@@ -459,11 +490,12 @@ var executableFiles = map[string]struct{}{
 | `internal/layers/dispatch.go` | ~364 | Mint URL deployment layer |
 | `internal/scaffold/scaffold.go` | ~146 | Embedded template system |
 | `internal/inference/inference.go` | ~26 | Provider interface |
-| `internal/inference/vertex/vertex.go` | ~80 | Vertex AI implementation |
+| `internal/inference/vertex/vertex.go` | ~80 | Agent Platform (Vertex AI) implementation |
 | `internal/config/config.go` | ~264 | Org/repo config structures |
 
 ## See Also
 
-- [Local Development](local-dev.md) - Development environment setup
-- [Infrastructure Reference](../admin/infrastructure-reference.md) - Admin infrastructure details
-- [Customizing Agents](../user/customizing-agents.md) - User customization guide
+- [Local Development](local-dev.md) — Development environment setup
+- [Setting up with pre-provisioned infrastructure](../admin/github-setup.md) — GitHub-only setup guide
+- [Infrastructure Reference](../admin/infrastructure-reference.md) — Admin infrastructure details
+- [Customizing Agents](../user/customizing-agents.md) — User customization guide


### PR DESCRIPTION
## Summary

- Add `docs/guides/admin/github-setup.md` — new guide for GitHub org/repo maintainers who set up fullsend with pre-provisioned GCP infrastructure (no GCP access required)
- Update `docs/guides/dev/cli-internals.md` — full command tree with mint/inference/github subcommands, command decomposition table mapping `admin install` phases to standalone commands, and 3 new source file entries
- Update `docs/guides/admin/installation.md` — add GitHub-only callout, standalone commands reference table, and cross-references to the new guide
- Update `docs/guides/admin/infrastructure-reference.md` — add CLI command cross-references to each infrastructure section
- Update `docs/guides/README.md` — add missing index entries (github-setup, infrastructure-reference, cli-internals)

## Context

PRs #1258, #1259, #1261 added three new CLI subcommand trees (`mint`, `inference`, `github`) that decompose the monolithic `admin install` into role-specific operations. The existing docs only covered `admin install` and assumed a single admin with both GCP and GitHub access. This PR documents the role-based model:

1. **GCP Admin (Mint)** — deploys/manages the token mint Cloud Function
2. **GCP Admin (Inference)** — provisions Vertex AI WIF infrastructure
3. **GitHub Maintainer** — configures GitHub org/repo using pre-provisioned values (primary audience)
4. **Full Admin** — uses `admin install` for all-in-one setup

## Test plan

- [ ] `make lint` passes (markdown links checker validates all cross-references)
- [ ] Command tree matches `grep 'Use:' internal/cli/*.go` output
- [ ] Flag tables in github-setup.md match source code flag definitions
- [ ] All relative links between docs resolve correctly