### PR TITLE
docs: accept ADR 0029 central token mint and secretless .fullsend

### DIFF
--- a/docs/ADRs/0029-central-token-mint-secretless-fullsend.md
+++ b/docs/ADRs/0029-central-token-mint-secretless-fullsend.md
@@ -1,6 +1,6 @@
 ---
 title: "29. Central token mint and shared apps for a secretless .fullsend"
-status: Proposed
+status: Accepted
 relates_to:
   - agent-infrastructure
   - security-threat-model
@@ -18,7 +18,7 @@ Date: 2026-05-05
 
 ## Status
 
-Proposed
+Accepted
 
 <!-- Once this ADR is Accepted, its content is frozen. Do not edit the Context,
      Decision, or Consequences sections. If circumstances change, write a new


### PR DESCRIPTION
## Summary

- Move [ADR 0029](docs/ADRs/0029-central-token-mint-secretless-fullsend.md) from **Proposed** to **Accepted** (frontmatter `status` and `## Status` section only).
- No changes to Context, Decision, or Consequences; content is frozen per ADR conventions once accepted.

## Review note

Human review of this ADR is already complete and the decision is effectively accepted. Please treat this PR as a **status-only** bookkeeping change—avoid substantive content feedback on the ADR body itself.

## Test plan

- [x] `./hack/lint-adr-status`
- [x] `./hack/lint-adr-frontmatter`
- [x] `./hack/lint-adr-numbers`

Made with [Cursor](https://cursor.com)