### PR TITLE
ADR 0015: Normative implementation contracts live under docs/normative/

### DIFF
--- a/docs/ADRs/0015-normative-specifications-directory.md
+++ b/docs/ADRs/0015-normative-specifications-directory.md
@@ -1,6 +1,6 @@
 ---
 title: "15. Normative implementation contracts live under docs/normative/"
-status: Proposed
+status: Accepted
 relates_to:
   - architectural-invariants
   - governance
@@ -17,7 +17,7 @@ Date: 2026-04-06
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Accept [ADR 0015](docs/ADRs/0015-normative-specifications-directory.md) by flipping its frontmatter `status` and the `## Status` section from Proposed to Accepted.

## Note

Human review is complete and ADR content is frozen per repo conventions (status-only change; Context, Decision, and Consequences unchanged).

## DCO

- Commit rewritten to include `Signed-off-by`.

## Test plan

- [x] `./hack/lint-adr-status`
- [x] `./hack/lint-adr-numbers`
- [x] `./hack/lint-adr-frontmatter`
- [ ] CI / pre-commit on PR