### PR TITLE
fix(dispatch): route issues opened/edited to triage in per-repo mode

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -164,7 +164,9 @@ jobs:
               ;;
 
             issues)
-              if [[ "${EVENT_ACTION}" == "labeled" ]]; then
+              if [[ "${EVENT_ACTION}" == "opened" || "${EVENT_ACTION}" == "edited" ]]; then
+                STAGE="triage"
+              elif [[ "${EVENT_ACTION}" == "labeled" ]]; then
                 if [[ "${TRIGGERING_LABEL}" == "ready-to-code" ]]; then
                   STAGE="code"
                 elif [[ "${TRIGGERING_LABEL}" == "ready-for-review" ]]; then


### PR DESCRIPTION
## Summary

- `reusable-dispatch.yml` was missing the `opened|edited → triage` branch in the `issues)` routing case
- Org-mode `dispatch.yml` has had this routing since the feature was introduced; per-repo was an omission from the original implementation (`3bcd099e`)
- The shim (`shim-per-repo.yaml`) already subscribes to `issues: [opened, edited, labeled]` — only the dispatch routing logic needed updating

Fixes #1241

## Test plan

- [ ] Open an issue in a per-repo-enrolled repository — triage agent should trigger
- [ ] Edit an issue in a per-repo-enrolled repository — triage agent should trigger
- [ ] Add `ready-to-code` label — code agent should still trigger (no regression)
- [ ] Add `ready-for-review` label — review agent should still trigger (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)