### PR TITLE
docs: deprecate ADR-0028 (GitLab support)

### DIFF
--- a/docs/ADRs/0028-gitlab-support.md
+++ b/docs/ADRs/0028-gitlab-support.md
@@ -1,6 +1,6 @@
 ---
 title: "28. GitLab Support Architecture"
-status: Proposed
+status: Deprecated
 relates_to:
   - agent-infrastructure
   - agent-architecture
@@ -17,7 +17,7 @@ Date: 2026-04-29
 
 ## Status
 
-Proposed
+Deprecated
 
 ## Context
 


### PR DESCRIPTION
## Summary
- Deprecates ADR-0028 (GitLab Support Architecture) by changing its status from Proposed to Deprecated in both the YAML frontmatter and body.

## Test plan
- [x] `hack/lint-adr-status` passes with all 41 ADRs valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)