### PR TITLE
docs: surface ADR rules in AGENTS.md and clarify PR status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,13 @@ All git forge operations (GitHub API calls, PR comments, issue creation, workflo
 **When writing code:** If you need a forge operation that `forge.Client` does not yet support, add a new method to the interface and implement it in the GitHub client — do not work around the interface.
 
 **When reviewing PRs:** Flag any direct `exec.Command("gh", ...)`, raw GitHub API calls, or other forge-specific operations outside `internal/forge/github/` as a medium-severity or higher finding. This is an architectural violation, not a style preference.
+
+## Architecture Decision Records (ADRs)
+
+These rules apply whenever you touch `docs/ADRs/` or review a PR that does. Full authoring guidance is in [`skills/writing-adrs/SKILL.md`](skills/writing-adrs/SKILL.md); invoke that skill when writing a new ADR.
+
+**Immutability:** Once an ADR on `main` has status **Accepted**, its Context, Decision, and Consequences sections are frozen. Do not add post-decision notes, rewrite rationale, or edit consequences in place. When circumstances change, write a **new** ADR that supersedes the old one. The only acceptable edits to an Accepted ADR on `main` are status changes (e.g., to Deprecated or Superseded) and links to the superseding ADR. Typos and broken links are narrow exceptions — call them out in the PR description.
+
+**New ADRs in pull requests:** Approval happens at **merge**, not when the branch is created. If the decision is made, set status to **Accepted** in the ADR you are proposing (not **Proposed** merely because the PR is open). Use **Proposed** or **Undecided** only when the decision itself is still unsettled. When status is Accepted, update `docs/architecture.md` and related problem docs in the same PR per the writing-adrs skill.
+
+**When reviewing PRs:** Flag in-place edits to Context, Decision, or Consequences on Accepted ADRs already on `main` as a policy violation. Allow status-only updates and supersession links. For brand-new ADR files on the PR branch, evaluate whether the recorded decision matches the diff — do not treat **Accepted** on a new file as a mistake if the ADR is ready for human review at merge.

--- a/skills/writing-adrs/SKILL.md
+++ b/skills/writing-adrs/SKILL.md
@@ -36,6 +36,27 @@ Consequences sections.
 If a decision turned out to be wrong, that is exactly what supersession is for.
 The original ADR remains as a historical record of what was decided and why.
 
+### Status and pull request review
+
+In this repo, **new ADRs are approved when a human merges the PR** — they do not
+appear on `main` until then. Merge is the approval event; an open PR is the review
+gate, not a reason to leave the decision itself unsettled in the document.
+
+When authoring a new ADR:
+
+- Use **Accepted** when the decision is made and the ADR is ready for review.
+  You are recording the decision as it should read once merged, not claiming it
+  is already binding on `main`.
+- Use **Proposed** only when the ADR is intentionally incomplete or the decision
+  is still being debated in the PR.
+- Use **Undecided** when options are documented but no choice has been made.
+
+Do **not** default to Proposed just because the file is new on a branch. Proposed
+means the decision is unsettled, not that the PR awaits merge.
+
+After merge to `main`, Accepted ADRs follow the immutability rules above. Agents
+and humans should also follow the summary in [AGENTS.md](../../AGENTS.md#architecture-decision-records-adrs).
+
 ### docs/architecture.md is always current
 
 Unlike ADRs, `docs/architecture.md` is a **living document**. It must always
@@ -124,11 +145,12 @@ Follow these steps in order:
    the `title` field and the `# heading` must have **no leading zeros**
    (e.g., `"1. Use ADRs"`, not `"0001. Use ADRs"`). The four-digit
    zero-padded format is only for filenames.
-4. **Choose the right status.** Use **Proposed** for a draft awaiting
-   discussion. Use **Undecided** when the problem is identified but no choice
-   has been made. Use **Accepted** when the decision is made. Include an
-   Options section only when there are genuine alternatives worth documenting;
-   if the decision is obvious, just decide it.
+4. **Choose the right status.** For agent-authored ADRs going through PR review,
+   default to **Accepted** when the decision is made (see "Status and pull
+   request review" above). Use **Undecided** when the problem is identified but
+   no choice has been made. Use **Proposed** only when the decision itself is
+   still open for debate. Include an Options section only when there are genuine
+   alternatives worth documenting; if the decision is obvious, just decide it.
 5. **Write the ADR.** Follow the conciseness rules above.
 6. **Run linters.** Execute `make lint` and fix any errors before committing.
 7. **If status is Accepted, update living documents** (see below).


### PR DESCRIPTION
## Summary

- Add an **Architecture Decision Records (ADRs)** section to `AGENTS.md` so all agents see immutability, PR review, and review expectations without invoking the `writing-adrs` skill.
- Update `skills/writing-adrs/SKILL.md` to treat **merge as approval**: new ADRs ready for review should default to **Accepted**, not **Proposed**, when the decision is made.

Closes #1648.

## Test plan

- [ ] Confirm `AGENTS.md` renders the new section and link to `writing-adrs`
- [ ] Spot-check that a code/review agent run loads ADR immutability rules from `AGENTS.md`
- [ ] `make lint` (ADR frontmatter unchanged; docs-only)


Made with [Cursor](https://cursor.com)