### PR TITLE
ci: add halfsend-03 through halfsend-06 to e2e org pool

### DIFF
--- a/e2e/admin/testutil.go
+++ b/e2e/admin/testutil.go
@@ -51,10 +51,10 @@ const (
 var orgPool = []string{
 	"halfsend-01",
 	"halfsend-02",
-	// "halfsend-03", // not yet enrolled in mint
-	// "halfsend-04", // not yet enrolled in mint
-	// "halfsend-05", // not yet enrolled in mint
-	// "halfsend-06", // not yet enrolled in mint
+	"halfsend-03",
+	"halfsend-04",
+	"halfsend-05",
+	"halfsend-06",
 }
 
 // acquireOrg scans the pool for an unlocked org and acquires its lock.


### PR DESCRIPTION
## Summary
- All four orgs (halfsend-03 through halfsend-06) have been enrolled in the token mint and have GitHub Apps installed
- Add them to the e2e org pool, increasing parallelism from 2 to 6 orgs

## Test plan
- [x] halfsend-04 verified passing in CI run 26595944014

🤖 Generated with [Claude Code](https://claude.com/claude-code)