### PR TITLE
fix: use Cloud Run API for env-var-only mint updates

### DIFF
--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -369,7 +369,7 @@ Inference authentication:
 					printer.StepInfo("Would auto-provision WIF provider in project " + inferenceProject)
 				} else {
 					printer.StepStart("Provisioning WIF infrastructure for inference")
-					gcpClient := gcf.NewLiveGCFClient()
+					gcpClient := gcf.NewLiveGCFClient(inferenceProject)
 					provisioner := gcf.NewProvisioner(gcf.Config{
 						ProjectID:  inferenceProject,
 						GitHubOrgs: []string{org},
@@ -689,7 +689,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 			ProjectID:  mintProject,
 			Region:     mintRegion,
 			GitHubOrgs: []string{owner},
-		}, gcf.NewLiveGCFClient())
+		}, gcf.NewLiveGCFClient(mintProject))
 
 		if mintURL != "" {
 			mintFound = true
@@ -901,7 +901,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 			FunctionSourceDir: mintSourceDir,
 			DeployMode:        deployMode,
 			Repo:              owner + "/" + repo,
-		}, gcf.NewLiveGCFClient())
+		}, gcf.NewLiveGCFClient(mintProject))
 
 		provResult, provErr := mintProvisioner.Provision(ctx)
 		if provErr != nil {
@@ -922,7 +922,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 			AgentPEMs:   agentPEMs,
 			MintURL:     mintURL,
 			Repo:        owner + "/" + repo,
-		}, gcf.NewLiveGCFClient())
+		}, gcf.NewLiveGCFClient(mintProject))
 
 		if _, err := mintProvisioner.Provision(ctx); err != nil {
 			printer.StepFail("Mint provisioning failed")
@@ -937,7 +937,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 			ProjectID:  inferenceProject,
 			GitHubOrgs: []string{owner},
 			Repo:       owner + "/" + repo,
-		}, gcf.NewLiveGCFClient())
+		}, gcf.NewLiveGCFClient(inferenceProject))
 		var provErr error
 		inferenceWIFProvider, provErr = provisioner.ProvisionWIF(ctx)
 		if provErr != nil {
@@ -1286,7 +1286,7 @@ func copySharedAppPEMs(ctx context.Context, client forge.Client, printer *ui.Pri
 		ProjectID:  mintProject,
 		Region:     mintRegion,
 		GitHubOrgs: []string{org},
-	}, gcf.NewLiveGCFClient())
+	}, gcf.NewLiveGCFClient(mintProject))
 
 	existingIDs, err := prov.GetExistingRoleAppIDs(ctx)
 	if err != nil {
@@ -1373,7 +1373,7 @@ func runAppSetup(ctx context.Context, client forge.Client, printer *ui.Printer, 
 		pemProvisioner = gcf.NewProvisioner(gcf.Config{
 			ProjectID:  mintProject,
 			GitHubOrgs: []string{org},
-		}, gcf.NewLiveGCFClient())
+		}, gcf.NewLiveGCFClient(mintProject))
 	}
 
 	// In OIDC mint mode, PEMs live in Secret Manager — check there.
@@ -1577,7 +1577,7 @@ func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, o
 			FunctionSourceDir: mintSourceDir,
 			DeployMode:        deployMode,
 			MintURL:           mintURL,
-		}, gcf.NewLiveGCFClient())
+		}, gcf.NewLiveGCFClient(mintProject))
 	}
 
 	stack := buildLayerStack(org, client, cfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, vendorBinary, vendorFullsendBinary, disp)

--- a/internal/cli/inference.go
+++ b/internal/cli/inference.go
@@ -158,7 +158,7 @@ func runInferenceProvision(cmd *cobra.Command, printer *ui.Printer, org, repo, p
 
 	ctx := cmd.Context()
 
-	gcpClient := gcf.NewLiveGCFClient()
+	gcpClient := gcf.NewLiveGCFClient(project)
 	provisioner := gcf.NewProvisioner(gcf.Config{
 		ProjectID:   project,
 		GitHubOrgs:  []string{org},
@@ -255,7 +255,7 @@ Use --format=json to get a machine-readable status + config output.`,
 
 func runInferenceStatus(cmd *cobra.Command, org, repo, project, pool, provider, format string) error {
 	ctx := cmd.Context()
-	gcpClient := gcf.NewLiveGCFClient()
+	gcpClient := gcf.NewLiveGCFClient(project)
 
 	poolName := pool
 	providerName := provider

--- a/internal/cli/mint.go
+++ b/internal/cli/mint.go
@@ -104,7 +104,7 @@ func newMintDeployCmd() *cobra.Command {
 				return nil
 			}
 
-			gcpClient := gcf.NewLiveGCFClient()
+			gcpClient := gcf.NewLiveGCFClient(project)
 
 			if sourceDir == "" {
 				sourceDir = gcf.DefaultFunctionSourceDir()
@@ -259,7 +259,7 @@ func runMintEnrollOrg(ctx context.Context, printer *ui.Printer, org, project, re
 	printer.Header("Enrolling org " + org + " in mint")
 	printer.Blank()
 
-	gcpClient := gcf.NewLiveGCFClient()
+	gcpClient := gcf.NewLiveGCFClient(project)
 	provisioner := gcf.NewProvisioner(gcf.Config{
 		ProjectID:  project,
 		Region:     region,
@@ -375,7 +375,7 @@ func runMintEnrollRepo(ctx context.Context, printer *ui.Printer, repoFullName, p
 	printer.Header("Enrolling repo " + repoFullName + " in mint")
 	printer.Blank()
 
-	gcpClient := gcf.NewLiveGCFClient()
+	gcpClient := gcf.NewLiveGCFClient(project)
 	provisioner := gcf.NewProvisioner(gcf.Config{
 		ProjectID:  project,
 		Region:     region,
@@ -643,7 +643,7 @@ func runMintUnenrollOrg(ctx context.Context, printer *ui.Printer, org, project, 
 	printer.Header("Unenrolling org " + org + " from mint")
 	printer.Blank()
 
-	gcpClient := gcf.NewLiveGCFClient()
+	gcpClient := gcf.NewLiveGCFClient(project)
 	provisioner := gcf.NewProvisioner(gcf.Config{
 		ProjectID:  project,
 		Region:     region,
@@ -764,7 +764,7 @@ func runMintUnenrollRepo(ctx context.Context, printer *ui.Printer, repoFullName,
 	printer.Header("Unenrolling repo " + repoFullName + " from mint")
 	printer.Blank()
 
-	gcpClient := gcf.NewLiveGCFClient()
+	gcpClient := gcf.NewLiveGCFClient(project)
 	provisioner := gcf.NewProvisioner(gcf.Config{
 		ProjectID:  project,
 		Region:     region,
@@ -893,7 +893,7 @@ func runMintStatus(ctx context.Context, printer *ui.Printer, project, region, or
 	printer.Header("Mint Status")
 	printer.Blank()
 
-	gcpClient := gcf.NewLiveGCFClient()
+	gcpClient := gcf.NewLiveGCFClient(project)
 	provisioner := gcf.NewProvisioner(gcf.Config{
 		ProjectID:  project,
 		Region:     region,

--- a/internal/dispatch/gcf/gcp.go
+++ b/internal/dispatch/gcf/gcp.go
@@ -25,6 +25,10 @@ var operationNamePattern = regexp.MustCompile(`^[a-zA-Z0-9/_-]+$`)
 // "projects/{project}/secrets/{secret}".
 var secretResourcePattern = regexp.MustCompile(`^projects/[a-z][a-z0-9-]+/secrets/[a-zA-Z0-9_-]+$`)
 
+// secretVersionPattern validates Secret Manager version resource paths like
+// "projects/{project_number}/secrets/{secret}/versions/{version_number}".
+var secretVersionPattern = regexp.MustCompile(`^projects/[0-9]+/secrets/[a-zA-Z0-9_-]+/versions/[0-9]+$`)
+
 // ErrSecretNotFound is returned when a Secret Manager secret does not exist.
 var ErrSecretNotFound = errors.New("secret not found")
 
@@ -471,8 +475,8 @@ func (c *LiveGCFClient) DisableSecretVersion(ctx context.Context, projectID, sec
 	if err := json.NewDecoder(io.LimitReader(getResp.Body, 1<<20)).Decode(&version); err != nil {
 		return fmt.Errorf("decoding secret version metadata: %w", err)
 	}
-	if version.Name == "" {
-		return fmt.Errorf("secret version metadata has empty name")
+	if !secretVersionPattern.MatchString(version.Name) {
+		return fmt.Errorf("secret version name %q does not match expected pattern", version.Name)
 	}
 
 	// Disable the resolved version.
@@ -484,6 +488,9 @@ func (c *LiveGCFClient) DisableSecretVersion(ctx context.Context, projectID, sec
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusNotFound {
+		return nil // Version deleted between resolve and disable; treat as success.
+	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 		return fmt.Errorf("unexpected status %d disabling secret version: %s", resp.StatusCode, gcp.ExtractErrorMessage(body))

--- a/internal/dispatch/gcf/gcp.go
+++ b/internal/dispatch/gcf/gcp.go
@@ -444,19 +444,46 @@ func (c *LiveGCFClient) AccessSecretVersion(ctx context.Context, projectID, secr
 }
 
 // DisableSecretVersion disables the latest version of a Secret Manager secret.
+// The disable API rejects the "latest" alias, so we first resolve it to a
+// numeric version via GET, then disable that version.
 func (c *LiveGCFClient) DisableSecretVersion(ctx context.Context, projectID, secretID string) error {
-	reqURL := fmt.Sprintf("https://secretmanager.googleapis.com/v1/projects/%s/secrets/%s/versions/latest:disable",
+	// Resolve "latest" to a numeric version name.
+	getURL := fmt.Sprintf("https://secretmanager.googleapis.com/v1/projects/%s/secrets/%s/versions/latest",
 		url.PathEscape(projectID), url.PathEscape(secretID))
 
-	resp, err := c.Client.DoRequest(ctx, http.MethodPost, reqURL, "{}")
+	getResp, err := c.Client.DoRequest(ctx, http.MethodGet, getURL, "")
+	if err != nil {
+		return fmt.Errorf("resolving latest secret version: %w", err)
+	}
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode == http.StatusNotFound {
+		return nil // No versions to disable.
+	}
+	if getResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(getResp.Body, 1<<20))
+		return fmt.Errorf("unexpected status %d resolving latest secret version: %s", getResp.StatusCode, gcp.ExtractErrorMessage(body))
+	}
+
+	var version struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(io.LimitReader(getResp.Body, 1<<20)).Decode(&version); err != nil {
+		return fmt.Errorf("decoding secret version metadata: %w", err)
+	}
+	if version.Name == "" {
+		return fmt.Errorf("secret version metadata has empty name")
+	}
+
+	// Disable the resolved version.
+	disableURL := fmt.Sprintf("https://secretmanager.googleapis.com/v1/%s:disable", version.Name)
+
+	resp, err := c.Client.DoRequest(ctx, http.MethodPost, disableURL, "{}")
 	if err != nil {
 		return fmt.Errorf("disabling secret version: %w", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound {
-		return nil // No versions to disable.
-	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 		return fmt.Errorf("unexpected status %d disabling secret version: %s", resp.StatusCode, gcp.ExtractErrorMessage(body))

--- a/internal/dispatch/gcf/gcp.go
+++ b/internal/dispatch/gcf/gcp.go
@@ -1092,6 +1092,9 @@ func (c *LiveGCFClient) UpdateServiceEnvVars(ctx context.Context, projectID, reg
 	if template == nil {
 		return fmt.Errorf("Cloud Run service has no template")
 	}
+	// Remove revision name so Cloud Run auto-generates one; re-sending the
+	// existing name causes a 409 "revision already exists" conflict.
+	delete(template, "revision")
 	containers, _ := template["containers"].([]interface{})
 	if len(containers) == 0 {
 		return fmt.Errorf("Cloud Run service has no containers")
@@ -1107,9 +1110,9 @@ func (c *LiveGCFClient) UpdateServiceEnvVars(ctx context.Context, projectID, reg
 		return fmt.Errorf("marshaling Cloud Run service update: %w", err)
 	}
 
-	// PATCH the service with updateMask scoped to template.containers to avoid
-	// clobbering unrelated fields in the read-modify-write cycle.
-	patchResp, err := c.Client.DoRequest(ctx, http.MethodPatch, serviceURL+"?updateMask=template.containers", string(payloadBytes))
+	// PATCH the service with updateMask covering both template.revision (cleared
+	// so Cloud Run auto-generates a new name) and template.containers (env vars).
+	patchResp, err := c.Client.DoRequest(ctx, http.MethodPatch, serviceURL+"?updateMask=template.revision,template.containers", string(payloadBytes))
 	if err != nil {
 		return fmt.Errorf("patching Cloud Run service: %w", err)
 	}

--- a/internal/dispatch/gcf/gcp.go
+++ b/internal/dispatch/gcf/gcp.go
@@ -1098,8 +1098,9 @@ func (c *LiveGCFClient) UpdateServiceEnvVars(ctx context.Context, projectID, reg
 		return fmt.Errorf("marshaling Cloud Run service update: %w", err)
 	}
 
-	// PATCH the service. Cloud Run creates a new revision with the updated env.
-	patchResp, err := c.Client.DoRequest(ctx, http.MethodPatch, serviceURL, string(payloadBytes))
+	// PATCH the service with updateMask scoped to template.containers to avoid
+	// clobbering unrelated fields in the read-modify-write cycle.
+	patchResp, err := c.Client.DoRequest(ctx, http.MethodPatch, serviceURL+"?updateMask=template.containers", string(payloadBytes))
 	if err != nil {
 		return fmt.Errorf("patching Cloud Run service: %w", err)
 	}
@@ -1111,18 +1112,24 @@ func (c *LiveGCFClient) UpdateServiceEnvVars(ctx context.Context, projectID, reg
 	}
 
 	var op struct {
-		Name string `json:"name"`
-		Done bool   `json:"done"`
+		Name  string `json:"name"`
+		Done  bool   `json:"done"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
 	}
 	if err := json.NewDecoder(patchResp.Body).Decode(&op); err != nil {
 		return fmt.Errorf("decoding Cloud Run patch response: %w", err)
 	}
 
 	if op.Done {
+		if op.Error != nil {
+			return fmt.Errorf("Cloud Run service update failed: %s", op.Error.Message)
+		}
 		return nil
 	}
 	if op.Name == "" {
-		return nil
+		return fmt.Errorf("Cloud Run PATCH returned incomplete response: done=false with no operation name")
 	}
 
 	return c.waitForCloudRunOperation(ctx, op.Name)
@@ -1132,6 +1139,9 @@ func (c *LiveGCFClient) UpdateServiceEnvVars(ctx context.Context, projectID, reg
 // Cloud Run operations are polled at run.googleapis.com, not
 // cloudfunctions.googleapis.com.
 func (c *LiveGCFClient) waitForCloudRunOperation(ctx context.Context, operationName string) error {
+	if !operationNamePattern.MatchString(operationName) {
+		return fmt.Errorf("invalid Cloud Run operation name format: %q", operationName)
+	}
 	reqURL := fmt.Sprintf("https://run.googleapis.com/v2/%s", operationName)
 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)

--- a/internal/dispatch/gcf/gcp.go
+++ b/internal/dispatch/gcf/gcp.go
@@ -1168,7 +1168,7 @@ func (c *LiveGCFClient) waitForCloudRunOperation(ctx context.Context, operationN
 				Message string `json:"message"`
 			} `json:"error"`
 		}
-		decodeErr := json.NewDecoder(resp.Body).Decode(&op)
+		decodeErr := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&op)
 		resp.Body.Close()
 		if decodeErr != nil {
 			return fmt.Errorf("decoding Cloud Run operation status: %w", decodeErr)

--- a/internal/dispatch/gcf/gcp.go
+++ b/internal/dispatch/gcf/gcp.go
@@ -111,11 +111,13 @@ type LiveGCFClient struct {
 	skipUploadURLCheck bool // testing only: skip googleapis.com domain validation
 }
 
-// NewLiveGCFClient creates a new LiveGCFClient.
-func NewLiveGCFClient() *LiveGCFClient {
-	return &LiveGCFClient{
-		Client: gcp.NewClient(),
-	}
+// NewLiveGCFClient creates a new LiveGCFClient. The quotaProject is
+// set as x-goog-user-project on every request so API quota is billed
+// to the target project, not the shared ADC OAuth client project.
+func NewLiveGCFClient(quotaProject string) *LiveGCFClient {
+	c := gcp.NewClient()
+	c.QuotaProject = quotaProject
+	return &LiveGCFClient{Client: c}
 }
 
 // CreateServiceAccount creates a new service account.

--- a/internal/dispatch/gcf/gcp.go
+++ b/internal/dispatch/gcf/gcp.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -1070,14 +1071,20 @@ func (c *LiveGCFClient) UpdateServiceEnvVars(ctx context.Context, projectID, reg
 	}
 
 	var service map[string]interface{}
-	if err := json.NewDecoder(getResp.Body).Decode(&service); err != nil {
+	if err := json.NewDecoder(io.LimitReader(getResp.Body, 10<<20)).Decode(&service); err != nil {
 		return fmt.Errorf("decoding Cloud Run service: %w", err)
 	}
 
 	// Build the env var array in Cloud Run format: [{name, value}, ...].
+	// Sort keys for deterministic PATCH payloads.
+	keys := make([]string, 0, len(envVars))
+	for k := range envVars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
 	envArray := make([]map[string]string, 0, len(envVars))
-	for k, v := range envVars {
-		envArray = append(envArray, map[string]string{"name": k, "value": v})
+	for _, k := range keys {
+		envArray = append(envArray, map[string]string{"name": k, "value": envVars[k]})
 	}
 
 	// Navigate to template.containers[0] and replace its env field.
@@ -1120,7 +1127,7 @@ func (c *LiveGCFClient) UpdateServiceEnvVars(ctx context.Context, projectID, reg
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	if err := json.NewDecoder(patchResp.Body).Decode(&op); err != nil {
+	if err := json.NewDecoder(io.LimitReader(patchResp.Body, 1<<20)).Decode(&op); err != nil {
 		return fmt.Errorf("decoding Cloud Run patch response: %w", err)
 	}
 

--- a/internal/dispatch/gcf/gcp.go
+++ b/internal/dispatch/gcf/gcp.go
@@ -92,6 +92,12 @@ type GCFClient interface {
 	CreateFunction(ctx context.Context, projectID, region, functionName string, cfg FunctionConfig) (string, error)
 	UpdateFunction(ctx context.Context, projectID, region, functionName string, cfg FunctionConfig) (string, error)
 	UpdateFunctionEnvVars(ctx context.Context, projectID, region, functionName string, envVars map[string]string) (string, error)
+	// UpdateServiceEnvVars updates environment variables on the underlying
+	// Cloud Run service directly, bypassing the Cloud Functions API. This
+	// avoids triggering a source rebuild — only a new revision is created
+	// reusing the existing container image. Polls the Cloud Run LRO
+	// internally and returns after the update is complete.
+	UpdateServiceEnvVars(ctx context.Context, projectID, region, serviceName string, envVars map[string]string) error
 	WaitForOperation(ctx context.Context, operationName string) error
 
 	// Project number lookup
@@ -1038,6 +1044,130 @@ func (c *LiveGCFClient) UpdateFunctionEnvVars(ctx context.Context, projectID, re
 	}
 
 	return result.Name, nil
+}
+
+// UpdateServiceEnvVars updates environment variables on the underlying
+// Cloud Run service directly via the Cloud Run Admin API v2, bypassing the
+// Cloud Functions API entirely. This avoids triggering a source rebuild —
+// only a new Cloud Run revision is created reusing the existing container
+// image. The method polls the Cloud Run LRO until the update completes.
+func (c *LiveGCFClient) UpdateServiceEnvVars(ctx context.Context, projectID, region, serviceName string, envVars map[string]string) error {
+	serviceURL := fmt.Sprintf("https://run.googleapis.com/v2/projects/%s/locations/%s/services/%s",
+		url.PathEscape(projectID), url.PathEscape(region), url.PathEscape(serviceName))
+
+	// GET current service to preserve container config (image, ports, etc.).
+	getResp, err := c.Client.DoRequest(ctx, http.MethodGet, serviceURL, "")
+	if err != nil {
+		return fmt.Errorf("getting Cloud Run service: %w", err)
+	}
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(getResp.Body, 1<<20))
+		return fmt.Errorf("unexpected status %d getting Cloud Run service: %s", getResp.StatusCode, gcp.ExtractErrorMessage(body))
+	}
+
+	var service map[string]interface{}
+	if err := json.NewDecoder(getResp.Body).Decode(&service); err != nil {
+		return fmt.Errorf("decoding Cloud Run service: %w", err)
+	}
+
+	// Build the env var array in Cloud Run format: [{name, value}, ...].
+	envArray := make([]map[string]string, 0, len(envVars))
+	for k, v := range envVars {
+		envArray = append(envArray, map[string]string{"name": k, "value": v})
+	}
+
+	// Navigate to template.containers[0] and replace its env field.
+	template, _ := service["template"].(map[string]interface{})
+	if template == nil {
+		return fmt.Errorf("Cloud Run service has no template")
+	}
+	containers, _ := template["containers"].([]interface{})
+	if len(containers) == 0 {
+		return fmt.Errorf("Cloud Run service has no containers")
+	}
+	container, _ := containers[0].(map[string]interface{})
+	if container == nil {
+		return fmt.Errorf("Cloud Run service container is not an object")
+	}
+	container["env"] = envArray
+
+	payloadBytes, err := json.Marshal(service)
+	if err != nil {
+		return fmt.Errorf("marshaling Cloud Run service update: %w", err)
+	}
+
+	// PATCH the service. Cloud Run creates a new revision with the updated env.
+	patchResp, err := c.Client.DoRequest(ctx, http.MethodPatch, serviceURL, string(payloadBytes))
+	if err != nil {
+		return fmt.Errorf("patching Cloud Run service: %w", err)
+	}
+	defer patchResp.Body.Close()
+
+	if patchResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(patchResp.Body, 1<<20))
+		return fmt.Errorf("unexpected status %d patching Cloud Run service: %s", patchResp.StatusCode, gcp.ExtractErrorMessage(body))
+	}
+
+	var op struct {
+		Name string `json:"name"`
+		Done bool   `json:"done"`
+	}
+	if err := json.NewDecoder(patchResp.Body).Decode(&op); err != nil {
+		return fmt.Errorf("decoding Cloud Run patch response: %w", err)
+	}
+
+	if op.Done {
+		return nil
+	}
+	if op.Name == "" {
+		return nil
+	}
+
+	return c.waitForCloudRunOperation(ctx, op.Name)
+}
+
+// waitForCloudRunOperation polls a Cloud Run LRO until it completes.
+// Cloud Run operations are polled at run.googleapis.com, not
+// cloudfunctions.googleapis.com.
+func (c *LiveGCFClient) waitForCloudRunOperation(ctx context.Context, operationName string) error {
+	reqURL := fmt.Sprintf("https://run.googleapis.com/v2/%s", operationName)
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	for {
+		resp, err := c.Client.DoRequest(ctx, http.MethodGet, reqURL, "")
+		if err != nil {
+			return fmt.Errorf("polling Cloud Run operation: %w", err)
+		}
+
+		var op struct {
+			Done  bool `json:"done"`
+			Error *struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		decodeErr := json.NewDecoder(resp.Body).Decode(&op)
+		resp.Body.Close()
+		if decodeErr != nil {
+			return fmt.Errorf("decoding Cloud Run operation status: %w", decodeErr)
+		}
+
+		if op.Done {
+			if op.Error != nil {
+				return fmt.Errorf("Cloud Run operation failed: %s", op.Error.Message)
+			}
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
 }
 
 // WaitForOperation polls a long-running operation until it completes or

--- a/internal/dispatch/gcf/gcp_test.go
+++ b/internal/dispatch/gcf/gcp_test.go
@@ -1345,6 +1345,61 @@ func TestLiveGCFClient_DisableSecretVersion(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unexpected status 403 disabling")
 	})
+
+	t.Run("empty_version_name", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"name": ""})
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).DisableSecretVersion(context.Background(), "proj", "secret")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match expected pattern")
+	})
+
+	t.Run("malformed_version_name", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"name": "../../evil/path"})
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).DisableSecretVersion(context.Background(), "proj", "secret")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match expected pattern")
+	})
+
+	t.Run("decode_failure", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintln(w, "not json")
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).DisableSecretVersion(context.Background(), "proj", "secret")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decoding secret version metadata")
+	})
+
+	t.Run("post_404_idempotent", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]string{
+					"name": "projects/123/secrets/s/versions/2",
+				})
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).DisableSecretVersion(context.Background(), "proj", "secret")
+		require.NoError(t, err)
+	})
 }
 
 // --- DeleteSecret ---

--- a/internal/dispatch/gcf/gcp_test.go
+++ b/internal/dispatch/gcf/gcp_test.go
@@ -1280,15 +1280,27 @@ func TestLiveGCFClient_GetProjectNumber(t *testing.T) {
 
 func TestLiveGCFClient_DisableSecretVersion(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
+		callCount := 0
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount == 1 {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "secrets/my-secret/versions/latest")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]string{
+					"name": "projects/123/secrets/my-secret/versions/5",
+				})
+				return
+			}
 			assert.Equal(t, http.MethodPost, r.Method)
-			assert.Contains(t, r.URL.Path, "secrets/my-secret/versions/latest:disable")
+			assert.Contains(t, r.URL.Path, "projects/123/secrets/my-secret/versions/5:disable")
 			w.WriteHeader(http.StatusOK)
 		}))
 		defer srv.Close()
 
 		err := newTestClient(srv).DisableSecretVersion(context.Background(), "proj", "my-secret")
 		require.NoError(t, err)
+		assert.Equal(t, 2, callCount)
 	})
 
 	t.Run("not found is idempotent", func(t *testing.T) {
@@ -1301,7 +1313,7 @@ func TestLiveGCFClient_DisableSecretVersion(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("error", func(t *testing.T) {
+	t.Run("resolve_error", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusForbidden)
 			fmt.Fprintln(w, `{"error":{"message":"permission denied"}}`)
@@ -1310,7 +1322,28 @@ func TestLiveGCFClient_DisableSecretVersion(t *testing.T) {
 
 		err := newTestClient(srv).DisableSecretVersion(context.Background(), "proj", "secret")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unexpected status 403")
+		assert.Contains(t, err.Error(), "unexpected status 403 resolving latest")
+	})
+
+	t.Run("disable_error", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]string{
+					"name": "projects/123/secrets/s/versions/2",
+				})
+				return
+			}
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprintln(w, `{"error":{"message":"permission denied"}}`)
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).DisableSecretVersion(context.Background(), "proj", "secret")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected status 403 disabling")
 	})
 }
 

--- a/internal/dispatch/gcf/gcp_test.go
+++ b/internal/dispatch/gcf/gcp_test.go
@@ -813,6 +813,7 @@ func TestLiveGCFClient_UpdateServiceEnvVars(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				json.NewEncoder(w).Encode(map[string]interface{}{
 					"template": map[string]interface{}{
+						"revision": "my-svc-00042-abc",
 						"containers": []interface{}{
 							map[string]interface{}{
 								"image": "gcr.io/proj/mint:latest",
@@ -825,11 +826,13 @@ func TestLiveGCFClient_UpdateServiceEnvVars(t *testing.T) {
 			}
 			// PATCH with updated env
 			assert.Equal(t, http.MethodPatch, r.Method)
-			assert.Contains(t, r.URL.RawQuery, "updateMask=template.containers")
+			assert.Contains(t, r.URL.RawQuery, "updateMask=template.revision,template.containers")
 
 			var body map[string]interface{}
 			json.NewDecoder(r.Body).Decode(&body)
 			tmpl := body["template"].(map[string]interface{})
+			_, hasRevision := tmpl["revision"]
+			assert.False(t, hasRevision, "revision should be stripped to avoid 409 conflict")
 			containers := tmpl["containers"].([]interface{})
 			container := containers[0].(map[string]interface{})
 			envs := container["env"].([]interface{})

--- a/internal/dispatch/gcf/gcp_test.go
+++ b/internal/dispatch/gcf/gcp_test.go
@@ -999,6 +999,153 @@ func TestLiveGCFClient_UpdateServiceEnvVars(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "incomplete response")
 	})
+
+	t.Run("no_template", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{})
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "has no template")
+	})
+
+	t.Run("container_not_object", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"template": map[string]interface{}{
+					"containers": []interface{}{"not-an-object"},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "container is not an object")
+	})
+
+	t.Run("malformed_get_response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("not json"))
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decoding Cloud Run service")
+	})
+
+	t.Run("polling_operation_error", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"template": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{"image": "img", "env": []interface{}{}},
+						},
+					},
+				})
+				return
+			}
+			if callCount == 2 {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"name": "projects/proj/locations/us-central1/operations/op-456",
+					"done": false,
+				})
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"done":  true,
+				"error": map[string]string{"message": "revision deployment failed"},
+			})
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{
+			"KEY": "val",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "revision deployment failed")
+	})
+
+	t.Run("invalid_operation_name", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"template": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{"image": "img", "env": []interface{}{}},
+						},
+					},
+				})
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"name": "../../../evil",
+				"done": false,
+			})
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{
+			"KEY": "val",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid Cloud Run operation name")
+	})
+
+	t.Run("multiple_env_vars_sorted", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"template": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{"image": "img", "env": []interface{}{}},
+						},
+					},
+				})
+				return
+			}
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			tmpl := body["template"].(map[string]interface{})
+			containers := tmpl["containers"].([]interface{})
+			container := containers[0].(map[string]interface{})
+			envs := container["env"].([]interface{})
+			assert.Len(t, envs, 3)
+			assert.Equal(t, "ALPHA", envs[0].(map[string]interface{})["name"])
+			assert.Equal(t, "BETA", envs[1].(map[string]interface{})["name"])
+			assert.Equal(t, "GAMMA", envs[2].(map[string]interface{})["name"])
+
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"done": true})
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{
+			"GAMMA": "3",
+			"ALPHA": "1",
+			"BETA":  "2",
+		})
+		require.NoError(t, err)
+	})
 }
 
 // --- WaitForOperation ---

--- a/internal/dispatch/gcf/gcp_test.go
+++ b/internal/dispatch/gcf/gcp_test.go
@@ -1146,6 +1146,44 @@ func TestLiveGCFClient_UpdateServiceEnvVars(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+
+	t.Run("context_canceled_during_polling", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"template": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{"image": "img", "env": []interface{}{}},
+						},
+					},
+				})
+				return
+			}
+			if callCount == 2 {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"name": "projects/proj/locations/us-central1/operations/op-789",
+					"done": false,
+				})
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"done": false})
+		}))
+		defer srv.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(ctx, "proj", "us-central1", "my-svc", map[string]string{
+			"KEY": "val",
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
 }
 
 // --- WaitForOperation ---

--- a/internal/dispatch/gcf/gcp_test.go
+++ b/internal/dispatch/gcf/gcp_test.go
@@ -1258,3 +1258,13 @@ func TestEncodeBase64(t *testing.T) {
 	result := encodeBase64([]byte("hello"))
 	assert.Equal(t, "aGVsbG8=", result)
 }
+
+func TestNewLiveGCFClient_SetsQuotaProject(t *testing.T) {
+	c := NewLiveGCFClient("target-project")
+	assert.Equal(t, "target-project", c.Client.QuotaProject)
+}
+
+func TestNewLiveGCFClient_EmptyQuotaProject(t *testing.T) {
+	c := NewLiveGCFClient("")
+	assert.Empty(t, c.Client.QuotaProject)
+}

--- a/internal/dispatch/gcf/gcp_test.go
+++ b/internal/dispatch/gcf/gcp_test.go
@@ -799,6 +799,208 @@ func TestLiveGCFClient_UpdateFunctionEnvVars(t *testing.T) {
 	})
 }
 
+// --- UpdateServiceEnvVars ---
+
+func TestLiveGCFClient_UpdateServiceEnvVars(t *testing.T) {
+	t.Run("success_immediate", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount == 1 {
+				// GET current service
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "/services/my-svc")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"template": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"image": "gcr.io/proj/mint:latest",
+								"env":   []interface{}{},
+							},
+						},
+					},
+				})
+				return
+			}
+			// PATCH with updated env
+			assert.Equal(t, http.MethodPatch, r.Method)
+			assert.Contains(t, r.URL.RawQuery, "updateMask=template.containers")
+
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			tmpl := body["template"].(map[string]interface{})
+			containers := tmpl["containers"].([]interface{})
+			container := containers[0].(map[string]interface{})
+			envs := container["env"].([]interface{})
+			assert.Len(t, envs, 1)
+			env := envs[0].(map[string]interface{})
+			assert.Equal(t, "ALLOWED_ORGS", env["name"])
+			assert.Equal(t, "org1", env["value"])
+
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"done": true})
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{
+			"ALLOWED_ORGS": "org1",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("success_with_polling", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount == 1 {
+				// GET service
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"template": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{"image": "img", "env": []interface{}{}},
+						},
+					},
+				})
+				return
+			}
+			if callCount == 2 {
+				// PATCH returns pending operation
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"name": "projects/proj/locations/us-central1/operations/op-123",
+					"done": false,
+				})
+				return
+			}
+			// Poll returns done
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"done": true})
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{
+			"KEY": "val",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 3, callCount)
+	})
+
+	t.Run("get_failure", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintln(w, `{"error":{"message":"service not found"}}`)
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected status 404")
+	})
+
+	t.Run("patch_failure", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"template": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{"image": "img", "env": []interface{}{}},
+						},
+					},
+				})
+				return
+			}
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprintln(w, `{"error":{"message":"permission denied"}}`)
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected status 403")
+	})
+
+	t.Run("no_containers", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"template": map[string]interface{}{
+					"containers": []interface{}{},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "has no containers")
+	})
+
+	t.Run("operation_error", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"template": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{"image": "img", "env": []interface{}{}},
+						},
+					},
+				})
+				return
+			}
+			// PATCH returns done with error
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"done":  true,
+				"error": map[string]string{"message": "quota exceeded"},
+			})
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{
+			"KEY": "val",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "quota exceeded")
+	})
+
+	t.Run("empty_op_name", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"template": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{"image": "img", "env": []interface{}{}},
+						},
+					},
+				})
+				return
+			}
+			// PATCH returns done=false with no name
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"done": false})
+		}))
+		defer srv.Close()
+
+		err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{
+			"KEY": "val",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "incomplete response")
+	})
+}
+
 // --- WaitForOperation ---
 
 func TestLiveGCFClient_WaitForOperation(t *testing.T) {

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -459,7 +459,7 @@ func (p *Provisioner) RegisterPerRepoWIF(ctx context.Context, repo string) error
 	}
 
 	if err := p.gcpAPI.UpdateServiceEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated); err != nil {
-		return fmt.Errorf("updating mint env vars: %w", err)
+		return fmt.Errorf("updating PER_REPO_WIF_REPOS: %w", err)
 	}
 	return nil
 }
@@ -1513,7 +1513,7 @@ func (p *Provisioner) RemoveOrgFromMint(ctx context.Context, org string) error {
 	updated["ALLOWED_ROLES"] = deriveAllowedRoles(updated["ROLE_APP_IDS"])
 
 	if err := p.gcpAPI.UpdateServiceEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated); err != nil {
-		return fmt.Errorf("updating mint env vars: %w", err)
+		return fmt.Errorf("removing org from mint env vars: %w", err)
 	}
 	return nil
 }
@@ -1547,7 +1547,7 @@ func (p *Provisioner) RemoveRepoFromMint(ctx context.Context, repo string) error
 	updated["PER_REPO_WIF_REPOS"] = strings.Join(filtered, ",")
 
 	if err := p.gcpAPI.UpdateServiceEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated); err != nil {
-		return fmt.Errorf("updating mint env vars: %w", err)
+		return fmt.Errorf("removing repo from mint env vars: %w", err)
 	}
 	return nil
 }

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -408,13 +408,8 @@ func (p *Provisioner) EnsureOrgInMint(ctx context.Context, expectedURL string, o
 		updated["ALLOWED_WORKFLOW_FILES"] = "*"
 	}
 
-	opName, err := p.gcpAPI.UpdateFunctionEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated)
-	if err != nil {
+	if err := p.gcpAPI.UpdateServiceEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated); err != nil {
 		return fmt.Errorf("updating mint env vars: %w", err)
-	}
-
-	if err := p.gcpAPI.WaitForOperation(ctx, opName); err != nil {
-		return fmt.Errorf("waiting for mint env vars update: %w", err)
 	}
 
 	return nil
@@ -463,11 +458,10 @@ func (p *Provisioner) RegisterPerRepoWIF(ctx context.Context, repo string) error
 		updated["PER_REPO_WIF_REPOS"] = existing + "," + repo
 	}
 
-	opName, err := p.gcpAPI.UpdateFunctionEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated)
-	if err != nil {
-		return fmt.Errorf("updating PER_REPO_WIF_REPOS: %w", err)
+	if err := p.gcpAPI.UpdateServiceEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated); err != nil {
+		return fmt.Errorf("updating mint env vars: %w", err)
 	}
-	return p.gcpAPI.WaitForOperation(ctx, opName)
+	return nil
 }
 
 // Provision creates the GCP infrastructure for the token mint.
@@ -1466,7 +1460,7 @@ func ValidateRepoSlug(slug string) bool {
 
 // RemoveOrgFromMint removes an org from ROLE_APP_IDS, ALLOWED_ORGS,
 // and re-derives ALLOWED_ROLES. Uses read-modify-write via
-// UpdateFunctionEnvVars (never --set-env-vars).
+// UpdateServiceEnvVars (Cloud Run API, no rebuild).
 func (p *Provisioner) RemoveOrgFromMint(ctx context.Context, org string) error {
 	org = strings.ToLower(org)
 
@@ -1518,15 +1512,14 @@ func (p *Provisioner) RemoveOrgFromMint(ctx context.Context, org string) error {
 	// Re-derive ALLOWED_ROLES.
 	updated["ALLOWED_ROLES"] = deriveAllowedRoles(updated["ROLE_APP_IDS"])
 
-	opName, err := p.gcpAPI.UpdateFunctionEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated)
-	if err != nil {
+	if err := p.gcpAPI.UpdateServiceEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated); err != nil {
 		return fmt.Errorf("updating mint env vars: %w", err)
 	}
-	return p.gcpAPI.WaitForOperation(ctx, opName)
+	return nil
 }
 
 // RemoveRepoFromMint removes a repo from PER_REPO_WIF_REPOS.
-// Uses read-modify-write via UpdateFunctionEnvVars.
+// Uses read-modify-write via UpdateServiceEnvVars.
 func (p *Provisioner) RemoveRepoFromMint(ctx context.Context, repo string) error {
 	repo = strings.ToLower(repo)
 
@@ -1553,11 +1546,10 @@ func (p *Provisioner) RemoveRepoFromMint(ctx context.Context, repo string) error
 	}
 	updated["PER_REPO_WIF_REPOS"] = strings.Join(filtered, ",")
 
-	opName, err := p.gcpAPI.UpdateFunctionEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated)
-	if err != nil {
-		return fmt.Errorf("updating PER_REPO_WIF_REPOS: %w", err)
+	if err := p.gcpAPI.UpdateServiceEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated); err != nil {
+		return fmt.Errorf("updating mint env vars: %w", err)
 	}
-	return p.gcpAPI.WaitForOperation(ctx, opName)
+	return nil
 }
 
 // DisablePEMSecrets disables the latest version of each PEM secret for an

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -75,9 +75,6 @@ type fakeGCFClient struct {
 	// Captured env vars from the last CreateFunction or UpdateFunction call.
 	lastCreateFunctionEnvVars map[string]string
 
-	// Captured env vars from the last UpdateFunctionEnvVars call.
-	lastUpdateFunctionEnvVars map[string]string
-
 	// Captured env vars from the last UpdateServiceEnvVars call.
 	lastUpdateServiceEnvVars map[string]string
 
@@ -226,7 +223,6 @@ func (f *fakeGCFClient) UpdateFunction(_ context.Context, _, _, _ string, cfg Fu
 }
 func (f *fakeGCFClient) UpdateFunctionEnvVars(_ context.Context, _, _, _ string, envVars map[string]string) (string, error) {
 	f.calls = append(f.calls, "UpdateFunctionEnvVars")
-	f.lastUpdateFunctionEnvVars = envVars
 	if err := f.errs["UpdateFunctionEnvVars"]; err != nil {
 		return "", err
 	}
@@ -2541,25 +2537,6 @@ func TestEnsureOrgInMint_NilReturn(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found in project")
 }
 
-func TestEnsureOrgInMint_UpdateServiceFails(t *testing.T) {
-	fake := newFakeGCFClient()
-	fake.functionInfo = &FunctionInfo{
-		URI: "https://mint.example.com",
-		EnvVars: map[string]string{
-			"ALLOWED_ORGS": "existing-org",
-			"ROLE_APP_IDS": `{"existing-org/coder":"100"}`,
-		},
-	}
-	fake.errs["UpdateServiceEnvVars"] = fmt.Errorf("operation timed out")
-
-	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
-	err := p.EnsureOrgInMint(context.Background(), "https://mint.example.com", "new-org", map[string]string{
-		"new-org/coder": "200",
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "updating mint env vars")
-}
-
 func TestEnsureOrgInMint_MalformedRoleAppIDs(t *testing.T) {
 	fake := newFakeGCFClient()
 	fake.functionInfo = &FunctionInfo{
@@ -2855,7 +2832,7 @@ func TestRemoveOrgFromMint_UpdateFails(t *testing.T) {
 	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
 	err := p.RemoveOrgFromMint(context.Background(), "acme")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "updating mint env vars")
+	assert.Contains(t, err.Error(), "removing org from mint env vars")
 }
 
 // --- RemoveRepoFromMint tests ---

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -78,6 +78,9 @@ type fakeGCFClient struct {
 	// Captured env vars from the last UpdateFunctionEnvVars call.
 	lastUpdateFunctionEnvVars map[string]string
 
+	// Captured env vars from the last UpdateServiceEnvVars call.
+	lastUpdateServiceEnvVars map[string]string
+
 	// Captured project IAM binding arguments.
 	projectIAMBindings []projectIAMBinding
 }
@@ -228,6 +231,11 @@ func (f *fakeGCFClient) UpdateFunctionEnvVars(_ context.Context, _, _, _ string,
 		return "", err
 	}
 	return "operations/envvar-update-789", nil
+}
+func (f *fakeGCFClient) UpdateServiceEnvVars(_ context.Context, _, _, _ string, envVars map[string]string) error {
+	f.calls = append(f.calls, "UpdateServiceEnvVars")
+	f.lastUpdateServiceEnvVars = envVars
+	return f.errs["UpdateServiceEnvVars"]
 }
 func (f *fakeGCFClient) WaitForOperation(_ context.Context, _ string) error {
 	return f.record("WaitForOperation")
@@ -628,7 +636,7 @@ func TestProvisioner_Provision_SkipDeployReusesExisting(t *testing.T) {
 	assert.NotContains(t, fake.calls, "UpdateFunction")
 
 	// EnsureOrgInMint still registers the org via env-var-only update.
-	assert.Contains(t, fake.calls, "UpdateFunctionEnvVars")
+	assert.Contains(t, fake.calls, "UpdateServiceEnvVars")
 	assert.Equal(t, "https://fullsend-mint-abc123.run.app", vars["FULLSEND_MINT_URL"])
 }
 
@@ -733,11 +741,11 @@ func TestProvisioner_Provision_SameCodeNewOrg_EnvVarOnlyUpdate(t *testing.T) {
 	assert.NotContains(t, fake.calls, "UpdateFunction")
 
 	// EnsureOrgInMint adds the new org via env-var-only update.
-	assert.Contains(t, fake.calls, "UpdateFunctionEnvVars")
+	assert.Contains(t, fake.calls, "UpdateServiceEnvVars")
 
 	// Verify new org was added to ALLOWED_ORGS alongside existing.
-	require.NotNil(t, fake.lastUpdateFunctionEnvVars)
-	allowedOrgs := fake.lastUpdateFunctionEnvVars["ALLOWED_ORGS"]
+	require.NotNil(t, fake.lastUpdateServiceEnvVars)
+	allowedOrgs := fake.lastUpdateServiceEnvVars["ALLOWED_ORGS"]
 	assert.Contains(t, allowedOrgs, "new-org")
 	assert.Contains(t, allowedOrgs, "existing-org")
 
@@ -1629,10 +1637,10 @@ func TestProvisioner_Provision_MultiOrg_MergeDoesNotOverwriteExistingPEMs(t *tes
 
 	// ROLE_APP_IDS should preserve existing-org's entries and add new-org's.
 	// After the refactor, code deploy preserves existing env vars, and
-	// EnsureOrgInMint merges the new org's entries via UpdateFunctionEnvVars.
-	require.NotNil(t, fake.lastUpdateFunctionEnvVars, "expected EnsureOrgInMint to update env vars")
-	assert.Contains(t, fake.lastUpdateFunctionEnvVars["ROLE_APP_IDS"], `"existing-org/coder":"999"`)
-	assert.Contains(t, fake.lastUpdateFunctionEnvVars["ROLE_APP_IDS"], `"new-org/coder"`)
+	// EnsureOrgInMint merges the new org's entries via UpdateServiceEnvVars.
+	require.NotNil(t, fake.lastUpdateServiceEnvVars, "expected EnsureOrgInMint to update env vars")
+	assert.Contains(t, fake.lastUpdateServiceEnvVars["ROLE_APP_IDS"], `"existing-org/coder":"999"`)
+	assert.Contains(t, fake.lastUpdateServiceEnvVars["ROLE_APP_IDS"], `"new-org/coder"`)
 }
 
 // --- ProvisionWIF tests ---
@@ -2390,7 +2398,7 @@ func TestEnsureOrgInMint_OrgAlreadyCovered(t *testing.T) {
 		"acme-corp/reviewer": "222",
 	})
 	require.NoError(t, err)
-	assert.NotContains(t, fake.calls, "UpdateFunctionEnvVars")
+	assert.NotContains(t, fake.calls, "UpdateServiceEnvVars")
 }
 
 func TestEnsureOrgInMint_AddsNewOrg(t *testing.T) {
@@ -2410,21 +2418,21 @@ func TestEnsureOrgInMint_AddsNewOrg(t *testing.T) {
 		"new-org/reviewer": "201",
 	})
 	require.NoError(t, err)
-	assert.Contains(t, fake.calls, "UpdateFunctionEnvVars")
-	assert.Contains(t, fake.calls, "WaitForOperation")
+	assert.Contains(t, fake.calls, "UpdateServiceEnvVars")
+	assert.NotContains(t, fake.calls, "WaitForOperation")
 
-	require.NotNil(t, fake.lastUpdateFunctionEnvVars)
-	assert.Contains(t, fake.lastUpdateFunctionEnvVars["ALLOWED_ORGS"], "new-org")
-	assert.Contains(t, fake.lastUpdateFunctionEnvVars["ALLOWED_ORGS"], "existing-org")
+	require.NotNil(t, fake.lastUpdateServiceEnvVars)
+	assert.Contains(t, fake.lastUpdateServiceEnvVars["ALLOWED_ORGS"], "new-org")
+	assert.Contains(t, fake.lastUpdateServiceEnvVars["ALLOWED_ORGS"], "existing-org")
 
 	var roleAppIDs map[string]string
-	require.NoError(t, json.Unmarshal([]byte(fake.lastUpdateFunctionEnvVars["ROLE_APP_IDS"]), &roleAppIDs))
+	require.NoError(t, json.Unmarshal([]byte(fake.lastUpdateServiceEnvVars["ROLE_APP_IDS"]), &roleAppIDs))
 	assert.Equal(t, "200", roleAppIDs["new-org/coder"])
 	assert.Equal(t, "201", roleAppIDs["new-org/reviewer"])
 	assert.Equal(t, "100", roleAppIDs["existing-org/coder"])
 
-	assert.Contains(t, fake.lastUpdateFunctionEnvVars["ALLOWED_ROLES"], "coder")
-	assert.Contains(t, fake.lastUpdateFunctionEnvVars["ALLOWED_ROLES"], "reviewer")
+	assert.Contains(t, fake.lastUpdateServiceEnvVars["ALLOWED_ROLES"], "coder")
+	assert.Contains(t, fake.lastUpdateServiceEnvVars["ALLOWED_ROLES"], "reviewer")
 }
 
 func TestEnsureOrgInMint_FunctionNotFound(t *testing.T) {
@@ -2473,10 +2481,10 @@ func TestEnsureOrgInMint_PartialCoverage(t *testing.T) {
 		"acme-corp/reviewer": "222",
 	})
 	require.NoError(t, err)
-	assert.Contains(t, fake.calls, "UpdateFunctionEnvVars")
+	assert.Contains(t, fake.calls, "UpdateServiceEnvVars")
 
 	var roleAppIDs map[string]string
-	require.NoError(t, json.Unmarshal([]byte(fake.lastUpdateFunctionEnvVars["ROLE_APP_IDS"]), &roleAppIDs))
+	require.NoError(t, json.Unmarshal([]byte(fake.lastUpdateServiceEnvVars["ROLE_APP_IDS"]), &roleAppIDs))
 	assert.Equal(t, "111", roleAppIDs["acme-corp/coder"])
 	assert.Equal(t, "222", roleAppIDs["acme-corp/reviewer"])
 }
@@ -2490,7 +2498,7 @@ func TestEnsureOrgInMint_UpdateFails(t *testing.T) {
 			"ROLE_APP_IDS": `{"existing-org/coder":"100"}`,
 		},
 	}
-	fake.errs["UpdateFunctionEnvVars"] = fmt.Errorf("permission denied")
+	fake.errs["UpdateServiceEnvVars"] = fmt.Errorf("permission denied")
 
 	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
 	err := p.EnsureOrgInMint(context.Background(), "https://mint.example.com", "new-org", map[string]string{
@@ -2514,10 +2522,10 @@ func TestEnsureOrgInMint_EmptyRoleAppIDs(t *testing.T) {
 		"new-org/coder": "200",
 	})
 	require.NoError(t, err)
-	assert.Contains(t, fake.calls, "UpdateFunctionEnvVars")
+	assert.Contains(t, fake.calls, "UpdateServiceEnvVars")
 
 	var roleAppIDs map[string]string
-	require.NoError(t, json.Unmarshal([]byte(fake.lastUpdateFunctionEnvVars["ROLE_APP_IDS"]), &roleAppIDs))
+	require.NoError(t, json.Unmarshal([]byte(fake.lastUpdateServiceEnvVars["ROLE_APP_IDS"]), &roleAppIDs))
 	assert.Equal(t, "200", roleAppIDs["new-org/coder"])
 }
 
@@ -2533,7 +2541,7 @@ func TestEnsureOrgInMint_NilReturn(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found in project")
 }
 
-func TestEnsureOrgInMint_WaitFails(t *testing.T) {
+func TestEnsureOrgInMint_UpdateServiceFails(t *testing.T) {
 	fake := newFakeGCFClient()
 	fake.functionInfo = &FunctionInfo{
 		URI: "https://mint.example.com",
@@ -2542,14 +2550,14 @@ func TestEnsureOrgInMint_WaitFails(t *testing.T) {
 			"ROLE_APP_IDS": `{"existing-org/coder":"100"}`,
 		},
 	}
-	fake.errs["WaitForOperation"] = fmt.Errorf("operation timed out")
+	fake.errs["UpdateServiceEnvVars"] = fmt.Errorf("operation timed out")
 
 	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
 	err := p.EnsureOrgInMint(context.Background(), "https://mint.example.com", "new-org", map[string]string{
 		"new-org/coder": "200",
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "waiting for mint env vars update")
+	assert.Contains(t, err.Error(), "updating mint env vars")
 }
 
 func TestEnsureOrgInMint_MalformedRoleAppIDs(t *testing.T) {
@@ -2586,10 +2594,10 @@ func TestEnsureOrgInMint_ValueMismatchTriggersUpdate(t *testing.T) {
 		"acme-corp/coder": "222",
 	})
 	require.NoError(t, err)
-	assert.Contains(t, fake.calls, "UpdateFunctionEnvVars")
+	assert.Contains(t, fake.calls, "UpdateServiceEnvVars")
 
 	var roleAppIDs map[string]string
-	require.NoError(t, json.Unmarshal([]byte(fake.lastUpdateFunctionEnvVars["ROLE_APP_IDS"]), &roleAppIDs))
+	require.NoError(t, json.Unmarshal([]byte(fake.lastUpdateServiceEnvVars["ROLE_APP_IDS"]), &roleAppIDs))
 	assert.Equal(t, "222", roleAppIDs["acme-corp/coder"])
 }
 
@@ -2609,9 +2617,9 @@ func TestEnsureOrgInMint_LowercasesOrg(t *testing.T) {
 		"acmecorp/coder": "200",
 	})
 	require.NoError(t, err)
-	assert.Contains(t, fake.calls, "UpdateFunctionEnvVars")
-	assert.Contains(t, fake.lastUpdateFunctionEnvVars["ALLOWED_ORGS"], "acmecorp")
-	assert.NotContains(t, fake.lastUpdateFunctionEnvVars["ALLOWED_ORGS"], "AcmeCorp")
+	assert.Contains(t, fake.calls, "UpdateServiceEnvVars")
+	assert.Contains(t, fake.lastUpdateServiceEnvVars["ALLOWED_ORGS"], "acmecorp")
+	assert.NotContains(t, fake.lastUpdateServiceEnvVars["ALLOWED_ORGS"], "AcmeCorp")
 }
 
 func TestEnsureOrgInMint_DefaultsAllowedWorkflowFiles(t *testing.T) {
@@ -2630,7 +2638,7 @@ func TestEnsureOrgInMint_DefaultsAllowedWorkflowFiles(t *testing.T) {
 		"new-org/coder": "200",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "*", fake.lastUpdateFunctionEnvVars["ALLOWED_WORKFLOW_FILES"])
+	assert.Equal(t, "*", fake.lastUpdateServiceEnvVars["ALLOWED_WORKFLOW_FILES"])
 }
 
 func TestEnsureOrgInMint_PreservesExistingAllowedWorkflowFiles(t *testing.T) {
@@ -2650,7 +2658,7 @@ func TestEnsureOrgInMint_PreservesExistingAllowedWorkflowFiles(t *testing.T) {
 		"new-org/coder": "200",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, ".github/workflows/ci.yml", fake.lastUpdateFunctionEnvVars["ALLOWED_WORKFLOW_FILES"])
+	assert.Equal(t, ".github/workflows/ci.yml", fake.lastUpdateServiceEnvVars["ALLOWED_WORKFLOW_FILES"])
 }
 
 func TestRegisterPerRepoWIF_AddsNewRepo(t *testing.T) {
@@ -2663,8 +2671,8 @@ func TestRegisterPerRepoWIF_AddsNewRepo(t *testing.T) {
 	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
 	err := p.RegisterPerRepoWIF(context.Background(), "acme-corp/my-service")
 	require.NoError(t, err)
-	assert.Contains(t, fake.calls, "UpdateFunctionEnvVars")
-	assert.Equal(t, "acme-corp/my-service", fake.lastUpdateFunctionEnvVars["PER_REPO_WIF_REPOS"])
+	assert.Contains(t, fake.calls, "UpdateServiceEnvVars")
+	assert.Equal(t, "acme-corp/my-service", fake.lastUpdateServiceEnvVars["PER_REPO_WIF_REPOS"])
 }
 
 func TestRegisterPerRepoWIF_AppendsToExisting(t *testing.T) {
@@ -2679,7 +2687,7 @@ func TestRegisterPerRepoWIF_AppendsToExisting(t *testing.T) {
 	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
 	err := p.RegisterPerRepoWIF(context.Background(), "acme-corp/second-repo")
 	require.NoError(t, err)
-	assert.Equal(t, "acme-corp/first-repo,acme-corp/second-repo", fake.lastUpdateFunctionEnvVars["PER_REPO_WIF_REPOS"])
+	assert.Equal(t, "acme-corp/first-repo,acme-corp/second-repo", fake.lastUpdateServiceEnvVars["PER_REPO_WIF_REPOS"])
 }
 
 func TestRegisterPerRepoWIF_Idempotent(t *testing.T) {
@@ -2694,7 +2702,7 @@ func TestRegisterPerRepoWIF_Idempotent(t *testing.T) {
 	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
 	err := p.RegisterPerRepoWIF(context.Background(), "acme-corp/my-service")
 	require.NoError(t, err)
-	assert.NotContains(t, fake.calls, "UpdateFunctionEnvVars")
+	assert.NotContains(t, fake.calls, "UpdateServiceEnvVars")
 }
 
 func TestRegisterPerRepoWIF_FunctionNotFound(t *testing.T) {
@@ -2717,7 +2725,7 @@ func TestRegisterPerRepoWIF_LowercasesRepo(t *testing.T) {
 	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
 	err := p.RegisterPerRepoWIF(context.Background(), "Acme-Corp/My-Service")
 	require.NoError(t, err)
-	assert.Equal(t, "acme-corp/my-service", fake.lastUpdateFunctionEnvVars["PER_REPO_WIF_REPOS"])
+	assert.Equal(t, "acme-corp/my-service", fake.lastUpdateServiceEnvVars["PER_REPO_WIF_REPOS"])
 }
 
 func TestRegisterPerRepoWIF_RejectsInvalidFormat(t *testing.T) {
@@ -2749,7 +2757,7 @@ func TestRegisterPerRepoWIF_NilEnvVars(t *testing.T) {
 	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
 	err := p.RegisterPerRepoWIF(context.Background(), "acme-corp/my-service")
 	require.NoError(t, err)
-	assert.Equal(t, "acme-corp/my-service", fake.lastUpdateFunctionEnvVars["PER_REPO_WIF_REPOS"])
+	assert.Equal(t, "acme-corp/my-service", fake.lastUpdateServiceEnvVars["PER_REPO_WIF_REPOS"])
 }
 
 func TestRegisterPerRepoWIF_GetFunctionError(t *testing.T) {
@@ -2779,21 +2787,21 @@ func TestRemoveOrgFromMint_RemovesOrgAndRoles(t *testing.T) {
 	err := p.RemoveOrgFromMint(context.Background(), "acme")
 	require.NoError(t, err)
 
-	assert.Contains(t, fake.calls, "UpdateFunctionEnvVars")
-	assert.Contains(t, fake.calls, "WaitForOperation")
+	assert.Contains(t, fake.calls, "UpdateServiceEnvVars")
+	assert.NotContains(t, fake.calls, "WaitForOperation")
 
 	// acme should be removed from ALLOWED_ORGS.
-	assert.Equal(t, "other-org", fake.lastUpdateFunctionEnvVars["ALLOWED_ORGS"])
+	assert.Equal(t, "other-org", fake.lastUpdateServiceEnvVars["ALLOWED_ORGS"])
 
 	// acme entries should be removed from ROLE_APP_IDS.
 	var roleAppIDs map[string]string
-	require.NoError(t, json.Unmarshal([]byte(fake.lastUpdateFunctionEnvVars["ROLE_APP_IDS"]), &roleAppIDs))
+	require.NoError(t, json.Unmarshal([]byte(fake.lastUpdateServiceEnvVars["ROLE_APP_IDS"]), &roleAppIDs))
 	assert.NotContains(t, roleAppIDs, "acme/coder")
 	assert.NotContains(t, roleAppIDs, "acme/triage")
 	assert.Equal(t, "333", roleAppIDs["other-org/coder"])
 
 	// ALLOWED_ROLES should be re-derived.
-	assert.Equal(t, "coder", fake.lastUpdateFunctionEnvVars["ALLOWED_ROLES"])
+	assert.Equal(t, "coder", fake.lastUpdateServiceEnvVars["ALLOWED_ROLES"])
 }
 
 func TestRemoveOrgFromMint_FunctionNotFound(t *testing.T) {
@@ -2830,7 +2838,7 @@ func TestRemoveOrgFromMint_LowercasesOrg(t *testing.T) {
 	err := p.RemoveOrgFromMint(context.Background(), "ACME")
 	require.NoError(t, err)
 
-	assert.Equal(t, "", fake.lastUpdateFunctionEnvVars["ALLOWED_ORGS"])
+	assert.Equal(t, "", fake.lastUpdateServiceEnvVars["ALLOWED_ORGS"])
 }
 
 func TestRemoveOrgFromMint_UpdateFails(t *testing.T) {
@@ -2842,7 +2850,7 @@ func TestRemoveOrgFromMint_UpdateFails(t *testing.T) {
 			"ROLE_APP_IDS": `{"acme/coder":"111"}`,
 		},
 	}
-	fake.errs["UpdateFunctionEnvVars"] = fmt.Errorf("permission denied")
+	fake.errs["UpdateServiceEnvVars"] = fmt.Errorf("permission denied")
 
 	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
 	err := p.RemoveOrgFromMint(context.Background(), "acme")
@@ -2865,8 +2873,8 @@ func TestRemoveRepoFromMint_RemovesRepo(t *testing.T) {
 	err := p.RemoveRepoFromMint(context.Background(), "acme/first")
 	require.NoError(t, err)
 
-	assert.Contains(t, fake.calls, "UpdateFunctionEnvVars")
-	assert.Equal(t, "acme/second", fake.lastUpdateFunctionEnvVars["PER_REPO_WIF_REPOS"])
+	assert.Contains(t, fake.calls, "UpdateServiceEnvVars")
+	assert.Equal(t, "acme/second", fake.lastUpdateServiceEnvVars["PER_REPO_WIF_REPOS"])
 }
 
 func TestRemoveRepoFromMint_LastRepo(t *testing.T) {
@@ -2882,7 +2890,7 @@ func TestRemoveRepoFromMint_LastRepo(t *testing.T) {
 	err := p.RemoveRepoFromMint(context.Background(), "acme/only")
 	require.NoError(t, err)
 
-	assert.Equal(t, "", fake.lastUpdateFunctionEnvVars["PER_REPO_WIF_REPOS"])
+	assert.Equal(t, "", fake.lastUpdateServiceEnvVars["PER_REPO_WIF_REPOS"])
 }
 
 func TestRemoveRepoFromMint_FunctionNotFound(t *testing.T) {
@@ -2908,7 +2916,7 @@ func TestRemoveRepoFromMint_LowercasesRepo(t *testing.T) {
 	err := p.RemoveRepoFromMint(context.Background(), "Acme/Widget")
 	require.NoError(t, err)
 
-	assert.Equal(t, "", fake.lastUpdateFunctionEnvVars["PER_REPO_WIF_REPOS"])
+	assert.Equal(t, "", fake.lastUpdateServiceEnvVars["PER_REPO_WIF_REPOS"])
 }
 
 // --- DisablePEMSecrets tests ---

--- a/internal/gcp/client.go
+++ b/internal/gcp/client.go
@@ -21,7 +21,8 @@ type Client struct {
 	httpClient *http.Client
 	// tokenFunc is the function used to obtain access tokens.
 	// It defaults to ADC but can be overridden for testing.
-	tokenFunc func(ctx context.Context) (string, error)
+	tokenFunc    func(ctx context.Context) (string, error)
+	QuotaProject string
 }
 
 // NewClient creates a new Client with default settings.
@@ -85,6 +86,9 @@ func (c *Client) DoRequest(ctx context.Context, method, url, body string) (*http
 	req.Header.Set("Authorization", "Bearer "+token)
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.QuotaProject != "" {
+		req.Header.Set("x-goog-user-project", c.QuotaProject)
 	}
 
 	return c.httpClient.Do(req)

--- a/internal/gcp/client_test.go
+++ b/internal/gcp/client_test.go
@@ -104,6 +104,41 @@ func TestAccessToken_WithTokenFunc(t *testing.T) {
 	assert.Equal(t, "custom-token", token)
 }
 
+func TestDoRequest_QuotaProjectHeader(t *testing.T) {
+	t.Run("sets x-goog-user-project when QuotaProject is non-empty", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "target-project", r.Header.Get("x-goog-user-project"))
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		c := NewClient()
+		c.tokenFunc = func(_ context.Context) (string, error) { return "test-token", nil }
+		c.QuotaProject = "target-project"
+
+		resp, err := c.DoRequest(context.Background(), http.MethodGet, srv.URL+"/test", "")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("omits x-goog-user-project when QuotaProject is empty", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Empty(t, r.Header.Get("x-goog-user-project"))
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		c := NewClient()
+		c.tokenFunc = func(_ context.Context) (string, error) { return "test-token", nil }
+
+		resp, err := c.DoRequest(context.Background(), http.MethodGet, srv.URL+"/test", "")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
 func TestAccessToken_ErrorPropagation(t *testing.T) {
 	c := NewClient()
 	c.tokenFunc = func(_ context.Context) (string, error) {


### PR DESCRIPTION
## Summary

- Switch env-var-only updates (enroll/unenroll) from Cloud Functions v2 API to Cloud Run Admin API v2 to avoid triggering source rebuilds
- Add `UpdateServiceEnvVars` method that PATCHes the underlying Cloud Run service directly, creating a new revision reusing the existing container image
- Keep code deploy paths (`CreateFunction`, `UpdateFunction`) on Cloud Functions API — only env-var mutations are switched
- Add `x-goog-user-project` header to all GCP API requests to prevent 429 quota billing against the shared ADC OAuth client project
- Bound all success-path JSON decoder reads with `io.LimitReader` to prevent unbounded memory allocation
- Sort env var keys for deterministic PATCH payloads

## Problem

`fullsend mint enroll` and `mint unenroll` fail when the deployed Cloud Function source is stale. The Cloud Functions v2 API triggers a full Cloud Build even when only `serviceConfig.environmentVariables` is in the `updateMask`. The build fails because GCP can't find the Go package in the workspace.

Additionally, `mint enroll` hits 429 rate limits on `cloudresourcemanager.googleapis.com` because the `x-goog-user-project` header is not set on GCP API requests, causing quota to be billed against the shared ADC OAuth client project instead of the target project.

## Approach

### Cloud Run API switch
For env-var-only updates, PATCH the Cloud Run service at `run.googleapis.com/v2` instead. This creates a new revision reusing the existing container image — no build triggered. The codebase already uses this API for IAM operations (`SetCloudRunInvoker`).

### Quota project header
Add a `QuotaProject` field to `gcp.Client` and set `x-goog-user-project` in `DoRequest`. `NewLiveGCFClient` now accepts a `quotaProject` parameter — all 16 call sites updated to pass the target GCP project.

### Call sites switched (4):
| Method | Command |
|--------|---------|
| `EnsureOrgInMint` | `mint enroll <org>`, `mint deploy`, `admin install` |
| `RegisterPerRepoWIF` | `mint enroll <owner/repo>` |
| `RemoveOrgFromMint` | `mint unenroll <org>` |
| `RemoveRepoFromMint` | `mint unenroll <owner/repo>` |

### Not changed:
- `CreateFunction` / `UpdateFunction` — code deploys stay on Cloud Functions API
- `WaitForOperation` — still used by deploy paths
- `SetCloudRunInvoker` — already on Cloud Run API

## Test plan
- [x] All unit tests pass (`make go-test`)
- [x] `make go-vet` clean
- [x] Header tests: verify `x-goog-user-project` set when QuotaProject non-empty, omitted when empty
- [x] Constructor tests: `NewLiveGCFClient` propagates QuotaProject correctly
- [x] Cloud Run structural validation: `no_template`, `container_not_object`, `malformed_get_response`
- [x] LRO polling errors: `polling_operation_error`, `invalid_operation_name`
- [x] Multi-env-var ordering: verify sorted deterministic output
- [ ] Manual: `./bin/fullsend mint deploy --project=<target-project>` — code deploy still works
- [ ] Manual: `./bin/fullsend mint enroll <org> --project=<target-project> --source-org=fullsend-ai` — env-var update succeeds without Cloud Build
- [ ] Manual: `./bin/fullsend mint unenroll <org> --project=<target-project>` — cleanup works
- [ ] GCP console: no new Cloud Build triggered for enroll/unenroll
- [ ] GCP request logs: `x-goog-user-project` header present, quota billed to target project