### PR TITLE
fix: prevent grep no-match from crashing pre-fetch-prior-review

### DIFF
--- a/internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review.sh
@@ -79,7 +79,7 @@ if [[ "${BYTE_COUNT}" -gt 1 ]]; then
     # Extract SHA from current section only (before sticky history sentinels)
     CURRENT_SECTION="$(awk '/<!-- sticky:history-start -->/{exit} {print}' "${PRIOR_FILE}")"
     PRIOR_SHA="$(echo "${CURRENT_SECTION}" \
-        | grep -oP '(?<=\*\*Head SHA:\*\* )[0-9a-f]{7,64}' | head -1)"
+        | grep -oP '(?<=\*\*Head SHA:\*\* )[0-9a-f]{7,64}' | head -1 || true)"
     echo "prior_sha=${PRIOR_SHA}" >> "${GITHUB_OUTPUT}"
     echo "Prior review SHA: ${PRIOR_SHA:-none}"
 else


### PR DESCRIPTION
## Summary
- `pre-fetch-prior-review.sh` crashes under `set -euo pipefail` when the prior review body lacks a `**Head SHA:**` line (e.g. stale-head discard notices)
- `grep -oP` returns exit code 1 on no match, which is fatal under pipefail, killing the script before it writes `GITHUB_OUTPUT` variables
- Appends `|| true` to the grep pipeline so a no-match is non-fatal — the existing `${PRIOR_SHA:-none}` fallback already handles the empty case

## Failure
- Run: https://github.com/fullsend-ai/.fullsend/actions/runs/26600603195/job/78384367068
- Step 8 ("Pre-fetch prior review context") exits 1 after printing `Prior review body: 271 bytes`
- The 271-byte body is a stale-head discard notice with no `**Head SHA:**` field

## Test plan
- [ ] Re-run the review workflow on PR #1664 after this merges and the scaffold syncs
- [ ] Verify the script completes with `prior_sha=` (empty) and `Prior review SHA: none` when no SHA line exists