### PR TITLE
fix: use tarball upload for fullsend binary in sandbox

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1803,8 +1803,11 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
 	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
 		return err
 	}
 	info, err := in.Stat()

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -721,8 +721,20 @@ func bootstrapSandbox(sandboxName, repoDir, fullsendBinary string, h *harness.Ha
 		if err := validateLinuxBinary(localBinary); err != nil {
 			return fmt.Errorf("fullsend binary %q is not valid for the sandbox: %w", localBinary, err)
 		}
-		remoteBinary := fmt.Sprintf("%s/bin/fullsend", sandbox.SandboxWorkspace)
-		if err := sandbox.Upload(sandboxName, localBinary, remoteBinary); err != nil {
+		// Use UploadDir (tarball-based) instead of Upload for the binary.
+		// Upload silently fails for large files (~16MB); the tarball
+		// approach compresses and extracts reliably inside the sandbox.
+		remoteBinDir := fmt.Sprintf("%s/bin", sandbox.SandboxWorkspace)
+		remoteBinary := fmt.Sprintf("%s/fullsend", remoteBinDir)
+		tmpDir, err := os.MkdirTemp("", "fullsend-bin-upload-*")
+		if err != nil {
+			return fmt.Errorf("creating temp dir for binary upload: %w", err)
+		}
+		defer os.RemoveAll(tmpDir)
+		if err := copyFile(localBinary, filepath.Join(tmpDir, "fullsend")); err != nil {
+			return fmt.Errorf("staging fullsend binary: %w", err)
+		}
+		if err := sandbox.UploadDir(sandboxName, tmpDir, remoteBinDir); err != nil {
 			return fmt.Errorf("copying fullsend binary to sandbox: %w", err)
 		}
 		chmodCmd := fmt.Sprintf("chmod +x %s", remoteBinary)
@@ -1778,6 +1790,28 @@ func validateLinuxBinary(path string) error {
 		return fmt.Errorf("ELF machine is %s, expected %s for %s (set FULLSEND_SANDBOX_ARCH to override)", f.Machine, expected, arch)
 	}
 	return nil
+}
+
+// copyFile copies src to dst, preserving permissions.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	return os.Chmod(dst, info.Mode())
 }
 
 var validArchs = map[string]bool{"amd64": true, "arm64": true}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -357,6 +357,32 @@ func TestBuildScanContextCommand_SourcesEnv(t *testing.T) {
 	assert.Contains(t, cmd, "-exec fullsend scan context")
 }
 
+func TestCopyFile(t *testing.T) {
+	t.Run("copies content and preserves permissions", func(t *testing.T) {
+		src := filepath.Join(t.TempDir(), "source")
+		dst := filepath.Join(t.TempDir(), "dest")
+
+		content := []byte("hello world")
+		require.NoError(t, os.WriteFile(src, content, 0o755))
+
+		require.NoError(t, copyFile(src, dst))
+
+		got, err := os.ReadFile(dst)
+		require.NoError(t, err)
+		assert.Equal(t, content, got)
+
+		info, err := os.Stat(dst)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+	})
+
+	t.Run("fails on missing source", func(t *testing.T) {
+		dst := filepath.Join(t.TempDir(), "dest")
+		err := copyFile("/no/such/file", dst)
+		assert.Error(t, err)
+	})
+}
+
 func TestCollectOpenshellLogs_EmptyRunDir(t *testing.T) {
 	// Should be a no-op when runDir is empty — no panic, no error.
 	printer := ui.New(io.Discard)


### PR DESCRIPTION
## Summary

- `sandbox.Upload()` silently succeeds but the file doesn't appear for large (~16MB) binaries. Observed in CI functional evals (run 26642640034).
- Switch `bootstrapSandbox` to use `UploadDir()` (tarball + extract) — the same mechanism used for uploading project code into the sandbox.
- Same class of issue that motivated `UploadFile` in commit `907d482e` (unmerged PR for #1649). This is a simpler, targeted fix for just the binary.

## Test plan

- [x] Unit tests for new `copyFile` helper (content + permissions)
- [x] `make go-test` passes
- [x] `make go-vet` passes
- [x] `make lint` passes
- [ ] CI green
- [ ] Verify in functional evals (once `ci/functional-evals` rebases onto this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)