### PR TITLE
fix(e2e): seed empty test-repo so enrollment PR creation succeeds

### DIFF
--- a/e2e/admin/cleanup.go
+++ b/e2e/admin/cleanup.go
@@ -54,6 +54,8 @@ func cleanupStaleResources(ctx context.Context, client forge.Client, token, org 
 		if seedErr := client.CreateFile(ctx, org, testRepo, "README.md", "chore: initialize repo for e2e testing", []byte("# test-repo\n\nE2E test repository.\n")); seedErr != nil {
 			t.Logf("[cleanup] Warning: could not seed %s: %v", testRepo, seedErr)
 		}
+	} else if getErr != nil {
+		t.Logf("[cleanup] Warning: could not check README in %s: %v", testRepo, getErr)
 	}
 
 	// 4. Delete stale enrollment and unenrollment branches from test-repo.

--- a/e2e/admin/cleanup.go
+++ b/e2e/admin/cleanup.go
@@ -39,12 +39,20 @@ func cleanupStaleResources(ctx context.Context, client forge.Client, token, org 
 		}
 	}
 
-	// 3. Ensure test-repo exists (needed for enrollment testing).
+	// 3. Ensure test-repo exists and has at least one commit (needed for
+	// enrollment testing). An empty repo (no commits) causes the
+	// reconcile-repos script to fail with "Could not get default branch tree".
 	_, err = client.GetRepo(ctx, org, testRepo)
 	if forge.IsNotFound(err) {
 		t.Logf("[cleanup] Creating missing %s repo", testRepo)
 		if _, createErr := client.CreateRepo(ctx, org, testRepo, "E2E test repo", false); createErr != nil {
 			t.Logf("[cleanup] Warning: could not create %s: %v", testRepo, createErr)
+		}
+	}
+	if _, getErr := client.GetFileContent(ctx, org, testRepo, "README.md"); forge.IsNotFound(getErr) {
+		t.Logf("[cleanup] Seeding %s with initial commit (repo is empty)", testRepo)
+		if seedErr := client.CreateFile(ctx, org, testRepo, "README.md", "chore: initialize repo for e2e testing", []byte("# test-repo\n\nE2E test repository.\n")); seedErr != nil {
+			t.Logf("[cleanup] Warning: could not seed %s: %v", testRepo, seedErr)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- e2e cleanup now seeds `test-repo` with a README when the repo exists but has no commits
- Fixes the `Could not get default branch tree for test-repo` error in `reconcile-repos.sh` that caused enrollment PR creation to silently fail
- Root cause of the last 3 consecutive e2e failures on `main` (not concurrency as #1678 hypothesized)

## Root cause

The `test-repo` in some test orgs (e.g. `halfsend-05`) existed but was empty — no commits, no default branch tree. The cleanup code created repos with `auto_init: true` but didn't handle pre-existing empty repos. The enrollment script then failed to read the git tree and skipped PR creation, causing Phase 2 to fail with `enrollment PR should exist for test-repo`.

Evidence: all 3 failing runs show `##[error]Could not get default branch tree for test-repo` in the repo-maintenance logs. All 4 passing runs show `✓ Created shim update PR for test-repo`. See #1678 for the full log analysis.

## Test plan

- [ ] e2e passes on this branch (tests the fix directly since it runs against the pool of `halfsend-*` orgs)
- [ ] Re-run e2e a few times to confirm statistical reliability

Fixes #1678

🤖 Generated with [Claude Code](https://claude.com/claude-code)