### PR TITLE
fix(inference): separate WIF pool from mint to prevent cross-domain interference

### DIFF
--- a/docs/guides/admin/github-setup.md
+++ b/docs/guides/admin/github-setup.md
@@ -15,7 +15,7 @@ For the all-in-one setup that provisions both GCP and GitHub in a single command
   - Token mint URL (`--mint-url`) — the HTTPS endpoint of the deployed mint Cloud Function
 - **From your Inference provider admin** (currently GCP Agent Platform, formerly Vertex AI; other providers planned):
   - GCP project ID (`--inference-project`) — the project where Agent Platform is enabled (e.g., `my-gcp-project`)
-  - WIF provider resource name (`--inference-wif-provider`) — the full resource path, e.g., `projects/123456789/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc` (note: the leading number is the GCP **project number**, not the project ID string; your GCP admin can find it with `gcloud projects describe <project-id> --format='value(projectNumber)'`)
+  - WIF provider resource name (`--inference-wif-provider`) — the full resource path, e.g., `projects/123456789/locations/global/workloadIdentityPools/fullsend-inference/providers/github-oidc` (note: the leading number is the GCP **project number**, not the project ID string; your GCP admin can find it with `gcloud projects describe <project-id> --format='value(projectNumber)'`)
   - GCP region for inference (`--inference-region`, defaults to `global`)
 
 > **Note:** You do NOT need GCP project access, `gcloud` authentication, or any IAM roles. All GCP infrastructure values are provided as flags.
@@ -89,7 +89,7 @@ Per-org mode creates a `.fullsend` config repository, deploys reusable workflows
 fullsend github setup acme-corp \
   --mint-url=<MINT_URL> \
   --inference-project=my-gcp-project \
-  --inference-wif-provider=projects/123456789/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc \
+  --inference-wif-provider=projects/123456789/locations/global/workloadIdentityPools/fullsend-inference/providers/github-oidc \
   --inference-region=global
 ```
 
@@ -124,7 +124,7 @@ Pass `--skip-app-setup` when the GitHub Apps are already installed on the org �
 fullsend github setup acme-corp \
   --mint-url=<MINT_URL> \
   --inference-project=my-gcp-project \
-  --inference-wif-provider=projects/123456789/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc \
+  --inference-wif-provider=projects/123456789/locations/global/workloadIdentityPools/fullsend-inference/providers/github-oidc \
   --skip-app-setup
 ```
 
@@ -155,7 +155,7 @@ Per-repo mode bootstraps a single repository with a `.fullsend/` directory, shim
 fullsend github setup acme-corp/my-service \
   --mint-url=<MINT_URL> \
   --inference-project=my-gcp-project \
-  --inference-wif-provider=projects/123456789/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc
+  --inference-wif-provider=projects/123456789/locations/global/workloadIdentityPools/fullsend-inference/providers/github-oidc
 ```
 
 Per-repo mode differs from per-org in these ways:

--- a/docs/guides/admin/infrastructure-reference.md
+++ b/docs/guides/admin/infrastructure-reference.md
@@ -125,7 +125,7 @@ Inference authentication uses GCP Workload Identity Federation (WIF) to allow Gi
 │  ┌─────────────────────────────────┐                        │
 │  │ GCP Security Token Service (STS)│                        │
 │  │                                 │                        │
-│  │ WIF Pool: fullsend-pool         │                        │
+│  │ WIF Pool: fullsend-inference     │                        │
 │  │ WIF Provider: fullsend-github   │                        │
 │  │                                 │                        │
 │  │ Validates OIDC issuer:          │                        │
@@ -163,7 +163,7 @@ Inference authentication uses GCP Workload Identity Federation (WIF) to allow Gi
 During installation, the GCF provisioner creates:
 
 1. **Service Account** — For the Cloud Function identity
-2. **WIF Pool** — `fullsend-pool` in the GCP project
+2. **WIF Pool** — `fullsend-inference` for inference, `fullsend-pool` for mint
 3. **WIF Provider** — Maps GitHub OIDC claims to GCP attributes
 4. **IAM Bindings** — Grants `roles/aiplatform.user` to federated identities
 5. **Per-repo providers** (per-repo mode) — Scoped WIF provider per repository via `BuildRepoProviderID()`
@@ -238,7 +238,7 @@ The GCF provisioner handles full GCP infrastructure deployment:
 │  └─────────┬─────────┘                                          │
 │            ▼                                                    │
 │  ┌───────────────────┐                                          │
-│  │ Create WIF Pool   │ fullsend-pool                            │
+│  │ Create WIF Pool   │ fullsend-inference (or fullsend-pool)     │
 │  │                   │ (skip if exists)                         │
 │  └─────────┬─────────┘                                          │
 │            ▼                                                    │

--- a/docs/guides/admin/infrastructure-reference.md
+++ b/docs/guides/admin/infrastructure-reference.md
@@ -126,7 +126,7 @@ Inference authentication uses GCP Workload Identity Federation (WIF) to allow Gi
 │  │ GCP Security Token Service (STS)│                        │
 │  │                                 │                        │
 │  │ WIF Pool: fullsend-inference     │                        │
-│  │ WIF Provider: fullsend-github   │                        │
+│  │ WIF Provider: github-oidc       │                        │
 │  │                                 │                        │
 │  │ Validates OIDC issuer:          │                        │
 │  │   token.actions.githubusercontent.com                    │
@@ -243,7 +243,7 @@ The GCF provisioner handles full GCP infrastructure deployment:
 │  └─────────┬─────────┘                                          │
 │            ▼                                                    │
 │  ┌───────────────────┐                                          │
-│  │ Create WIF        │ fullsend-github                          │
+│  │ Create WIF        │ github-oidc                              │
 │  │ Provider          │ OIDC issuer:                             │
 │  │                   │   token.actions.githubusercontent.com    │
 │  │                   │ (skip if exists)                         │

--- a/docs/guides/admin/installation.md
+++ b/docs/guides/admin/installation.md
@@ -99,7 +99,7 @@ fullsend admin install "$ORG_NAME" \
   --mint-project "$GCP_PROJECT"
 ```
 
-The installer automatically provisions [Workload Identity Federation (WIF)](https://cloud.google.com/iam/docs/workload-identity-federation) infrastructure (pool `fullsend-pool`, provider `github-oidc`, IAM bindings) in the inference project. WIF eliminates long-lived credentials — GitHub Actions exchange short-lived OIDC tokens for GCP access tokens. To use a pre-existing WIF provider instead, pass `--inference-wif-provider "$WIF_PROVIDER"` with the full resource name (`projects/{number}/locations/global/workloadIdentityPools/{pool}/providers/{id}`) — the CLI validates the format and skips auto-provisioning (see [Advanced: pre-configure WIF](#advanced-pre-configure-wif) below).
+The installer automatically provisions [Workload Identity Federation (WIF)](https://cloud.google.com/iam/docs/workload-identity-federation) infrastructure (pool `fullsend-inference`, provider `github-oidc`, IAM bindings) in the inference project. WIF eliminates long-lived credentials — GitHub Actions exchange short-lived OIDC tokens for GCP access tokens. To use a pre-existing WIF provider instead, pass `--inference-wif-provider "$WIF_PROVIDER"` with the full resource name (`projects/{number}/locations/global/workloadIdentityPools/{pool}/providers/{id}`) — the CLI validates the format and skips auto-provisioning (see [Advanced: pre-configure WIF](#advanced-pre-configure-wif) below).
 
 `--mint-project` specifies the GCP project where the OIDC token mint Cloud Function is deployed. It can be the same project as `--inference-project` or a separate project. The installer automatically provisions a Cloud Function, WIF pool (`fullsend-pool`), WIF provider (`github-oidc`), and Secret Manager secrets in the mint project. A service account (`fullsend-mint`) is also created as the Cloud Function's runtime identity to access Secret Manager — this is internal infrastructure and does not require any admin setup.
 
@@ -533,14 +533,14 @@ If you need custom pool names, attribute conditions, or want to share a provider
 export GCP_PROJECT="<gcp-project>"
 export ORG_NAME="<org-name>"
 
-gcloud iam workload-identity-pools create fullsend-pool \
+gcloud iam workload-identity-pools create fullsend-inference \
   --location=global \
-  --display-name="Fullsend" \
+  --display-name="Fullsend Inference" \
   --project="$GCP_PROJECT"
 
 gcloud iam workload-identity-pools providers create-oidc github-oidc \
   --location=global \
-  --workload-identity-pool=fullsend-pool \
+  --workload-identity-pool=fullsend-inference \
   --issuer-uri="https://token.actions.githubusercontent.com" \
   --attribute-mapping="google.subject=assertion.sub,attribute.repository_owner=assertion.repository_owner,attribute.repository=assertion.repository" \
   --attribute-condition="assertion.repository_owner == '$ORG_NAME'" \
@@ -551,7 +551,7 @@ gcloud iam workload-identity-pools providers create-oidc github-oidc \
 
 ```bash
 export PROJECT_NUMBER=$(gcloud projects describe "$GCP_PROJECT" --format='value(projectNumber)')
-export WIF_PRINCIPAL="principalSet://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/fullsend-pool/attribute.repository_owner/$ORG_NAME"
+export WIF_PRINCIPAL="principalSet://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/fullsend-inference/attribute.repository_owner/$ORG_NAME"
 
 gcloud projects add-iam-policy-binding "$GCP_PROJECT" \
   --role="roles/aiplatform.user" \
@@ -566,7 +566,7 @@ gcloud projects add-iam-policy-binding "$GCP_PROJECT" \
 **Pass the provider to the installer:**
 
 ```bash
-export WIF_PROVIDER="projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc"
+export WIF_PROVIDER="projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/fullsend-inference/providers/github-oidc"
 
 fullsend admin install "$ORG_NAME" \
   --inference-project "$GCP_PROJECT" \

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -371,8 +371,9 @@ Inference authentication:
 					printer.StepStart("Provisioning WIF infrastructure for inference")
 					gcpClient := gcf.NewLiveGCFClient(inferenceProject)
 					provisioner := gcf.NewProvisioner(gcf.Config{
-						ProjectID:  inferenceProject,
-						GitHubOrgs: []string{org},
+						ProjectID:   inferenceProject,
+						GitHubOrgs:  []string{org},
+						WIFPoolName: gcf.DefaultInferencePool,
 					}, gcpClient)
 					inferenceWIFProvider, err = provisioner.ProvisionWIF(ctx)
 					if err != nil {
@@ -789,7 +790,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 		if needsWIFProvision {
 			printer.StepInfo("Would provision WIF infrastructure in GCP project " + inferenceProject)
 			printer.StepInfo(fmt.Sprintf("  Service account: fullsend-mint@%s.iam.gserviceaccount.com", inferenceProject))
-			printer.StepInfo("  WIF pool: fullsend-pool")
+			printer.StepInfo("  WIF pool: " + gcf.DefaultInferencePool)
 			printer.StepInfo(fmt.Sprintf("  WIF provider: %s", gcf.BuildRepoProviderID(owner, repo)))
 			printer.StepInfo(fmt.Sprintf("  Repo restriction: %s/%s", owner, repo))
 			printer.Blank()
@@ -934,9 +935,10 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 	if needsWIFProvision {
 		printer.StepStart("Provisioning WIF infrastructure")
 		provisioner := gcf.NewProvisioner(gcf.Config{
-			ProjectID:  inferenceProject,
-			GitHubOrgs: []string{owner},
-			Repo:       owner + "/" + repo,
+			ProjectID:   inferenceProject,
+			GitHubOrgs:  []string{owner},
+			Repo:        owner + "/" + repo,
+			WIFPoolName: gcf.DefaultInferencePool,
 		}, gcf.NewLiveGCFClient(inferenceProject))
 		var provErr error
 		inferenceWIFProvider, provErr = provisioner.ProvisionWIF(ctx)

--- a/internal/cli/inference.go
+++ b/internal/cli/inference.go
@@ -110,7 +110,7 @@ WIF pools are always created at locations/global.`,
 	}
 
 	cmd.Flags().StringVar(&project, "project", "", "GCP project ID for Agent Platform (required)")
-	cmd.Flags().StringVar(&pool, "pool", "fullsend-pool", "WIF pool name")
+	cmd.Flags().StringVar(&pool, "pool", gcf.DefaultInferencePool, "WIF pool name")
 	cmd.Flags().StringVar(&provider, "provider", "github-oidc", "WIF provider name (org-scoped only)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview changes without making them")
 
@@ -255,7 +255,7 @@ Use --format=json to get a machine-readable status + config output.`,
 	}
 
 	cmd.Flags().StringVar(&project, "project", "", "GCP project ID for Agent Platform (required)")
-	cmd.Flags().StringVar(&pool, "pool", "fullsend-pool", "WIF pool name")
+	cmd.Flags().StringVar(&pool, "pool", gcf.DefaultInferencePool, "WIF pool name")
 	cmd.Flags().StringVar(&provider, "provider", "github-oidc", "WIF provider name")
 	cmd.Flags().StringVar(&format, "format", "text", "output format: text, json, env")
 
@@ -470,7 +470,7 @@ the GCP console or via gcloud.`,
 	}
 
 	cmd.Flags().StringVar(&project, "project", "", "GCP project ID for Agent Platform (required)")
-	cmd.Flags().StringVar(&pool, "pool", "fullsend-pool", "WIF pool name")
+	cmd.Flags().StringVar(&pool, "pool", gcf.DefaultInferencePool, "WIF pool name")
 	cmd.Flags().StringVar(&provider, "provider", "github-oidc", "WIF provider name (org-scoped only)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview changes without making them")
 

--- a/internal/cli/inference_test.go
+++ b/internal/cli/inference_test.go
@@ -81,7 +81,7 @@ func TestInferenceProvisionCmd_Flags(t *testing.T) {
 
 	poolFlag := cmd.Flags().Lookup("pool")
 	require.NotNil(t, poolFlag, "expected --pool flag")
-	assert.Equal(t, "fullsend-pool", poolFlag.DefValue)
+	assert.Equal(t, "fullsend-inference", poolFlag.DefValue)
 
 	providerFlag := cmd.Flags().Lookup("provider")
 	require.NotNil(t, providerFlag, "expected --provider flag")
@@ -229,7 +229,7 @@ func TestInferenceStatusCmd_Flags(t *testing.T) {
 
 	poolFlag := cmd.Flags().Lookup("pool")
 	require.NotNil(t, poolFlag, "expected --pool flag")
-	assert.Equal(t, "fullsend-pool", poolFlag.DefValue)
+	assert.Equal(t, "fullsend-inference", poolFlag.DefValue)
 
 	providerFlag := cmd.Flags().Lookup("provider")
 	require.NotNil(t, providerFlag, "expected --provider flag")
@@ -312,7 +312,7 @@ func TestFormatStatusJSON(t *testing.T) {
 	result := &inferenceStatusResult{
 		Status:      "healthy",
 		ProjectID:   "my-project",
-		WIFProvider: "projects/123/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc",
+		WIFProvider: "projects/123/locations/global/workloadIdentityPools/fullsend-inference/providers/github-oidc",
 		Details:     []string{"Project number: 123", "WIF provider: found"},
 	}
 
@@ -325,7 +325,7 @@ func TestFormatStatusJSON(t *testing.T) {
 
 	assert.Equal(t, "healthy", parsed["status"])
 	assert.Equal(t, "my-project", parsed["FULLSEND_GCP_PROJECT_ID"])
-	assert.Equal(t, "projects/123/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc", parsed["FULLSEND_GCP_WIF_PROVIDER"])
+	assert.Equal(t, "projects/123/locations/global/workloadIdentityPools/fullsend-inference/providers/github-oidc", parsed["FULLSEND_GCP_WIF_PROVIDER"])
 	details, ok := parsed["details"].([]interface{})
 	require.True(t, ok, "expected details to be an array")
 	assert.Len(t, details, 2)
@@ -356,13 +356,13 @@ func TestFormatStatusEnv(t *testing.T) {
 	result := &inferenceStatusResult{
 		Status:      "healthy",
 		ProjectID:   "my-project",
-		WIFProvider: "projects/123/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc",
+		WIFProvider: "projects/123/locations/global/workloadIdentityPools/fullsend-inference/providers/github-oidc",
 	}
 
 	output := formatStatusEnv(result)
 	assert.Contains(t, output, "FULLSEND_INFERENCE_STATUS=healthy")
 	assert.Contains(t, output, "FULLSEND_GCP_PROJECT_ID=my-project")
-	assert.Contains(t, output, "FULLSEND_GCP_WIF_PROVIDER=projects/123/locations/global/workloadIdentityPools/fullsend-pool/providers/github-oidc")
+	assert.Contains(t, output, "FULLSEND_GCP_WIF_PROVIDER=projects/123/locations/global/workloadIdentityPools/fullsend-inference/providers/github-oidc")
 	assert.NotContains(t, output, "FULLSEND_GCP_REGION")
 	assert.NotContains(t, output, "Status:")
 }
@@ -529,7 +529,7 @@ func TestInferenceDeprovisionCmd_Flags(t *testing.T) {
 
 	poolFlag := cmd.Flags().Lookup("pool")
 	require.NotNil(t, poolFlag, "expected --pool flag")
-	assert.Equal(t, "fullsend-pool", poolFlag.DefValue)
+	assert.Equal(t, "fullsend-inference", poolFlag.DefValue)
 
 	providerFlag := cmd.Flags().Lookup("provider")
 	require.NotNil(t, providerFlag, "expected --provider flag")

--- a/internal/cli/mint.go
+++ b/internal/cli/mint.go
@@ -558,13 +558,17 @@ func runMintEnrollOrg(ctx context.Context, printer *ui.Printer, org, project, re
 		return nil
 	}
 
-	// Step 3: Copy PEM secrets from app set.
+	// Step 3: Copy PEM secrets from app set (or re-enable if disabled by unenroll).
 	for _, role := range roleList {
 		exists, existsErr := provisioner.SecretExists(ctx, org, role)
 		if existsErr != nil {
 			return fmt.Errorf("checking PEM for %s/%s: %w", org, role, existsErr)
 		}
 		if exists {
+			if err := provisioner.EnablePEMSecrets(ctx, org, []string{role}); err != nil {
+				printer.StepFail(fmt.Sprintf("Failed to re-enable PEM for %s/%s", org, role))
+				return fmt.Errorf("re-enabling PEM for %s/%s: %w", org, role, err)
+			}
 			printer.StepDone(fmt.Sprintf("PEM exists: %s/%s", org, role))
 			continue
 		}

--- a/internal/cli/mint.go
+++ b/internal/cli/mint.go
@@ -551,7 +551,7 @@ func runMintEnrollOrg(ctx context.Context, printer *ui.Printer, org, project, re
 			}
 		}
 		printer.StepInfo(fmt.Sprintf("  Would add %s to ALLOWED_ORGS", org))
-		printer.StepInfo(fmt.Sprintf("  Would copy PEMs from %s for %d roles", appSet, len(roleList)))
+		printer.StepInfo(fmt.Sprintf("  Would copy or re-enable PEMs from %s for %d roles", appSet, len(roleList)))
 		printer.StepInfo(fmt.Sprintf("  Would add %s to WIF provider condition", org))
 		printer.Blank()
 		printer.StepInfo("To grant Agent Platform access, run 'fullsend inference provision' separately")

--- a/internal/cli/mint.go
+++ b/internal/cli/mint.go
@@ -552,6 +552,7 @@ func runMintEnrollOrg(ctx context.Context, printer *ui.Printer, org, project, re
 		}
 		printer.StepInfo(fmt.Sprintf("  Would add %s to ALLOWED_ORGS", org))
 		printer.StepInfo(fmt.Sprintf("  Would copy PEMs from %s for %d roles", appSet, len(roleList)))
+		printer.StepInfo(fmt.Sprintf("  Would add %s to WIF provider condition", org))
 		printer.Blank()
 		printer.StepInfo("To grant Agent Platform access, run 'fullsend inference provision' separately")
 		return nil
@@ -582,6 +583,14 @@ func runMintEnrollOrg(ctx context.Context, printer *ui.Printer, org, project, re
 		return fmt.Errorf("registering org: %w", err)
 	}
 	printer.StepDone("Org registered in mint")
+
+	// Step 5: Ensure org is in WIF provider condition.
+	printer.StepStart("Updating WIF provider condition")
+	if err := provisioner.EnsureOrgInWIFCondition(ctx, org); err != nil {
+		printer.StepFail("Failed to update WIF condition")
+		return fmt.Errorf("updating WIF condition: %w", err)
+	}
+	printer.StepDone("WIF condition updated")
 
 	printer.Blank()
 	printer.Summary("Enrollment complete", []string{

--- a/internal/cli/mint.go
+++ b/internal/cli/mint.go
@@ -569,7 +569,7 @@ func runMintEnrollOrg(ctx context.Context, printer *ui.Printer, org, project, re
 				printer.StepFail(fmt.Sprintf("Failed to re-enable PEM for %s/%s", org, role))
 				return fmt.Errorf("re-enabling PEM for %s/%s: %w", org, role, err)
 			}
-			printer.StepDone(fmt.Sprintf("PEM exists: %s/%s", org, role))
+			printer.StepDone(fmt.Sprintf("PEM ready: %s/%s (re-enabled)", org, role))
 			continue
 		}
 		printer.StepStart(fmt.Sprintf("Copying PEM for %s/%s from %s", org, role, appSet))

--- a/internal/dispatch/gcf/gcp.go
+++ b/internal/dispatch/gcf/gcp.go
@@ -471,13 +471,17 @@ func (c *LiveGCFClient) DisableSecretVersion(ctx context.Context, projectID, sec
 	}
 
 	var version struct {
-		Name string `json:"name"`
+		Name  string `json:"name"`
+		State string `json:"state"`
 	}
 	if err := json.NewDecoder(io.LimitReader(getResp.Body, 1<<20)).Decode(&version); err != nil {
 		return fmt.Errorf("decoding secret version metadata: %w", err)
 	}
 	if !secretVersionPattern.MatchString(version.Name) {
 		return fmt.Errorf("secret version name %q does not match expected pattern", version.Name)
+	}
+	if version.State == "DISABLED" || version.State == "DESTROYED" {
+		return nil
 	}
 
 	// Disable the resolved version.
@@ -532,6 +536,9 @@ func (c *LiveGCFClient) EnableSecretVersion(ctx context.Context, projectID, secr
 	}
 	if version.State == "ENABLED" {
 		return nil
+	}
+	if version.State == "DESTROYED" {
+		return fmt.Errorf("secret version %s is destroyed and cannot be re-enabled", version.Name)
 	}
 
 	enableURL := fmt.Sprintf("https://secretmanager.googleapis.com/v1/%s:enable", version.Name)

--- a/internal/dispatch/gcf/gcp.go
+++ b/internal/dispatch/gcf/gcp.go
@@ -82,6 +82,7 @@ type GCFClient interface {
 	AddSecretVersion(ctx context.Context, projectID, secretID string, data []byte) error
 	AccessSecretVersion(ctx context.Context, projectID, secretID string) ([]byte, error)
 	DisableSecretVersion(ctx context.Context, projectID, secretID string) error
+	EnableSecretVersion(ctx context.Context, projectID, secretID string) error
 	DeleteSecret(ctx context.Context, projectID, secretID string) error
 
 	// IAM bindings
@@ -494,6 +495,59 @@ func (c *LiveGCFClient) DisableSecretVersion(ctx context.Context, projectID, sec
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 		return fmt.Errorf("unexpected status %d disabling secret version: %s", resp.StatusCode, gcp.ExtractErrorMessage(body))
+	}
+	return nil
+}
+
+// EnableSecretVersion enables the latest version of a Secret Manager secret.
+// Mirrors DisableSecretVersion: resolves "latest" to a numeric version, then
+// enables it. No-op if the version is already enabled or does not exist.
+func (c *LiveGCFClient) EnableSecretVersion(ctx context.Context, projectID, secretID string) error {
+	getURL := fmt.Sprintf("https://secretmanager.googleapis.com/v1/projects/%s/secrets/%s/versions/latest",
+		url.PathEscape(projectID), url.PathEscape(secretID))
+
+	getResp, err := c.Client.DoRequest(ctx, http.MethodGet, getURL, "")
+	if err != nil {
+		return fmt.Errorf("resolving latest secret version: %w", err)
+	}
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if getResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(getResp.Body, 1<<20))
+		return fmt.Errorf("unexpected status %d resolving latest secret version: %s", getResp.StatusCode, gcp.ExtractErrorMessage(body))
+	}
+
+	var version struct {
+		Name  string `json:"name"`
+		State string `json:"state"`
+	}
+	if err := json.NewDecoder(io.LimitReader(getResp.Body, 1<<20)).Decode(&version); err != nil {
+		return fmt.Errorf("decoding secret version metadata: %w", err)
+	}
+	if !secretVersionPattern.MatchString(version.Name) {
+		return fmt.Errorf("secret version name %q does not match expected pattern", version.Name)
+	}
+	if version.State == "ENABLED" {
+		return nil
+	}
+
+	enableURL := fmt.Sprintf("https://secretmanager.googleapis.com/v1/%s:enable", version.Name)
+
+	resp, err := c.Client.DoRequest(ctx, http.MethodPost, enableURL, "{}")
+	if err != nil {
+		return fmt.Errorf("enabling secret version: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		return fmt.Errorf("unexpected status %d enabling secret version: %s", resp.StatusCode, gcp.ExtractErrorMessage(body))
 	}
 	return nil
 }

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -1591,6 +1591,25 @@ func (p *Provisioner) DisablePEMSecrets(ctx context.Context, org string, roles [
 	return nil
 }
 
+// EnablePEMSecrets re-enables the latest version of each PEM secret for an
+// org's roles. This reverses DisablePEMSecrets after a re-enrollment.
+// Skips secrets that do not exist.
+func (p *Provisioner) EnablePEMSecrets(ctx context.Context, org string, roles []string) error {
+	for _, role := range roles {
+		sid := secretID(org, role)
+		if err := p.gcpAPI.GetSecret(ctx, p.cfg.ProjectID, sid); err != nil {
+			if errors.Is(err, ErrSecretNotFound) {
+				continue
+			}
+			return fmt.Errorf("checking secret %s: %w", sid, err)
+		}
+		if err := p.gcpAPI.EnableSecretVersion(ctx, p.cfg.ProjectID, sid); err != nil {
+			return fmt.Errorf("enabling secret %s: %w", sid, err)
+		}
+	}
+	return nil
+}
+
 // DeletePEMSecrets permanently deletes PEM secrets for an org's roles.
 // Skips secrets that do not exist.
 func (p *Provisioner) DeletePEMSecrets(ctx context.Context, org string, roles []string) error {

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -86,6 +86,11 @@ const (
 	oidcIssuer      = "https://token.actions.githubusercontent.com"
 	oidcAudience    = "fullsend-mint"
 	functionName    = "fullsend-mint"
+
+	// DefaultInferencePool is the WIF pool used by inference commands.
+	// Separate from the mint pool (defaultPool) so that mint and inference
+	// lifecycle operations don't interfere with each other.
+	DefaultInferencePool = "fullsend-inference"
 )
 
 // Config holds the inputs for GCF mint provisioning.

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -163,6 +163,10 @@ func (f *fakeGCFClient) DisableSecretVersion(_ context.Context, _ string, sid st
 	f.calls = append(f.calls, "DisableSecretVersion")
 	return f.errs["DisableSecretVersion"]
 }
+func (f *fakeGCFClient) EnableSecretVersion(_ context.Context, _ string, sid string) error {
+	f.calls = append(f.calls, "EnableSecretVersion")
+	return f.errs["EnableSecretVersion"]
+}
 func (f *fakeGCFClient) DeleteSecret(_ context.Context, _ string, sid string) error {
 	f.calls = append(f.calls, "DeleteSecret")
 	if f.secrets != nil {

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -2943,6 +2943,62 @@ func TestDisablePEMSecrets_GetSecretError(t *testing.T) {
 	assert.Contains(t, err.Error(), "checking secret")
 }
 
+// --- EnablePEMSecrets tests ---
+
+func TestEnablePEMSecrets_EnablesExistingSecrets(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.secrets = map[string]bool{
+		"fullsend-acme--coder-app-pem":  true,
+		"fullsend-acme--triage-app-pem": true,
+	}
+
+	p := NewProvisioner(Config{ProjectID: "proj1"}, fake)
+	err := p.EnablePEMSecrets(context.Background(), "acme", []string{"coder", "triage"})
+	require.NoError(t, err)
+
+	enableCount := 0
+	for _, call := range fake.calls {
+		if call == "EnableSecretVersion" {
+			enableCount++
+		}
+	}
+	assert.Equal(t, 2, enableCount)
+}
+
+func TestEnablePEMSecrets_SkipsMissingSecrets(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.secrets = map[string]bool{}
+
+	p := NewProvisioner(Config{ProjectID: "proj1"}, fake)
+	err := p.EnablePEMSecrets(context.Background(), "acme", []string{"coder"})
+	require.NoError(t, err)
+
+	assert.NotContains(t, fake.calls, "EnableSecretVersion")
+}
+
+func TestEnablePEMSecrets_GetSecretError(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.errs["GetSecret"] = fmt.Errorf("permission denied")
+
+	p := NewProvisioner(Config{ProjectID: "proj1"}, fake)
+	err := p.EnablePEMSecrets(context.Background(), "acme", []string{"coder"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checking secret")
+}
+
+func TestEnablePEMSecrets_EnableError(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.secrets = map[string]bool{
+		"fullsend-acme--coder-app-pem": true,
+	}
+	fake.errs["EnableSecretVersion"] = fmt.Errorf("version destroyed")
+
+	p := NewProvisioner(Config{ProjectID: "proj1"}, fake)
+	err := p.EnablePEMSecrets(context.Background(), "acme", []string{"coder"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "enabling secret")
+}
+
 // --- DeletePEMSecrets tests ---
 
 func TestDeletePEMSecrets_DeletesExistingSecrets(t *testing.T) {


### PR DESCRIPTION
## Summary

- Introduces a dedicated `fullsend-inference` WIF pool for inference, separating it from mint's `fullsend-pool`
- Restores the missing `EnsureOrgInWIFCondition()` call in `mint enroll` that was removed in d93bf391
- Updates `admin install` to provision inference WIF in the new pool

## Problem

Mint and inference shared the same WIF pool (`fullsend-pool`) and org-scoped provider (`github-oidc`). This coupling caused:

1. **`mint unenroll` breaks inference** — removes the org from the shared provider's attribute condition, which also breaks `google-github-actions/auth` for Vertex AI access
2. **`mint enroll` doesn't restore the WIF condition** — `EnsureOrgInWIFCondition()` was removed in d93bf391 and never re-added, so any unenroll/enroll cycle leaves the org unable to authenticate

## Changes

| File | What changed |
|------|-------------|
| `internal/dispatch/gcf/provisioner.go` | Added `DefaultInferencePool` constant (`fullsend-inference`) |
| `internal/cli/inference.go` | Changed `--pool` flag defaults to `DefaultInferencePool` in all 3 subcommands |
| `internal/cli/admin.go` | Updated inference WIF provision paths and dry-run output to use new pool |
| `internal/cli/mint.go` | Added `EnsureOrgInWIFCondition()` to `runMintEnrollOrg()` and its dry-run path |
| `internal/cli/inference_test.go` | Updated pool default assertions and status output strings |

## Migration

- **No action required for existing users** — `FULLSEND_GCP_WIF_PROVIDER` still points to `fullsend-pool`. Old pool, provider, and IAM bindings remain intact.
- **To migrate**: Re-run `fullsend inference provision <org> --project=<project>` to create `fullsend-inference` pool, then update `FULLSEND_GCP_WIF_PROVIDER`.
- **Cleanup (optional)**: After migration, remove old inference IAM bindings from `fullsend-pool`.

## Test plan

- [x] All 22 test packages pass (`make go-test`)
- [x] `go vet ./...` clean
- [x] `make lint` clean
- [ ] E2E: mint unenroll/enroll cycle on nonflux verifies WIF condition restored
- [ ] E2E: `inference provision nonflux` creates `fullsend-inference` pool
- [ ] E2E: Workflow succeeds with new pool's WIF provider

Fixes #1666