### PR TITLE
docs: document required IAM roles for standalone mint and inference commands

### DIFF
--- a/docs/ADRs/0023-user-documentation-structure.md
+++ b/docs/ADRs/0023-user-documentation-structure.md
@@ -92,3 +92,7 @@ docs/guides/
 - New guides follow a consistent structure enforced by the writing rules, reducing maintenance burden.
 - The audience split must be maintained as new guides are added; the `docs/guides/README.md` index is the enforcement point.
 - Existing design documents (`docs/problems/`, `docs/ADRs/`, `docs/architecture.md`) remain unchanged — guides link into them, not the other way around.
+
+## Revision (2026-05)
+
+The original `admin/` directory was split into `getting-started/` and `infrastructure/` to better reflect the distinct audiences: **org maintainers** who onboard organizations (getting-started) vs. **platform operators** who deploy and manage GCP infrastructure like the token mint and WIF (infrastructure). The `user/` and `dev/` directories remain unchanged. See `docs/guides/README.md` for the current layout.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -4,14 +4,20 @@ Practical how-to documentation for fullsend, organized by audience. For design d
 
 Structure decided in [ADR 0023](../ADRs/0023-user-documentation-structure.md).
 
-## Administration
+## Getting started
 
-Guides for org administrators who install, configure, and manage fullsend.
+Guides for onboarding organizations and configuring GitHub — the first thing most users need.
 
-- [Installing fullsend](admin/installation.md) — All-in-one setup for a GitHub organization (GCP + GitHub)
-- [Setting up with pre-provisioned infrastructure](admin/github-setup.md) — GitHub-only setup when GCP infrastructure is already provisioned
-- [Infrastructure reference](admin/infrastructure-reference.md) — Token mint, WIF, and secrets deployment details
-- [Enabling fullsend on private repositories](admin/private-repositories.md) — Additional guardrails and configuration for private repos
+- [Installing fullsend](getting-started/installation.md) — End-user setup (inference + GitHub) and all-in-one admin install
+- [Setting up with pre-provisioned infrastructure](getting-started/github-setup.md) — GitHub-only setup when GCP infrastructure is already provisioned
+
+## Infrastructure
+
+Guides for platform operators who deploy and manage the GCP-side infrastructure (token mint, WIF, secrets).
+
+- [Mint service administration](infrastructure/mint-administration.md) — Deploying and managing the token mint Cloud Function
+- [Infrastructure reference](infrastructure/infrastructure-reference.md) — Token mint, WIF, and secrets deployment details
+- [Enabling fullsend on private repositories](infrastructure/private-repositories.md) — Additional guardrails and configuration for private repos
 
 ## User guides
 
@@ -19,6 +25,9 @@ Guides for developers working in repositories where fullsend is active.
 
 - [Bugfix workflow](user/bugfix-workflow.md) — End-to-end guide to how fullsend handles a bug report from issue to merge
 - [Running agents locally](user/running-agents-locally.md) — Run fullsend agents on your machine using released binaries (macOS + Linux)
+- [Customizing agents](user/customizing-agents.md) — Harness configurations and layered content resolution for your org and repos
+- [Customizing with AGENTS.md](user/customizing-with-agents-md.md) — Guide agents using your repo's AGENTS.md file
+- [Customizing with skills](user/customizing-with-skills.md) — Extend or replace built-in agent skills with custom skill documents
 
 ## Development
 

--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -47,11 +47,12 @@ The `admin install` command performs all setup in a single invocation. The `mint
 
 | `admin install` Phase | Standalone Command | Required Access |
 |-----------------------|--------------------|-----------------|
-| Phases 1-3: Mint provisioning | `fullsend mint deploy` + `fullsend mint enroll` | GCP project (mint) |
-| Phase 4: WIF provisioning | `fullsend inference provision` | GCP project (inference) |
+| Phases 1-3: Mint deployment | `fullsend mint deploy` | GCP project (mint): `roles/iam.serviceAccountAdmin`, `roles/iam.workloadIdentityPoolAdmin`, `roles/cloudfunctions.developer`, `roles/run.admin`; with `--pem-dir` also `roles/secretmanager.admin`, `roles/resourcemanager.projectIamAdmin` |
+| Phases 1-3: Mint enrollment | `fullsend mint enroll` | GCP project (mint): `roles/secretmanager.admin`, `roles/cloudfunctions.viewer`, `roles/run.admin`, `roles/iam.workloadIdentityPoolAdmin`; per-repo mode also needs `roles/resourcemanager.projectIamAdmin` |
+| Phase 4: WIF provisioning | `fullsend inference provision` | GCP project (inference): `roles/iam.workloadIdentityPoolAdmin`, `roles/resourcemanager.projectIamAdmin` |
 | Phases 5-7: GitHub setup + enrollment | `fullsend github setup` | GitHub only |
 
-The typical handoff: a GCP admin runs `mint deploy`, `mint enroll`, and `inference provision`, then passes the mint URL and WIF provider resource name to a GitHub maintainer who runs `github setup --mint-url=... --inference-wif-provider=...`. See [Setting up with pre-provisioned infrastructure](../admin/github-setup.md).
+The typical handoff: a GCP admin runs `mint deploy`, `mint enroll`, and `inference provision`, then passes the mint URL and WIF provider resource name to a GitHub maintainer who runs `github setup --mint-url=... --inference-wif-provider=...`. See [Setting up with pre-provisioned infrastructure](../getting-started/github-setup.md).
 
 ### Token Resolution Chain
 
@@ -497,6 +498,8 @@ var executableFiles = map[string]struct{}{
 ## See Also
 
 - [Local Development](local-dev.md) — Development environment setup
-- [Setting up with pre-provisioned infrastructure](../admin/github-setup.md) — GitHub-only setup guide
-- [Infrastructure Reference](../admin/infrastructure-reference.md) — Admin infrastructure details
+- [Installing fullsend](../getting-started/installation.md) — End-user setup and all-in-one admin install
+- [Setting up with pre-provisioned infrastructure](../getting-started/github-setup.md) — GitHub-only setup guide
+- [Mint service administration](../infrastructure/mint-administration.md) — Deploying and managing the token mint
+- [Infrastructure Reference](../infrastructure/infrastructure-reference.md) — Infrastructure details
 - [Customizing Agents](../user/customizing-agents.md) — User customization guide

--- a/docs/guides/getting-started/github-setup.md
+++ b/docs/guides/getting-started/github-setup.md
@@ -22,21 +22,19 @@ For the all-in-one setup that provisions both GCP and GitHub in a single command
 
 ## Roles and responsibilities
 
-fullsend separates infrastructure management into distinct roles. A single person can hold multiple roles, but the CLI supports splitting them across teams:
+This guide covers the **GitHub Maintainer** role. The GCP-side work (token mint and inference WIF) is handled by a GCP administrator before you start. Here's where this guide fits in the overall workflow:
 
-| Role | Commands | Access Required | Provisions |
-|------|----------|-----------------|------------|
-| **GCP Admin (Mint)**\* | `fullsend mint deploy`, `mint enroll`, `mint unenroll`, `mint status` | GCP project with Cloud Functions, Secret Manager, IAM | Token mint Cloud Function, PEM secrets |
-| **GCP Admin (Inference)** | `fullsend inference provision`, `inference deprovision`, `inference status` | GCP project with IAM, Agent Platform enabled | WIF pool/provider, IAM bindings for Agent Platform |
-| **GitHub Maintainer (org)** | `fullsend github setup <org>`, `github enroll`, `github unenroll`, `github set`, `github status`, `github uninstall`, `github sync-scaffold` | GitHub org owner (`admin:org` scope) | GitHub Apps, config repo, org variables, workflows, enrollment |
-| **GitHub Maintainer (repo)** | `fullsend github setup <owner/repo>`, `github set` | GitHub repo admin (`repo` + `workflow` scopes) | Repo-level secrets, variables, shim workflow |
-| **Full Admin** | `fullsend admin install` | GCP + GitHub | Everything above in one command |
+| Role | What they do | Covered in |
+|------|-------------|------------|
+| **GCP Admin (Mint)** | Deploy token mint, enroll orgs | [Mint service administration](../infrastructure/mint-administration.md) |
+| **GCP Admin (Inference)** | Provision WIF and Agent Platform access | [Installing fullsend — standalone commands](installation.md#standalone-commands) |
+| **GitHub Maintainer (org)** | Configure GitHub org — Apps, config repo, enrollment | **This guide** |
+| **GitHub Maintainer (repo)** | Configure a single repo — secrets, variables, shim workflow | **This guide** ([per-repo setup](#per-repo-setup)) |
+| **Full Admin** | All of the above in one command | [Installing fullsend — all-in-one](installation.md#all-in-one-admin-install) |
 
-\*The mint is fully self-hostable, but most users currently use the mint service hosted by the fullsend team for convenience. Work is in progress to offer this as a secure, trusted public service — reducing the need for per-org `mint enroll` operations and GCP-side management.
+The typical workflow: a GCP admin runs `mint deploy` + `mint enroll` + `inference provision`, then hands you the mint URL and WIF provider resource name. You run `github setup` with those values. For the full role breakdown with IAM roles, see [Installing fullsend — standalone commands](installation.md#standalone-commands).
 
-The typical workflow: a GCP admin runs `mint deploy` (one-time), `mint enroll` (once per new org or repo), and `inference provision` (to create WIF and grant Agent Platform access), then hands off the mint URL and WIF provider resource name to a GitHub maintainer who runs `github setup`. For users of the fullsend-hosted mint, `mint deploy` is already done — only `mint enroll` and `inference provision` are needed for new orgs (planned to be simplified in a future release).
-
-**Ordering flexibility:** GCP operations (`mint deploy`, `mint enroll`, `inference provision`) are pure GCP — they do not interact with GitHub and do not require the GitHub Apps to be installed. `mint enroll` copies app IDs from the mint's existing configuration (defaulting to `--app-set=fullsend-ai`), not from the target org's GitHub installations. The GitHub Apps must be installed on the target org before **agents can run**, but the timing relative to GCP setup is flexible:
+The GitHub Apps must be installed on the target org before **agents can run**, but the timing relative to GCP setup is flexible:
 
 - **Per-org mode** — `github setup <org>` handles app installation interactively (opens a browser for each role), so a single org owner can run it without pre-installing apps.
 - **Per-org with `--skip-app-setup`** — an org owner must [pre-install the apps](#default-fullsend-ai-app-set-installation-urls) before running setup.
@@ -56,30 +54,6 @@ When using the default app set, an **org owner** installs each app from these UR
 | prioritize | <https://github.com/apps/fullsend-ai-prioritize/installations/new> |
 
 > **Tip:** To verify apps are installed, run `gh api /orgs/{org}/installations --jq '.installations[].app_slug'`.
-
-### Bootstrapping PEMs during mint deploy (optional)
-
-Most `mint deploy` runs need only `--project` and `--region` — they deploy or update the Cloud Function and GCP infrastructure without touching PEM secrets.
-
-For **first-time setup only**, the optional `--pem-dir` flag seeds the default app set's PEM secrets during deployment. This allows `mint enroll` to work immediately without running `admin install` first.
-
-```bash
-# Typical deploy (no PEMs needed):
-fullsend mint deploy --project=<PROJECT>
-
-# First-time bootstrap with PEMs:
-fullsend mint deploy --project=<PROJECT> --pem-dir=/path/to/pems
-```
-
-The `--pem-dir` directory must contain one `{role}.pem` file per agent role (e.g., `fullsend.pem`, `triage.pem`, `coder.pem`, `review.pem`, `retro.pem`, `prioritize.pem`). The CLI auto-discovers each app's numeric ID from the GitHub API by looking up the public app slug (`fullsend-ai-{role}`).
-
-After deploying with PEMs, enrollment works directly:
-
-```bash
-fullsend mint enroll acme-corp --project=<PROJECT>
-```
-
-> **Note:** PEM bootstrapping requires the GitHub Apps to already exist as public apps. For the default `fullsend-ai` app set, these are the apps maintained by the fullsend-ai organization. If you are using a custom app set with private apps, use `admin install` instead.
 
 ## Per-org setup
 
@@ -272,6 +246,7 @@ Use `admin install` when one person has both GCP and GitHub access. Use the stan
 
 ## See Also
 
-- [Installing fullsend](installation.md) — All-in-one setup (GCP + GitHub)
-- [Infrastructure Reference](infrastructure-reference.md) — Token mint, WIF, and secrets details
+- [Installing fullsend](installation.md) — End-user setup (inference + GitHub) and all-in-one admin install
+- [Mint service administration](../infrastructure/mint-administration.md) — Deploying and managing the token mint
+- [Infrastructure Reference](../infrastructure/infrastructure-reference.md) — Token mint, WIF, and secrets details
 - [CLI Internals](../dev/cli-internals.md) — Command structure and implementation details

--- a/docs/guides/getting-started/installation.md
+++ b/docs/guides/getting-started/installation.md
@@ -1,29 +1,140 @@
 # How to onboard a new organization
 
-This guide walks through installing fullsend in a GitHub organization and enrolling your first repository.
+This guide walks through setting up fullsend in a GitHub organization and enrolling your first repository.
 
-> **GitHub-only setup:** If your GCP admin has already deployed the token mint and inference infrastructure, you do not need GCP access. See [Setting up with pre-provisioned infrastructure](github-setup.md) for the GitHub-only path using `fullsend github setup`.
+## Choose your setup path
 
-## Prerequisites
+Your setup path depends on what GCP infrastructure is already in place and how much control you need. Most users follow the **end-user path** — your organization is enrolled in a hosted mint service, and you provision inference access and configure GitHub yourself. This is the fastest way to get started.
 
+| Path | When to use | What you need |
+|------|-------------|---------------|
+| **[End-user setup](#end-user-setup)** | Mint service is hosted for you (most common) | GCP project for inference + GitHub org access |
+| **[GitHub-only setup](github-setup.md)** | Both GCP inference and mint are pre-provisioned | GitHub org access + GCP config values from your admin (no GCP credentials needed) |
+| **[All-in-one admin install](#all-in-one-admin-install)** | You manage everything — GCP mint, inference, and GitHub | Full GCP + GitHub access |
+
+> **Mint service note:** The token mint is fully self-hostable, but most users currently use the mint service hosted by the fullsend team. Work is in progress to offer this as a secure, trusted public service — reducing the need for per-org enrollment. See [Mint service administration](../infrastructure/mint-administration.md) for self-hosting details.
+
+---
+
+## End-user setup
+
+This is the standard path for organizations using a hosted mint service. You provision GCP inference access and configure GitHub — the mint service admin handles enrollment.
+
+### Prerequisites
+
+- **From your mint service admin:** Before starting, confirm that your organization is enrolled in the hosted mint and obtain the token mint URL (the HTTPS endpoint for OIDC token exchange). This is a blocking prerequisite — contact your mint admin first.
 - **GitHub organization** with admin access
 - **GitHub CLI** (`gh`) authenticated — no special scopes are needed upfront. The installer runs a preflight check and tells you exactly which scopes are missing before making any changes. When prompted, run the `gh auth refresh -s <scopes>` command it suggests.
 
   > **Note on scope breadth:** `gh auth` scopes apply to *every* organization your account belongs to — GitHub does not support per-org scoping for classic OAuth tokens. If that is a concern, create a [fine-grained personal access token](https://github.com/settings/tokens?type=beta) scoped to the target organization and export it as `GH_TOKEN` before running the installer.
 
-- **fullsend CLI** — download the latest binary from [GitHub Releases](https://github.com/fullsend-ai/fullsend/releases). The binary includes an embedded copy of the mint Cloud Function source, so it works standalone without needing the repository checked out.
-
-  *Note*: If running from a local clone of the repository, the CLI uses the local `internal/mint/` source instead of the embedded copy (a log message confirms this). This lets developers iterate on the mint source without rebuilding the binary. Use `go run ./cmd/fullsend/main.go <command>` to run from source.
-
+- **fullsend CLI** — download the latest binary from [GitHub Releases](https://github.com/fullsend-ai/fullsend/releases)
 - **GCP project** with the following APIs enabled:
-  - [Agent Platform](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) (inference)
-  - [Cloud Functions](https://console.cloud.google.com/apis/library/cloudfunctions.googleapis.com) (token mint)
-  - [Cloud Run](https://console.cloud.google.com/apis/library/run.googleapis.com) (token mint runtime)
-  - [Secret Manager](https://console.cloud.google.com/apis/library/secretmanager.googleapis.com) (PEM storage)
-  - [IAM Credentials](https://console.cloud.google.com/apis/library/iamcredentials.googleapis.com) (WIF token exchange)
-  - [Cloud Resource Manager](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com) (project number lookup)
 
-- **GCP IAM roles** — the user running `fullsend admin install` authenticates via ADC (`gcloud auth application-default login`) and needs the following IAM roles on the target GCP project:
+  ```bash
+  gcloud services enable \
+    iam.googleapis.com \
+    cloudresourcemanager.googleapis.com \
+    aiplatform.googleapis.com \
+    --project="$GCP_PROJECT"
+  ```
+
+- **GCP IAM roles** for inference provisioning — the user authenticates via ADC (`gcloud auth application-default login`) and needs:
+
+  | Role | What it covers |
+  |------|----------------|
+  | `roles/iam.workloadIdentityPoolAdmin` | Create WIF pool and provider for GitHub Actions OIDC authentication |
+  | `roles/resourcemanager.projectIamAdmin` | Grant `roles/aiplatform.user` to WIF principals via project IAM policy |
+
+  An administrator can grant the required roles:
+
+  ```bash
+  export GCP_PROJECT="my-project-id"
+  export USER_EMAIL="alice@example.com"
+
+  for ROLE in \
+    roles/iam.workloadIdentityPoolAdmin \
+    roles/resourcemanager.projectIamAdmin; do
+    gcloud projects add-iam-policy-binding "$GCP_PROJECT" \
+      --member="user:$USER_EMAIL" \
+      --role="$ROLE"
+  done
+  ```
+
+### Step 1: Request mint enrollment
+
+Contact your mint service admin and request enrollment for your GitHub organization. They will run `fullsend mint enroll <your-org>` on the mint project (see [Mint service administration](../infrastructure/mint-administration.md)). Once enrolled, they will provide you with the mint URL.
+
+### Step 2: Provision inference access
+
+Provision [Workload Identity Federation (WIF)](https://cloud.google.com/iam/docs/workload-identity-federation) infrastructure and grant Agent Platform access in your GCP project:
+
+```bash
+export ORG_NAME="<your-github-org>"
+export GCP_PROJECT="<your-gcp-project>"
+
+fullsend inference provision "$ORG_NAME" \
+  --project "$GCP_PROJECT"
+```
+
+This creates a WIF pool (`fullsend-inference`), an OIDC provider (`github-oidc`), and grants `roles/aiplatform.user` to the WIF principal — allowing GitHub Actions workflows to authenticate and call Agent Platform models. The command is idempotent and safe to re-run.
+
+Note the WIF provider resource name printed by the command — you will need it for the next step.
+
+### Step 3: Set up GitHub
+
+Configure your GitHub organization with the mint URL and inference settings:
+
+```bash
+fullsend github setup "$ORG_NAME" \
+  --mint-url="<MINT_URL>" \
+  --inference-project "$GCP_PROJECT" \
+  --inference-wif-provider "<WIF_PROVIDER_FROM_STEP_2>"
+```
+
+This creates the `.fullsend` config repository, installs GitHub Apps (opens browser windows for each agent role), configures org-level variables and secrets, and prompts you to enroll repositories.
+
+The `--inference-region` flag defaults to `global` for the broadest model availability. For a list of all available regions, see the [Agent Platform documentation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/use-claude).
+
+See [Setting up with pre-provisioned infrastructure](github-setup.md) for the full `github setup` reference, including per-repo mode, `--skip-app-setup`, and day-2 operations.
+
+### Step 4: Merge enrollment PRs
+
+If you enrolled repositories during setup, the installer dispatches a workflow that creates an enrollment PR in each enrolled repo. These PRs add a shim workflow (`.github/workflows/fullsend.yaml`) that wires events to the agent pipeline.
+
+Review and merge each enrollment PR to complete enrollment.
+
+### Step 5: Test the pipeline
+
+Once a repo is enrolled (enrollment PR merged):
+
+1. Create an issue in the enrolled repo
+2. The triage agent picks it up automatically — check the Actions tab in both the target repo and `.fullsend` for workflow run logs
+
+---
+
+## All-in-one admin install
+
+For administrators who manage both GCP infrastructure and GitHub configuration, `fullsend admin install` provisions everything in a single command: token mint, inference WIF, GitHub Apps, and repository enrollment.
+
+### Additional prerequisites
+
+All prerequisites from the [end-user setup](#prerequisites) above, plus:
+
+- **GCP project** with the following additional APIs enabled (for the token mint):
+
+  ```bash
+  gcloud services enable \
+    cloudfunctions.googleapis.com \
+    run.googleapis.com \
+    secretmanager.googleapis.com \
+    iamcredentials.googleapis.com \
+    --project="$GCP_PROJECT"
+  ```
+
+  > **Note:** `iamcredentials.googleapis.com` is a runtime dependency — the deployed mint Cloud Function uses it for WIF token exchange, not the CLI itself. It must be enabled before deployment.
+
+- **GCP IAM roles** — the full set required for both mint and inference:
 
   | Role | What it covers |
   |------|----------------|
@@ -36,7 +147,7 @@ This guide walks through installing fullsend in a GitHub organization and enroll
 
   `roles/owner` covers all of the above for users with broad access.
 
-  An administrator with elevated access to the GCP project (for example, with the ability to set IAM policy) can grant all required roles with a single script:
+  An administrator with elevated access to the GCP project can grant all required roles with a single script:
 
   ```bash
   export GCP_PROJECT="my-project-id"    # target GCP project
@@ -70,9 +181,7 @@ The table below lists every scope the installer may request and why. You are nev
 
 > **Per-repo scope note:** Per-repo install (`fullsend admin install <owner/repo>`) only requires `repo` and `workflow` when reusing existing GitHub Apps. Creating new apps requires `admin:org`.
 
-The `--inference-region` flag defaults to `global` for the broadest model availability. For a list of all available regions, see the [Agent Platform documentation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/use-claude).
-
-## 1. Run the installer
+### Run the installer
 
 The installer is interactive. It will open multiple browser windows to create and install a GitHub App for each agent role. Follow the prompts in each window to complete the app setup.
 
@@ -130,84 +239,21 @@ The `--skip-mint-check` flag bypasses all mint validation, GCP provisioning, and
 
 The installer automatically detects when the deployed mint function is up-to-date (same source hash) and skips code redeployment, only updating WIF infrastructure, org registration, and PEM secrets. Use `--skip-mint-deploy` to explicitly skip the Cloud Function deployment step.
 
-> **Mint URL stability:** The mint URL is stable across redeploys within the same project and region — updating the Cloud Function does not change its URL. Adding a new org to an existing mint only updates env vars (`ROLE_APP_IDS`, `ALLOWED_ORGS`) without redeploying the function. Existing enrolled repos continue working with no changes. However, deploying to a **different region** (e.g., changing `--mint-region` from `us-central1` to `us-east5`) creates a new Cloud Run service with a different URL. All enrolled repos store the mint URL in a repo variable (`FULLSEND_MINT_URL`) or org variable, so changing the region requires updating every enrolled repo's variable to the new URL. Avoid changing `--mint-region` after initial deployment unless you plan to update all consumers.
-
 ### Multi-org setup
 
-A single token mint can serve multiple GitHub organizations. The first org deploys the mint infrastructure and creates **public unlisted** GitHub Apps; additional orgs reuse the existing mint and install the same apps.
+A single token mint can serve multiple GitHub organizations. See [Mint service administration — Multi-org setup](../infrastructure/mint-administration.md#multi-org-setup) for the complete multi-org workflow.
 
-**First org (deploys mint + creates public apps):**
-
-Set the variables for the first organization:
-
-```bash
-export FIRST_ORG="<first-github-org>"
-export GCP_PROJECT="<your-gcp-project>"
-```
-
-```bash
-fullsend admin install "$FIRST_ORG" \
-  --inference-project "$GCP_PROJECT" \
-  --mint-project "$GCP_PROJECT" \
-  --public
-```
-
-The `--public` flag creates GitHub Apps as public unlisted — they won't appear in the marketplace but can be installed by other organizations via their installation URL.
-
-When the first org uses a custom app set prefix, pass `--app-set` so the apps are named accordingly:
-
-```bash
-fullsend admin install "$FIRST_ORG" \
-  --inference-project "$GCP_PROJECT" \
-  --mint-project "$GCP_PROJECT" \
-  --public \
-  --app-set "$FIRST_ORG"
-```
-
-This creates public apps named `{first-org}-fullsend`, `{first-org}-coder`, etc.
-
-**Additional orgs (install existing public apps):**
-
-Set the variables for the additional organization:
-
-```bash
-export ADDITIONAL_ORG="<additional-github-org>"
-```
-
-`GCP_PROJECT` and `FIRST_ORG` carry over from the first-org step above.
-
-```bash
-fullsend admin install "$ADDITIONAL_ORG" \
-  --inference-project "$GCP_PROJECT" \
-  --mint-project "$GCP_PROJECT"
-```
-
-The installer auto-detects shared public apps by matching installed app IDs against the mint's `ROLE_APP_IDS`. It copies PEM secrets from the app set to the new org's scoped key and records the actual app slug in `config.yaml`, so subsequent operations find the correct app regardless of naming convention.
-
-If the public apps were created with a custom `--app-set`, pass the same value so the CLI uses the correct slug prefix for convention-based lookups:
-
-```bash
-fullsend admin install "$ADDITIONAL_ORG" \
-  --inference-project "$GCP_PROJECT" \
-  --mint-project "$GCP_PROJECT" \
-  --app-set "$FIRST_ORG"
-```
-
-You can also pass `--mint-url "$MINT_URL"` explicitly to skip the auto-discovery step. PEMs use org-scoped naming (`fullsend-{org}--{role}-app-pem`), so each org's secrets are stored independently. For public apps (shared across orgs), the provisioner copies the same PEM under each org's scoped key.
-
-> **Note:** Multi-org with `--public` requires all orgs to share the same GitHub Apps. Private apps (the default) are single-org only.
-
-## 2. Merge enrollment PRs
+### Merge enrollment PRs
 
 If you chose to enroll repositories during install, the installer dispatches a workflow that creates an enrollment PR in each enrolled repo. These PRs add a shim workflow (`.github/workflows/fullsend.yaml`) that wires events to the agent pipeline.
 
-Review and merge each enrollment PR to complete enrollment.
+Review and merge each enrollment PR to complete enrollment. Then follow [Step 5: Test the pipeline](#step-5-test-the-pipeline) from the end-user setup to verify agent workflows are running.
 
-## 3. Managing repository enrollment
+### Managing repository enrollment
 
 After installation, you can enroll or unenroll repositories at any time using the `repos` subcommands.
 
-### Enable repositories
+#### Enable repositories
 
 Set the variables for your environment:
 
@@ -232,7 +278,7 @@ The enable command:
 - Triggers the `repo-maintenance` workflow to create enrollment PRs
 - Validates that repositories exist in the organization before making changes
 
-### Disable repositories
+#### Disable repositories
 
 `ORG_NAME` carries over from the enable step above, or set it now:
 
@@ -264,14 +310,7 @@ The disable command:
 - Warns (but does not reject) repository names not found in the config, allowing safe cleanup of deleted repos
 - Does not delete existing shim workflows (merge the unenrollment PR to remove them)
 
-## 4. Test the pipeline
-
-Once a repo is enrolled (enrollment PR merged):
-
-1. Create an issue in the enrolled repo
-2. The triage agent picks it up automatically — check the Actions tab in both the target repo and `.fullsend` for workflow run logs
-
-## 5. Analyze installation status
+### Analyze installation status
 
 The `analyze` command checks the current state of a fullsend installation and reports what is installed, missing, or needs updating. It requires `repo` and `admin:org` scopes.
 
@@ -285,7 +324,7 @@ fullsend admin analyze "$ORG_NAME"
 
 This is a read-only operation — it makes no changes.
 
-## 6. Uninstall
+### Uninstall
 
 The `uninstall` command tears down the fullsend installation for a GitHub organization, removing the `.fullsend` config repo and associated resources. It prompts for confirmation by requiring you to type the exact organization name.
 
@@ -502,10 +541,6 @@ The `admin install` command performs all setup in a single invocation. For organ
 
 | Role | Command | What it does |
 |------|---------|-------------|
-| GCP Admin (Mint) | `fullsend mint deploy` | Deploy the token mint Cloud Function |
-| GCP Admin (Mint) | `fullsend mint enroll <org\|owner/repo>` | Register an org or repo in the mint, store PEMs (does not grant Agent Platform access — use `inference provision`) |
-| GCP Admin (Mint) | `fullsend mint unenroll <org\|owner/repo>` | Remove an org or repo from the mint |
-| GCP Admin (Mint) | `fullsend mint status` | Inspect mint state and PEM health |
 | GCP Admin (Inference) | `fullsend inference provision <org\|owner/repo>` | Create WIF pool/provider and grant Agent Platform access (idempotent — safe to re-run for new orgs) |
 | GCP Admin (Inference) | `fullsend inference deprovision <org\|owner/repo>` | Remove org or repo from WIF |
 | GCP Admin (Inference) | `fullsend inference status <org\|owner/repo>` | Check WIF health, print config values |
@@ -516,8 +551,59 @@ The `admin install` command performs all setup in a single invocation. For organ
 | GitHub Maintainer | `fullsend github status <org>` | Analyze GitHub-side installation state |
 | GitHub Maintainer | `fullsend github sync-scaffold <org>` | Update workflow templates to current CLI version |
 | GitHub Maintainer | `fullsend github uninstall <org>` | Remove GitHub configuration (org-level only) |
+| GCP Admin (Mint) | `fullsend mint deploy` | Deploy the token mint Cloud Function |
+| GCP Admin (Mint) | `fullsend mint enroll <org\|owner/repo>` | Register an org or repo in the mint, store PEMs (does not grant Agent Platform access — use `inference provision`) |
+| GCP Admin (Mint) | `fullsend mint unenroll <org\|owner/repo>` | Remove an org or repo from the mint |
+| GCP Admin (Mint) | `fullsend mint status` | Inspect mint state and PEM health |
 
-See [Setting up with pre-provisioned infrastructure](github-setup.md) for the complete GitHub maintainer guide.
+See [Setting up with pre-provisioned infrastructure](github-setup.md) for the complete GitHub maintainer guide and [Mint service administration](../infrastructure/mint-administration.md) for the mint admin guide.
+
+### Per-command IAM role breakdown
+
+When using the split-responsibility workflow, each standalone command requires a subset of IAM roles. Use this table to request only what you need.
+
+| IAM Role | `inference provision` | `inference deprovision` | `inference status` | `mint deploy` | `mint enroll` | `mint unenroll` | `mint status` |
+|----------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| `roles/iam.workloadIdentityPoolAdmin` | x | x | | x | x | x | |
+| `roles/resourcemanager.projectIamAdmin` | x | | | \* | \*\* | | |
+| `roles/iam.serviceAccountAdmin` | | | | x | | | |
+| `roles/secretmanager.admin` | | | | \* | x | x† | |
+| `roles/cloudfunctions.developer` | | | | x | | | |
+| `roles/cloudfunctions.viewer` | | | | | x | x | x |
+| `roles/run.admin` | | | | x | x | x | |
+| `roles/iam.workloadIdentityPoolViewer` | | | x\*\*\* | | | | |
+| `roles/secretmanager.viewer` | | | | | | | x |
+
+\* `roles/resourcemanager.projectIamAdmin` and `roles/secretmanager.admin` are required for `mint deploy` only when using `--pem-dir` (first-time bootstrap). Standard deploys without `--pem-dir` do not need these roles.
+
+\*\* `roles/resourcemanager.projectIamAdmin` is required for `mint enroll` only in per-repo mode (`mint enroll owner/repo`). Org-scoped enrollment does not grant IAM bindings — use `inference provision` separately.
+
+† `roles/secretmanager.admin` is required for `mint unenroll` only in org-scoped mode. Repo-scoped unenroll does not touch PEM secrets.
+
+\*\*\* All commands that call GCP APIs also require `resourcemanager.projects.get` (typically available via `roles/browser` or any project-level viewer role). This is only notable for `inference status` where it is not covered by the other listed roles.
+
+Required GCP APIs also differ by command group:
+
+```bash
+# Inference commands (inference provision/deprovision/status):
+gcloud services enable \
+  iam.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  aiplatform.googleapis.com \
+  --project="$GCP_PROJECT"
+
+# Mint commands (mint deploy/enroll/unenroll/status):
+gcloud services enable \
+  iam.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  cloudfunctions.googleapis.com \
+  run.googleapis.com \
+  secretmanager.googleapis.com \
+  iamcredentials.googleapis.com \
+  --project="$GCP_PROJECT"
+```
+
+> **Note:** `iamcredentials.googleapis.com` is a runtime dependency — the deployed mint Cloud Function uses it for WIF token exchange, not the CLI itself. It must be enabled before `mint deploy`.
 
 ---
 
@@ -559,7 +645,7 @@ gcloud projects add-iam-policy-binding "$GCP_PROJECT" \
   --condition=None
 ```
 
-> **⚠️ Warning — broad WIF scope:** The `attribute.repository_owner` condition above grants WIF access to _all_ repositories in the organization, not just `.fullsend`. This is required for orgs using per-repo mode (where multiple repos need to authenticate to GCP independently), but it significantly widens the trust boundary compared to per-org-only setups. Note that `fullsend admin install <owner/repo>` auto-provisions a **per-repo** WIF provider scoped to a single repository — the org-wide condition here is broader than what the automated path creates.
+> **Warning — broad WIF scope:** The `attribute.repository_owner` condition above grants WIF access to _all_ repositories in the organization, not just `.fullsend`. This is required for orgs using per-repo mode (where multiple repos need to authenticate to GCP independently), but it significantly widens the trust boundary compared to per-org-only setups. Note that `fullsend admin install <owner/repo>` auto-provisions a **per-repo** WIF provider scoped to a single repository — the org-wide condition here is broader than what the automated path creates.
 >
 > **For per-org-only setups**, use the tighter `assertion.repository == '$ORG_NAME/.fullsend'` condition instead, and scope the WIF principal to `attribute.repository/$ORG_NAME/.fullsend`. See [Google Cloud WIF documentation](https://cloud.google.com/iam/docs/workload-identity-federation) for condition syntax.
 
@@ -579,6 +665,7 @@ fullsend admin install "$ORG_NAME" \
 ## See Also
 
 - [Setting up with pre-provisioned infrastructure](github-setup.md) — GitHub-only setup when GCP is already provisioned
-- [Infrastructure Reference](infrastructure-reference.md) — Token mint, WIF, and secrets deployment details
-- [Enabling fullsend on private repositories](private-repositories.md) — Additional guardrails for private repos
+- [Mint service administration](../infrastructure/mint-administration.md) — Deploying and managing the token mint
+- [Infrastructure Reference](../infrastructure/infrastructure-reference.md) — Token mint, WIF, and secrets deployment details
+- [Enabling fullsend on private repositories](../infrastructure/private-repositories.md) — Additional guardrails for private repos
 - [CLI Internals](../dev/cli-internals.md) — Command structure and implementation details

--- a/docs/guides/infrastructure/infrastructure-reference.md
+++ b/docs/guides/infrastructure/infrastructure-reference.md
@@ -1,6 +1,6 @@
 # Infrastructure Reference
 
-This guide provides implementation details for fullsend's infrastructure components: the OIDC token mint, Workload Identity Federation (WIF), and secrets deployment. For basic installation instructions, see the [Installation Guide](installation.md).
+This guide provides implementation details for fullsend's infrastructure components: the OIDC token mint, Workload Identity Federation (WIF), and secrets deployment. For basic installation instructions, see the [Installation Guide](../getting-started/installation.md).
 
 ## Token Mint (OIDC) — GCF Cloud Function
 
@@ -172,7 +172,7 @@ During installation, the GCF provisioner creates:
 
 ## GitHub Secrets & Variables Deployment
 
-> Individual values can be updated with `fullsend github set <target> <key> <value>`. See [Setting up with pre-provisioned infrastructure](github-setup.md) for the full GitHub management guide.
+> Individual values can be updated with `fullsend github set <target> <key> <value>`. See [Setting up with pre-provisioned infrastructure](../getting-started/github-setup.md) for the full GitHub management guide.
 
 Secrets and variables are deployed at different scopes depending on the installation mode.
 
@@ -290,6 +290,7 @@ The GCF provisioner avoids redundant Cloud Function deployments by computing a S
 
 ## See Also
 
-- [Installation Guide](installation.md) — All-in-one setup instructions
-- [Setting up with pre-provisioned infrastructure](github-setup.md) — GitHub-only setup guide
+- [Installation Guide](../getting-started/installation.md) — Setup instructions (end-user and all-in-one)
+- [Mint service administration](mint-administration.md) — Deploying and managing the token mint
+- [Setting up with pre-provisioned infrastructure](../getting-started/github-setup.md) — GitHub-only setup guide
 - [Local Development](../dev/local-dev.md) — Developer setup

--- a/docs/guides/infrastructure/mint-administration.md
+++ b/docs/guides/infrastructure/mint-administration.md
@@ -1,0 +1,216 @@
+# Mint service administration
+
+This guide covers deploying and managing the fullsend token mint Cloud Function. The mint is the OIDC token exchange service that lets GitHub Actions workflows authenticate as GitHub Apps — it is infrastructure that serves all enrolled organizations and repositories.
+
+> **This guide is for platform operators** who deploy, manage, or troubleshoot the token mint Cloud Function. If you are an end user setting up fullsend for your organization, see [Installing fullsend](../getting-started/installation.md) instead — the mint is typically deployed once by a platform operator, and organizations are enrolled as needed. Work is in progress to offer a hosted public mint service, which will further reduce the need for per-org mint administration.
+
+## Prerequisites
+
+- **GCP project** with the following APIs enabled:
+
+  ```bash
+  gcloud services enable \
+    iam.googleapis.com \
+    cloudresourcemanager.googleapis.com \
+    cloudfunctions.googleapis.com \
+    run.googleapis.com \
+    secretmanager.googleapis.com \
+    iamcredentials.googleapis.com \
+    --project="$GCP_PROJECT"
+  ```
+
+  > **Note:** `iamcredentials.googleapis.com` is a runtime dependency — the deployed mint Cloud Function uses it for WIF token exchange, not the CLI itself. It must be enabled before `mint deploy`.
+
+- **fullsend CLI** — download the latest binary from [GitHub Releases](https://github.com/fullsend-ai/fullsend/releases)
+
+- **GCP IAM roles** — the user running mint commands authenticates via ADC (`gcloud auth application-default login`). The required roles depend on the command:
+
+  | IAM Role | `mint deploy` | `mint enroll` | `mint unenroll` | `mint status` |
+  |----------|:---:|:---:|:---:|:---:|
+  | `roles/iam.serviceAccountAdmin` | x | | | |
+  | `roles/iam.workloadIdentityPoolAdmin` | x | x | x | |
+  | `roles/resourcemanager.projectIamAdmin` | \* | \*\* | | |
+  | `roles/secretmanager.admin` | \* | x | x† | |
+  | `roles/cloudfunctions.developer` | x | | | |
+  | `roles/cloudfunctions.viewer` | | x | x | x |
+  | `roles/run.admin` | x | x | x | |
+  | `roles/secretmanager.viewer` | | | | x |
+
+  \* `roles/resourcemanager.projectIamAdmin` and `roles/secretmanager.admin` are required for `mint deploy` only when using `--pem-dir` (first-time bootstrap). Standard deploys without `--pem-dir` do not need these roles.
+
+  \*\* `roles/resourcemanager.projectIamAdmin` is required for `mint enroll` only in per-repo mode (`mint enroll owner/repo`). Org-scoped enrollment does not grant IAM bindings — use `inference provision` separately.
+
+  † `roles/secretmanager.admin` is required for `mint unenroll` only in org-scoped mode. Repo-scoped unenroll does not touch PEM secrets.
+
+  `roles/owner` covers all of the above for users with broad access.
+
+  An administrator can grant all required roles with a single script:
+
+  ```bash
+  export GCP_PROJECT="my-project-id"    # target GCP project
+  export USER_EMAIL="alice@example.com" # email of the user who will run mint commands
+
+  for ROLE in \
+    roles/iam.workloadIdentityPoolAdmin \
+    roles/iam.serviceAccountAdmin \
+    roles/resourcemanager.projectIamAdmin \
+    roles/secretmanager.admin \
+    roles/cloudfunctions.developer \
+    roles/run.admin; do
+    gcloud projects add-iam-policy-binding "$GCP_PROJECT" \
+      --member="user:$USER_EMAIL" \
+      --role="$ROLE"
+  done
+  ```
+
+## Deploying the mint
+
+`fullsend mint deploy` creates or updates the token mint Cloud Function and its supporting GCP infrastructure (service account, WIF pool/provider, Secret Manager secrets).
+
+```bash
+export GCP_PROJECT="<your-gcp-project>"
+
+fullsend mint deploy --project="$GCP_PROJECT"
+```
+
+The binary includes an embedded copy of the mint Cloud Function source, so it works standalone without needing the repository checked out. If you are developing or testing changes to the mint source, run the CLI from a local clone — the `--source-dir` flag (default `internal/mint/`) uses your local copy when the path exists, falling back to the embedded source when it does not.
+
+The deploy command automatically detects when the deployed function is up-to-date (same source hash) and skips code redeployment, only updating WIF infrastructure and configuration.
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--project` | | GCP project ID for the mint (required) |
+| `--region` | `us-central1` | Cloud region for the mint function |
+| `--pem-dir` | | Path to directory containing `{role}.pem` files (first-time bootstrap only); uses the default app set (`fullsend-ai`) |
+| `--source-dir` | (embedded) | Path to local mint source directory (for development; default uses the embedded copy) |
+| `--skip-deploy` | `false` | Skip code upload, reuse existing function (only update WIF/config) |
+| `--dry-run` | `false` | Preview changes without making them |
+
+### Bootstrapping PEMs (first-time only)
+
+For first-time setup, the optional `--pem-dir` flag seeds the default app set's PEM secrets during deployment. This allows `mint enroll` to work immediately without running `admin install` first.
+
+```bash
+# First-time bootstrap with PEMs:
+fullsend mint deploy --project="$GCP_PROJECT" --pem-dir=/path/to/pems
+```
+
+The `--pem-dir` directory must contain one `{role}.pem` file per agent role (e.g., `fullsend.pem`, `triage.pem`, `coder.pem`, `review.pem`, `retro.pem`, `prioritize.pem`). The CLI auto-discovers each app's numeric ID from the GitHub API by looking up the public app slug (`fullsend-ai-{role}`).
+
+> **Note:** PEM bootstrapping requires `roles/resourcemanager.projectIamAdmin` and `roles/secretmanager.admin` in addition to the base roles. It also requires the GitHub Apps to already exist as public apps.
+
+### Mint URL stability
+
+The mint URL is stable across redeploys within the same project and region — updating the Cloud Function does not change its URL. Adding a new org to an existing mint only updates env vars (`ROLE_APP_IDS`, `ALLOWED_ORGS`) without redeploying the function. Existing enrolled repos continue working with no changes.
+
+Deploying to a **different region** (e.g., changing `--region` from `us-central1` to `us-east5`) creates a new Cloud Run service with a different URL. All enrolled repos store the mint URL in a repo or org variable (`FULLSEND_MINT_URL`), so changing the region requires updating every enrolled repo's variable. Avoid changing `--region` after initial deployment unless you plan to update all consumers.
+
+## Enrolling organizations and repositories
+
+`fullsend mint enroll` registers an organization or repository in the mint, copies PEM secrets, and configures WIF to accept OIDC tokens from the target.
+
+```bash
+# Enroll an organization
+fullsend mint enroll acme-corp --project="$GCP_PROJECT"
+
+# Enroll a specific repository
+fullsend mint enroll acme-corp/my-repo --project="$GCP_PROJECT"
+```
+
+Enrollment does **not** grant Agent Platform (inference) access — use `fullsend inference provision` separately after enrollment. See [Installing fullsend](../getting-started/installation.md) for the end-user inference setup path.
+
+### What enrollment does
+
+1. Copies GitHub App PEM secrets to the new org's scoped key (`fullsend-{org}--{role}-app-pem`)
+2. Updates the mint Cloud Function environment variables (`ALLOWED_ORGS`, `ROLE_APP_IDS`)
+3. Configures the mint-side WIF provider to accept OIDC tokens from the organization's repositories
+
+## Unenrolling organizations and repositories
+
+`fullsend mint unenroll` removes an organization or repository from the mint.
+
+```bash
+# Unenroll an organization
+fullsend mint unenroll acme-corp --project="$GCP_PROJECT"
+
+# Unenroll a specific repository
+fullsend mint unenroll acme-corp/my-repo --project="$GCP_PROJECT"
+```
+
+Org-scoped unenroll removes PEM secrets and updates WIF providers. Repo-scoped unenroll only removes or disables the repo-specific WIF provider — it does not touch PEM secrets.
+
+## Checking mint status
+
+`fullsend mint status` inspects the deployed mint function and PEM health. This is a read-only operation requiring only viewer-level access.
+
+```bash
+fullsend mint status --project="$GCP_PROJECT"
+```
+
+## Multi-org setup
+
+A single token mint can serve multiple GitHub organizations. The first org deploys the mint infrastructure and creates **public unlisted** GitHub Apps; additional orgs reuse the existing mint and install the same apps.
+
+**First org (deploys mint + creates public apps):**
+
+```bash
+export FIRST_ORG="<first-github-org>"
+export GCP_PROJECT="<your-gcp-project>"
+
+fullsend admin install "$FIRST_ORG" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-project "$GCP_PROJECT" \
+  --public
+```
+
+The `--public` flag creates GitHub Apps as public unlisted — they won't appear in the marketplace but can be installed by other organizations via their installation URL.
+
+When the first org uses a custom app set prefix, pass `--app-set` so the apps are named accordingly:
+
+```bash
+fullsend admin install "$FIRST_ORG" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-project "$GCP_PROJECT" \
+  --public \
+  --app-set "$FIRST_ORG"
+```
+
+This creates public apps named `{first-org}-fullsend`, `{first-org}-coder`, etc.
+
+**Additional orgs (install existing public apps):**
+
+```bash
+export ADDITIONAL_ORG="<additional-github-org>"
+```
+
+`GCP_PROJECT` and `FIRST_ORG` carry over from the first-org step above.
+
+```bash
+fullsend admin install "$ADDITIONAL_ORG" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-project "$GCP_PROJECT"
+```
+
+The installer auto-detects shared public apps by matching installed app IDs against the mint's `ROLE_APP_IDS`. It copies PEM secrets from the app set to the new org's scoped key and records the actual app slug in `config.yaml`, so subsequent operations find the correct app regardless of naming convention.
+
+If the public apps were created with a custom `--app-set`, pass the same value so the CLI uses the correct slug prefix for convention-based lookups:
+
+```bash
+fullsend admin install "$ADDITIONAL_ORG" \
+  --inference-project "$GCP_PROJECT" \
+  --mint-project "$GCP_PROJECT" \
+  --app-set "$FIRST_ORG"
+```
+
+You can also pass `--mint-url "$MINT_URL"` explicitly to skip the auto-discovery step. PEMs use org-scoped naming (`fullsend-{org}--{role}-app-pem`), so each org's secrets are stored independently. For public apps (shared across orgs), the provisioner copies the same PEM under each org's scoped key.
+
+> **Note:** Multi-org with `--public` requires all orgs to share the same GitHub Apps. Private apps (the default) are single-org only.
+
+## See Also
+
+- [Installing fullsend](../getting-started/installation.md) — End-user setup (inference + GitHub)
+- [Setting up with pre-provisioned infrastructure](../getting-started/github-setup.md) — GitHub-only setup when GCP is already provisioned
+- [Infrastructure Reference](infrastructure-reference.md) — Token mint, WIF, and secrets deployment details
+- [CLI Internals](../dev/cli-internals.md) — Command structure and implementation details

--- a/docs/guides/infrastructure/private-repositories.md
+++ b/docs/guides/infrastructure/private-repositories.md
@@ -193,7 +193,7 @@ Not all private repos are equal. A repo containing open-source code that happens
 
 ## See also
 
-- [Installation guide](installation.md) — Initial fullsend setup
+- [Installation guide](../getting-started/installation.md) — Initial fullsend setup
 - [Customizing agents](../user/customizing-agents.md) — Harness configuration and layered overrides
 - [Security threat model](../../problems/security-threat-model.md) — Threat priority and defense considerations
 - [#1189](https://github.com/fullsend-ai/fullsend/issues/1189) — Retro agent private content leak risk

--- a/docs/guides/user/bugfix-workflow.md
+++ b/docs/guides/user/bugfix-workflow.md
@@ -1,6 +1,6 @@
 # Bugfix workflow
 
-How fullsend handles a bug report from issue creation to merged fix, end to end. This guide is for developers working in a repo where fullsend is [installed and enrolled](../admin/installation.md).
+How fullsend handles a bug report from issue creation to merged fix, end to end. This guide is for developers working in a repo where fullsend is [installed and enrolled](../getting-started/installation.md).
 
 ## Overview
 
@@ -167,5 +167,5 @@ Fullsend does not lock you out. The labels are the state machine, and you have f
 
 - [ADR 0002](../../ADRs/0002-initial-fullsend-design.md) — initial fullsend design (full workflow specification)
 - [Architecture overview](../../architecture.md) — component vocabulary and execution stack
-- [Installing fullsend](../admin/installation.md) — prerequisite: admin setup guide
+- [Installing fullsend](../getting-started/installation.md) — prerequisite: admin setup guide
 - [Security threat model](../../problems/security-threat-model.md) — how fullsend thinks about security

--- a/docs/guides/user/customizing-agents.md
+++ b/docs/guides/user/customizing-agents.md
@@ -297,6 +297,6 @@ my-repo/
 
 ## See Also
 
-- [Installation Guide](../admin/installation.md) - Initial setup
+- [Installation Guide](../getting-started/installation.md) - Initial setup
 - [Bugfix Workflow](bugfix-workflow.md) - How agents work together
 - [ADR 0035: Layered Content Resolution](../../ADRs/0035-layered-content-resolution.md)

--- a/internal/cli/inference.go
+++ b/internal/cli/inference.go
@@ -76,7 +76,16 @@ Repo-scoped mode (e.g. 'fullsend inference provision acme/widget'):
 After provisioning, prints the WIF provider resource name for handoff
 to the GitHub admin who runs 'fullsend admin install'.
 
-WIF pools are always created at locations/global.`,
+WIF pools are always created at locations/global.
+
+Required GCP APIs (gcloud services enable):
+  - iam.googleapis.com
+  - cloudresourcemanager.googleapis.com
+  - aiplatform.googleapis.com
+
+Required IAM roles on the target project:
+  - roles/iam.workloadIdentityPoolAdmin        (create WIF pools and providers)
+  - roles/resourcemanager.projectIamAdmin      (grant roles/aiplatform.user to WIF principals)`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if project == "" {
@@ -220,7 +229,13 @@ func newInferenceStatusCmd() *cobra.Command {
 configuration values for handoff to the GitHub admin.
 
 Use --format=env to print KEY=value pairs suitable for copying.
-Use --format=json to get a machine-readable status + config output.`,
+Use --format=json to get a machine-readable status + config output.
+
+Requires the same GCP APIs as 'inference provision' (see 'fullsend inference provision --help').
+
+Required IAM roles on the target project:
+  - roles/iam.workloadIdentityPoolViewer          (read WIF pools and providers)
+  - roles/browser                                  (resourcemanager.projects.get)`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if project == "" {
@@ -436,7 +451,12 @@ Repo-scoped mode (e.g. 'fullsend inference deprovision acme/widget'):
 
 Note: the IAM binding (roles/aiplatform.user) is NOT automatically
 revoked. To fully revoke access, remove the IAM binding manually in
-the GCP console or via gcloud.`,
+the GCP console or via gcloud.
+
+Requires the same GCP APIs as 'inference provision' (see 'fullsend inference provision --help').
+
+Required IAM roles on the target project:
+  - roles/iam.workloadIdentityPoolAdmin        (update or delete WIF providers)`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if project == "" {

--- a/internal/cli/mint.go
+++ b/internal/cli/mint.go
@@ -295,7 +295,25 @@ func newMintDeployCmd() *cobra.Command {
 
 Most runs need only --project and --region. The optional --pem-dir flag is
 for first-time bootstrap only: it seeds the default app set's PEM secrets so
-that 'mint enroll' can work without running 'admin install' first.`,
+that 'mint enroll' can work without running 'admin install' first.
+
+Required GCP APIs (gcloud services enable):
+  - iam.googleapis.com
+  - cloudresourcemanager.googleapis.com
+  - cloudfunctions.googleapis.com
+  - run.googleapis.com
+  - secretmanager.googleapis.com
+  - iamcredentials.googleapis.com              (runtime: used by deployed function, not CLI)
+
+Required IAM roles on the target project:
+  - roles/iam.serviceAccountAdmin             (create mint service account)
+  - roles/iam.workloadIdentityPoolAdmin        (create WIF pool and provider)
+  - roles/cloudfunctions.developer             (deploy Cloud Function)
+  - roles/run.admin                            (set Cloud Run invoker policy)
+
+When using --pem-dir, additionally requires:
+  - roles/secretmanager.admin                  (create and manage PEM secrets)
+  - roles/resourcemanager.projectIamAdmin      (grant roles/aiplatform.user to WIF principals)`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if project == "" {
@@ -433,7 +451,18 @@ Per-org enrollment (fullsend mint enroll acme):
 Per-repo enrollment (fullsend mint enroll acme/widget):
   - Same as per-org plus:
   - Adds repo to PER_REPO_WIF_REPOS
-  - Creates a dedicated WIF provider for the repo`,
+  - Creates a dedicated WIF provider for the repo
+
+Requires the same GCP APIs as 'mint deploy' (see 'fullsend mint deploy --help').
+
+Required IAM roles on the mint project:
+  - roles/secretmanager.admin                  (copy PEM secrets)
+  - roles/cloudfunctions.viewer                (read Cloud Function metadata)
+  - roles/run.admin                            (update Cloud Run service env vars)
+  - roles/iam.workloadIdentityPoolAdmin        (update WIF provider condition; create repo-scoped providers)
+
+When enrolling a repo (per-repo mode), additionally requires:
+  - roles/resourcemanager.projectIamAdmin      (grant roles/aiplatform.user to repo WIF principal)`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if project == "" {
@@ -822,7 +851,15 @@ By default, PEM secrets are disabled (not deleted) and WIF providers are
 disabled (not deleted). Use --delete-secrets or --delete-provider for
 permanent removal.
 
-Requires typing the org/repo name to confirm (unless --dry-run or --yolo).`,
+Requires typing the org/repo name to confirm (unless --dry-run or --yolo).
+
+Requires the same GCP APIs as 'mint deploy' (see 'fullsend mint deploy --help').
+
+Required IAM roles on the mint project:
+  - roles/cloudfunctions.viewer                (read Cloud Function metadata)
+  - roles/run.admin                            (update Cloud Run service env vars)
+  - roles/secretmanager.admin                  (disable or delete PEM secrets; org-scoped only)
+  - roles/iam.workloadIdentityPoolAdmin        (update, disable, or delete WIF providers)`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if project == "" {
@@ -1110,7 +1147,11 @@ func newMintStatusCmd() *cobra.Command {
 
 Shows function info, enrolled orgs, role-app-id mappings, per-repo WIF
 repos, and overall health status. If an org argument is provided, drills
-into that org's PEM secret status.`,
+into that org's PEM secret status.
+
+Required IAM roles on the mint project:
+  - roles/cloudfunctions.viewer                   (read Cloud Function metadata)
+  - roles/secretmanager.viewer                    (list and read secret metadata)`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if project == "" {

--- a/web/docs/README.md
+++ b/web/docs/README.md
@@ -18,7 +18,7 @@ Design and behavior are described in the [docs browser design spec](../../docs/s
 Shared links should use the **`#/`** fragment so navigation stays in the docs SPA without path segments under `/docs/`.
 
 - **Document:** `/docs/#/<routeKey>`
-  Example: `/docs/#/guides/admin/installation` — `routeKey` matches the manifest path to the Markdown file (POSIX-style segments, no leading slash in the fragment).
+  Example: `/docs/#/guides/getting-started/installation` — `routeKey` matches the manifest path to the Markdown file (POSIX-style segments, no leading slash in the fragment).
 
 - **Heading / in-page target:** `/docs/#/<routeKey>::<slug>`
   The **`::`** delimiter separates the document key from the heading **slug** (the `id` of the target element in the rendered page). It is not part of the slug itself; it only appears in the URL fragment so the app can load the right page and scroll to the right anchor.

--- a/web/docs/build/markdown.test.ts
+++ b/web/docs/build/markdown.test.ts
@@ -20,10 +20,10 @@ describe("markdownToHtml", () => {
     const md = "[x](./other.md)";
     const { html } = await markdownToHtml(
       md,
-      "docs/guides/admin/installation.md",
+      "docs/guides/getting-started/installation.md",
       repoRoot,
     );
-    expect(html).toContain('href="#/guides/admin/other"');
+    expect(html).toContain('href="#/guides/getting-started/other"');
   });
 
   it("strips front matter from HTML body", async () => {
@@ -38,10 +38,10 @@ describe("markdownToHtml", () => {
     const md = "[z](./other.md#Section-One)";
     const { html } = await markdownToHtml(
       md,
-      "docs/guides/admin/installation.md",
+      "docs/guides/getting-started/installation.md",
       repoRoot,
     );
-    expect(html).toMatch(/href="#\/guides\/admin\/other::section-one"/);
+    expect(html).toMatch(/href="#\/guides\/getting-started\/other::section-one"/);
   });
 
   it("marks mermaid fence for client render", async () => {
@@ -55,7 +55,7 @@ describe("markdownToHtml", () => {
     const md = "[p](../../problems)";
     const { html } = await markdownToHtml(
       md,
-      "docs/guides/admin/installation.md",
+      "docs/guides/getting-started/installation.md",
       repoRoot,
     );
     expect(html).toContain('href="#/problems/"');

--- a/web/docs/build/paths.test.ts
+++ b/web/docs/build/paths.test.ts
@@ -11,21 +11,21 @@ import path from "node:path";
 
 describe("paths", () => {
   it("filePathToRouteKey strips docs/ and .md", () => {
-    expect(filePathToRouteKey("docs/guides/admin/installation.md")).toBe(
-      "guides/admin/installation",
+    expect(filePathToRouteKey("docs/guides/getting-started/installation.md")).toBe(
+      "guides/getting-started/installation",
     );
     expect(filePathToRouteKey("docs/README.md")).toBe("README");
   });
 
   it("routeKeyToUrl", () => {
-    expect(routeKeyToUrl("guides/admin/installation")).toBe(
-      "/docs/guides/admin/installation",
+    expect(routeKeyToUrl("guides/getting-started/installation")).toBe(
+      "/docs/guides/getting-started/installation",
     );
   });
 
   it("pathnameToRouteKey", () => {
-    expect(pathnameToRouteKey("/docs/guides/admin/installation")).toBe(
-      "guides/admin/installation",
+    expect(pathnameToRouteKey("/docs/guides/getting-started/installation")).toBe(
+      "guides/getting-started/installation",
     );
     expect(pathnameToRouteKey("/docs/")).toBe("");
   });

--- a/web/docs/build/paths.ts
+++ b/web/docs/build/paths.ts
@@ -40,7 +40,7 @@ export function listDocMarkdownFiles(
   return out;
 }
 
-/** `docs/guides/admin/installation.md` → `guides/admin/installation` */
+/** `docs/guides/getting-started/installation.md` → `guides/getting-started/installation` */
 export function filePathToRouteKey(repoRelativeMd: DocsFilePath): string {
   const withoutPrefix = repoRelativeMd.slice("docs/".length);
   if (!withoutPrefix.endsWith(".md")) {
@@ -49,7 +49,7 @@ export function filePathToRouteKey(repoRelativeMd: DocsFilePath): string {
   return withoutPrefix.slice(0, -".md".length);
 }
 
-/** `guides/admin/installation` → `/docs/guides/admin/installation` */
+/** `guides/getting-started/installation` → `/docs/guides/getting-started/installation` */
 export function routeKeyToUrl(routeKey: string): string {
   const k = routeKey.replace(/^\/+/, "");
   return `/docs/${k}`;

--- a/web/docs/src/lib/filterTree.test.ts
+++ b/web/docs/src/lib/filterTree.test.ts
@@ -9,18 +9,18 @@ const tree: ManifestNode[] = [
     children: [
       {
         type: "dir",
-        name: "admin",
+        name: "getting-started",
         children: [
           {
             type: "file",
             name: "installation",
-            routeKey: "guides/admin/installation",
+            routeKey: "guides/getting-started/installation",
             title: "Installation Guide",
           },
           {
             type: "file",
             name: "config",
-            routeKey: "guides/admin/config",
+            routeKey: "guides/getting-started/config",
             title: "Configuration",
           },
         ],
@@ -74,12 +74,12 @@ describe("filterTree", () => {
         children: [
           {
             type: "dir",
-            name: "admin",
+            name: "getting-started",
             children: [
               {
                 type: "file",
                 name: "installation",
-                routeKey: "guides/admin/installation",
+                routeKey: "guides/getting-started/installation",
                 title: "Installation Guide",
               },
             ],
@@ -102,7 +102,7 @@ describe("filterTree", () => {
   });
 
   it("matches dir name and keeps full subtree", () => {
-    const result = filterTree(tree, "admin");
+    const result = filterTree(tree, "getting-started");
     expect(result).toEqual([
       {
         type: "dir",
@@ -110,18 +110,18 @@ describe("filterTree", () => {
         children: [
           {
             type: "dir",
-            name: "admin",
+            name: "getting-started",
             children: [
               {
                 type: "file",
                 name: "installation",
-                routeKey: "guides/admin/installation",
+                routeKey: "guides/getting-started/installation",
                 title: "Installation Guide",
               },
               {
                 type: "file",
                 name: "config",
-                routeKey: "guides/admin/config",
+                routeKey: "guides/getting-started/config",
                 title: "Configuration",
               },
             ],
@@ -140,12 +140,12 @@ describe("filterTree", () => {
         children: [
           {
             type: "dir",
-            name: "admin",
+            name: "getting-started",
             children: [
               {
                 type: "file",
                 name: "installation",
-                routeKey: "guides/admin/installation",
+                routeKey: "guides/getting-started/installation",
                 title: "Installation Guide",
               },
             ],
@@ -156,7 +156,7 @@ describe("filterTree", () => {
   });
 
   it("matches against file routeKey (path)", () => {
-    const result = filterTree(tree, "admin config");
+    const result = filterTree(tree, "started config");
     expect(result).toEqual([
       {
         type: "dir",
@@ -164,12 +164,12 @@ describe("filterTree", () => {
         children: [
           {
             type: "dir",
-            name: "admin",
+            name: "getting-started",
             children: [
               {
                 type: "file",
                 name: "config",
-                routeKey: "guides/admin/config",
+                routeKey: "guides/getting-started/config",
                 title: "Configuration",
               },
             ],
@@ -180,7 +180,7 @@ describe("filterTree", () => {
   });
 
   it("multi-word query with no combined match returns empty", () => {
-    const result = filterTree(tree, "admin readme");
+    const result = filterTree(tree, "started readme");
     expect(result).toEqual([]);
   });
 });

--- a/web/docs/src/lib/hashRoute.test.ts
+++ b/web/docs/src/lib/hashRoute.test.ts
@@ -7,16 +7,16 @@ import {
 
 describe("parseDocHash", () => {
   it("parses file route only", () => {
-    expect(parseDocHash("#/guides/admin/installation")).toEqual({
+    expect(parseDocHash("#/guides/getting-started/installation")).toEqual({
       kind: "file",
-      routeKey: "guides/admin/installation",
+      routeKey: "guides/getting-started/installation",
     });
   });
 
   it("parses directory route with trailing slash", () => {
-    expect(parseDocHash("#/guides/admin/")).toEqual({
+    expect(parseDocHash("#/guides/getting-started/")).toEqual({
       kind: "dir",
-      dirPath: "guides/admin",
+      dirPath: "guides/getting-started",
     });
   });
 
@@ -51,7 +51,7 @@ describe("formatDocDirHash", () => {
 
 describe("formatDocHash", () => {
   it("round-trips file routes", () => {
-    const k = "guides/admin/installation";
+    const k = "guides/getting-started/installation";
     expect(parseDocHash(formatDocHash(k))).toEqual({
       kind: "file",
       routeKey: k,

--- a/web/docs/src/lib/hashRoute.ts
+++ b/web/docs/src/lib/hashRoute.ts
@@ -17,7 +17,7 @@ function normalizeDirPath(raw: string): string {
 
 /**
  * Empty hash or `#/` means “use default document” (caller resolves).
- * Directory URLs use a trailing slash: `#/guides/admin/`.
+ * Directory URLs use a trailing slash: `#/guides/getting-started/`.
  */
 export function parseDocHash(hash: string): ParsedDocHash | null {
   const raw = hash.startsWith("#") ? hash.slice(1) : hash;

--- a/web/docs/src/lib/manifestDirs.test.ts
+++ b/web/docs/src/lib/manifestDirs.test.ts
@@ -11,12 +11,12 @@ describe("collectDirPaths", () => {
         children: [
           {
             type: "dir",
-            name: "admin",
+            name: "getting-started",
             children: [
               {
                 type: "file",
                 name: "installation",
-                routeKey: "guides/admin/installation",
+                routeKey: "guides/getting-started/installation",
                 title: "Install",
               },
             ],
@@ -24,6 +24,6 @@ describe("collectDirPaths", () => {
         ],
       },
     ];
-    expect(collectDirPaths(tree)).toEqual(new Set(["guides", "guides/admin"]));
+    expect(collectDirPaths(tree)).toEqual(new Set(["guides", "guides/getting-started"]));
   });
 });


### PR DESCRIPTION
## Summary

- Add required GCP IAM roles and API names to CLI `--help` text for all standalone `inference` and `mint` commands (provision, deprovision, status, deploy, enroll, unenroll)
- Add a per-command IAM role breakdown table to `installation.md` so users of the split-responsibility workflow know exactly which roles to request
- Restructure `docs/guides/admin/` into `getting-started/` (end-user onboarding) and `infrastructure/` (platform operator guides)
- Add `mint-administration.md` — a dedicated guide for deploying and managing the token mint Cloud Function
- Scope `github-setup.md` to its target audience (GitHub maintainers), removing GCP admin details that belong in other guides
- Add 3 missing user guides to `docs/guides/README.md`
- Update stale `guides/admin/` references across web/docs test fixtures

## Motivation

A user ran `fullsend inference provision` on their GCP project and hit a 403 for `iam.workloadIdentityPools.create`. The required IAM roles were only documented for `fullsend admin install` — users running standalone commands had no way to know which roles or APIs to request. The guide restructuring separates content by audience so each persona finds only what they need.

## Test plan

- [x] `go build ./cmd/fullsend/` passes
- [x] `go test ./internal/cli/` passes
- [x] `go vet ./...` passes
- [x] `make lint` passes (including markdown link validation)
- [x] `fullsend inference provision --help` / `inference status --help` show required roles
- [x] `fullsend mint deploy --help` / `mint status --help` show required roles
- [x] CI: build, test, web, e2e, commit-lint, DCO all green