### PR TITLE
fix: check CSMA output for rate limit errors even on exit 0

### DIFF
--- a/internal/scaffold/fullsend-repo/scripts/lib/github-api-csma.sh
+++ b/internal/scaffold/fullsend-repo/scripts/lib/github-api-csma.sh
@@ -182,10 +182,8 @@ github_csma_run() {
 
     : >"${outfile}"
     : >"${errfile}"
-    if gh "$@" >"${outfile}" 2>"${errfile}"; then
-      cat "${outfile}"
-      return 0
-    fi
+    local rc=0
+    gh "$@" >"${outfile}" 2>"${errfile}" || rc=$?
 
     combined=$(cat "${outfile}" "${errfile}")
     if github_csma_is_rate_limit "${combined}"; then
@@ -193,10 +191,16 @@ github_csma_run() {
         _github_csma_sleep_after_rate_limit "${attempt}" "${resource}"
         continue
       fi
+      _github_csma_emit_failure "${combined}"
+      return 1
     fi
 
-    _github_csma_emit_failure "${combined}"
-    return 1
+    if (( rc != 0 )); then
+      _github_csma_emit_failure "${combined}"
+      return 1
+    fi
+    cat "${outfile}"
+    return 0
   done
 
   return 1
@@ -223,10 +227,8 @@ github_csma_run_pipe() {
 
     : >"${outfile}"
     : >"${errfile}"
-    if gh "$@" <"${infile}" >"${outfile}" 2>"${errfile}"; then
-      cat "${outfile}"
-      return 0
-    fi
+    local rc=0
+    gh "$@" <"${infile}" >"${outfile}" 2>"${errfile}" || rc=$?
 
     combined=$(cat "${outfile}" "${errfile}")
     if github_csma_is_rate_limit "${combined}"; then
@@ -234,10 +236,16 @@ github_csma_run_pipe() {
         _github_csma_sleep_after_rate_limit "${attempt}" "${resource}"
         continue
       fi
+      _github_csma_emit_failure "${combined}"
+      return 1
     fi
 
-    _github_csma_emit_failure "${combined}"
-    return 1
+    if (( rc != 0 )); then
+      _github_csma_emit_failure "${combined}"
+      return 1
+    fi
+    cat "${outfile}"
+    return 0
   done
 
   return 1
@@ -264,10 +272,8 @@ github_csma_run_cmd() {
 
     : >"${outfile}"
     : >"${errfile}"
-    if "$@" <"${infile}" >"${outfile}" 2>"${errfile}"; then
-      cat "${outfile}"
-      return 0
-    fi
+    local rc=0
+    "$@" <"${infile}" >"${outfile}" 2>"${errfile}" || rc=$?
 
     combined=$(cat "${outfile}" "${errfile}")
     if github_csma_is_rate_limit "${combined}"; then
@@ -275,10 +281,16 @@ github_csma_run_cmd() {
         _github_csma_sleep_after_rate_limit "${attempt}" "${resource}"
         continue
       fi
+      _github_csma_emit_failure "${combined}"
+      return 1
     fi
 
-    _github_csma_emit_failure "${combined}"
-    return 1
+    if (( rc != 0 )); then
+      _github_csma_emit_failure "${combined}"
+      return 1
+    fi
+    cat "${outfile}"
+    return 0
   done
 
   return 1

--- a/internal/scaffold/fullsend-repo/scripts/post-prioritize-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-prioritize-test.sh
@@ -47,6 +47,15 @@ if [[ "\${GH_CSMA_FAIL_MODE:-}" == "auth" ]] && [[ "\$1" != "api" || "\$2" != "r
   exit 1
 fi
 
+# Simulate gh exiting 0 but printing a rate limit error to stdout.
+# This is how "gh project view" behaves on GraphQL rate limits.
+if [[ "\${GH_CSMA_FAIL_MODE:-}" == "exit0-ratelimit" ]] && [[ "\$1" != "api" || "\$2" != "rate_limit" ]]; then
+  if (( fail_count <= GH_CSMA_FAIL_UNTIL )); then
+    echo "GraphQL: API rate limit exceeded for installation ID 131739396." >&2
+    exit 0
+  fi
+fi
+
 if [[ -n "\${GH_CSMA_FAIL_UNTIL:-}" ]] && (( fail_count <= GH_CSMA_FAIL_UNTIL )); then
   echo "You have exceeded a secondary rate limit. Please retry again later." >&2
   exit 1
@@ -146,6 +155,7 @@ run_test() {
   local fail_until="${2:-}"
   local min_gh_calls="${3:-1}"
   local expect_failure="${4:-false}"
+  local fail_mode="${5:-}"
 
   local run_dir="${TEST_TMPDIR}/run-${test_name}"
   mkdir -p "${run_dir}/iteration-1/output"
@@ -153,9 +163,12 @@ run_test() {
 
   > "${GH_LOG}"
   rm -f "${GH_FAIL_COUNT}"
-  unset GH_CSMA_FAIL_UNTIL
+  unset GH_CSMA_FAIL_UNTIL GH_CSMA_FAIL_MODE
   if [[ -n "${fail_until}" ]]; then
     export GH_CSMA_FAIL_UNTIL="${fail_until}"
+  fi
+  if [[ -n "${fail_mode}" ]]; then
+    export GH_CSMA_FAIL_MODE="${fail_mode}"
   fi
 
   local exit_code=0
@@ -292,6 +305,15 @@ run_test_failure_stderr "auth-error" "" "Resource not accessible by integration"
 # Exhausted retries on persistent rate limits.
 export GITHUB_CSMA_MAX_ATTEMPTS=3
 run_test_failure_stderr "exhausted-retries" "100" "secondary rate limit"
+unset GITHUB_CSMA_MAX_ATTEMPTS
+
+# gh exits 0 but output contains rate limit error (gh project view behavior).
+# First 2 calls fail with exit-0 rate limit, then succeed.
+run_test "exit0-rate-limit-retry" "2" 10 "false" "exit0-ratelimit"
+
+# Exhausted retries when gh keeps exiting 0 with rate limit errors.
+export GITHUB_CSMA_MAX_ATTEMPTS=3
+run_test_failure_stderr "exit0-rate-limit-exhausted" "100" "rate limit exceeded" "exit0-ratelimit"
 unset GITHUB_CSMA_MAX_ATTEMPTS
 
 if [[ ${FAILURES} -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- The `gh` CLI (notably `gh project view`) can exit 0 while printing a GraphQL rate limit error to stderr. The CSMA wrapper previously only entered the retry loop on non-zero exit codes, so these errors passed through undetected — downstream `jq` would fail to parse the error text and `set -e` would kill the script with no retries.
- Now all three CSMA runners (`github_csma_run`, `github_csma_run_pipe`, `github_csma_run_cmd`) always inspect combined stdout+stderr for rate limit patterns regardless of exit code.
- Two new test cases cover the exit-0 rate limit scenario: transient retry and exhausted retries.

**Root cause:** [prioritize run 26447310264](https://github.com/fullsend-ai/.fullsend/actions/runs/26447310264/job/77856891352) failed because `gh project view` returned exit 0 with `GraphQL: API rate limit exceeded for installation ID 131739396.` on stderr. The CSMA wrapper saw exit 0 and returned success. The error text was then piped to `jq` which couldn't parse it, and `set -e` killed the script immediately — zero retries.

## Test plan

- [x] New test `exit0-rate-limit-retry`: gh exits 0 with rate limit error for first 2 calls, then succeeds — verifies CSMA retries and the full script completes
- [x] New test `exit0-rate-limit-exhausted`: persistent exit-0 rate limit errors — verifies CSMA exhausts retries and reports the rate limit error on stderr
- [x] All existing tests still pass (happy-path, rate-limit-retry, auth-error, exhausted-retries)
- [x] shellcheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)