### PR TITLE
fix(ci): correct reusable-dispatch stage skip expression

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -49,7 +49,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      stage: ${{ steps.role-check.outputs.skipped == 'true' && '' || steps.route.outputs.stage }}
+      stage: ${{ steps.role-check.outputs.skipped != 'true' && steps.route.outputs.stage || '' }}
       trigger_source: ${{ steps.route.outputs.trigger_source }}
       event_payload: ${{ steps.payload.outputs.event_payload }}
     steps:


### PR DESCRIPTION
## Summary

- Fixes the `route` job `stage` output in `.github/workflows/reusable-dispatch.yml` so per-repo silent-skip works when a routed stage's role is not in `defaults.roles`.
- Replaces `skipped == 'true' && '' || stage` (always evaluates to `stage` because `''` is falsy in GHA) with `skipped != 'true' && stage || ''`.

Fixes #1199

## Test plan

- [ ] On a per-repo install, trigger dispatch for a stage whose mapped role is **not** in `.fullsend/config.yaml` `roles` — `route` should output empty `stage` and all stage jobs should be skipped.
- [ ] Trigger dispatch for a configured role — stage jobs should still run as before.


Made with [Cursor](https://cursor.com)