### PR TITLE
fix(cli): update followup commands from 'admin install' to 'github setup'

### DIFF
--- a/internal/cli/inference.go
+++ b/internal/cli/inference.go
@@ -23,7 +23,7 @@ func newInferenceCmd() *cobra.Command {
 These commands only require GCP project access — no GitHub token or
 mint project is needed. Use them to set up Workload Identity Federation
 for Agent Platform inference, then hand off the WIF provider resource name
-to the GitHub admin who runs 'fullsend admin install'.`,
+to the GitHub admin who runs 'fullsend github setup'.`,
 	}
 	cmd.AddCommand(newInferenceProvisionCmd())
 	cmd.AddCommand(newInferenceStatusCmd())
@@ -74,7 +74,7 @@ Repo-scoped mode (e.g. 'fullsend inference provision acme/widget'):
   Creates a WIF pool and a dedicated provider scoped to a single repo.
 
 After provisioning, prints the WIF provider resource name for handoff
-to the GitHub admin who runs 'fullsend admin install'.
+to the GitHub admin who runs 'fullsend github setup'.
 
 WIF pools are always created at locations/global.
 
@@ -198,7 +198,7 @@ func runInferenceProvision(cmd *cobra.Command, printer *ui.Printer, org, repo, p
 		targetArg = repo
 	}
 	printer.StepInfo("Pass this value to the GitHub setup command:")
-	printer.StepInfo(fmt.Sprintf("  fullsend admin install %s \\", targetArg))
+	printer.StepInfo(fmt.Sprintf("  fullsend github setup %s \\", targetArg))
 	printer.StepInfo(fmt.Sprintf("    --inference-project=%s \\", project))
 	printer.StepInfo(fmt.Sprintf("    --inference-wif-provider=%s", wifProvider))
 	printer.Blank()

--- a/internal/cli/mint.go
+++ b/internal/cli/mint.go
@@ -269,7 +269,7 @@ func newMintCmd() *cobra.Command {
 		Long: `Manage the GCP Cloud Function that mints GitHub App installation tokens.
 
 These commands require GCP project access but do NOT require a GitHub token.
-Use 'fullsend admin install' for GitHub-side setup.`,
+Use 'fullsend github setup' for GitHub-side setup.`,
 	}
 	cmd.AddCommand(newMintDeployCmd())
 	cmd.AddCommand(newMintEnrollCmd())
@@ -631,7 +631,7 @@ func runMintEnrollOrg(ctx context.Context, printer *ui.Printer, org, project, re
 		fmt.Sprintf("Roles: %s", strings.Join(roleList, ", ")),
 		fmt.Sprintf("Mint URL: %s", discovery.URL),
 		fmt.Sprintf("Next: fullsend inference provision %s --project=<inference-gcp-project>", org),
-		fmt.Sprintf("Then: fullsend admin install %s --mint-url=%s --skip-mint-check", org, discovery.URL),
+		fmt.Sprintf("Then: fullsend github setup %s --mint-url=%s --inference-project=<project> --inference-wif-provider=<wif-provider>", org, discovery.URL),
 	})
 
 	return nil


### PR DESCRIPTION
## Summary
- Update `inference provision` and `mint enroll` followup instructions to reference `fullsend github setup` instead of the all-in-one `fullsend admin install`
- Drop `--skip-mint-check` from `mint enroll` followup since that flag does not exist on `github setup`
- Verified all referenced flags (`--inference-project`, `--inference-wif-provider`, `--mint-url`) exist on `fullsend github setup`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/cli/ -run "Inference|Mint"` passes
- [x] `make lint` passes