### PR TITLE
fix(#1734): scope mint token to enabled repos only in repo-maintenance

### DIFF
--- a/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Extract enrolled repo names from config
         id: repo-list
         run: |
-          REPOS=$(yq '.repos | keys | join(",")' config.yaml)
+          REPOS=$(yq '[.repos | to_entries[] | select(.value.enabled == true) | .key] | join(",")' config.yaml)
           if [[ -z "$REPOS" ]]; then
-            echo "::error::No repos found in config.yaml"
+            echo "::error::No enabled repos found in config.yaml"
             exit 1
           fi
           echo "names=$REPOS" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- `repo-maintenance.yml` passed all repos (enabled + disabled) to `mint-token`, causing GitHub to return 422 when disabled repos aren't covered by the app installation
- Filter to `enabled: true` only, matching the behaviour of `reconcile-repos.sh`

## Test plan

- [ ] Verify `yq` expression returns only enabled repos: `yq '[.repos | to_entries[] | select(.value.enabled == true) | .key] | join(",")' config.yaml`
- [ ] Trigger `repo-maintenance` on a `.fullsend` repo that has disabled repos — confirm no 422 from mint

Closes #1734

🤖 Generated with [Claude Code](https://claude.com/claude-code)