### PR TITLE
feat(cli): wire URL-referenced harness resources into fullsend run

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -24,8 +24,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/fullsend-ai/fullsend/internal/config"
 	"github.com/fullsend-ai/fullsend/internal/envfile"
+	"github.com/fullsend-ai/fullsend/internal/fetch"
 	"github.com/fullsend-ai/fullsend/internal/harness"
+	"github.com/fullsend-ai/fullsend/internal/resolve"
 	"github.com/fullsend-ai/fullsend/internal/sandbox"
 	"github.com/fullsend-ai/fullsend/internal/scaffold"
 	"github.com/fullsend-ai/fullsend/internal/security"
@@ -49,6 +52,7 @@ func newRunCmd() *cobra.Command {
 	var envFiles []string
 	var noPostScript bool
 	var debugFilter string
+	var offline bool
 
 	cmd := &cobra.Command{
 		Use:   "run <agent-name>",
@@ -58,7 +62,7 @@ func newRunCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agentName := args[0]
 			printer := ui.New(os.Stdout)
-			return runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary, envFiles, noPostScript, debugFilter, printer)
+			return runAgent(cmd.Context(), agentName, fullsendDir, outputBase, targetRepo, fullsendBinary, envFiles, noPostScript, debugFilter, offline, printer)
 		},
 	}
 
@@ -70,13 +74,14 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&noPostScript, "no-post-script", false, "skip post-script execution (agent still runs full inference)")
 	cmd.Flags().StringVar(&debugFilter, "debug", "", `enable Claude Code debug logging with optional category filter (e.g. "api,hooks")`)
 	cmd.Flags().Lookup("debug").NoOptDefVal = "*"
+	cmd.Flags().BoolVar(&offline, "offline", false, "reject network fetches; only use cached remote resources")
 	_ = cmd.MarkFlagRequired("fullsend-dir")
 	_ = cmd.MarkFlagRequired("target-repo")
 
 	return cmd
 }
 
-func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary string, envFiles []string, noPostScript bool, debug string, printer *ui.Printer) (runErr error) {
+func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRepo, fullsendBinary string, envFiles []string, noPostScript bool, debug string, offline bool, printer *ui.Printer) (runErr error) {
 	printer.Banner(Version())
 	printer.Blank()
 	printer.Header("Running agent: " + agentName)
@@ -107,6 +112,49 @@ func runAgent(agentName, fullsendDir, outputBase, targetRepo, fullsendBinary str
 	if err := h.ResolveRelativeTo(absFullsendDir); err != nil {
 		printer.StepFail("Path validation failed")
 		return fmt.Errorf("resolving paths: %w", err)
+	}
+
+	if h.HasURLReferences() {
+		orgConfigPath := filepath.Join(absFullsendDir, "config.yaml")
+		orgConfigData, err := os.ReadFile(orgConfigPath)
+		if err != nil {
+			printer.StepFail("Failed to load org config")
+			if os.IsNotExist(err) {
+				return fmt.Errorf("URL-referenced resources require an org-level config.yaml with allowed_remote_resources (expected at %s)", orgConfigPath)
+			}
+			return fmt.Errorf("reading org config for remote resource validation: %w", err)
+		}
+		orgCfg, err := config.ParseOrgConfig(orgConfigData)
+		if err != nil {
+			printer.StepFail("Failed to parse org config")
+			return fmt.Errorf("parsing org config: %w", err)
+		}
+
+		if err := h.ValidateAllowedRemoteResources(orgCfg.AllowedRemoteResources); err != nil {
+			printer.StepFail("Remote resource allowlist validation failed")
+			return fmt.Errorf("validating allowed remote resources: %w", err)
+		}
+
+		policy := fetch.DefaultPolicy
+		policy.Offline = offline
+
+		deps, err := resolve.ResolveHarness(ctx, h, resolve.ResolveOpts{
+			WorkspaceRoot: absFullsendDir,
+			FetchPolicy:   policy,
+			AuditLogPath:  filepath.Join(absFullsendDir, ".fullsend-cache", "fetch-audit.jsonl"),
+		})
+		if err != nil {
+			printer.StepFail("Remote resource resolution failed")
+			return fmt.Errorf("resolving remote resources: %w", err)
+		}
+
+		for _, dep := range deps {
+			if dep.CacheHit {
+				printer.StepInfo(fmt.Sprintf("Resolved %s (cache hit)", dep.URL))
+			} else {
+				printer.StepInfo(fmt.Sprintf("Fetched %s -> %s", dep.URL, dep.LocalPath))
+			}
+		}
 	}
 
 	if resolved, overridden := applySandboxImageOverride(h.Image); overridden {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -81,6 +81,13 @@ func TestRunCommand_HasTargetRepoFlag(t *testing.T) {
 	require.Contains(t, annotations, "cobra_annotation_bash_completion_one_required_flag")
 }
 
+func TestRunCommand_HasOfflineFlag(t *testing.T) {
+	cmd := newRunCmd()
+	flag := cmd.Flags().Lookup("offline")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}
+
 func TestBuildClaudeCommand_Basic(t *testing.T) {
 	cmd := buildClaudeCommand("hello-world", "", "/tmp/workspace/repo", nil, "")
 	assert.Contains(t, cmd, "cd /tmp/workspace/repo")

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -424,11 +424,13 @@ func (h *Harness) ValidateRunnerEnv() error {
 }
 
 // ValidateFilesExist checks that all file paths referenced by the harness
-// exist on disk. Call after ResolveRelativeTo so paths are absolute.
-// Pre/post scripts run on the host and must be file paths (no inline args).
+// exist on disk. Callers must invoke ResolveRelativeTo first (to make
+// paths absolute), then resolve.ResolveHarness (to replace any URL
+// references with local cache paths). The IsURL guard inside is
+// defense-in-depth in case the ordering is violated.
 func (h *Harness) ValidateFilesExist() error {
 	check := func(label, path string) error {
-		if path == "" {
+		if path == "" || IsURL(path) {
 			return nil
 		}
 		if _, err := os.Stat(path); err != nil {
@@ -604,6 +606,21 @@ func (h *Harness) ValidateResourceTypes() error {
 	}
 
 	return nil
+}
+
+// HasURLReferences reports whether any declarative field (agent, policy, skills)
+// contains a URL. Used to skip remote resource validation and resolution when
+// the harness references only local paths.
+func (h *Harness) HasURLReferences() bool {
+	if IsURL(h.Agent) || IsURL(h.Policy) {
+		return true
+	}
+	for _, s := range h.Skills {
+		if IsURL(s) {
+			return true
+		}
+	}
+	return false
 }
 
 // MatchesAllowedPrefix reports whether rawURL starts with any entry in

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -952,6 +952,45 @@ func TestValidateResourceTypes(t *testing.T) {
 	})
 }
 
+func TestHasURLReferences(t *testing.T) {
+	tests := []struct {
+		name string
+		h    Harness
+		want bool
+	}{
+		{
+			name: "local only",
+			h:    Harness{Agent: "agents/test.md", Policy: "policies/p.yaml", Skills: []string{"skills/a"}},
+			want: false,
+		},
+		{
+			name: "empty fields",
+			h:    Harness{Agent: "agents/test.md"},
+			want: false,
+		},
+		{
+			name: "URL agent",
+			h:    Harness{Agent: "https://example.com/agents/test.md#sha256=abc"},
+			want: true,
+		},
+		{
+			name: "URL policy",
+			h:    Harness{Agent: "agents/test.md", Policy: "https://example.com/p.yaml#sha256=abc"},
+			want: true,
+		},
+		{
+			name: "URL skill",
+			h:    Harness{Agent: "agents/test.md", Skills: []string{"skills/a", "https://example.com/s.md#sha256=abc"}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.h.HasURLReferences())
+		})
+	}
+}
+
 func TestMatchesAllowedPrefix(t *testing.T) {
 	h := &Harness{
 		Agent: "agents/test.md",


### PR DESCRIPTION
## Summary

- Integrates the resource resolver (PR #1623) into `fullsend run` so URL-referenced declarative resources (agent, policy, skills) are fetched, cached, and validated end-to-end
- Adds `--offline` flag to reject network fetches and use only cached resources
- Adds `HasURLReferences()` helper to skip resolution logic entirely for local-only harnesses (zero behavioral change for existing users)
- Inserts validation and resolution between `ResolveRelativeTo` and `ValidateFilesExist`: `ValidateResourceTypes` → `ValidateAllowedRemoteResources` → `ResolveHarness`

This is PR 8 — the final PR for Phase 1 of universal harness access (ADR-0038).

**Depends on:** #1623 (merged)

## Test plan

- [x] `HasURLReferences()` table-driven tests (local-only, URL agent, URL policy, URL skill)
- [x] `--offline` flag registration test
- [x] `go test ./...` — all existing and new tests pass
- [x] `go vet ./...` — clean
- [x] Pre-commit hooks pass
- [ ] Manual: run an existing local-only harness — verify no behavioral change
- [ ] Manual: create a harness with URL-referenced agent + `allowed_remote_resources` — verify fetch, cache, and execution
- [ ] Manual: `fullsend run --offline` with URL harness — verify cache miss fails, cache hit succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)