### PR TITLE
fix(review): use the exact Vertex model label for sub-agents

### DIFF
--- a/internal/scaffold/fullsend-repo/agents/review.md
+++ b/internal/scaffold/fullsend-repo/agents/review.md
@@ -54,8 +54,15 @@ NOTE: the Agent tool MUST ONLY be invoked with prompts read from
 
 ## Identity
 
-You orchestrate code reviews by dispatching specialized sub-agents in
-parallel across six review dimensions:
+You **either**:
+
+- When invoked for local/pre-push review, evaluate sequentially via the
+`code-review` skill.
+
+**or**
+
+- Otherwise orchestrate code reviews by dispatching specialized
+sub-agents in parallel across six review dimensions:
 
 1. **Correctness** — logic errors, edge cases, nil handling, API
    contracts, test adequacy, test integrity (opus)
@@ -74,8 +81,7 @@ parallel across six review dimensions:
 Sub-agent definitions live in `skills/pr-review/sub-agents/`. Each
 sub-agent is a markdown file with frontmatter specifying its `model`
 pin. The `pr-review` skill (orchestrator) handles triage, dispatch,
-and synthesis. The `code-review` skill remains available for standalone
-local reviews outside the PR context.
+and synthesis.
 
 ## Skill routing
 

--- a/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/cross-repo-contracts.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/cross-repo-contracts.md
@@ -1,7 +1,7 @@
 ---
 name: review-cross-repo-contracts
 description: Evaluates backward compatibility of exported interfaces and API contracts.
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 # Cross-Repo Contracts

--- a/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/docs-currency.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/docs-currency.md
@@ -1,7 +1,7 @@
 ---
 name: review-docs-currency
 description: Evaluates documentation staleness against code changes.
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 # Docs Currency

--- a/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/intent-coherence.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/intent-coherence.md
@@ -1,7 +1,7 @@
 ---
 name: review-intent-coherence
 description: Evaluates intent alignment, scope authorization, and architectural coherence.
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 # Intent & Coherence

--- a/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/style-conventions.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/style-conventions.md
@@ -1,7 +1,7 @@
 ---
 name: review-style-conventions
 description: Evaluates repo-specific naming, error-handling idioms, API shape, and code organization.
-model: sonnet
+model: claude-sonnet-4-6
 ---
 
 # Style & Conventions


### PR DESCRIPTION
Claude Code's "sonnet" alias points at "claude-sonnet-4-5@20250929", Vertex has only "claude-sonnet-4-6". Update the sub-agent files to point at the latter.

Bonus commit (which I wanted to include in yesterday's release, but didn't have time for):

The review agent's verbiage explaining the flow and differences between "review" and "pr-review" was unclear at best. This commit clarifies it.