### PR TITLE
fix(dispatch): map fix stage to coder role in per-org scaffold

### DIFF
--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -271,7 +271,7 @@ jobs:
           set -euo pipefail
           STAGE_ROLE="$STAGE"
           case "$STAGE" in
-            code) STAGE_ROLE="coder" ;;
+            code|fix) STAGE_ROLE="coder" ;;
             retro|prioritize) STAGE_ROLE="fullsend" ;;
           esac
 


### PR DESCRIPTION
## Summary

The per-org scaffold `dispatch.yml` is missing the `fix→coder` role mapping that `reusable-dispatch.yml` already has. This causes `/fs-fix` to be silently skipped on all per-org installations:

```
Stage 'fix' skipped — role 'fix' not in defaults.roles
```

## Root cause

Commit `709d8af0` correctly added `code|fix) STAGE_ROLE="coder"` to the scaffold dispatch on main. However, the merge of PR #1022 (`c7c57170`) resolved a conflict in the case statement using the branch version that lacked the `fix` mapping, regressing the fix.

The per-repo path (`reusable-dispatch.yml:267`) was fixed separately in commit `005ac0a1` and survived the merge. Only per-org installations are affected.

## Change

One-line fix: add `fix` to the existing `code)` case in the stage-to-role mapping at `internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml:274`:

```bash
# Before:
code) STAGE_ROLE="coder" ;;

# After:
code|fix) STAGE_ROLE="coder" ;;
```

This aligns with the per-repo dispatch and with `reusable-fix.yml`, which already mints a coder token (`role: coder`).

## Test plan

- Trigger `/fs-fix` on a per-org repo whose `config.yaml` has default roles (no `fix` entry) — dispatch should route to fix stage instead of skipping
- Confirm `code`, `retro`, and `prioritize` stage mappings are unaffected

## Superseded by #1611

**Note:** PR #1611 (ADR 41 — synchronous `workflow_call` dispatch refactor) includes this same fix as part of a larger architectural change that replaces the entire dispatch mechanism. If #1611 merges first, this PR can be closed as superseded. This PR exists as the minimal surgical fix in case #1611 needs more review time.

Partially addresses #1725
Related: #1186 (closed prematurely — only per-repo path was fixed by #1187)