### PR TITLE
fix(harness): exit gracefully when all repos are disabled

### DIFF
--- a/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
@@ -25,14 +25,16 @@ jobs:
       - name: Extract enrolled repo names from config
         id: repo-list
         run: |
-          REPOS=$(yq '.repos | keys | join(",")' config.yaml)
+          REPOS=$(yq '[.repos | to_entries[] | select(.value.enabled == true) | .key] | join(",")' config.yaml)
           if [[ -z "$REPOS" ]]; then
-            echo "::error::No repos found in config.yaml"
-            exit 1
+            echo "::notice::No enabled repos found in config.yaml — nothing to do"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           echo "names=$REPOS" >> "$GITHUB_OUTPUT"
 
       - name: Checkout upstream scripts
+        if: steps.repo-list.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           repository: fullsend-ai/fullsend
@@ -42,6 +44,7 @@ jobs:
             internal/scaffold/fullsend-repo/scripts/
 
       - name: Prepare scripts
+        if: steps.repo-list.outputs.skip != 'true'
         run: |
           set -euo pipefail
           mkdir -p scripts
@@ -57,6 +60,7 @@ jobs:
           rm -rf .defaults
 
       - name: Mint fullsend token
+        if: steps.repo-list.outputs.skip != 'true'
         id: app-token
         uses: fullsend-ai/fullsend/.github/actions/mint-token@v0
         with:
@@ -65,6 +69,7 @@ jobs:
           mint_url: ${{ vars.FULLSEND_MINT_URL }}
 
       - name: Reconcile target repos
+        if: steps.repo-list.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           WORKSPACE: ${{ github.workspace }}


### PR DESCRIPTION
## Summary

- When every repo in `config.yaml` has `enabled: false`, the repo-maintenance workflow now emits a `::notice::` and exits 0 instead of failing with `::error::` and exit 1
- The `yq` query is updated to filter by `enabled == true`, so disabled repos are excluded from reconciliation
- All downstream steps (checkout upstream scripts, prepare scripts, mint token, reconcile) are guarded with `if: steps.repo-list.outputs.skip != 'true'` so they are skipped when there are no enabled repos

Fixes #1735

## Test plan

- [x] YAML parses correctly (verified with Python `yaml.safe_load`)
- [x] `go vet ./...` passes
- [x] `go test ./internal/scaffold/ ./internal/layers/` passes (including `TestWorkflowsLayer_Install_RepoMaintenanceContent`)
- [x] `reconcile-repos-test.sh` passes
- [x] Security review: no secrets exposed, token mint correctly guarded, no new permissions or external actions

Made with [Cursor](https://cursor.com)