### PR TITLE
feat: include fullsend version in scaffold commit messages

### DIFF
--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -965,7 +965,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 
 	printer.StepStart("Writing per-repo scaffold files")
 	committed, err := client.CommitFiles(ctx, owner, repo,
-		"chore: initialize fullsend per-repo installation", files)
+		fmt.Sprintf("chore: initialize fullsend-%s per-repo installation", version), files)
 	if err != nil {
 		printer.StepFail("Failed to write scaffold files")
 		return fmt.Errorf("committing scaffold files: %w", err)
@@ -1680,7 +1680,7 @@ func runUninstall(ctx context.Context, client forge.Client, printer *ui.Printer,
 	emptyCfg := config.NewOrgConfig(nil, nil, nil, nil, "")
 	stack := layers.NewStack(
 		layers.NewConfigRepoLayer(org, client, emptyCfg, printer, false),
-		layers.NewWorkflowsLayer(org, client, printer, ""),
+		layers.NewWorkflowsLayer(org, client, printer, "", version),
 		layers.NewSecretsLayer(org, client, nil, printer),
 		layers.NewInferenceLayer(org, client, nil, printer),
 		dispatchLayer,
@@ -1846,7 +1846,7 @@ func buildLayerStack(
 
 	return layers.NewStack(
 		layers.NewConfigRepoLayer(org, client, cfg, printer, privateRepo),
-		layers.NewWorkflowsLayer(org, client, printer, user),
+		layers.NewWorkflowsLayer(org, client, printer, user, version),
 		layers.NewVendorBinaryLayer(org, forge.ConfigRepoName, client, printer, vendorBinary, vendorFn),
 		layers.NewSecretsLayer(org, client, agentCreds, printer).WithOIDCMode(),
 		layers.NewInferenceLayer(org, client, inferenceProvider, printer),

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -1198,7 +1198,7 @@ func TestCheckInstallScopes_SyncWithLayers(t *testing.T) {
 	emptyCfg := &config.OrgConfig{}
 	stack := layers.NewStack(
 		layers.NewConfigRepoLayer("test-org", nil, emptyCfg, ui.New(&discardWriter{}), false),
-		layers.NewWorkflowsLayer("test-org", nil, ui.New(&discardWriter{}), ""),
+		layers.NewWorkflowsLayer("test-org", nil, ui.New(&discardWriter{}), "", "test-version"),
 		layers.NewSecretsLayer("test-org", nil, nil, ui.New(&discardWriter{})),
 		layers.NewInferenceLayer("test-org", nil, nil, ui.New(&discardWriter{})),
 		layers.NewOIDCDispatchLayer("test-org", nil, nil, nil, ui.New(&discardWriter{})),

--- a/internal/cli/github.go
+++ b/internal/cli/github.go
@@ -280,7 +280,7 @@ func runGitHubSetupPerRepo(ctx context.Context, client forge.Client, printer *ui
 
 	printer.StepStart("Writing per-repo scaffold files")
 	committed, err := client.CommitFiles(ctx, owner, repo,
-		"chore: initialize fullsend per-repo installation", files)
+		fmt.Sprintf("chore: initialize fullsend-%s per-repo installation", version), files)
 	if err != nil {
 		printer.StepFail("Failed to write scaffold files")
 		return fmt.Errorf("committing scaffold files: %w", err)
@@ -989,7 +989,7 @@ func runGitHubSyncScaffold(ctx context.Context, client forge.Client, printer *ui
 		return fmt.Errorf("getting authenticated user: %w", err)
 	}
 
-	workflowsLayer := layers.NewWorkflowsLayer(org, client, printer, user)
+	workflowsLayer := layers.NewWorkflowsLayer(org, client, printer, user, version)
 
 	if err := workflowsLayer.Install(ctx); err != nil {
 		return fmt.Errorf("syncing scaffold: %w", err)

--- a/internal/layers/workflows.go
+++ b/internal/layers/workflows.go
@@ -37,6 +37,7 @@ type WorkflowsLayer struct {
 	client            forge.Client
 	ui                *ui.Printer
 	authenticatedUser string
+	version           string
 }
 
 // Compile-time check that WorkflowsLayer implements Layer.
@@ -44,12 +45,14 @@ var _ Layer = (*WorkflowsLayer)(nil)
 
 // NewWorkflowsLayer creates a new WorkflowsLayer.
 // user is the authenticated user who will own CODEOWNERS entries.
-func NewWorkflowsLayer(org string, client forge.Client, printer *ui.Printer, user string) *WorkflowsLayer {
+// version is the fullsend CLI version that generated the scaffold.
+func NewWorkflowsLayer(org string, client forge.Client, printer *ui.Printer, user, version string) *WorkflowsLayer {
 	return &WorkflowsLayer{
 		org:               org,
 		client:            client,
 		ui:                printer,
 		authenticatedUser: user,
+		version:           version,
 	}
 }
 
@@ -106,7 +109,7 @@ func (l *WorkflowsLayer) Install(ctx context.Context) error {
 
 	l.ui.StepStart("Writing scaffold files")
 	committed, err := l.client.CommitFiles(ctx, l.org, forge.ConfigRepoName,
-		"chore: update fullsend scaffold", files)
+		fmt.Sprintf("chore: update fullsend-%s scaffold", l.version), files)
 	if err != nil {
 		l.ui.StepFail("Failed to write scaffold files")
 		return fmt.Errorf("committing scaffold files: %w", err)

--- a/internal/layers/workflows_test.go
+++ b/internal/layers/workflows_test.go
@@ -19,7 +19,7 @@ func newWorkflowsLayer(t *testing.T, client *forge.FakeClient) (*WorkflowsLayer,
 	t.Helper()
 	var buf bytes.Buffer
 	printer := ui.New(&buf)
-	layer := NewWorkflowsLayer("test-org", client, printer, "admin-user")
+	layer := NewWorkflowsLayer("test-org", client, printer, "admin-user", "test-version")
 	return layer, &buf
 }
 


### PR DESCRIPTION
## Summary

- Scaffold commit messages now include the CLI version that generated them, e.g. `chore: update fullsend-v0.13.0 scaffold`
- Threads the `version` var through `WorkflowsLayer` for org-level scaffold commits
- Uses the package-level `version` directly in the two per-repo install paths (`github.go`, `admin.go`)

## Test plan

- [x] `go test ./internal/layers/ ./internal/cli/` passes
- [x] `make lint` passes