### PR TITLE
feat(retro): add agent-scaffolding skill to retro harness

### DIFF
--- a/internal/scaffold/fullsend-repo/harness/retro.yaml
+++ b/internal/scaffold/fullsend-repo/harness/retro.yaml
@@ -20,6 +20,7 @@ host_files:
 skills:
   - skills/retro-analysis
   - skills/finding-agent-runs
+  - skills/agent-scaffolding
 
 pre_script: scripts/pre-retro.sh
 


### PR DESCRIPTION
## Summary

- Adds the `agent-scaffolding` skill to the retro agent's harness config
- Gives the retro agent access to scaffolding diagnostic principles (verification > documentation, deterministic enforcement, minimal context, etc.) so it can ground improvement recommendations in those ideas

## Test plan

- [ ] Verify retro agent picks up the skill in a test run
- [ ] Check that retro recommendations reference scaffolding principles where relevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)