### PR TITLE
feat(mint): add Cloud Run revision awareness to status and enroll commands

### DIFF
--- a/internal/cli/mint.go
+++ b/internal/cli/mint.go
@@ -528,6 +528,94 @@ func parseAndResolveRoles(rolesStr string) ([]string, error) {
 	return resolved, nil
 }
 
+// verifyEnrollment checks the Cloud Run revision state after enrollment and
+// performs post-write verification by reading back the traffic-serving
+// revision's env vars to confirm the enrollment took effect.
+func verifyEnrollment(ctx context.Context, printer *ui.Printer, provisioner *gcf.Provisioner, org string, appIDs map[string]string, project string) {
+	// Step 4a: Verify revision state.
+	printer.StepStart("Verifying Cloud Run revision state")
+	revInfo, revErr := provisioner.GetServiceRevisionInfo(ctx)
+	if revErr != nil {
+		printer.StepWarn(fmt.Sprintf("Could not verify revision state: %v", revErr))
+	} else if revInfo.TrafficRevisionShort == "" {
+		printer.StepWarn("Could not determine traffic-serving revision")
+	} else if revInfo.TemplateMatchesTraffic {
+		if revInfo.TrafficPercent > 0 {
+			printer.StepDone(fmt.Sprintf("Traffic: %s (%d%%)", revInfo.TrafficRevisionShort, revInfo.TrafficPercent))
+		} else {
+			printer.StepDone(fmt.Sprintf("Traffic: %s", revInfo.TrafficRevisionShort))
+		}
+	} else {
+		printer.StepWarn(fmt.Sprintf("Traffic still on %s — new revision may not be serving", revInfo.TrafficRevisionShort))
+	}
+
+	// Step 4b: Post-write verification — read back the traffic-serving
+	// revision's env vars and confirm the enrollment took effect.
+	// Reuse env vars from GetServiceRevisionInfo when available to avoid
+	// a redundant API round-trip; fall back to GetServiceTrafficEnvVars
+	// if revision info was unavailable.
+	printer.StepStart("Post-write verification")
+	var verifyEnvVars map[string]string
+	if revErr == nil && revInfo.TrafficEnvVars != nil {
+		verifyEnvVars = revInfo.TrafficEnvVars
+	} else {
+		var verifyErr error
+		verifyEnvVars, verifyErr = provisioner.GetServiceTrafficEnvVars(ctx)
+		if verifyErr != nil {
+			printer.StepWarn(fmt.Sprintf("Could not read traffic revision env vars: %v", verifyErr))
+			return
+		}
+	}
+
+	orgPresent := false
+	allowedOrgs := verifyEnvVars["ALLOWED_ORGS"]
+	for _, o := range strings.Split(allowedOrgs, ",") {
+		if strings.EqualFold(strings.TrimSpace(o), org) {
+			orgPresent = true
+			break
+		}
+	}
+
+	// Check ALL expected keys are present, not just any one.
+	var verifyRoleAppIDs map[string]string
+	rolePresent := len(appIDs) == 0 // vacuously true if no keys expected
+	if raw := verifyEnvVars["ROLE_APP_IDS"]; raw != "" {
+		if err := json.Unmarshal([]byte(raw), &verifyRoleAppIDs); err != nil {
+			printer.StepWarn(fmt.Sprintf("ROLE_APP_IDS contains invalid JSON: %v", err))
+		} else {
+			rolePresent = true
+			for key := range appIDs {
+				if _, ok := verifyRoleAppIDs[key]; !ok {
+					rolePresent = false
+					break
+				}
+			}
+		}
+	}
+
+	if orgPresent && rolePresent {
+		orgCount := 0
+		for _, o := range strings.Split(allowedOrgs, ",") {
+			if strings.TrimSpace(o) != "" {
+				orgCount++
+			}
+		}
+		roleCount := len(verifyRoleAppIDs) // reuse already-parsed map
+		printer.StepDone(fmt.Sprintf("ALLOWED_ORGS: %d orgs (%s present)", orgCount, org))
+		printer.StepDone(fmt.Sprintf("ROLE_APP_IDS: %d keys (%s/* present)", roleCount, org))
+	} else {
+		printer.StepFail("Post-write verification FAILED")
+		if !orgPresent {
+			printer.StepInfo(fmt.Sprintf("ALLOWED_ORGS: %s MISSING from traffic-serving revision", org))
+		}
+		if !rolePresent {
+			printer.StepInfo(fmt.Sprintf("ROLE_APP_IDS: %s/* MISSING from traffic-serving revision", org))
+		}
+		printer.StepInfo("The enrollment may not have taken effect on the serving revision.")
+		printer.StepInfo(fmt.Sprintf("Run 'fullsend mint status --project=%s' to investigate.", project))
+	}
+}
+
 func runMintEnrollOrg(ctx context.Context, printer *ui.Printer, org, project, region, appSet, roleAppIDsJSON string, roleList []string, dryRun bool) error {
 	org = strings.ToLower(org)
 	appSet = strings.ToLower(appSet)
@@ -616,6 +704,8 @@ func runMintEnrollOrg(ctx context.Context, printer *ui.Printer, org, project, re
 		return fmt.Errorf("registering org: %w", err)
 	}
 	printer.StepDone("Org registered in mint")
+
+	verifyEnrollment(ctx, printer, provisioner, org, appIDs, project)
 
 	// Step 5: Ensure org is in WIF provider condition.
 	printer.StepStart("Updating WIF provider condition")
@@ -726,6 +816,8 @@ func runMintEnrollRepo(ctx context.Context, printer *ui.Printer, repoFullName, p
 		return fmt.Errorf("registering org: %w", err)
 	}
 	printer.StepDone("Org registered in mint")
+
+	verifyEnrollment(ctx, printer, provisioner, owner, appIDs, project)
 
 	// Step 5: Register per-repo WIF.
 	printer.StepStart("Registering per-repo WIF")
@@ -1223,6 +1315,73 @@ func runMintStatus(ctx context.Context, printer *ui.Printer, project, region, or
 	printer.KeyValue("Project", project)
 	printer.KeyValue("Region", region)
 
+	// Step 2a: Cloud Run revision info.
+	printer.StepStart("Querying Cloud Run revision state")
+	revInfo, revErr := provisioner.GetServiceRevisionInfo(ctx)
+	if revErr != nil {
+		printer.StepWarn(fmt.Sprintf("Could not query Cloud Run revisions: %v", revErr))
+	} else {
+		printer.StepDone("Revision info retrieved")
+		printer.Blank()
+		printer.Header("Cloud Run Revision")
+		if revInfo.TrafficRevisionShort != "" {
+			if revInfo.TrafficPercent > 0 {
+				printer.KeyValue("Traffic", fmt.Sprintf("%s (%d%%)", revInfo.TrafficRevisionShort, revInfo.TrafficPercent))
+			} else {
+				printer.KeyValue("Traffic", revInfo.TrafficRevisionShort)
+			}
+		} else {
+			printer.KeyValue("Traffic", "unknown")
+		}
+
+		allocType := revInfo.TrafficAllocType
+		if allocType == "" {
+			allocType = "unknown"
+		}
+		printer.KeyValue("Alloc type", allocType)
+
+		if revInfo.TemplateMatchesTraffic {
+			printer.KeyValue("Template", fmt.Sprintf("%s (matches traffic)", revInfo.TrafficRevisionShort))
+		} else {
+			// Show a divergence warning.
+			printer.Blank()
+			printer.StepWarn("Service template diverges from traffic-serving revision")
+			printer.StepInfo("Template env vars may not match what the mint is actually serving.")
+			printer.StepInfo(fmt.Sprintf("Traffic revision: %s", revInfo.TrafficRevisionShort))
+			latestShort := revInfo.TemplateRevision
+			if latestShort != "" {
+				parts := strings.Split(latestShort, "/")
+				latestShort = parts[len(parts)-1]
+			}
+			printer.StepInfo(fmt.Sprintf("Template latest:  %s", latestShort))
+		}
+
+		if len(revInfo.RecentRevisions) > 0 {
+			printer.Blank()
+			printer.StepInfo("Recent revisions:")
+			for _, rev := range revInfo.RecentRevisions {
+				status := "Inactive"
+				suffix := ""
+				if rev.Active {
+					status = "Active"
+				}
+				if rev.Name == revInfo.TrafficRevisionShort {
+					suffix = " (current)"
+				}
+				// Format create time to be shorter. Use a safe fallback
+				// if parsing fails to prevent raw API data (which could
+				// contain control characters) from reaching the terminal.
+				createTime := rev.CreateTime
+				if t, err := time.Parse(time.RFC3339Nano, createTime); err == nil {
+					createTime = t.Format("2006-01-02 15:04")
+				} else {
+					createTime = "(unknown)"
+				}
+				printer.StepInfo(fmt.Sprintf("  %s  %s  %-8s%s", rev.Name, createTime, status, suffix))
+			}
+		}
+	}
+
 	// Parse enrolled orgs from ROLE_APP_IDS.
 	var enrolledOrgs []string
 	orgSet := make(map[string]bool)
@@ -1306,15 +1465,25 @@ func runMintStatus(ctx context.Context, printer *ui.Printer, project, region, or
 
 	// Step 4: Determine health.
 	health := "healthy"
+	var healthReasons []string
 	if len(enrolledOrgs) == 0 {
 		health = "degraded"
+		healthReasons = append(healthReasons, "no enrolled orgs")
+	}
+	if revErr == nil && !revInfo.TemplateMatchesTraffic {
+		health = "degraded"
+		healthReasons = append(healthReasons, "template diverges from traffic-serving revision")
 	}
 
 	printer.Blank()
-	printer.Summary("Status", []string{
+	summaryItems := []string{
 		fmt.Sprintf("Health: %s", health),
 		fmt.Sprintf("Enrolled orgs: %d", len(enrolledOrgs)),
-	})
+	}
+	if len(healthReasons) > 0 {
+		summaryItems = append(summaryItems, fmt.Sprintf("Issues: %s", strings.Join(healthReasons, "; ")))
+	}
+	printer.Summary("Status", summaryItems)
 
 	return nil
 }

--- a/internal/dispatch/gcf/gcp.go
+++ b/internal/dispatch/gcf/gcp.go
@@ -54,6 +54,36 @@ type FunctionInfo struct {
 	EnvVars map[string]string
 }
 
+// ServiceRevisionInfo holds Cloud Run service details including which
+// revision is serving traffic, recent revision history, and whether
+// the service template diverges from the traffic-serving revision.
+type ServiceRevisionInfo struct {
+	// TrafficRevision is the full resource name of the revision currently serving traffic.
+	TrafficRevision string
+	// TrafficRevisionShort is the short revision name (e.g., "fullsend-mint-00114-fm9").
+	TrafficRevisionShort string
+	// TrafficAllocType is the traffic allocation type (e.g., "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST").
+	TrafficAllocType string
+	// TrafficPercent is the percentage of traffic the serving revision receives.
+	TrafficPercent int
+	// TemplateRevision is the revision name from the service template (latest created).
+	TemplateRevision string
+	// TemplateMatchesTraffic is true when the template's latest revision matches
+	// the traffic-serving revision.
+	TemplateMatchesTraffic bool
+	// RecentRevisions lists the most recent revisions (up to 5), newest first.
+	RecentRevisions []RevisionSummary
+	// TrafficEnvVars holds the env vars from the traffic-serving revision.
+	TrafficEnvVars map[string]string
+}
+
+// RevisionSummary is a brief snapshot of a Cloud Run revision.
+type RevisionSummary struct {
+	Name       string // short name, e.g. "fullsend-mint-00114-fm9"
+	CreateTime string // RFC3339 timestamp
+	Active     bool   // true if the revision has conditions indicating it is active/ready
+}
+
 // FunctionConfig holds parameters for creating a Cloud Function.
 type FunctionConfig struct {
 	ServiceAccount string
@@ -108,11 +138,18 @@ type GCFClient interface {
 	// matching Cloud Functions deploy behavior). Returns the new revision
 	// name.
 	UpdateServiceEnvVars(ctx context.Context, projectID, region, serviceName string, envVars map[string]string) (string, error)
+
+	// GetServiceRevisionInfo returns Cloud Run service details including the
+	// traffic-serving revision, template revision, allocation type, and recent
+	// revision history. Used by mint status for revision awareness.
+	GetServiceRevisionInfo(ctx context.Context, projectID, region, serviceName string) (*ServiceRevisionInfo, error)
+
 	// GetServiceTrafficEnvVars reads environment variables from the Cloud Run
 	// revision currently serving traffic, rather than from the service template.
 	// This avoids reading stale data when the template and traffic-serving
 	// revision have diverged.
 	GetServiceTrafficEnvVars(ctx context.Context, projectID, region, serviceName string) (map[string]string, error)
+
 	WaitForOperation(ctx context.Context, operationName string) error
 
 	// Project number lookup
@@ -1335,6 +1372,11 @@ func (c *LiveGCFClient) handleCloudRunLRO(ctx context.Context, resp *http.Respon
 // API ever returns unexpected data.
 var revisionNamePattern = regexp.MustCompile(`^projects/[^/]+/locations/[^/]+/services/[^/]+/revisions/[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
+// revisionShortNamePattern validates short Cloud Run revision names
+// (e.g., "fullsend-mint-00114-fm9"). Used to sanitize revision names
+// from list responses before displaying in terminal output.
+var revisionShortNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
 // GetServiceTrafficEnvVars reads environment variables from the Cloud Run
 // revision that is currently serving traffic, rather than from the service
 // template. Although UpdateServiceEnvVars now pins traffic to the new
@@ -1494,6 +1536,181 @@ func (c *LiveGCFClient) waitForCloudRunOperation(ctx context.Context, operationN
 		case <-time.After(3 * time.Second):
 		}
 	}
+}
+
+// GetServiceRevisionInfo returns Cloud Run service details including the
+// traffic-serving revision, template revision, allocation type, and recent
+// revision history.
+func (c *LiveGCFClient) GetServiceRevisionInfo(ctx context.Context, projectID, region, serviceName string) (*ServiceRevisionInfo, error) {
+	serviceURL := fmt.Sprintf("https://run.googleapis.com/v2/projects/%s/locations/%s/services/%s",
+		url.PathEscape(projectID), url.PathEscape(region), url.PathEscape(serviceName))
+
+	// 1. GET the service.
+	getResp, err := c.Client.DoRequest(ctx, http.MethodGet, serviceURL, "")
+	if err != nil {
+		return nil, fmt.Errorf("getting Cloud Run service: %w", err)
+	}
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(getResp.Body, 1<<20))
+		return nil, fmt.Errorf("unexpected status %d getting Cloud Run service: %s", getResp.StatusCode, gcp.ExtractErrorMessage(body))
+	}
+
+	var service struct {
+		Template struct {
+			Revision   string `json:"revision"`
+			Containers []struct {
+				Env []struct {
+					Name  string `json:"name"`
+					Value string `json:"value"`
+				} `json:"env"`
+			} `json:"containers"`
+		} `json:"template"`
+		// trafficStatuses is the observed state (output-only), with resolved
+		// revision names. Preferred over the traffic field (desired/input)
+		// which may have empty revision names for LATEST-type entries.
+		TrafficStatuses []struct {
+			Type     string `json:"type"`
+			Revision string `json:"revision"`
+			Percent  int    `json:"percent"`
+		} `json:"trafficStatuses"`
+		LatestReadyRevision string `json:"latestReadyRevision"`
+	}
+	svcBody, _ := io.ReadAll(io.LimitReader(getResp.Body, 10<<20))
+	if err := json.Unmarshal(svcBody, &service); err != nil {
+		return nil, fmt.Errorf("decoding Cloud Run service: %w", err)
+	}
+
+	info := &ServiceRevisionInfo{
+		TemplateRevision: service.Template.Revision,
+	}
+
+	// Find the revision currently serving the most traffic. Uses
+	// trafficStatuses (observed state) rather than traffic (desired config)
+	// so revision names are always resolved and the data reflects actual
+	// serving state. When traffic is split, pick the highest-percent entry.
+	var maxPercent int
+	for _, t := range service.TrafficStatuses {
+		if t.Percent > maxPercent && t.Revision != "" {
+			maxPercent = t.Percent
+			info.TrafficRevision = t.Revision
+			info.TrafficAllocType = t.Type
+		}
+	}
+
+	info.TrafficPercent = maxPercent
+
+	// Extract short revision name from the full resource name.
+	if info.TrafficRevision != "" {
+		parts := strings.Split(info.TrafficRevision, "/")
+		info.TrafficRevisionShort = parts[len(parts)-1]
+	}
+
+	// Determine if template matches traffic.
+	latestReadyShort := ""
+	if service.LatestReadyRevision != "" {
+		lParts := strings.Split(service.LatestReadyRevision, "/")
+		latestReadyShort = lParts[len(lParts)-1]
+	}
+	if info.TrafficRevisionShort == "" {
+		// Cannot determine traffic state — treat as not matching to avoid false confidence.
+		info.TemplateMatchesTraffic = false
+	} else {
+		info.TemplateMatchesTraffic = info.TrafficRevisionShort == latestReadyShort
+	}
+
+	// 2. List recent revisions.
+	revisionsURL := fmt.Sprintf("%s/revisions?pageSize=5", serviceURL)
+	revListResp, err := c.Client.DoRequest(ctx, http.MethodGet, revisionsURL, "")
+	if err != nil {
+		// Non-fatal: we can still return partial info.
+		return info, nil
+	}
+	defer revListResp.Body.Close()
+
+	if revListResp.StatusCode == http.StatusOK {
+		var revList struct {
+			Revisions []struct {
+				Name       string `json:"name"`
+				CreateTime string `json:"createTime"`
+				Conditions []struct {
+					Type   string `json:"type"`
+					State  string `json:"state"`
+					Status string `json:"status"`
+				} `json:"conditions"`
+			} `json:"revisions"`
+		}
+		revBody, _ := io.ReadAll(io.LimitReader(revListResp.Body, 10<<20))
+		if err := json.Unmarshal(revBody, &revList); err == nil {
+			for _, rev := range revList.Revisions {
+				parts := strings.Split(rev.Name, "/")
+				shortName := parts[len(parts)-1]
+				// Validate revision short name to prevent terminal injection from
+				// malformed API responses. Skip entries that don't match the expected
+				// Cloud Run revision name format.
+				if !revisionShortNamePattern.MatchString(shortName) {
+					continue
+				}
+				active := false
+				for _, cond := range rev.Conditions {
+					if cond.Type == "Ready" && (cond.State == "CONDITION_SUCCEEDED" || cond.Status == "True") {
+						active = true
+						break
+					}
+				}
+				// Mark the traffic-serving revision as active regardless.
+				if shortName == info.TrafficRevisionShort {
+					active = true
+				}
+				info.RecentRevisions = append(info.RecentRevisions, RevisionSummary{
+					Name:       shortName,
+					CreateTime: rev.CreateTime,
+					Active:     active,
+				})
+			}
+		}
+	}
+
+	// 3. Read traffic revision's env vars.
+	if info.TrafficRevision != "" && revisionNamePattern.MatchString(info.TrafficRevision) {
+		revisionURL := fmt.Sprintf("https://run.googleapis.com/v2/%s", info.TrafficRevision)
+		revResp, err := c.Client.DoRequest(ctx, http.MethodGet, revisionURL, "")
+		if err == nil {
+			defer revResp.Body.Close()
+			if revResp.StatusCode == http.StatusOK {
+				var revision struct {
+					Containers []struct {
+						Env []struct {
+							Name  string `json:"name"`
+							Value string `json:"value"`
+						} `json:"env"`
+					} `json:"containers"`
+				}
+				revBody, _ := io.ReadAll(io.LimitReader(revResp.Body, 10<<20))
+				if err := json.Unmarshal(revBody, &revision); err == nil {
+					envVars := make(map[string]string)
+					if len(revision.Containers) > 0 {
+						for _, e := range revision.Containers[0].Env {
+							envVars[e.Name] = e.Value
+						}
+					}
+					info.TrafficEnvVars = envVars
+				}
+			}
+		}
+	}
+
+	// Fall back to template env vars if we couldn't read traffic revision.
+	if info.TrafficEnvVars == nil && len(service.Template.Containers) > 0 {
+		envVars := make(map[string]string)
+		for _, e := range service.Template.Containers[0].Env {
+			envVars[e.Name] = e.Value
+		}
+		info.TrafficEnvVars = envVars
+	}
+
+	return info, nil
 }
 
 // WaitForOperation polls a long-running operation until it completes or

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -1739,6 +1739,18 @@ func (p *Provisioner) DeleteWIFProvider(ctx context.Context, providerID string) 
 	return p.gcpAPI.DeleteWIFProvider(ctx, projectNumber, p.cfg.WIFPoolName, providerID)
 }
 
+// GetServiceRevisionInfo queries the Cloud Run service for revision details
+// including traffic routing, template divergence, and recent revision history.
+func (p *Provisioner) GetServiceRevisionInfo(ctx context.Context) (*ServiceRevisionInfo, error) {
+	return p.gcpAPI.GetServiceRevisionInfo(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
+}
+
+// GetServiceTrafficEnvVars reads env vars from the traffic-serving Cloud Run
+// revision. This is a convenience wrapper around the GCFClient method.
+func (p *Provisioner) GetServiceTrafficEnvVars(ctx context.Context) (map[string]string, error) {
+	return p.gcpAPI.GetServiceTrafficEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
+}
+
 func (p *Provisioner) zeroPEMs() {
 	for role, pem := range p.cfg.AgentPEMs {
 		for i := range pem {

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -88,6 +88,9 @@ type fakeGCFClient struct {
 	// If nil, falls back to functionInfo.EnvVars.
 	trafficEnvVars map[string]string
 
+	// Track revision info for GetServiceRevisionInfo.
+	revisionInfo *ServiceRevisionInfo
+
 	// Captured project IAM binding arguments.
 	projectIAMBindings []projectIAMBinding
 }
@@ -266,6 +269,20 @@ func (f *fakeGCFClient) GetServiceTrafficEnvVars(_ context.Context, _, _, _ stri
 		return f.functionInfo.EnvVars, nil
 	}
 	return nil, nil
+}
+func (f *fakeGCFClient) GetServiceRevisionInfo(_ context.Context, _, _, _ string) (*ServiceRevisionInfo, error) {
+	f.calls = append(f.calls, "GetServiceRevisionInfo")
+	if err := f.errs["GetServiceRevisionInfo"]; err != nil {
+		return nil, err
+	}
+	if f.revisionInfo != nil {
+		return f.revisionInfo, nil
+	}
+	return &ServiceRevisionInfo{
+		TrafficRevisionShort:   "fullsend-mint-00001-abc",
+		TrafficAllocType:       "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST",
+		TemplateMatchesTraffic: true,
+	}, nil
 }
 func (f *fakeGCFClient) WaitForOperation(_ context.Context, _ string) error {
 	return f.record("WaitForOperation")
@@ -3421,4 +3438,95 @@ func TestValidateRegion(t *testing.T) {
 	assert.True(t, ValidateRegion("europe-west4"))
 	assert.False(t, ValidateRegion("invalid"))
 	assert.False(t, ValidateRegion(""))
+}
+
+// --- Cloud Run revision awareness tests ---
+
+func TestProvisioner_GetServiceRevisionInfo(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.revisionInfo = &ServiceRevisionInfo{
+		TrafficRevision:        "projects/p/locations/r/services/s/revisions/fullsend-mint-00114-fm9",
+		TrafficRevisionShort:   "fullsend-mint-00114-fm9",
+		TrafficAllocType:       "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION",
+		TemplateMatchesTraffic: true,
+	}
+
+	p := newTestProvisioner(Config{
+		ProjectID: "my-project",
+		Region:    "us-central1",
+	}, fake)
+
+	info, err := p.GetServiceRevisionInfo(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "fullsend-mint-00114-fm9", info.TrafficRevisionShort)
+	assert.Contains(t, fake.calls, "GetServiceRevisionInfo")
+}
+
+func TestProvisioner_GetServiceTrafficEnvVars(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.trafficEnvVars = map[string]string{
+		"ALLOWED_ORGS": "acme",
+		"ROLE_APP_IDS": `{"acme/coder":"111"}`,
+	}
+
+	p := newTestProvisioner(Config{
+		ProjectID: "my-project",
+		Region:    "us-central1",
+	}, fake)
+
+	envVars, err := p.GetServiceTrafficEnvVars(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "acme", envVars["ALLOWED_ORGS"])
+	assert.Contains(t, fake.calls, "GetServiceTrafficEnvVars")
+}
+
+func TestProvisioner_EnsureOrgInMint_PreservesInfraKeysFromTrafficRevision(t *testing.T) {
+	// UpdateServiceEnvVars on main uses REVISION-pinned routing, so the
+	// traffic-serving revision always contains the full env var set including
+	// infrastructure keys. EnsureOrgInMint builds the updated env vars
+	// entirely from the traffic-serving revision state.
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		URI:     "https://fullsend-mint-abc123.run.app",
+		EnvVars: map[string]string{},
+	}
+	// Traffic revision has both infra keys and org data.
+	fake.trafficEnvVars = map[string]string{
+		"GCP_PROJECT_NUMBER":     "123456789",
+		"WIF_POOL_NAME":          "fullsend-pool",
+		"WIF_PROVIDER_NAME":      "github-oidc",
+		"OIDC_AUDIENCE":          "fullsend-mint",
+		"FULLSEND_SOURCE_HASH":   "abc123",
+		"ALLOWED_ORGS":           "existing-org",
+		"ROLE_APP_IDS":           `{"existing-org/coder":"99999"}`,
+		"ALLOWED_WORKFLOW_FILES": "*",
+	}
+
+	p := newTestProvisioner(Config{
+		ProjectID:  "my-project",
+		GitHubOrgs: []string{"new-org"},
+	}, fake)
+
+	err := p.EnsureOrgInMint(context.Background(), "https://fullsend-mint-abc123.run.app", "new-org", map[string]string{"new-org/coder": "11111"})
+	require.NoError(t, err)
+
+	require.NotNil(t, fake.lastUpdateServiceEnvVars)
+
+	// Infrastructure keys from traffic revision should be preserved.
+	assert.Equal(t, "123456789", fake.lastUpdateServiceEnvVars["GCP_PROJECT_NUMBER"])
+	assert.Equal(t, "fullsend-pool", fake.lastUpdateServiceEnvVars["WIF_POOL_NAME"])
+	assert.Equal(t, "github-oidc", fake.lastUpdateServiceEnvVars["WIF_PROVIDER_NAME"])
+	assert.Equal(t, "fullsend-mint", fake.lastUpdateServiceEnvVars["OIDC_AUDIENCE"])
+	assert.Equal(t, "abc123", fake.lastUpdateServiceEnvVars["FULLSEND_SOURCE_HASH"])
+
+	// Org-relevant keys should include both existing and new org.
+	assert.Contains(t, fake.lastUpdateServiceEnvVars["ALLOWED_ORGS"], "existing-org")
+	assert.Contains(t, fake.lastUpdateServiceEnvVars["ALLOWED_ORGS"], "new-org")
+}
+
+func TestMergeRoleAppIDs_EmptyExistingPreservesDesired(t *testing.T) {
+	existing := map[string]string{"ROLE_APP_IDS": ""}
+	desired := map[string]string{"ROLE_APP_IDS": `{"new-org/coder":"111"}`}
+	mergeRoleAppIDs(existing, desired)
+	assert.Equal(t, `{"new-org/coder":"111"}`, desired["ROLE_APP_IDS"])
 }


### PR DESCRIPTION
## Summary

Add Cloud Run revision awareness to `mint status` and `mint enroll` commands so operators can detect when the service template diverges from the traffic-serving revision (#1858).

Builds on the prerequisite fixes in #1845 and #1846 (now merged).

## Changes

### `mint status` — Revision section
- Reports which Cloud Run revision is serving traffic
- Shows traffic allocation type (LATEST vs REVISION-pinned)
- Detects template/traffic divergence with a warning
- Lists recent revision history (last 5 revisions)
- Flags health as "degraded" when template diverges from traffic

### `mint enroll` — Post-enrollment verification
- Reports which revision is serving after enrollment
- Post-write verification reads back the traffic-serving revision's env vars
- Confirms the enrolled org is present in ALLOWED_ORGS and ROLE_APP_IDS (all keys verified)
- Reports clear success/failure with actionable next steps

### New GCFClient method
- `GetServiceRevisionInfo` — queries Cloud Run for traffic routing (via `trafficStatuses`), revision history, and template divergence

### Provisioner convenience wrappers
- `Provisioner.GetServiceRevisionInfo`
- `Provisioner.GetServiceTrafficEnvVars`

## Test plan
- `make go-test` — all tests pass with race detector
- `make go-vet` — clean
- New tests: `TestProvisioner_GetServiceRevisionInfo`, `TestProvisioner_GetServiceTrafficEnvVars`, `TestProvisioner_EnsureOrgInMint_PreservesInfraKeysFromTrafficRevision`, `TestMergeRoleAppIDs_EmptyExistingPreservesDesired`

## Closes
Closes #1858