### PR TITLE
fix(mint): grant retro role pull_requests:write for PR comments

### DIFF
--- a/docs/guides/infrastructure/infrastructure-reference.md
+++ b/docs/guides/infrastructure/infrastructure-reference.md
@@ -84,7 +84,7 @@ The mint enforces minimum permission sets per role. Tokens cannot exceed these s
 | **coder** | write | write | write | — | read | — | — | — | read |
 | **review** | read | write | write | — | read | — | — | — | read |
 | **fix** | write | write | write | — | — | — | — | — | read |
-| **retro** | read | read | write | read | — | — | — | — | read |
+| **retro** | read | write | write | read | — | — | — | — | read |
 | **prioritize** | read | — | write | — | — | — | — | write | read |
 
 ### Mint Security Controls

--- a/docs/superpowers/specs/2026-05-04-retro-agent-design.md
+++ b/docs/superpowers/specs/2026-05-04-retro-agent-design.md
@@ -50,7 +50,7 @@ Read-only. The retro agent needs:
 - No filesystem write capability
 - No push/commit capability
 
-The sandbox and post-script share a single minted token with `issues:write` and `pull_requests:read`. The sandbox uses it for read operations (`gh run view`, `gh pr view`); the post-script uses it to file issues and post comments.
+The sandbox and post-script share a single minted token with `issues:write` and `pull_requests:write`. The sandbox uses it for read operations (`gh run view`, `gh pr view`); the post-script uses `issues:write` to file issues and `pull_requests:write` to post comments on PRs (GitHub requires `pull_requests:write` to comment on PRs even via the REST Issues endpoint — see [community discussion #26644](https://github.com/orgs/community/discussions/26644)).
 
 ## Input Assembly
 
@@ -152,7 +152,7 @@ How to know the change had the desired effect. Measurable or observable outcomes
 The post-script reads the proposal files from the output directory and:
 
 1. **Files a GitHub issue** for each proposal in the `target_repo` specified in the frontmatter, using `gh issue create`
-2. **Posts a summary comment** on the originating PR or issue using the REST Issues API (`POST /repos/{owner}/{repo}/issues/{number}/comments` via `gh api`), linking to all filed issues. This endpoint only requires `issues:write` and works for both PRs and issues since GitHub treats PRs as issues in the REST API.
+2. **Posts a summary comment** on the originating PR or issue using the REST Issues API (`POST /repos/{owner}/{repo}/issues/{number}/comments` via `gh api`), linking to all filed issues. Despite being an "issues" endpoint, GitHub requires `pull_requests:write` when the target is a PR (see [community discussion #26644](https://github.com/orgs/community/discussions/26644)).
 
 ## Dispatch Integration
 
@@ -184,7 +184,7 @@ A standard dispatch workflow that runs `fullsend run retro` with the provided in
 - **Credential isolation (ADR 0017):** Write credentials (`gh` token with issue-create and comment permissions) are held only by the post-script, outside the sandbox.
 - **Unidirectional control flow (ADR 0016):** The retro agent proposes changes via issues. Changes go through standard review (CODEOWNERS, human approval) and take effect in future invocations, never the current one.
 - **Adversarial feedback risk:** A malicious reviewer could post `/fs-retro` with misleading context to bias the retro agent's proposals. The mitigation is the same human approval gate on the resulting issues — a proposal only takes effect if a maintainer approves and merges the change.
-- **Per-role GitHub App (ADR 0007):** The retro agent gets its own GitHub App with scoped permissions: read access to repos, PRs, workflow runs, and artifacts; write access to issues only. The post-script uses the REST Issues API (`POST /repos/{owner}/{repo}/issues/{number}/comments`) to comment on PRs, which requires only `issues: write` — avoiding `pull_requests: write` and the broader capabilities it grants.
+- **Per-role GitHub App (ADR 0007):** The retro agent gets its own GitHub App with scoped permissions: read access to repos, workflow runs, and artifacts; write access to issues and pull requests. `pull_requests:write` is required by GitHub to comment on PRs even via the REST Issues endpoint ([community discussion #26644](https://github.com/orgs/community/discussions/26644)). This grants broader capabilities than commenting (merge, edit, dismiss reviews), but the retro agent's read-only sandbox and lack of push/commit tools constrain it to comment-only operations.
 
 ## Architectural Constraints
 

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -859,6 +859,16 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 
 	// Phase 2: App creation + mint provisioning based on discovered state.
 	if needAppSetup {
+		// Ensure the mint service account exists before storing PEM
+		// secrets — StoreAgentPEM grants the SA access to each secret,
+		// which fails if the SA hasn't been created yet.
+		if mintProject != "" {
+			prov := gcf.NewProvisioner(gcf.Config{ProjectID: mintProject}, gcf.NewLiveGCFClient(mintProject))
+			if err := prov.EnsureMintServiceAccount(ctx); err != nil {
+				return fmt.Errorf("ensuring mint service account: %w", err)
+			}
+		}
+
 		var sharedSlugs map[string]string
 		if mintProject != "" {
 			slugs, storedIDs, slugErr := copySharedAppPEMs(ctx, client, printer, owner, roles, mintProject, mintRegion)

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -494,6 +494,16 @@ Inference authentication:
 			}
 			printer.Blank()
 
+			// Ensure the mint service account exists before storing PEM
+			// secrets — StoreAgentPEM grants the SA access to each secret,
+			// which fails if the SA hasn't been created yet.
+			if mintProject != "" && !skipAppSetup && !skipMintCheck {
+				prov := gcf.NewProvisioner(gcf.Config{ProjectID: mintProject}, gcf.NewLiveGCFClient(mintProject))
+				if err := prov.EnsureMintServiceAccount(ctx); err != nil {
+					return fmt.Errorf("ensuring mint service account: %w", err)
+				}
+			}
+
 			// Pre-copy PEM secrets for shared public apps before app setup.
 			var sharedSlugs map[string]string
 			var perOrgStoredIDs map[string]string

--- a/internal/dispatch/gcf/mintsrc/mintcore/github.go.embed
+++ b/internal/dispatch/gcf/mintsrc/mintcore/github.go.embed
@@ -44,7 +44,7 @@ var canonicalRolePermissions = map[string]map[string]string{
 	"coder":      {"contents": "write", "pull_requests": "write", "issues": "write", "checks": "read", "metadata": "read"},
 	"review":     {"contents": "read", "pull_requests": "write", "issues": "write", "checks": "read", "metadata": "read"},
 	"fix":        {"contents": "write", "pull_requests": "write", "issues": "write", "metadata": "read"},
-	"retro":      {"actions": "read", "contents": "read", "pull_requests": "read", "issues": "write", "metadata": "read"},
+	"retro":      {"actions": "read", "contents": "read", "pull_requests": "write", "issues": "write", "metadata": "read"},
 	"prioritize": {"contents": "read", "issues": "write", "organization_projects": "write", "metadata": "read"},
 	"fullsend":   {"actions": "write", "actions_variables": "read", "contents": "write", "pull_requests": "write", "workflows": "write", "metadata": "read"},
 }

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -179,6 +179,16 @@ func (p *Provisioner) SecretExists(ctx context.Context, org, role string) (bool,
 	return false, fmt.Errorf("checking secret %s: %w", sid, err)
 }
 
+// EnsureMintServiceAccount creates the mint service account if it does not
+// already exist. Call this before StoreAgentPEM so the IAM binding on
+// secrets can reference the service account.
+func (p *Provisioner) EnsureMintServiceAccount(ctx context.Context) error {
+	if p.cfg.ProjectID == "" {
+		return fmt.Errorf("project ID is required")
+	}
+	return p.gcpAPI.CreateServiceAccount(ctx, p.cfg.ProjectID, saName, "Fullsend token mint Cloud Function")
+}
+
 // StoreAgentPEM persists a single org/role's PEM in Secret Manager.
 // Called during App setup so each PEM is stored immediately after creation.
 func (p *Provisioner) StoreAgentPEM(ctx context.Context, org, role string, pemData []byte) error {

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -432,6 +432,23 @@ func TestStoreAgentPEM_GetSecretNonNotFoundError(t *testing.T) {
 	assert.Contains(t, err.Error(), "permission denied")
 }
 
+func TestEnsureMintServiceAccount(t *testing.T) {
+	fake := newFakeGCFClient()
+	p := newTestProvisioner(Config{ProjectID: "my-project"}, fake)
+
+	err := p.EnsureMintServiceAccount(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"CreateServiceAccount"}, fake.calls)
+}
+
+func TestEnsureMintServiceAccount_MissingProjectID(t *testing.T) {
+	p := newTestProvisioner(Config{}, newFakeGCFClient())
+	err := p.EnsureMintServiceAccount(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project ID is required")
+}
+
 // --- self-managed provision tests ---
 
 func TestProvisioner_Provision_FullFlow(t *testing.T) {

--- a/internal/forge/github/types.go
+++ b/internal/forge/github/types.go
@@ -133,7 +133,7 @@ func AgentAppConfig(org, role, appSet string) AppConfig {
 		base.Permissions = AppPermissions{
 			Actions:      "read",
 			Contents:     "read",
-			PullRequests: "read",
+			PullRequests: "write",
 			Issues:       "write",
 		}
 		// No webhook events — triggered via workflow_dispatch from other agents.

--- a/internal/forge/github/types_test.go
+++ b/internal/forge/github/types_test.go
@@ -94,7 +94,7 @@ func TestAgentAppConfig_Retro(t *testing.T) {
 	assert.Equal(t, "fullsend-retro", cfg.Name)
 	assert.Equal(t, "read", cfg.Permissions.Actions)
 	assert.Equal(t, "read", cfg.Permissions.Contents)
-	assert.Equal(t, "read", cfg.Permissions.PullRequests)
+	assert.Equal(t, "write", cfg.Permissions.PullRequests)
 	assert.Equal(t, "write", cfg.Permissions.Issues)
 	assert.Empty(t, cfg.Permissions.OrganizationProjects)
 

--- a/internal/mintcore/github.go
+++ b/internal/mintcore/github.go
@@ -44,7 +44,7 @@ var canonicalRolePermissions = map[string]map[string]string{
 	"coder":      {"contents": "write", "pull_requests": "write", "issues": "write", "checks": "read", "metadata": "read"},
 	"review":     {"contents": "read", "pull_requests": "write", "issues": "write", "checks": "read", "metadata": "read"},
 	"fix":        {"contents": "write", "pull_requests": "write", "issues": "write", "metadata": "read"},
-	"retro":      {"actions": "read", "contents": "read", "pull_requests": "read", "issues": "write", "metadata": "read"},
+	"retro":      {"actions": "read", "contents": "read", "pull_requests": "write", "issues": "write", "metadata": "read"},
 	"prioritize": {"contents": "read", "issues": "write", "organization_projects": "write", "metadata": "read"},
 	"fullsend":   {"actions": "write", "actions_variables": "read", "contents": "write", "pull_requests": "write", "workflows": "write", "metadata": "read"},
 }

--- a/internal/scaffold/fullsend-repo/policies/retro.yaml
+++ b/internal/scaffold/fullsend-repo/policies/retro.yaml
@@ -4,7 +4,8 @@ version: 1
 #
 # Read-only agent: needs GitHub API (gh run list, gh run view, gh pr view)
 # and Vertex AI for inference. The sandbox token has issues:write (needed by
-# the post-script on the runner) but not pull_requests:write or contents:write.
+# the post-script on the runner) and pull_requests:write (required by GitHub to
+# comment on PRs via the issues endpoint) but not contents:write.
 # curl intentionally excluded to prevent disallowedTools bypass via raw HTTP
 # with the injected GH_TOKEN.
 

--- a/internal/scaffold/fullsend-repo/scripts/post-retro.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-retro.sh
@@ -6,7 +6,7 @@
 #
 # Required env vars:
 #   ORIGINATING_URL — HTML URL of the originating PR or issue
-#   GH_TOKEN        — GitHub token with issues:write scope (no pull_requests:write needed)
+#   GH_TOKEN        — GitHub token with issues:write and pull_requests:write scope
 #
 # The agent writes its result to output/agent-result.json (relative to
 # the iteration directory). This script finds the most recent iteration's output.
@@ -108,9 +108,9 @@ for i in $(seq 0 $((PROPOSAL_COUNT - 1))); do
 done
 
 # Post summary comment on the originating PR/issue.
-# Uses REST API (not gh issue comment) because the GraphQL addComment mutation
-# requires pull_requests:write for PRs. The REST issues endpoint only needs
-# issues:write, which the retro role already has.
+# Uses REST API (not gh issue comment) for consistency. Note: despite being
+# an "issues" endpoint, GitHub requires pull_requests:write when the target
+# number is a PR. See https://github.com/orgs/community/discussions/26644
 SUMMARY=$(jq -r '.summary // empty' "${RESULT_FILE}")
 if [[ -z "${SUMMARY}" ]]; then
   echo "ERROR: .summary is missing or empty in agent result"


### PR DESCRIPTION
## Summary

- Grant retro role `pull_requests:write` in the mint downscope — the retro post-script was getting 403 when commenting on PRs because the minted token only had `pull_requests:read`. All other roles that comment on PRs already had write.
- Bump the retro GitHub App manifest to request `pull_requests:write` (the App permission is the ceiling for what the mint can downscope to).
- Fix the misleading comments in `post-retro.sh` — GitHub requires `pull_requests:write` to comment on PRs even through the issues endpoint.
- Ensure the `fullsend-mint` service account exists before `StoreAgentPEM` tries to grant it IAM access on secrets. On fresh installs the SA didn't exist yet because `Provision()` runs after app setup.

Closes #1076

## Test plan

- [x] `make go-test` passes
- [x] `make lint` passes
- [ ] Fresh `admin install` with `--mint-project` succeeds past app setup