### PR TITLE
perf: cache sandbox image in GitHub Actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -246,29 +246,48 @@ runs:
 
     - name: Restore cached sandbox image
       id: sandbox-cache
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: /tmp/sandbox-image.tar
-        key: sandbox-image-${{ runner.os }}-${{ runner.arch }}
+        key: sandbox-image-${{ runner.os }}-${{ runner.arch }}-${{ env.FULLSEND_SANDBOX_IMAGE || 'ghcr.io/fullsend-ai/fullsend-code:latest' }}
+        restore-keys: |
+          sandbox-image-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Load cached sandbox image
       if: steps.sandbox-cache.outputs.cache-hit == 'true'
       shell: bash
-      run: podman load -i /tmp/sandbox-image.tar
+      run: podman load -i /tmp/sandbox-image.tar || echo "::warning::Cached image load failed; will pull fresh"
 
     - name: Pre-pull sandbox image
+      id: sandbox-pull
       shell: bash
       run: |
         IMAGE="${FULLSEND_SANDBOX_IMAGE:-ghcr.io/fullsend-ai/fullsend-code:latest}"
         echo "Pre-pulling sandbox image: ${IMAGE}"
+        DIGEST_BEFORE="$(podman image inspect --format '{{.Digest}}' -- "${IMAGE}" 2>/dev/null || true)"
         timeout 300 podman pull -- "${IMAGE}" || echo "::warning::Image pre-pull failed; sandbox create will pull on demand"
+        DIGEST_AFTER="$(podman image inspect --format '{{.Digest}}' -- "${IMAGE}" 2>/dev/null || true)"
+        if [ "${DIGEST_BEFORE}" != "${DIGEST_AFTER}" ]; then
+          echo "changed=true" >> "${GITHUB_OUTPUT}"
+        fi
 
     - name: Save sandbox image for cache
-      if: steps.sandbox-cache.outputs.cache-hit != 'true'
+      if: steps.sandbox-cache.outputs.cache-hit != 'true' || steps.sandbox-pull.outputs.changed == 'true'
       shell: bash
       run: |
         IMAGE="${FULLSEND_SANDBOX_IMAGE:-ghcr.io/fullsend-ai/fullsend-code:latest}"
-        podman save -o /tmp/sandbox-image.tar "${IMAGE}"
+        if podman image exists -- "${IMAGE}"; then
+          podman save -o /tmp/sandbox-image.tar -- "${IMAGE}"
+        else
+          echo "::warning::Image not available to cache"
+        fi
+
+    - name: Update sandbox image cache
+      if: steps.sandbox-cache.outputs.cache-hit != 'true' || steps.sandbox-pull.outputs.changed == 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: /tmp/sandbox-image.tar
+        key: sandbox-image-${{ runner.os }}-${{ runner.arch }}-${{ env.FULLSEND_SANDBOX_IMAGE || 'ghcr.io/fullsend-ai/fullsend-code:latest' }}
 
     - name: Install validation dependencies
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -244,12 +244,31 @@ runs:
         openshell gateway add http://127.0.0.1:8080 --local --name local
         openshell gateway select local
 
+    - name: Restore cached sandbox image
+      id: sandbox-cache
+      uses: actions/cache@v4
+      with:
+        path: /tmp/sandbox-image.tar
+        key: sandbox-image-${{ runner.os }}-${{ runner.arch }}
+
+    - name: Load cached sandbox image
+      if: steps.sandbox-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: podman load -i /tmp/sandbox-image.tar
+
     - name: Pre-pull sandbox image
       shell: bash
       run: |
         IMAGE="${FULLSEND_SANDBOX_IMAGE:-ghcr.io/fullsend-ai/fullsend-code:latest}"
         echo "Pre-pulling sandbox image: ${IMAGE}"
         timeout 300 podman pull -- "${IMAGE}" || echo "::warning::Image pre-pull failed; sandbox create will pull on demand"
+
+    - name: Save sandbox image for cache
+      if: steps.sandbox-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        IMAGE="${FULLSEND_SANDBOX_IMAGE:-ghcr.io/fullsend-ai/fullsend-code:latest}"
+        podman save -o /tmp/sandbox-image.tar "${IMAGE}"
 
     - name: Install validation dependencies
       shell: bash


### PR DESCRIPTION
## Summary

- Cache the sandbox container image (`ghcr.io/fullsend-ai/fullsend-code:latest`) using `actions/cache` with `podman save/load`
- On cache hit, `podman load` restores the image from a tarball and `podman pull` becomes a no-op digest check
- Tested in [ralphbean/test-podman-cache](https://github.com/ralphbean/test-podman-cache): **44s → 17s** pull time (~60% reduction)

## Why not cache the raw podman storage?

Rootless podman's overlay storage contains files owned by subuids (user namespace remapping). `tar` can't read them, so `actions/cache` fails on save. Using `podman save/load` to export/import a tarball avoids this.

## Cache behavior

- Key: `sandbox-image-{os}-{arch}` (static per runner type)
- GitHub evicts cache entries after 7 days without access; every run restores the cache, resetting the timer
- On image rebuild: first run is a cache miss (full pull + save), subsequent runs are cache hits

## Test plan

- [x] Validated in [ralphbean/test-podman-cache](https://github.com/ralphbean/test-podman-cache) across 4 runs (baseline, broken approach, cache miss, cache hit)