### PR TITLE
feat: move agent status comments into fullsend run

### DIFF
--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -175,3 +175,7 @@ jobs:
         with:
           agent: code
           version: ${{ inputs.fullsend_version }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          status-repo: ${{ inputs.source_repo }}
+          status-number: ${{ fromJSON(inputs.event_payload).issue.number }}
+          status-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -377,3 +377,7 @@ jobs:
         with:
           agent: fix
           version: ${{ inputs.fullsend_version }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          status-repo: ${{ inputs.source_repo }}
+          status-number: ${{ steps.context.outputs.pr_number }}
+          status-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable-retro.yml
+++ b/.github/workflows/reusable-retro.yml
@@ -150,3 +150,7 @@ jobs:
         with:
           agent: retro
           version: ${{ inputs.fullsend_version }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          status-repo: ${{ inputs.source_repo }}
+          status-number: ${{ fromJSON(inputs.event_payload).pull_request.number || fromJSON(inputs.event_payload).issue.number }}
+          status-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -166,3 +166,7 @@ jobs:
         with:
           agent: review
           version: ${{ inputs.fullsend_version }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          status-repo: ${{ inputs.source_repo }}
+          status-number: ${{ fromJSON(inputs.event_payload).pull_request.number || fromJSON(inputs.event_payload).issue.number }}
+          status-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable-triage.yml
+++ b/.github/workflows/reusable-triage.yml
@@ -146,3 +146,7 @@ jobs:
         with:
           agent: triage
           version: ${{ inputs.fullsend_version }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          status-repo: ${{ inputs.source_repo }}
+          status-number: ${{ fromJSON(inputs.event_payload).issue.number }}
+          status-token: ${{ steps.app-token.outputs.token }}

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,18 @@ inputs:
     description: >-
       GitHub token for authenticated API calls (avoids 60 req/hour unauthenticated rate limit).
     default: ${{ github.token }}
+  run-url:
+    description: URL of the CI/CD run for status comments (optional).
+    default: ""
+  status-repo:
+    description: Repository (owner/repo) for status comments (optional).
+    default: ""
+  status-number:
+    description: Issue/PR number for status comments (optional).
+    default: ""
+  status-token:
+    description: Token for status comments (defaults to GH_TOKEN env var).
+    default: ""
 
 runs:
   using: composite
@@ -262,6 +274,10 @@ runs:
         AGENT: ${{ inputs.agent }}
         FULLSEND_DIR: ${{ inputs.fullsend-dir }}
         TARGET_REPO: ${{ inputs.target-repo }}
+        STATUS_RUN_URL: ${{ inputs.run-url }}
+        STATUS_REPO: ${{ inputs.status-repo }}
+        STATUS_NUMBER: ${{ inputs.status-number }}
+        STATUS_TOKEN: ${{ inputs.status-token }}
       run: |
         set -euo pipefail
         FULLSEND_DIR="${FULLSEND_DIR:-${GITHUB_WORKSPACE}}"
@@ -271,10 +287,24 @@ runs:
         # Post-scripts enforce secret scanning, protected-path blocks,
         # and review-downgrade controls. Skipping them in CI bypasses
         # all post-push security gates.
+        if [[ -n "${STATUS_TOKEN}" ]]; then
+          echo "::add-mask::${STATUS_TOKEN}"
+        fi
+        STATUS_FLAGS=()
+        if [[ -n "${STATUS_REPO}" && -n "${STATUS_NUMBER}" ]]; then
+          STATUS_FLAGS+=(--status-repo "${STATUS_REPO}" --status-number "${STATUS_NUMBER}")
+          if [[ -n "${STATUS_RUN_URL}" ]]; then
+            STATUS_FLAGS+=(--run-url "${STATUS_RUN_URL}")
+          fi
+          if [[ -n "${STATUS_TOKEN}" ]]; then
+            STATUS_FLAGS+=(--status-token "${STATUS_TOKEN}")
+          fi
+        fi
         fullsend run "${AGENT}" \
           --fullsend-dir "${FULLSEND_DIR}" \
           --output-dir "${GITHUB_WORKSPACE}/output" \
-          --target-repo "${TARGET_REPO}"
+          --target-repo "${TARGET_REPO}" \
+          "${STATUS_FLAGS[@]+"${STATUS_FLAGS[@]}"}"
 
     - name: Upload fullsend artifacts
       if: always() && inputs.agent != '__install_only__'

--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -32,6 +32,17 @@ fullsend
 │   ├── uninstall    <org>                   # Remove fullsend GitHub configuration
 │   └── sync-scaffold <org>                  # Update workflow templates
 ├── run                                      # Execute an agent in a sandbox
+│   ├── --fullsend-dir <path>                #   Base directory with .fullsend layout
+│   ├── --target-repo <path>                 #   Path to the target repository
+│   ├── --output-dir <path>                  #   Base directory for run output
+│   ├── --env-file <path>                    #   Load env vars from dotenv file (repeatable)
+│   ├── --no-post-script                     #   Skip post-script execution
+│   ├── --debug [filter]                     #   Enable Claude Code debug logging
+│   ├── --offline                            #   Reject network fetches
+│   ├── --run-url <url>                      #   CI/CD run URL for status comments
+│   ├── --status-repo <owner/repo>           #   Repository for status comments
+│   ├── --status-number <int>                #   Issue/PR number for status comments
+│   └── --status-token <token>               #   Token for status comments (default: GH_TOKEN)
 ├── scan                                     # Run security scanner on input/output
 │   ├── input                                # Scan event payload for prompt injection
 │   ├── output                               # Scan agent output for leaked secrets

--- a/docs/guides/getting-started/installation.md
+++ b/docs/guides/getting-started/installation.md
@@ -687,6 +687,33 @@ fullsend admin install "$ORG_NAME" \
 
 > **Note:** IAM policy bindings may take several minutes to propagate. If agent workflows fail with a permission error immediately after setup, wait a few minutes and retry.
 
+## Status notifications
+
+Agent workflows post status comments on issues and PRs when they start and
+complete. This behavior is controlled by the `status_notifications` section in
+`config.yaml`:
+
+```yaml
+defaults:
+  status_notifications:
+    comment:
+      start: enabled      # "enabled" (default) | "disabled"
+      completion: enabled  # "enabled" (default) | "disabled"
+```
+
+When `status_notifications` is omitted, comments default to enabled.
+
+The composite action accepts four optional inputs for status notifications:
+
+| Input | Description |
+|-------|-------------|
+| `run-url` | URL of the CI/CD run shown in the status comment |
+| `status-repo` | Repository (`owner/repo`) to post status comments on |
+| `status-number` | Issue or PR number for status comments |
+| `status-token` | Token for posting comments (defaults to `GH_TOKEN`) |
+
+All reusable workflows pass these inputs automatically.
+
 ## See Also
 
 - [Setting up with pre-provisioned infrastructure](github-setup.md) — GitHub-only setup when GCP is already provisioned

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -256,7 +256,7 @@ fullsend run triage \
 ```
 
 Status comment behavior is configured via `status_notifications` in
-`config.yaml`. See the [config reference](../../ADRs/0011-admin-install-org-config-yaml-v1.md).
+`config.yaml`. See the [installation guide](../getting-started/installation.md#status-notifications).
 
 ## Simulating Fullsend's real customization layers
 

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -230,6 +230,34 @@ fullsend run code \
   --env-file fullsend-code.env
 ```
 
+### Status notification flags
+
+When running agents locally you can optionally enable status comments on the
+target issue/PR. These flags mirror what the CI workflows pass automatically:
+
+| Flag | Description |
+|------|-------------|
+| `--run-url` | URL of the CI/CD run shown in the status comment |
+| `--status-repo` | Repository (`owner/repo`) to post status comments on |
+| `--status-number` | Issue or PR number for status comments |
+| `--status-token` | Token for posting comments (defaults to `GH_TOKEN`) |
+
+Example:
+
+```bash
+fullsend run triage \
+  --fullsend-dir /tmp/fullsend-ai_fullsend/internal/scaffold/fullsend-repo/ \
+  --target-repo /tmp/target-repo/ \
+  --env-file fullsend-gcp.env \
+  --env-file fullsend-triage.env \
+  --status-repo myorg/myrepo \
+  --status-number 42 \
+  --run-url "https://github.com/myorg/myrepo/actions/runs/12345"
+```
+
+Status comment behavior is configured via `status_notifications` in
+`config.yaml`. See the [config reference](../../ADRs/0011-admin-install-org-config-yaml-v1.md).
+
 ## Simulating Fullsend's real customization layers
 
 Fullsend automatically aggregates different layers of information before running `fullsend run`.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -27,12 +27,14 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/config"
 	"github.com/fullsend-ai/fullsend/internal/envfile"
 	"github.com/fullsend-ai/fullsend/internal/fetch"
+	gh "github.com/fullsend-ai/fullsend/internal/forge/github"
 	"github.com/fullsend-ai/fullsend/internal/harness"
 	"github.com/fullsend-ai/fullsend/internal/resolve"
 	agentruntime "github.com/fullsend-ai/fullsend/internal/runtime"
 	"github.com/fullsend-ai/fullsend/internal/sandbox"
 	"github.com/fullsend-ai/fullsend/internal/scaffold"
 	"github.com/fullsend-ai/fullsend/internal/security"
+	"github.com/fullsend-ai/fullsend/internal/statuscomment"
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
@@ -51,6 +53,14 @@ var agentWorkingDirExcludes = []string{
 	".fullsend-workspace/",
 }
 
+// statusOpts holds the optional status notification parameters for a run.
+type statusOpts struct {
+	runURL      string
+	statusRepo  string
+	statusNum   int
+	statusToken string
+}
+
 func newRunCmd() *cobra.Command {
 	var fullsendDir string
 	var outputBase string
@@ -61,6 +71,7 @@ func newRunCmd() *cobra.Command {
 	var debugFilter string
 	var offline bool
 	var keepSandbox bool
+	var sOpts statusOpts
 
 	cmd := &cobra.Command{
 		Use:   "run <agent-name>",
@@ -70,7 +81,7 @@ func newRunCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agentName := args[0]
 			printer := ui.New(os.Stdout)
-			return runAgent(cmd.Context(), agentName, fullsendDir, outputBase, targetRepo, fullsendBinary, envFiles, noPostScript, debugFilter, offline, printer, keepSandbox)
+			return runAgent(cmd.Context(), agentName, fullsendDir, outputBase, targetRepo, fullsendBinary, envFiles, noPostScript, debugFilter, offline, sOpts, printer, keepSandbox)
 		},
 	}
 
@@ -84,13 +95,17 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&debugFilter, "debug", "", `enable Claude Code debug logging with optional category filter (e.g. "api,hooks")`)
 	cmd.Flags().Lookup("debug").NoOptDefVal = "*"
 	cmd.Flags().BoolVar(&offline, "offline", false, "reject network fetches; only use cached remote resources")
+	cmd.Flags().StringVar(&sOpts.runURL, "run-url", "", "URL of the CI/CD run for status comments")
+	cmd.Flags().StringVar(&sOpts.statusRepo, "status-repo", "", "repository (owner/repo) for status comments")
+	cmd.Flags().IntVar(&sOpts.statusNum, "status-number", 0, "issue/PR number for status comments")
+	cmd.Flags().StringVar(&sOpts.statusToken, "status-token", "", "token for status comments (defaults to GH_TOKEN)")
 	_ = cmd.MarkFlagRequired("fullsend-dir")
 	_ = cmd.MarkFlagRequired("target-repo")
 
 	return cmd
 }
 
-func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRepo, fullsendBinary string, envFiles []string, noPostScript bool, debug string, offline bool, printer *ui.Printer, keepSandbox bool) (runErr error) {
+func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRepo, fullsendBinary string, envFiles []string, noPostScript bool, debug string, offline bool, sOpts statusOpts, printer *ui.Printer, keepSandbox bool) (runErr error) {
 	printer.Banner(Version())
 	printer.Blank()
 	printer.Header("Running agent: " + agentName)
@@ -258,6 +273,38 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 			printer.KeyValue("Token scoped to", strings.Join(repos, ", "))
 		} else if repos != nil {
 			printer.StepWarn("Token is an installation token but has access to 0 repositories")
+		}
+	}
+
+	// 1c. Set up status notifications (comments on the issue/PR).
+	// Lives in the CLI layer (not harness or post-script) so it wraps the
+	// entire run lifecycle including sandbox setup, validation loop, and
+	// post-script — and can report cancellation/failure even when the
+	// sandbox never starts. See #1859.
+	if sOpts.statusRepo != "" && sOpts.statusNum > 0 {
+		notifier, notifyErr := setupStatusNotifier(absFullsendDir, sOpts, printer)
+		if notifyErr != nil {
+			printer.StepWarn("Status notifications disabled: " + notifyErr.Error())
+		} else {
+			description := titleCase(strings.ReplaceAll(agentName, "-", " "))
+			if err := notifier.PostStart(ctx, description); err != nil {
+				printer.StepWarn("Failed to post start status: " + err.Error())
+			} else {
+				printer.StepDone("Posted start status comment")
+			}
+			defer func() {
+				status := "success"
+				if ctx.Err() != nil {
+					status = "cancelled"
+				} else if runErr != nil {
+					status = "failure"
+				}
+				dCtx, dCancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+				defer dCancel()
+				if err := notifier.PostCompletion(dCtx, description, status); err != nil {
+					printer.StepWarn("Failed to post completion status: " + err.Error())
+				}
+			}()
 		}
 	}
 
@@ -1821,4 +1868,57 @@ func crossCompileFullsend(arch, destPath string) error {
 		return fmt.Errorf("cross-compiling for linux/%s: %w", arch, err)
 	}
 	return nil
+}
+
+func titleCase(s string) string {
+	words := strings.Fields(s)
+	for i, w := range words {
+		if len(w) > 0 {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+func setupStatusNotifier(fullsendDir string, sOpts statusOpts, printer *ui.Printer) (*statuscomment.Notifier, error) {
+	parts := strings.SplitN(sOpts.statusRepo, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("--status-repo must be in owner/repo format, got %q", sOpts.statusRepo)
+	}
+	owner, repo := parts[0], parts[1]
+
+	token := sOpts.statusToken
+	if token == "" {
+		token = os.Getenv("GH_TOKEN")
+	}
+	if token == "" {
+		return nil, fmt.Errorf("no status token available (set --status-token or GH_TOKEN)")
+	}
+
+	var notifyCfg config.StatusNotificationConfig
+	orgConfigPath := filepath.Join(fullsendDir, "config.yaml")
+	if data, err := os.ReadFile(orgConfigPath); err == nil {
+		orgCfg, parseErr := config.ParseOrgConfig(data)
+		if parseErr != nil {
+			printer.StepWarn("Failed to parse config.yaml for status notifications: " + parseErr.Error())
+		} else if orgCfg.Defaults.StatusNotifications != nil {
+			notifyCfg = *orgCfg.Defaults.StatusNotifications
+		}
+	} else if !os.IsNotExist(err) {
+		printer.StepWarn("Failed to read config.yaml for status notifications: " + err.Error())
+	}
+
+	client := gh.New(token)
+
+	sha := os.Getenv("GITHUB_SHA")
+	runID := os.Getenv("GITHUB_RUN_ID")
+	if runID == "" {
+		runID = fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+
+	n := statuscomment.New(client, notifyCfg, owner, repo, sOpts.statusNum, sOpts.runURL, sha, runID)
+	n.SetWarnFunc(func(format string, args ...any) {
+		printer.StepWarn(fmt.Sprintf(format, args...))
+	})
+	return n, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,14 +28,31 @@ type InferenceConfig struct {
 	Provider string `yaml:"provider"`
 }
 
+// StatusNotificationConfig controls status comments posted on issues/PRs
+// when agents start and complete.
+type StatusNotificationConfig struct {
+	Comment CommentNotificationConfig `yaml:"comment,omitempty"`
+}
+
+// CommentNotificationConfig controls start/completion comments.
+// Valid values: "enabled" (default when parent is set), "disabled".
+type CommentNotificationConfig struct {
+	Start      string `yaml:"start,omitempty"`
+	Completion string `yaml:"completion,omitempty"`
+}
+
 // RepoDefaults holds default settings applied to all repos.
 type RepoDefaults struct {
-	Roles                    []string `yaml:"roles"`
-	MaxImplementationRetries int      `yaml:"max_implementation_retries"`
-	AutoMerge                bool     `yaml:"auto_merge"`
+	Roles                    []string                  `yaml:"roles"`
+	MaxImplementationRetries int                       `yaml:"max_implementation_retries"`
+	AutoMerge                bool                      `yaml:"auto_merge"`
+	StatusNotifications      *StatusNotificationConfig `yaml:"status_notifications,omitempty"`
 }
 
 // RepoConfig holds per-repo configuration.
+// StatusNotifications is intentionally absent here — notification style is an
+// org-wide UX decision (consistent appearance across all repos), unlike roles
+// and auto_merge which are operationally per-repo.
 type RepoConfig struct {
 	Roles   []string `yaml:"roles,omitempty"`
 	Enabled bool     `yaml:"enabled"`
@@ -159,6 +176,23 @@ func (c *OrgConfig) Validate() error {
 		if !slices.Contains(validProviders, c.Inference.Provider) {
 			return fmt.Errorf("invalid inference provider %q: must be one of %s", c.Inference.Provider, strings.Join(validProviders, ", "))
 		}
+	}
+	if err := validateStatusNotifications(c.Defaults.StatusNotifications); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateStatusNotifications(cfg *StatusNotificationConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	validCommentValues := []string{"", "enabled", "disabled"}
+	if !slices.Contains(validCommentValues, cfg.Comment.Start) {
+		return fmt.Errorf("invalid status_notifications.comment.start %q: must be \"enabled\" or \"disabled\"", cfg.Comment.Start)
+	}
+	if !slices.Contains(validCommentValues, cfg.Comment.Completion) {
+		return fmt.Errorf("invalid status_notifications.comment.completion %q: must be \"enabled\" or \"disabled\"", cfg.Comment.Completion)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -752,3 +752,130 @@ repos: {}
 		assert.NotContains(t, string(data), "allowed_remote_resources")
 	})
 }
+
+// --- StatusNotifications tests ---
+
+func TestParseOrgConfig_WithStatusNotifications(t *testing.T) {
+	yamlData := `
+version: "1"
+dispatch:
+  platform: github-actions
+defaults:
+  roles:
+    - fullsend
+  max_implementation_retries: 2
+  status_notifications:
+    comment:
+      start: enabled
+      completion: disabled
+agents: []
+repos: {}
+`
+	cfg, err := ParseOrgConfig([]byte(yamlData))
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Defaults.StatusNotifications)
+	assert.Equal(t, "enabled", cfg.Defaults.StatusNotifications.Comment.Start)
+	assert.Equal(t, "disabled", cfg.Defaults.StatusNotifications.Comment.Completion)
+}
+
+func TestParseOrgConfig_WithoutStatusNotifications(t *testing.T) {
+	yamlData := `
+version: "1"
+dispatch:
+  platform: github-actions
+defaults:
+  roles:
+    - fullsend
+  max_implementation_retries: 2
+agents: []
+repos: {}
+`
+	cfg, err := ParseOrgConfig([]byte(yamlData))
+	require.NoError(t, err)
+	assert.Nil(t, cfg.Defaults.StatusNotifications)
+}
+
+func TestOrgConfigValidate_ValidStatusNotifications(t *testing.T) {
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend"},
+			MaxImplementationRetries: 2,
+			StatusNotifications: &StatusNotificationConfig{
+				Comment: CommentNotificationConfig{Start: "enabled", Completion: "disabled"},
+			},
+		},
+	}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestOrgConfigValidate_InvalidCommentStart(t *testing.T) {
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend"},
+			MaxImplementationRetries: 2,
+			StatusNotifications: &StatusNotificationConfig{
+				Comment: CommentNotificationConfig{Start: "bogus"},
+			},
+		},
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status_notifications.comment.start")
+}
+
+func TestOrgConfigValidate_InvalidCommentCompletion(t *testing.T) {
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend"},
+			MaxImplementationRetries: 2,
+			StatusNotifications: &StatusNotificationConfig{
+				Comment: CommentNotificationConfig{Completion: "bogus"},
+			},
+		},
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status_notifications.comment.completion")
+}
+
+func TestOrgConfigMarshal_WithStatusNotifications(t *testing.T) {
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend"},
+			MaxImplementationRetries: 2,
+			StatusNotifications: &StatusNotificationConfig{
+				Comment: CommentNotificationConfig{Start: "enabled"},
+			},
+		},
+		Agents: []AgentEntry{},
+		Repos:  map[string]RepoConfig{},
+	}
+	data, err := cfg.Marshal()
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "status_notifications:")
+	assert.Contains(t, string(data), "start: enabled")
+}
+
+func TestOrgConfigMarshal_WithoutStatusNotifications(t *testing.T) {
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{
+			Roles:                    []string{"fullsend"},
+			MaxImplementationRetries: 2,
+		},
+		Agents: []AgentEntry{},
+		Repos:  map[string]RepoConfig{},
+	}
+	data, err := cfg.Marshal()
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "status_notifications")
+}

--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -168,6 +168,7 @@ type FakeClient struct {
 	CreatedReviews      []ReviewRecord
 	DismissedReviews    []DismissedReviewRecord
 	CommittedFiles      []CommitFilesRecord
+	DeletedComments []int // comment IDs
 
 	// internal counters
 	proposalCounter int
@@ -782,6 +783,24 @@ func (f *FakeClient) UpdateIssueComment(_ context.Context, owner, repo string, c
 		for i, c := range comments {
 			if c.ID == commentID {
 				f.IssueComments[key][i].Body = body
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+func (f *FakeClient) DeleteIssueComment(_ context.Context, _, _ string, commentID int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e := f.err("DeleteIssueComment"); e != nil {
+		return e
+	}
+	f.DeletedComments = append(f.DeletedComments, commentID)
+	for key, comments := range f.IssueComments {
+		for i, c := range comments {
+			if c.ID == commentID {
+				f.IssueComments[key] = append(comments[:i], comments[i+1:]...)
 				return nil
 			}
 		}

--- a/internal/forge/fake_test.go
+++ b/internal/forge/fake_test.go
@@ -464,6 +464,9 @@ func TestFakeClient_ErrorInjection(t *testing.T) {
 			_, err := fc.GetOrgVariableRepos(ctx, "o", "n")
 			return err
 		}},
+		{"DeleteIssueComment", func(fc *FakeClient) error {
+			return fc.DeleteIssueComment(ctx, "o", "r", 1)
+		}},
 	}
 
 	for _, m := range methods {
@@ -531,6 +534,7 @@ func TestFakeClient_ThreadSafety(t *testing.T) {
 			_ = fc.DeleteOrgVariable(ctx, "o", "n")
 			_ = fc.SetOrgVariableRepos(ctx, "o", "n", []int64{1, 2})
 			_, _ = fc.GetOrgVariableRepos(ctx, "o", "n")
+			_ = fc.DeleteIssueComment(ctx, "o", "r", 1)
 		}(i)
 	}
 

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -227,6 +227,7 @@ type Client interface {
 	ListIssueComments(ctx context.Context, owner, repo string, number int) ([]IssueComment, error)
 	CreateIssueComment(ctx context.Context, owner, repo string, number int, body string) (*IssueComment, error)
 	UpdateIssueComment(ctx context.Context, owner, repo string, commentID int, body string) error
+	DeleteIssueComment(ctx context.Context, owner, repo string, commentID int) error
 	MinimizeComment(ctx context.Context, nodeID, reason string) error
 
 	// Pull request operations

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -1445,6 +1445,11 @@ func (c *LiveClient) UpdateIssueComment(ctx context.Context, owner, repo string,
 	return nil
 }
 
+// DeleteIssueComment deletes an issue comment by its numeric ID.
+func (c *LiveClient) DeleteIssueComment(ctx context.Context, owner, repo string, commentID int) error {
+	return c.delete_(ctx, fmt.Sprintf("/repos/%s/%s/issues/comments/%d", owner, repo, commentID))
+}
+
 // MinimizeComment minimizes (hides) an issue or review comment via the
 // GitHub GraphQL API. The caller provides the GraphQL node ID directly
 // (available in IssueComment.NodeID and PullRequestReview.NodeID).

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -1415,3 +1415,16 @@ func TestCommitFiles_Empty(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, committed)
 }
+
+func TestDeleteIssueComment(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/repos/org/repo/issues/comments/42", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.DeleteIssueComment(context.Background(), "org", "repo", 42)
+	require.NoError(t, err)
+}

--- a/internal/statuscomment/statuscomment.go
+++ b/internal/statuscomment/statuscomment.go
@@ -167,6 +167,7 @@ func (n *Notifier) analyzeTimeline(ctx context.Context) (agentPosted, startIsLas
 		}
 	}
 	if startIdx < 0 {
+		n.warnf("start comment %d not found on timeline; it may have been deleted externally", n.startCommentID)
 		return false, false, nil
 	}
 

--- a/internal/statuscomment/statuscomment.go
+++ b/internal/statuscomment/statuscomment.go
@@ -1,0 +1,291 @@
+// Package statuscomment posts agent start/completion status comments
+// on issues and pull requests via the forge abstraction.
+//
+// Unlike internal/sticky, which manages persistent bot comments that
+// accumulate history across multiple runs (e.g. review output),
+// statuscomment manages transient lifecycle markers: a start comment
+// created when the agent begins, updated or replaced on completion,
+// and deleted on cancellation. The two packages share the HTML-marker
+// convention but have different lifecycles and placement heuristics.
+package statuscomment
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/fullsend-ai/fullsend/internal/config"
+	"github.com/fullsend-ai/fullsend/internal/forge"
+)
+
+// Notifier manages status comment lifecycle for a single agent run.
+type Notifier struct {
+	client      forge.Client
+	cfg         config.StatusNotificationConfig
+	owner, repo string
+	number      int
+	runURL      string
+	sha         string
+	marker      string
+
+	startCommentID int
+	startTime      time.Time
+	now            func() time.Time
+	warnf          func(string, ...any)
+}
+
+// New creates a Notifier. The runID is embedded in the HTML marker comment
+// so multiple concurrent runs on the same issue don't collide.
+func New(client forge.Client, cfg config.StatusNotificationConfig,
+	owner, repo string, number int, runURL, sha, runID string) *Notifier {
+	return &Notifier{
+		client: client,
+		cfg:    cfg,
+		owner:  owner,
+		repo:   repo,
+		number: number,
+		runURL: runURL,
+		sha:    sha,
+		marker: fmt.Sprintf("<!-- fullsend:agent-status:%s -->", runID),
+		now:    time.Now,
+		warnf:  func(string, ...any) {},
+	}
+}
+
+// SetWarnFunc sets a function called for non-fatal warnings (e.g. API
+// errors during fail-open operations). Defaults to a no-op.
+func (n *Notifier) SetWarnFunc(f func(string, ...any)) {
+	n.warnf = f
+}
+
+func commentEnabled(val string) bool {
+	return val == "" || val == "enabled"
+}
+
+// PostStart posts a start comment on the issue/PR.
+func (n *Notifier) PostStart(ctx context.Context, description string) error {
+	n.startTime = n.now().UTC()
+
+	if commentEnabled(n.cfg.Comment.Start) {
+		body := n.buildStartBody(description)
+		comment, err := n.client.CreateIssueComment(ctx, n.owner, n.repo, n.number, body)
+		if err != nil {
+			return fmt.Errorf("posting start comment: %w", err)
+		}
+		n.startCommentID = comment.ID
+	}
+
+	return nil
+}
+
+// PostCompletion posts or edits a completion comment.
+// status should be "success", "failure", or "cancelled".
+//
+// Cancellation deletes the start comment (if one exists), leaving no
+// trace on the timeline. No completion comment is posted.
+//
+// For success/failure, placement follows three rules:
+//  1. If the agent posted output after the start comment (a bot-authored
+//     comment that is not a status marker), the start comment is updated
+//     in place — the agent's output is the visible forward signal and a
+//     separate end comment would be redundant.
+//  2. If no agent output was posted and the start comment is still the
+//     last entry on the timeline, the start comment is updated in place.
+//  3. Otherwise (other activity pushed past the start, but no agent
+//     output), a new completion comment is posted so the user sees the
+//     result while reading forward.
+func (n *Notifier) PostCompletion(ctx context.Context, description, status string) error {
+	if status == "cancelled" {
+		return n.handleCancelled(ctx)
+	}
+
+	completionTime := n.now().UTC()
+
+	if !commentEnabled(n.cfg.Comment.Completion) {
+		// Completion comments disabled — clean up the start comment so it
+		// doesn't remain orphaned in its "Started" state.
+		if n.startCommentID != 0 {
+			if err := n.client.DeleteIssueComment(ctx, n.owner, n.repo, n.startCommentID); err != nil {
+				n.warnf("failed to delete start comment when completion disabled: %v", err)
+			}
+		}
+		return nil
+	}
+
+	body := n.buildCompletionBody(description, status, completionTime)
+
+	if n.startCommentID != 0 {
+		agentPosted, startIsLast, err := n.analyzeTimeline(ctx)
+		if err != nil {
+			n.warnf("failed to analyze timeline, updating start comment in place: %v", err)
+			if err := n.client.UpdateIssueComment(ctx, n.owner, n.repo, n.startCommentID, body); err != nil {
+				return fmt.Errorf("updating start comment with completion: %w", err)
+			}
+		} else if agentPosted || startIsLast {
+			if err := n.client.UpdateIssueComment(ctx, n.owner, n.repo, n.startCommentID, body); err != nil {
+				return fmt.Errorf("updating start comment with completion: %w", err)
+			}
+		} else {
+			if _, err := n.client.CreateIssueComment(ctx, n.owner, n.repo, n.number, body); err != nil {
+				return fmt.Errorf("posting completion comment: %w", err)
+			}
+		}
+	} else {
+		if _, err := n.client.CreateIssueComment(ctx, n.owner, n.repo, n.number, body); err != nil {
+			return fmt.Errorf("posting completion comment: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (n *Notifier) handleCancelled(ctx context.Context) error {
+	if n.startCommentID != 0 {
+		if err := n.client.DeleteIssueComment(ctx, n.owner, n.repo, n.startCommentID); err != nil {
+			n.warnf("failed to delete start comment on cancellation: %v", err)
+		}
+	}
+	return nil
+}
+
+// analyzeTimeline lists comments and determines two things:
+//   - agentPosted: whether the bot posted non-status output after the start comment
+//   - startIsLast: whether the start comment is the last on the timeline
+func (n *Notifier) analyzeTimeline(ctx context.Context) (agentPosted, startIsLast bool, err error) {
+	comments, err := n.client.ListIssueComments(ctx, n.owner, n.repo, n.number)
+	if err != nil {
+		return false, false, err
+	}
+
+	startIdx := -1
+	for i, c := range comments {
+		if c.ID == n.startCommentID {
+			startIdx = i
+			break
+		}
+	}
+	if startIdx < 0 {
+		return false, false, nil
+	}
+
+	startIsLast = startIdx == len(comments)-1
+
+	botUser, err := n.client.GetAuthenticatedUser(ctx)
+	if err != nil {
+		n.warnf("failed to get authenticated user, falling back to position-only logic: %v", err)
+	}
+	if botUser == "" {
+		return false, startIsLast, nil
+	}
+
+	for _, c := range comments[startIdx+1:] {
+		if c.Author == botUser && !strings.Contains(c.Body, "fullsend:agent-status:") {
+			agentPosted = true
+			break
+		}
+	}
+
+	return agentPosted, startIsLast, nil
+}
+
+func (n *Notifier) buildStartBody(description string) string {
+	var b strings.Builder
+	b.WriteString(n.marker)
+	b.WriteString("\n")
+	fmt.Fprintf(&b, "🤖 %s · Started %s", description, formatTime(n.startTime))
+
+	line2 := n.buildSecondLine()
+	if line2 != "" {
+		b.WriteString("\n")
+		b.WriteString(line2)
+	}
+	return b.String()
+}
+
+func (n *Notifier) buildCompletionBody(description, status string, completionTime time.Time) string {
+	statusLabel := statusEmoji(status) + " " + capitalize(status)
+
+	var b strings.Builder
+	b.WriteString(n.marker)
+	b.WriteString("\n")
+	fmt.Fprintf(&b, "🤖 Finished %s · %s · Started %s · Completed %s",
+		description, statusLabel, formatTime(n.startTime), formatTime(completionTime))
+
+	line2 := n.buildSecondLine()
+	if line2 != "" {
+		b.WriteString("\n")
+		b.WriteString(line2)
+	}
+	return b.String()
+}
+
+func (n *Notifier) buildSecondLine() string {
+	var parts []string
+	if short := shortSHA(n.sha); short != "" {
+		parts = append(parts, fmt.Sprintf("Commit: `%s`", short))
+	}
+	if n.runURL != "" && isSafeURL(n.runURL) {
+		parts = append(parts, fmt.Sprintf("[View workflow run →](%s)", n.runURL))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, " · ")
+}
+
+func isSafeURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "https" {
+		return false
+	}
+	if strings.ContainsAny(raw, ")]\n\r") {
+		return false
+	}
+	return true
+}
+
+func isHexOnly(s string) bool {
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
+func shortSHA(sha string) string {
+	if !isHexOnly(sha) {
+		return ""
+	}
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}
+
+func formatTime(t time.Time) string {
+	return t.Format("3:04 PM UTC")
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func statusEmoji(status string) string {
+	switch status {
+	case "success":
+		return "✅"
+	case "failure":
+		return "❌"
+	default:
+		return "⚠️"
+	}
+}

--- a/internal/statuscomment/statuscomment_test.go
+++ b/internal/statuscomment/statuscomment_test.go
@@ -1,0 +1,526 @@
+package statuscomment
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fullsend-ai/fullsend/internal/config"
+	"github.com/fullsend-ai/fullsend/internal/forge"
+)
+
+func fixedTime() time.Time {
+	return time.Date(2026, 6, 3, 14, 34, 0, 0, time.UTC)
+}
+
+func newTestNotifier(fc *forge.FakeClient, cfg config.StatusNotificationConfig) *Notifier {
+	fc.AuthenticatedUser = "fullsend-bot[bot]"
+	n := New(fc, cfg, "org", "repo", 7, "https://ci/run/42", "a1b2c3d4e5f6789", "run-42")
+	n.now = fixedTime
+	return n
+}
+
+func TestPostStart_CommentEnabled(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Reviewing this PR")
+	require.NoError(t, err)
+
+	comments := fc.IssueComments["org/repo/7"]
+	require.Len(t, comments, 1)
+	assert.Contains(t, comments[0].Body, "<!-- fullsend:agent-status:run-42 -->")
+	assert.Contains(t, comments[0].Body, "🤖 Reviewing this PR · Started 2:34 PM UTC")
+	assert.Contains(t, comments[0].Body, "Commit: `a1b2c3d`")
+	assert.Contains(t, comments[0].Body, "[View workflow run →](https://ci/run/42)")
+}
+
+func TestPostStart_CommentDisabled(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "disabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working on issue")
+	require.NoError(t, err)
+
+	assert.Empty(t, fc.IssueComments)
+}
+
+func TestPostStart_DefaultEnabled(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+
+	assert.Len(t, fc.IssueComments["org/repo/7"], 1)
+}
+
+func TestPostCompletion_EditInPlace(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Reviewing this PR")
+	require.NoError(t, err)
+	require.Equal(t, 1, n.startCommentID)
+
+	completionTime := fixedTime().Add(7 * time.Minute)
+	n.now = func() time.Time { return completionTime }
+
+	err = n.PostCompletion(context.Background(), "Reviewing this PR", "success")
+	require.NoError(t, err)
+
+	require.Len(t, fc.UpdatedComments, 1)
+	assert.Equal(t, 1, fc.UpdatedComments[0].CommentID)
+	assert.Contains(t, fc.UpdatedComments[0].Body, "Finished Reviewing this PR")
+	assert.Contains(t, fc.UpdatedComments[0].Body, "✅ Success")
+	assert.Contains(t, fc.UpdatedComments[0].Body, "Started 2:34 PM UTC")
+	assert.Contains(t, fc.UpdatedComments[0].Body, "Completed 2:41 PM UTC")
+}
+
+func TestPostCompletion_NewComment_WhenInterveningHumanActivity(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Triaging issue")
+	require.NoError(t, err)
+
+	// Simulate a human comment (different author than the bot).
+	fc.IssueComments["org/repo/7"] = append(fc.IssueComments["org/repo/7"], forge.IssueComment{
+		ID:     9999,
+		Body:   "A human comment",
+		Author: "some-human",
+	})
+
+	n.now = func() time.Time { return fixedTime().Add(5 * time.Minute) }
+	err = n.PostCompletion(context.Background(), "Triaging issue", "success")
+	require.NoError(t, err)
+
+	assert.Empty(t, fc.UpdatedComments, "should post new comment when non-bot activity intervenes")
+
+	comments := fc.IssueComments["org/repo/7"]
+	require.Len(t, comments, 3)
+	assert.Contains(t, comments[2].Body, "Finished Triaging issue")
+}
+
+func TestPostCompletion_EditStart_WhenAgentPostedOutput(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Triaging issue")
+	require.NoError(t, err)
+
+	// Agent posts its own output (same bot author, no status marker).
+	fc.CreateIssueComment(context.Background(), "org", "repo", 7, "<!-- fullsend:triage-agent -->\nTriage result here")
+
+	n.now = func() time.Time { return fixedTime().Add(5 * time.Minute) }
+	err = n.PostCompletion(context.Background(), "Triaging issue", "success")
+	require.NoError(t, err)
+
+	// Start comment should be updated in place — agent output is the visible signal.
+	require.Len(t, fc.UpdatedComments, 1)
+	assert.Equal(t, 1, fc.UpdatedComments[0].CommentID)
+	assert.Contains(t, fc.UpdatedComments[0].Body, "Finished Triaging issue")
+
+	// No new completion comment should be created (only start + agent output = 2).
+	comments := fc.IssueComments["org/repo/7"]
+	assert.Len(t, comments, 2)
+}
+
+func TestPostCompletion_EditStart_WhenAgentAndHumanPosted(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Reviewing this PR")
+	require.NoError(t, err)
+
+	// Human comments, then agent posts output.
+	fc.IssueComments["org/repo/7"] = append(fc.IssueComments["org/repo/7"], forge.IssueComment{
+		ID:     9999,
+		Body:   "Human question here",
+		Author: "some-human",
+	})
+	fc.CreateIssueComment(context.Background(), "org", "repo", 7, "<!-- fullsend:review-agent -->\nReview findings")
+
+	n.now = func() time.Time { return fixedTime().Add(7 * time.Minute) }
+	err = n.PostCompletion(context.Background(), "Reviewing this PR", "success")
+	require.NoError(t, err)
+
+	// Agent posted output → edit start in place, even though human also commented.
+	require.Len(t, fc.UpdatedComments, 1)
+	assert.Equal(t, 1, fc.UpdatedComments[0].CommentID)
+	assert.Contains(t, fc.UpdatedComments[0].Body, "Finished Reviewing this PR")
+}
+
+func TestPostCompletion_Cancelled(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+	require.Len(t, fc.IssueComments["org/repo/7"], 1)
+
+	err = n.PostCompletion(context.Background(), "Working", "cancelled")
+	require.NoError(t, err)
+
+	require.Len(t, fc.DeletedComments, 1)
+	assert.Equal(t, 1, fc.DeletedComments[0])
+}
+
+func TestAllDisabled_NoAPICalls(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "disabled", Completion: "disabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+
+	n.now = func() time.Time { return fixedTime().Add(time.Minute) }
+	err = n.PostCompletion(context.Background(), "Working", "success")
+	require.NoError(t, err)
+
+	assert.Empty(t, fc.IssueComments)
+	assert.Empty(t, fc.UpdatedComments)
+}
+
+func TestRunURL_Omitted(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{}
+	n := New(fc, cfg, "org", "repo", 7, "", "abc123", "run-1")
+	n.now = fixedTime
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+
+	body := fc.IssueComments["org/repo/7"][0].Body
+	assert.NotContains(t, body, "View workflow run")
+	assert.Contains(t, body, "Commit: `abc123`")
+}
+
+func TestSHA_Omitted(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{}
+	n := New(fc, cfg, "org", "repo", 7, "https://ci/run/1", "", "run-1")
+	n.now = fixedTime
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+
+	body := fc.IssueComments["org/repo/7"][0].Body
+	assert.NotContains(t, body, "Commit:")
+	assert.Contains(t, body, "[View workflow run →](https://ci/run/1)")
+}
+
+func TestPostCompletion_Failure(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Coding issue #42")
+	require.NoError(t, err)
+
+	n.now = func() time.Time { return fixedTime().Add(10 * time.Minute) }
+	err = n.PostCompletion(context.Background(), "Coding issue #42", "failure")
+	require.NoError(t, err)
+
+	require.Len(t, fc.UpdatedComments, 1)
+	assert.Contains(t, fc.UpdatedComments[0].Body, "❌ Failure")
+}
+
+func TestPostCompletion_UnknownStatus(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+
+	n.now = func() time.Time { return fixedTime().Add(3 * time.Minute) }
+	err = n.PostCompletion(context.Background(), "Working", "timeout")
+	require.NoError(t, err)
+
+	require.Len(t, fc.UpdatedComments, 1)
+	assert.Contains(t, fc.UpdatedComments[0].Body, "⚠️ Timeout")
+}
+
+func TestPostCompletion_NoStartComment(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "disabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+
+	n.now = func() time.Time { return fixedTime().Add(time.Minute) }
+	err = n.PostCompletion(context.Background(), "Working", "success")
+	require.NoError(t, err)
+
+	comments := fc.IssueComments["org/repo/7"]
+	require.Len(t, comments, 1)
+	assert.Contains(t, comments[0].Body, "Finished Working")
+}
+
+func TestCapitalize(t *testing.T) {
+	assert.Equal(t, "Success", capitalize("success"))
+	assert.Equal(t, "Failure", capitalize("failure"))
+	assert.Equal(t, "", capitalize(""))
+}
+
+func TestFormatTime(t *testing.T) {
+	ts := time.Date(2026, 1, 15, 9, 5, 0, 0, time.UTC)
+	assert.Equal(t, "9:05 AM UTC", formatTime(ts))
+}
+
+func TestShortSHA(t *testing.T) {
+	assert.Equal(t, "a1b2c3d", shortSHA("a1b2c3d4e5f6789"))
+	assert.Equal(t, "abc", shortSHA("abc"))
+}
+
+func TestMarkerUniqueness(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{}
+	n1 := New(fc, cfg, "org", "repo", 7, "", "", "run-1")
+	n2 := New(fc, cfg, "org", "repo", 7, "", "", "run-2")
+	assert.NotEqual(t, n1.marker, n2.marker)
+	assert.Contains(t, n1.marker, "run-1")
+	assert.Contains(t, n2.marker, "run-2")
+}
+
+func TestPostCompletion_CompletionDisabled_CleansUpStartComment(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "disabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+	require.Equal(t, 1, n.startCommentID)
+
+	n.now = func() time.Time { return fixedTime().Add(time.Minute) }
+	err = n.PostCompletion(context.Background(), "Working", "success")
+	require.NoError(t, err)
+
+	assert.Empty(t, fc.UpdatedComments, "should not update start comment")
+	require.Len(t, fc.DeletedComments, 1, "should delete orphaned start comment")
+	assert.Equal(t, 1, fc.DeletedComments[0])
+	assert.Empty(t, fc.IssueComments["org/repo/7"], "start comment should be removed")
+}
+
+func TestRunURL_UnsafeDropped(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		inBody bool
+	}{
+		{"https valid", "https://github.com/org/repo/actions/runs/123", true},
+		{"http rejected", "http://example.com/run", false},
+		{"javascript rejected", "javascript:alert(1)", false},
+		{"paren in url", "https://example.com/run)", false},
+		{"bracket in url", "https://evil.com/x](evil)[click", false},
+		{"newline in url", "https://example.com/run\ninjected", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc := forge.NewFakeClient()
+			cfg := config.StatusNotificationConfig{}
+			n := New(fc, cfg, "org", "repo", 7, tt.url, "abc123", "run-1")
+			n.now = fixedTime
+
+			err := n.PostStart(context.Background(), "Working")
+			require.NoError(t, err)
+
+			body := fc.IssueComments["org/repo/7"][0].Body
+			if tt.inBody {
+				assert.Contains(t, body, "View workflow run")
+			} else {
+				assert.NotContains(t, body, "View workflow run")
+			}
+		})
+	}
+}
+
+func TestAnalyzeTimeline_EmptyBotUser_FallsBackToPositionOnly(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	fc.AuthenticatedUser = ""
+	n := New(fc, cfg, "org", "repo", 7, "https://ci/run/42", "a1b2c3d4e5f6789", "run-42")
+	n.now = fixedTime
+
+	err := n.PostStart(context.Background(), "Reviewing this PR")
+	require.NoError(t, err)
+	require.Equal(t, 1, n.startCommentID)
+
+	// Start is the last comment → should edit in place even without bot user identity.
+	n.now = func() time.Time { return fixedTime().Add(5 * time.Minute) }
+	err = n.PostCompletion(context.Background(), "Reviewing this PR", "success")
+	require.NoError(t, err)
+
+	require.Len(t, fc.UpdatedComments, 1, "should edit start in place via startIsLast fallback")
+	assert.Contains(t, fc.UpdatedComments[0].Body, "Finished Reviewing this PR")
+}
+
+func TestAnalyzeTimeline_EmptyBotUser_NewCommentWhenNotLast(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	fc.AuthenticatedUser = ""
+	n := New(fc, cfg, "org", "repo", 7, "https://ci/run/42", "a1b2c3d4e5f6789", "run-42")
+	n.now = fixedTime
+
+	err := n.PostStart(context.Background(), "Reviewing this PR")
+	require.NoError(t, err)
+
+	// Agent posts output, but since botUser is empty it can't be identified as agent output.
+	fc.IssueComments["org/repo/7"] = append(fc.IssueComments["org/repo/7"], forge.IssueComment{
+		ID:     9999,
+		Body:   "Some output",
+		Author: "fullsend-bot[bot]",
+	})
+
+	n.now = func() time.Time { return fixedTime().Add(5 * time.Minute) }
+	err = n.PostCompletion(context.Background(), "Reviewing this PR", "success")
+	require.NoError(t, err)
+
+	// Without bot identity, agentPosted is false and startIsLast is false → new comment.
+	assert.Empty(t, fc.UpdatedComments, "should not edit start when bot identity unknown and not last")
+	comments := fc.IssueComments["org/repo/7"]
+	require.Len(t, comments, 3)
+	assert.Contains(t, comments[2].Body, "Finished Reviewing this PR")
+}
+
+func TestAnalyzeTimeline_GetAuthenticatedUserError_Warns(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	fc.AuthenticatedUser = ""
+	fc.Errors["GetAuthenticatedUser"] = fmt.Errorf("token expired")
+	n := New(fc, cfg, "org", "repo", 7, "https://ci/run/42", "a1b2c3d4e5f6789", "run-42")
+	n.now = fixedTime
+
+	var warnings []string
+	n.SetWarnFunc(func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	})
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+
+	n.now = func() time.Time { return fixedTime().Add(5 * time.Minute) }
+	err = n.PostCompletion(context.Background(), "Working", "success")
+	require.NoError(t, err)
+
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "failed to get authenticated user")
+	assert.Contains(t, warnings[0], "token expired")
+}
+
+func TestShortSHA_NonHexRejected(t *testing.T) {
+	assert.Equal(t, "", shortSHA("not-a-sha"))
+	assert.Equal(t, "", shortSHA("abc`injected"))
+	assert.Equal(t, "", shortSHA(""))
+	assert.Equal(t, "abc123", shortSHA("abc123"))
+	assert.Equal(t, "a1b2c3d", shortSHA("a1b2c3d4e5f6789"))
+	assert.Equal(t, "ABCDEF0", shortSHA("ABCDEF0123456789"))
+}
+
+func TestPostStart_ErrorPropagated(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.Errors["CreateIssueComment"] = fmt.Errorf("api down")
+	cfg := config.StatusNotificationConfig{}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "posting start comment")
+}
+
+func TestPostCompletion_CancelledWithNoStartComment(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "disabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n.startCommentID)
+
+	err = n.PostCompletion(context.Background(), "Working", "cancelled")
+	require.NoError(t, err)
+
+	assert.Empty(t, fc.DeletedComments, "should not attempt deletion when no start comment exists")
+	assert.Empty(t, fc.IssueComments, "should not post any comment")
+}
+
+func TestPostCompletion_AnalyzeTimelineError_UpdatesStartInPlace(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+	require.Equal(t, 1, n.startCommentID)
+
+	// Inject error into ListIssueComments so analyzeTimeline fails.
+	fc.Errors["ListIssueComments"] = fmt.Errorf("api timeout")
+
+	var warnings []string
+	n.SetWarnFunc(func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	})
+
+	n.now = func() time.Time { return fixedTime().Add(5 * time.Minute) }
+	err = n.PostCompletion(context.Background(), "Working", "success")
+	require.NoError(t, err)
+
+	// Should have warned about timeline analysis failure.
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "failed to analyze timeline")
+
+	// Should fall back to updating the start comment in place to avoid orphaning it.
+	require.Len(t, fc.UpdatedComments, 1, "should update start comment on timeline error")
+	assert.Equal(t, 1, fc.UpdatedComments[0].CommentID)
+	assert.Contains(t, fc.UpdatedComments[0].Body, "Finished Working")
+	comments := fc.IssueComments["org/repo/7"]
+	assert.Len(t, comments, 1, "should not create a new comment")
+}


### PR DESCRIPTION
Closes #1859, #1873. Supersedes #1860. Related: #837, #957.

## Summary

Adds forge-portable agent status comments to `fullsend run`. When agents start and complete, the CLI posts status comments on the originating issue/PR — all driven by `config.yaml` settings and passed via CLI flags from the CI dispatcher.

- **Config-driven**: A new `status_notifications` section in `config.yaml` controls comment start/completion (enabled/disabled)
- **Forge-portable**: Uses `forge.Client` interface methods, not `gh` CLI or GitHub-specific shell commands — works for any forge implementation
- **Edit-in-place**: When the start comment is still the last entry on the issue, the completion overwrites it to reduce noise; otherwise a new comment is posted to preserve timeline ordering
- **Non-blocking**: Status notification failures log warnings but never fail the agent run

### Comment format

**Start:**
```
<!-- fullsend:agent-status:{RUN_ID} -->
🤖 Reviewing This PR · Started 2:34 PM UTC
Commit: `a1b2c3d` · [View workflow run →](https://...)
```

**Completion (edited in place when possible):**
```
<!-- fullsend:agent-status:{RUN_ID} -->
🤖 Finished Reviewing This PR · ✅ Success · Started 2:34 PM UTC · Completed 2:41 PM UTC
Commit: `a1b2c3d` · [View workflow run →](https://...)
```

**Cancellation:** Deletes the start comment, leaving no trace on the timeline.

### Config example

```yaml
defaults:
  status_notifications:
    comment:
      start: enabled      # "enabled" (default) | "disabled"
      completion: enabled  # "enabled" (default) | "disabled"
```

When `status_notifications` is omitted from config, comments default to enabled.

## Changes

### Config layer (`internal/config/`)
- `StatusNotificationConfig`, `CommentNotificationConfig` struct types
- `StatusNotifications *StatusNotificationConfig` field on `RepoDefaults` (omitempty — existing configs unaffected)
- Validation: comment values must be `""`, `"enabled"`, or `"disabled"`

### Forge layer (`internal/forge/`)
- 1 new method on `Client` interface: `DeleteIssueComment`
- GitHub implementation: DELETEs by comment ID
- `FakeClient` stub with recorder slice (`DeletedComments`)

### Status comment package (`internal/statuscomment/`)
- New `Notifier` struct managing the full lifecycle
- `PostStart`: creates comment with HTML marker for identification
- `PostCompletion`: finds start comment via timeline analysis, edits in place if still last or if agent posted output, otherwise posts new completion comment
- Cancellation path: deletes start comment
- Completion-disabled path: deletes start comment to prevent orphaning

### CLI wiring (`internal/cli/run.go`)
- New flags: `--run-url`, `--status-repo`, `--status-number`, `--status-token`
- `setupStatusNotifier()` reads `StatusNotifications` from `config.yaml`, creates a `forge/github` client, and returns a `Notifier`
- Posts start comment before sandbox creation; defers completion with success/failure derived from `runErr`
- Falls back to `GH_TOKEN` env var when `--status-token` is not provided
- Uses `GITHUB_SHA` and `GITHUB_RUN_ID` env vars for commit and run identification

### Composite action + workflows
- `action.yml`: 4 new optional inputs (`run-url`, `status-repo`, `status-number`, `status-token`); conditional flag construction in the "Run fullsend" step
- All 5 reusable workflows (`reusable-{code,fix,retro,review,triage}.yml`) pass `run-url`, `status-repo`, `status-number`, `status-token` to the action

## Test plan

- [x] `go test ./internal/config/...` — notification config parse/validate/marshal
- [x] `go test ./internal/forge/github/...` — DeleteIssueComment API test
- [x] `go test ./internal/statuscomment/...` — full lifecycle with FakeClient
- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — clean
- [x] `make lint` — all checks pass
- [ ] Deploy to staging and verify comments appear on a real issue/PR
- [ ] Verify edit-in-place works when no intervening comments
- [ ] Verify new completion comment when human comments between start and completion
- [ ] Verify cancellation deletes the start comment
- [ ] Verify no API calls when `status_notifications` is omitted from config

🤖 Generated with [Claude Code](https://claude.com/claude-code)