### PR TITLE
fix(mint): handle short revision names and update admin guide

### DIFF
--- a/docs/guides/infrastructure/mint-administration.md
+++ b/docs/guides/infrastructure/mint-administration.md
@@ -121,11 +121,44 @@ fullsend mint enroll acme-corp/my-repo --project="$GCP_PROJECT"
 
 Enrollment does **not** grant Agent Platform (inference) access — use `fullsend inference provision` separately after enrollment. See [Installing fullsend](../getting-started/installation.md) for the end-user inference setup path.
 
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--project` | | GCP project ID (required) |
+| `--region` | `us-central1` | Cloud region for the mint service |
+| `--app-set` | `fullsend-ai` | App set to copy PEMs and app IDs from |
+| `--role-app-ids` | | Explicit JSON map of role→app-id (overrides `--app-set`) |
+| `--roles` | `fullsend,triage,coder,review,retro,prioritize` | Comma-separated roles to enroll |
+| `--dry-run` | `false` | Preview changes without making them |
+
 ### What enrollment does
 
-1. Copies GitHub App PEM secrets to the new org's scoped key (`fullsend-{org}--{role}-app-pem`)
-2. Updates the mint Cloud Function environment variables (`ALLOWED_ORGS`, `ROLE_APP_IDS`)
-3. Configures the mint-side WIF provider to accept OIDC tokens from the organization's repositories
+1. Discovers the existing mint infrastructure and resolves role→app-id mappings
+2. Copies GitHub App PEM secrets to the new org's scoped key (`fullsend-{org}--{role}-app-pem`)
+3. Updates the mint Cloud Run service environment variables (`ALLOWED_ORGS`, `ROLE_APP_IDS`) using REVISION-pinned traffic routing
+4. Runs post-enrollment verification (see below)
+5. Configures the mint-side WIF provider to accept OIDC tokens from the organization's repositories
+
+### Post-enrollment verification
+
+After updating the mint, the CLI automatically verifies that the enrollment took effect on the traffic-serving revision:
+
+- **Revision state check** — confirms which Cloud Run revision is serving traffic and whether it matches the latest template
+- **Env var read-back** — reads `ALLOWED_ORGS` and `ROLE_APP_IDS` from the traffic-serving revision (not the template) to confirm the enrolled org is present
+- **Key completeness** — verifies all expected role keys (e.g., `acme-corp/coder`, `acme-corp/review`) are present in `ROLE_APP_IDS`
+
+If verification fails, the CLI prints actionable diagnostics and suggests running `mint status` to investigate. See [Troubleshooting](#troubleshooting) for common failure scenarios.
+
+### REVISION-pinned traffic routing
+
+The CLI updates the Cloud Run service using a two-step process: first it patches the service template (env vars), then it explicitly routes 100% of traffic to the newly created revision. This is called REVISION-pinned routing.
+
+This prevents a class of bugs where the service template is updated but traffic continues serving from an older revision with stale env vars. Without REVISION-pinned routing, a newly enrolled org might not be recognized by the mint because the traffic-serving revision still has the old `ALLOWED_ORGS` value.
+
+### Enrollment ordering
+
+Enroll organizations serially — do not run concurrent enrollment commands against the same mint. The CLI reads the current env vars, merges the new org's entries, and writes the result back. Two concurrent enrollments will race, and one org's entries may be lost.
 
 ## Unenrolling organizations and repositories
 
@@ -139,15 +172,59 @@ fullsend mint unenroll acme-corp --project="$GCP_PROJECT"
 fullsend mint unenroll acme-corp/my-repo --project="$GCP_PROJECT"
 ```
 
-Org-scoped unenroll removes PEM secrets and updates WIF providers. Repo-scoped unenroll only removes or disables the repo-specific WIF provider — it does not touch PEM secrets.
+Org-scoped unenroll disables PEM secrets (or permanently deletes them with `--delete-secrets`) and removes the org from the shared WIF provider's attribute condition. Repo-scoped unenroll only disables the repo-specific WIF provider (or permanently deletes it with `--delete-provider`) — it does not touch PEM secrets.
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--project` | | GCP project ID (required) |
+| `--region` | `us-central1` | Cloud region for the mint service |
+| `--delete-secrets` | `false` | Permanently delete PEM secrets (org-scoped only) |
+| `--delete-provider` | `false` | Permanently delete WIF provider (repo-scoped only) |
+| `--dry-run` | `false` | Preview changes without making them |
+| `--yolo` | `false` | Skip interactive confirmation (for automation) |
 
 ## Checking mint status
 
-`fullsend mint status` inspects the deployed mint function and PEM health. This is a read-only operation requiring only viewer-level access.
+`fullsend mint status` inspects the deployed mint function, Cloud Run revision state, enrolled orgs, and PEM health. This is a read-only operation requiring only viewer-level access.
 
 ```bash
+# Overview of all enrolled orgs
 fullsend mint status --project="$GCP_PROJECT"
+
+# Drill into a specific org's PEM status
+fullsend mint status acme-corp --project="$GCP_PROJECT"
 ```
+
+### What status reports
+
+**Cloud Run revision section:**
+
+- **Traffic revision** — which Cloud Run revision is currently serving requests (e.g., `fullsend-mint-00114-fm9`)
+- **Allocation type** — `TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION` (pinned to a specific revision) or `TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST` (auto-routes to newest)
+- **Template divergence** — a warning when the service template's latest revision does not match the traffic-serving revision, meaning the mint may be serving stale configuration
+- **Recent revisions** — the last 5 revisions with their create time and active/inactive status
+
+**Enrollment section:**
+
+- List of enrolled organizations (parsed from `ROLE_APP_IDS`)
+- Role→app-id mappings per org
+- Per-repo WIF repos list
+
+**Per-org drill-down** (when an org argument is provided):
+
+- PEM secret status for each role (present/missing)
+
+**Health summary:**
+
+The status command reports overall health as one of:
+
+| Health | Condition |
+|--------|-----------|
+| `healthy` | At least one org enrolled, template matches traffic revision |
+| `degraded` | No enrolled orgs, OR template diverges from traffic-serving revision |
+| `not-installed` | Mint function not found in the specified project/region |
 
 ## Multi-org setup
 
@@ -207,6 +284,126 @@ fullsend admin install "$ADDITIONAL_ORG" \
 You can also pass `--mint-url "$MINT_URL"` explicitly to skip the auto-discovery step. PEMs use org-scoped naming (`fullsend-{org}--{role}-app-pem`), so each org's secrets are stored independently. For public apps (shared across orgs), the provisioner copies the same PEM under each org's scoped key.
 
 > **Note:** Multi-org with `--public` requires all orgs to share the same GitHub Apps. Private apps (the default) are single-org only.
+
+## Troubleshooting
+
+### Template/traffic revision divergence
+
+**Symptom:** `mint status` reports health as "degraded" with the message "template diverges from traffic-serving revision".
+
+**What it means:** The Cloud Run service template was updated (e.g., env vars changed) but traffic is still routed to an older revision. The mint is serving requests with the old revision's configuration — newly enrolled orgs may not be recognized.
+
+**Common causes:**
+
+- A manual edit in the GCP Console that updated the template without routing traffic
+- A failed traffic routing step during enrollment (the template PATCH succeeded but the traffic PATCH failed)
+- An external tool (Terraform, `gcloud run deploy`) that doesn't use REVISION-pinned routing
+
+**Resolution:**
+
+1. Run `fullsend mint status --project="$GCP_PROJECT"` to confirm which revision is serving and what the template expects
+2. Re-run `fullsend mint enroll` for any org — this triggers a new revision and routes traffic to it
+3. If no enrollment is needed, manually route traffic with:
+
+   ```bash
+   gcloud run services update-traffic fullsend-mint \
+     --project="$GCP_PROJECT" --region="$MINT_REGION" \
+     --to-latest
+   ```
+
+### Post-enrollment verification failure
+
+**Symptom:** After `mint enroll`, the CLI reports "Post-write verification FAILED" — the enrolled org is missing from the traffic-serving revision's `ALLOWED_ORGS` or `ROLE_APP_IDS`.
+
+**What it means:** The env var update was applied to the service template, but the traffic-serving revision does not reflect the change. This typically means traffic routing did not complete.
+
+**Resolution:**
+
+1. Run `fullsend mint status --project="$GCP_PROJECT"` to check revision state
+2. If the template diverges from traffic, re-run the enrollment command — the CLI will detect the org is already in the template and route traffic to the new revision
+3. Check the CLI output for partial failure messages — if the traffic PATCH failed, the new revision name is reported for manual recovery
+
+### LATEST allocation type
+
+**Symptom:** `mint status` shows allocation type as `TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST` instead of `REVISION`.
+
+**What it means:** Traffic is auto-routed to the newest revision. This can cause issues if a non-enrollment deployment creates a new revision that doesn't include the latest env vars (e.g., deploying new source code via `gcloud functions deploy` without preserving env vars).
+
+**Resolution:** Re-run `fullsend mint enroll` for any org. The CLI always uses REVISION-pinned routing, which overrides the LATEST setting.
+
+### Concurrent enrollment race
+
+**Symptom:** After enrolling two orgs in parallel, one org is missing from `ALLOWED_ORGS` or `ROLE_APP_IDS`.
+
+**What it means:** Both enrollment commands read the same initial state, merged their org independently, and wrote back. The second write overwrote the first org's entries.
+
+**Resolution:**
+
+1. Run `fullsend mint status` to confirm which org is missing
+2. Re-run `fullsend mint enroll` for the missing org
+3. Always enroll orgs serially — one at a time
+
+### Mint not found
+
+**Symptom:** `mint enroll` or `mint status` reports "mint not found in project X region Y".
+
+**Resolution:**
+
+1. Verify the `--project` and `--region` flags match where the mint was deployed
+2. Run `fullsend mint deploy --project="$GCP_PROJECT"` to create the mint if it doesn't exist
+3. If the mint was deployed to a different region, use the correct `--region` flag
+
+### PEM secret errors
+
+**Symptom:** `mint enroll` fails with "source secret not found" or `mint status` reports PEM secrets as missing.
+
+**Common causes:**
+
+- The app set (`--app-set`) doesn't have PEM secrets bootstrapped yet — run `mint deploy --pem-dir` first
+- PEM secrets were disabled (not deleted) during a previous unenroll — the CLI re-enables them automatically during re-enrollment
+- The GCP service account lacks `roles/secretmanager.admin`
+
+### Debugging with gcloud
+
+When the CLI output is insufficient, inspect the Cloud Run service
+directly. The commands below are **read-only** — they do not modify the
+mint.
+
+> **DANGER — never use `--set-env-vars` to modify the mint service.**
+> `--set-env-vars` **replaces all** env vars, destroying ALLOWED_ORGS,
+> ROLE_APP_IDS, PEM secret references, and every other variable. If you
+> need to fix an env var manually, use `--update-env-vars` which
+> **merges** the provided values into the existing set. Prefer
+> `fullsend mint enroll` over manual `gcloud` env var edits — the CLI
+> handles read-merge-write with REVISION-pinned traffic routing.
+
+```bash
+export MINT_SERVICE="fullsend-mint"
+export MINT_REGION="us-central1"  # change if deployed elsewhere
+
+# Read env vars from the traffic-serving revision (not the template)
+TRAFFIC_REV=$(gcloud run services describe "$MINT_SERVICE" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" \
+  --format="value(status.traffic[0].revisionName)")
+gcloud run revisions describe "$TRAFFIC_REV" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" \
+  --format="yaml(spec.containers[0].env)"
+
+# Read env vars from the service template (may differ from traffic)
+gcloud run services describe "$MINT_SERVICE" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" \
+  --format="yaml(spec.template.spec.containers[0].env)"
+
+# List recent revisions
+gcloud run revisions list \
+  --service="$MINT_SERVICE" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" \
+  --limit=5
+
+# Read mint Cloud Function logs
+gcloud functions logs read fullsend-mint \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" --gen2 --limit=50
+```
 
 ## See Also
 

--- a/internal/dispatch/gcf/gcp.go
+++ b/internal/dispatch/gcf/gcp.go
@@ -1308,12 +1308,24 @@ func (c *LiveGCFClient) UpdateServiceEnvVars(ctx context.Context, projectID, reg
 		return "", fmt.Errorf("Cloud Run service has no latestCreatedRevision after template update")
 	}
 
+	// The Cloud Run v2 API returns fully qualified revision names from GET
+	// (projects/P/locations/L/services/S/revisions/R) but the traffic PATCH
+	// expects short names (e.g., "fullsend-mint-00115-qp5"). Extract the
+	// short name for the traffic payload.
+	revisionShort := newRevision
+	if parts := strings.Split(newRevision, "/"); len(parts) > 1 {
+		revisionShort = parts[len(parts)-1]
+	}
+	if !revisionShortNamePattern.MatchString(revisionShort) {
+		return "", fmt.Errorf("unexpected revision name format in latestCreatedRevision: %q", newRevision)
+	}
+
 	// Step 4: PATCH traffic to pin 100% to the new revision.
 	trafficPayload, err := json.Marshal(map[string]interface{}{
 		"traffic": []map[string]interface{}{
 			{
 				"type":     "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION",
-				"revision": newRevision,
+				"revision": revisionShort,
 				"percent":  100,
 			},
 		},
@@ -1375,7 +1387,7 @@ var revisionNamePattern = regexp.MustCompile(`^projects/[^/]+/locations/[^/]+/se
 // revisionShortNamePattern validates short Cloud Run revision names
 // (e.g., "fullsend-mint-00114-fm9"). Used to sanitize revision names
 // from list responses before displaying in terminal output.
-var revisionShortNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+var revisionShortNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 
 // GetServiceTrafficEnvVars reads environment variables from the Cloud Run
 // revision that is currently serving traffic, rather than from the service
@@ -1452,13 +1464,22 @@ func (c *LiveGCFClient) GetServiceTrafficEnvVars(ctx context.Context, projectID,
 		return envVars, nil
 	}
 
-	// Validate revision resource name before URL construction.
-	if !revisionNamePattern.MatchString(trafficRevision) {
+	// The Cloud Run v2 API may return either a fully qualified resource name
+	// (projects/P/locations/L/services/S/revisions/R) or a short revision
+	// name (e.g., "fullsend-mint-00114-fm9"). Validate whichever format we
+	// receive and construct the full URL accordingly.
+	var revisionResourceName string
+	if revisionNamePattern.MatchString(trafficRevision) {
+		revisionResourceName = trafficRevision
+	} else if revisionShortNamePattern.MatchString(trafficRevision) {
+		revisionResourceName = fmt.Sprintf("projects/%s/locations/%s/services/%s/revisions/%s",
+			url.PathEscape(projectID), url.PathEscape(region), url.PathEscape(serviceName), url.PathEscape(trafficRevision))
+	} else {
 		return nil, fmt.Errorf("unexpected traffic revision name format: %q", trafficRevision)
 	}
 
 	// GET the specific traffic-serving revision.
-	revisionURL := fmt.Sprintf("https://run.googleapis.com/v2/%s", trafficRevision)
+	revisionURL := fmt.Sprintf("https://run.googleapis.com/v2/%s", revisionResourceName)
 	revResp, err := c.Client.DoRequest(ctx, http.MethodGet, revisionURL, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting traffic-serving revision: %w", err)
@@ -1673,8 +1694,22 @@ func (c *LiveGCFClient) GetServiceRevisionInfo(ctx context.Context, projectID, r
 	}
 
 	// 3. Read traffic revision's env vars.
-	if info.TrafficRevision != "" && revisionNamePattern.MatchString(info.TrafficRevision) {
-		revisionURL := fmt.Sprintf("https://run.googleapis.com/v2/%s", info.TrafficRevision)
+	// Accept both fully qualified resource names and short revision names.
+	var revResourceName string
+	if info.TrafficRevision != "" {
+		if revisionNamePattern.MatchString(info.TrafficRevision) {
+			revResourceName = info.TrafficRevision
+		} else if revisionShortNamePattern.MatchString(info.TrafficRevision) {
+			revResourceName = fmt.Sprintf("projects/%s/locations/%s/services/%s/revisions/%s",
+				url.PathEscape(projectID), url.PathEscape(region), url.PathEscape(serviceName), url.PathEscape(info.TrafficRevision))
+		}
+		// When format matches neither pattern, revResourceName stays empty
+		// and the env var read below is skipped. This is intentional:
+		// GetServiceRevisionInfo returns partial data on non-fatal errors,
+		// matching the pattern at the revision list step above.
+	}
+	if revResourceName != "" {
+		revisionURL := fmt.Sprintf("https://run.googleapis.com/v2/%s", revResourceName)
 		revResp, err := c.Client.DoRequest(ctx, http.MethodGet, revisionURL, "")
 		if err == nil {
 			defer revResp.Body.Close()

--- a/internal/dispatch/gcf/gcp_test.go
+++ b/internal/dispatch/gcf/gcp_test.go
@@ -975,6 +975,59 @@ func TestLiveGCFClient_UpdateServiceEnvVars(t *testing.T) {
 		assert.Equal(t, 4, callCount)
 	})
 
+	t.Run("success_extracts_short_name_from_fq_latestCreatedRevision", func(t *testing.T) {
+		// When latestCreatedRevision returns a fully qualified name,
+		// the traffic PATCH must use the short name.
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			switch callCount {
+			case 1:
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(serviceWithRevision("my-svc-00042-abc"))
+			case 2:
+				assert.Equal(t, http.MethodPatch, r.Method)
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{"done": true})
+			case 3:
+				// GET returns FQ latestCreatedRevision
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"latestCreatedRevision": "projects/proj/locations/us-central1/services/my-svc/revisions/my-svc-00043-def",
+					"template": map[string]interface{}{
+						"revision": "my-svc-00043-def",
+						"containers": []interface{}{
+							map[string]interface{}{
+								"image": "gcr.io/proj/mint:latest",
+								"env":   []interface{}{},
+							},
+						},
+					},
+				})
+			case 4:
+				// Traffic PATCH must use short name, not FQ
+				assert.Equal(t, http.MethodPatch, r.Method)
+				var body map[string]interface{}
+				json.NewDecoder(r.Body).Decode(&body)
+				traffic := body["traffic"].([]interface{})
+				require.Len(t, traffic, 1)
+				entry := traffic[0].(map[string]interface{})
+				assert.Equal(t, "my-svc-00043-def", entry["revision"], "traffic PATCH must use short revision name")
+
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{"done": true})
+			}
+		}))
+		defer srv.Close()
+
+		rev, err := newTestClient(srv).UpdateServiceEnvVars(context.Background(), "proj", "us-central1", "my-svc", map[string]string{
+			"ALLOWED_ORGS": "org1",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "projects/proj/locations/us-central1/services/my-svc/revisions/my-svc-00043-def", rev, "returns FQ name from latestCreatedRevision")
+		assert.Equal(t, 4, callCount)
+	})
+
 	t.Run("success_with_polling", func(t *testing.T) {
 		// Template PATCH returns a pending LRO that must be polled.
 		callCount := 0
@@ -1856,6 +1909,118 @@ func TestLiveGCFClient_GetServiceTrafficEnvVars(t *testing.T) {
 		_, err := newTestClient(srv).GetServiceTrafficEnvVars(context.Background(), "proj", "us-central1", "my-svc")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unexpected status 500")
+	})
+
+	t.Run("reads_from_short_revision_name_in_traffic", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount == 1 {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "/services/my-svc")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"template": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"env": []interface{}{
+									map[string]string{"name": "ALLOWED_ORGS", "value": ""},
+								},
+							},
+						},
+					},
+					"trafficStatuses": []interface{}{
+						map[string]interface{}{
+							"type":     "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION",
+							"revision": "my-svc-00114-fm9",
+							"percent":  100,
+						},
+					},
+				})
+				return
+			}
+			// Verify the revision URL is properly constructed from the short name.
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Contains(t, r.URL.Path, "/projects/proj/locations/us-central1/services/my-svc/revisions/my-svc-00114-fm9")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"containers": []interface{}{
+					map[string]interface{}{
+						"env": []interface{}{
+							map[string]string{"name": "ALLOWED_ORGS", "value": "org-short"},
+						},
+					},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		envVars, err := newTestClient(srv).GetServiceTrafficEnvVars(context.Background(), "proj", "us-central1", "my-svc")
+		require.NoError(t, err)
+		assert.Equal(t, "org-short", envVars["ALLOWED_ORGS"])
+		assert.Equal(t, 2, callCount)
+	})
+}
+
+// --- GetServiceRevisionInfo (short revision names) ---
+
+func TestLiveGCFClient_GetServiceRevisionInfo_ShortRevisionName(t *testing.T) {
+	t.Run("constructs_revision_url_from_short_name", func(t *testing.T) {
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			switch callCount {
+			case 1:
+				// GET service
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "/services/my-svc")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"template": map[string]interface{}{
+						"revision":  "my-svc-00042-abc",
+						"containers": []interface{}{map[string]interface{}{}},
+					},
+					"trafficStatuses": []interface{}{
+						map[string]interface{}{
+							"type":     "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION",
+							"revision": "my-svc-00042-abc",
+							"percent":  100,
+						},
+					},
+					"latestReadyRevision": "my-svc-00042-abc",
+				})
+			case 2:
+				// GET revisions list
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "/revisions")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"revisions": []interface{}{},
+				})
+			case 3:
+				// GET revision by short-name-constructed URL
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "/projects/proj/locations/us-central1/services/my-svc/revisions/my-svc-00042-abc")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"env": []interface{}{
+								map[string]string{"name": "ALLOWED_ORGS", "value": "org-x"},
+							},
+						},
+					},
+				})
+			}
+		}))
+		defer srv.Close()
+
+		info, err := newTestClient(srv).GetServiceRevisionInfo(context.Background(), "proj", "us-central1", "my-svc")
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "my-svc-00042-abc", info.TrafficRevisionShort)
+		assert.Equal(t, "org-x", info.TrafficEnvVars["ALLOWED_ORGS"])
+		assert.Equal(t, 3, callCount)
 	})
 }
 

--- a/skills/mint-enroll/SKILL.md
+++ b/skills/mint-enroll/SKILL.md
@@ -49,7 +49,7 @@ Verify credentials and that the fullsend CLI is available:
 
 ```bash
 gcloud auth list --filter=status:ACTIVE --format="value(account)"
-fullsend version
+fullsend --version
 ```
 
 ## Constraints

--- a/skills/mint-enroll/SKILL.md
+++ b/skills/mint-enroll/SKILL.md
@@ -2,16 +2,22 @@
 name: mint-enroll
 description: >
   SRE runbook for enrolling new GitHub orgs or repos into the fullsend token
-  mint service. Use when onboarding a new org, adding a per-repo WIF provider,
-  copying shared app PEM secrets, or updating mint Cloud Function env vars.
+  mint service using the fullsend CLI. Use when onboarding a new org, adding a
+  per-repo WIF provider, or re-enrolling after infrastructure changes.
 allowed-tools: Bash
+triggers:
+  - mint enroll
+  - onboard org
+  - enroll organization
+  - enroll repo
+  - mint onboarding
 ---
 
 # Mint Service Enrollment
 
-Enroll a new GitHub org or per-repo into the fullsend token mint. The mint is
-a stateless GCP Cloud Function that exchanges GitHub OIDC JWTs for scoped
-GitHub App installation tokens.
+Enroll a new GitHub org or per-repo into the fullsend token mint using the
+`fullsend mint` CLI. The mint is a stateless GCP Cloud Function that exchanges
+GitHub OIDC JWTs for scoped GitHub App installation tokens.
 
 Follow these steps in order. Do not skip steps.
 
@@ -21,53 +27,42 @@ wrong project.
 
 ## Setup
 
-Collect deployment-specific values. Never hardcode project names, IDs, or
-URLs — resolve them from the deployed resources.
+**STOP — ask the operator for these values before proceeding:**
 
-The operator needs these IAM roles on the GCP project: Secret Manager Admin,
-Workload Identity Pool Admin, Cloud Functions Developer, Cloud Run Admin.
+- `GCP_PROJECT` — the GCP project ID where the mint is deployed. Do not
+  infer from `gcloud config get-value project`.
+- `MINT_REGION` — the Cloud region (default: `us-central1`). Confirm with
+  the operator if unsure.
+- `TARGET` — the GitHub org (`acme`) or repo (`acme/widget`) to enroll.
 
 ```bash
-set -o pipefail
 GCP_PROJECT="<your-gcp-project-id>"
-MINT_FUNCTION="fullsend-mint"
-MINT_REGION="us-central1"
-WIF_POOL="fullsend-pool"
-APP_SET="fullsend-ai"
-SA_EMAIL="fullsend-mint@${GCP_PROJECT}.iam.gserviceaccount.com"
+MINT_REGION="us-central1"   # default; change if deployed elsewhere
+```
 
-GCP_PROJECT_NUMBER=$(gcloud projects describe "${GCP_PROJECT}" --format="value(projectNumber)") \
-  || { echo "ERROR: failed to resolve project number for ${GCP_PROJECT}" >&2; exit 1; }
-MINT_URL=$(gcloud functions describe "${MINT_FUNCTION}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" --gen2 \
-  --format="value(serviceConfig.uri)") \
-  || { echo "ERROR: failed to resolve mint URL" >&2; exit 1; }
-MINT_SERVICE_FULL=$(gcloud functions describe "${MINT_FUNCTION}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" --gen2 \
-  --format="value(serviceConfig.service)") \
-  || { echo "ERROR: failed to resolve mint service" >&2; exit 1; }
-MINT_SERVICE=$(basename "${MINT_SERVICE_FULL}")
-WIF_POOL_RESOURCE=$(gcloud iam workload-identity-pools describe "${WIF_POOL}" \
-  --project="${GCP_PROJECT}" --location=global \
-  --format="value(name)") \
-  || { echo "ERROR: WIF pool '${WIF_POOL}' not found in ${GCP_PROJECT}" >&2; exit 1; }
-WIF_POOL_LOCATION=$(echo "${WIF_POOL_RESOURCE}" | sed 's|.*/locations/\([^/]*\)/.*|\1|')
-if [ -z "${WIF_POOL_LOCATION}" ]; then
-  echo "ERROR: could not resolve WIF pool location from ${WIF_POOL_RESOURCE}" >&2; exit 1
-fi
+Verify the operator has the required IAM roles: Secret Manager Admin,
+Workload Identity Pool Admin, Cloud Functions Viewer, Cloud Run Admin.
+Per-repo enrollment additionally requires Project IAM Admin (to grant
+`roles/aiplatform.user` to the repo WIF principal).
+
+Verify credentials and that the fullsend CLI is available:
+
+```bash
+gcloud auth list --filter=status:ACTIVE --format="value(account)"
+fullsend version
 ```
 
 ## Constraints
 
-- **NEVER use `--set-env-vars`** — always `--update-env-vars` (set replaces ALL env vars).
-- **NEVER remove entries** — only add/merge. Removal is a separate deliberate operation (see Rollback).
-- **No concurrent enrollment** — two operators reading and writing env vars simultaneously will race. Coordinate enrollment operations serially.
-- **Always check before create** — read current state, show diff, then apply.
-- **Dual audiences on per-repo WIF providers** — always include both `fullsend-mint` AND the full IAM URL. Exception: orgs using external inference (e.g., agentshed) only need `fullsend-mint`.
-- **PEM secret naming** — `fullsend-{org}--{role}-app-pem` (double-dash separator).
-- **WIF provider ID** — `gh-{owner}-{repo}` (lowercase, max 32 chars, no trailing hyphen). Non-alphanumeric characters are replaced with hyphens. Long names are truncated at 32 chars with trailing hyphens stripped. Consecutive hyphens are NOT collapsed (matches Go code) — verify the generated ID is unique.
-- **Use `gcloud run services update` for env var changes** — `gcloud functions deploy --update-env-vars` triggers a full rebuild. Update the underlying Cloud Run service (`MINT_SERVICE`) directly to apply env vars without rebuilding.
-- **Use `^|^` delimiter for `--update-env-vars`** — ROLE_APP_IDS is JSON containing commas, which conflicts with gcloud's default comma separator.
+- **No concurrent enrollment** — two operators enrolling simultaneously will
+  race on env var reads/writes. Coordinate enrollment operations serially.
+- **Always verify app installation** — the mint cannot produce tokens for
+  GitHub Apps that are not installed on the target org. Confirm installation
+  before the repo admin triggers a workflow.
+- **Use `--dry-run` first** — especially for new operators or unfamiliar
+  environments. Dry run previews all changes without applying them.
+- **Do not enroll `.fullsend` repos** — `.fullsend` repos use the shared
+  per-org WIF provider. Enroll the org instead.
 
 ## Shared App Model
 
@@ -77,758 +72,312 @@ The fullsend-ai org maintains public GitHub Apps shared across orgs.
 |------|----------|-------|
 | fullsend | fullsend-ai-fullsend | Dispatch/admin. Per-org only — excluded from per-repo installs. |
 | triage | fullsend-ai-triage | |
-| coder | fullsend-ai-coder | `fix` role shares this app and PEM but has distinct token permissions (no `checks:read`). No separate enrollment needed. |
+| coder | fullsend-ai-coder | `fix` role shares this app and PEM but has distinct token permissions. |
 | review | fullsend-ai-review | |
 | retro | fullsend-ai-retro | |
 | prioritize | fullsend-ai-prioritize | |
 
 PEM keys are tied to the app, not the org. Enrolling a new org copies PEMs
-from the app set (e.g., `fullsend-ai`).
-
-**PEM bootstrapping (first-time only):** On a fresh mint with no existing
-PEM secrets, the optional `--pem-dir` flag on `mint deploy` seeds the
-default app set's PEMs during deployment. App IDs are auto-discovered from
-the GitHub API. After this, `mint enroll <org>` copies from the bootstrapped
-app set. Most `mint deploy` runs do not need `--pem-dir`.
+from the app set (default: `fullsend-ai`).
 
 Apps must be installed on the target org before the mint can produce tokens.
 An org admin installs via `https://github.com/apps/{slug}/installations/new`
 or by running `fullsend admin install`.
 
+## Enrollment Steps
+
 ### 1. Triage
 
-Determine enrollment type and set variables. Choose one — per-org or per-repo:
+Determine enrollment type and target. Choose one:
 
 ```bash
-# Per-org (set ORG only, leave REPO unset)
-ORG="<github-org>"
-unset REPO
-ROLES="fullsend,triage,coder,review,retro,prioritize"
+# Per-org enrollment
+TARGET="<github-org>"
 
-# Per-repo (set both ORG and REPO)
-ORG="<github-org>"
-REPO="<repo-name>"
-ROLES="triage,coder,review,retro,prioritize"
+# Per-repo enrollment
+TARGET="<github-org>/<repo-name>"
 ```
 
-Validate and normalize inputs:
+Validate the target is a valid GitHub org or owner/repo name before
+proceeding.
+
+### 2. Pre-check current state
+
+Run `mint status` to see the current mint state, enrolled orgs, Cloud Run
+revision info, and PEM health:
 
 ```bash
-ORG=$(echo "${ORG}" | tr '[:upper:]' '[:lower:]')
-if [ -n "${REPO}" ]; then
-  REPO=$(echo "${REPO}" | tr '[:upper:]' '[:lower:]')
-fi
-
-# GitHub org names: alphanumeric and hyphens only, no consecutive hyphens,
-# no leading/trailing hyphens, max 39 chars (matches Go githubOrgPattern)
-if [ -z "${ORG}" ] || [[ "${ORG}" =~ $'\n' ]] \
-  || ! [[ "${ORG}" =~ ^[a-z0-9]([a-z0-9-]{0,37}[a-z0-9])?$ ]] \
-  || [[ "${ORG}" == *--* ]]; then
-  echo "ERROR: ORG must be a valid GitHub org name (alphanumeric/hyphens, no consecutive hyphens, max 39 chars)" >&2; exit 1
-fi
-if [ -n "${REPO}" ]; then
-  # GitHub repo names: alphanumeric, hyphens, dots, underscores; no .git suffix
-  if [[ "${REPO}" =~ $'\n' ]] \
-    || ! [[ "${REPO}" =~ ^[a-z0-9._][a-z0-9._-]{0,99}$ ]] \
-    || [[ "${REPO}" == "." ]] || [[ "${REPO}" == ".." ]] \
-    || [[ "${REPO}" == *..* ]] \
-    || [[ "${REPO}" == *.git ]]; then
-    echo "ERROR: REPO must be a valid GitHub repo name" >&2; exit 1
-  fi
-  if [ "${REPO}" = ".fullsend" ]; then
-    echo "ERROR: .fullsend repos use the shared per-org provider — enroll the org instead" >&2; exit 1
-  fi
-fi
-
-# Validate ROLES against allowlist
-VALID_ROLES="fullsend,triage,coder,review,retro,prioritize"
-for ROLE in $(echo "${ROLES}" | tr ',' ' '); do
-  if ! echo ",${VALID_ROLES}," | grep -Fq ",${ROLE},"; then
-    echo "ERROR: role '${ROLE}' is not in allowlist: ${VALID_ROLES}" >&2; exit 1
-  fi
-done
+fullsend mint status --project="$GCP_PROJECT" --region="$MINT_REGION"
 ```
 
-Pre-flight check for per-repo WIF provider ID collision (before any
-mutating steps):
+If the mint is not deployed yet, deploy it first:
 
 ```bash
-if [ -n "${REPO}" ]; then
-  PROVIDER_ID="gh-${ORG}-${REPO}"
-  PROVIDER_ID=$(echo "${PROVIDER_ID}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-' | cut -c1-32 | sed 's/-*$//')
-  echo "Computed WIF provider ID: ${PROVIDER_ID} (${#PROVIDER_ID} chars)"
-  PREFLIGHT_COND=$(gcloud iam workload-identity-pools providers describe "${PROVIDER_ID}" \
-    --project="${GCP_PROJECT}" \
-    --workload-identity-pool="${WIF_POOL}" \
-    --location="${WIF_POOL_LOCATION}" \
-    --format="value(attributeCondition)" 2>/dev/null) || true
-  if [ -n "${PREFLIGHT_COND}" ] && [ "${PREFLIGHT_COND}" != "assertion.repository == '${ORG}/${REPO}'" ]; then
-    echo "ERROR: Provider ID collision — ${PROVIDER_ID} belongs to a different repo:" >&2
-    echo "  Existing: ${PREFLIGHT_COND}" >&2
-    echo "Aborting before any mutations." >&2
-    exit 1
-  fi
-fi
+fullsend mint deploy --project="$GCP_PROJECT" --region="$MINT_REGION"
 ```
 
-### 2. Verify prerequisites
+Check the status output for:
 
-Confirm correct GCP project and active credentials. If `gcloud config
-get-value project` does not match `GCP_PROJECT`, the commands still
-target the right project via explicit `--project` flags — but run
-`gcloud config set project "${GCP_PROJECT}"` to avoid confusion.
+- **Health**: should be "healthy" or "degraded" (not "not-installed")
+- **Template divergence**: if the service template diverges from the
+  traffic-serving revision, enrollment will fix this (the CLI uses
+  REVISION-pinned traffic routing)
+- **Existing enrollment**: if the target org is already listed, re-enrollment
+  is safe — the CLI merges entries idempotently
+
+For per-org drill-down into PEM status (accepts org name only, not
+`owner/repo` — for per-repo enrollment, use just the org portion):
 
 ```bash
-gcloud config get-value project
-gcloud auth list --filter=status:ACTIVE --format="value(account)"
+fullsend mint status "<github-org>" --project="$GCP_PROJECT" --region="$MINT_REGION"
 ```
 
-### 3. Audit current state
+**STOP — show the status output to the operator.** Confirm the mint is
+healthy and the enrollment target is correct before proceeding.
 
-Run ALL of these before making any changes.
+### 3. Enroll
+
+Preview the enrollment first with `--dry-run`:
 
 ```bash
-# ALLOWED_ORGS
-gcloud run services describe "${MINT_SERVICE}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-  --format="value(spec.template.spec.containers[0].env.filter(name=ALLOWED_ORGS).value)"
-
-# ROLE_APP_IDS (JSON)
-gcloud run services describe "${MINT_SERVICE}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-  --format="value(spec.template.spec.containers[0].env.filter(name=ROLE_APP_IDS).value)"
-
-# PER_REPO_WIF_REPOS (per-repo only)
-gcloud run services describe "${MINT_SERVICE}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-  --format="value(spec.template.spec.containers[0].env.filter(name=PER_REPO_WIF_REPOS).value)"
-
-# ALLOWED_ROLES
-gcloud run services describe "${MINT_SERVICE}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-  --format="value(spec.template.spec.containers[0].env.filter(name=ALLOWED_ROLES).value)"
-
-# ALLOWED_WORKFLOW_FILES (must not be empty)
-gcloud run services describe "${MINT_SERVICE}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-  --format="value(spec.template.spec.containers[0].env.filter(name=ALLOWED_WORKFLOW_FILES).value)"
-
-# PEM secrets for the org
-gcloud secrets list --project="${GCP_PROJECT}" \
-  --filter="name:fullsend-${ORG}--" \
-  --format="table(name,createTime)"
-
-# WIF providers
-gcloud iam workload-identity-pools providers list \
-  --project="${GCP_PROJECT}" \
-  --workload-identity-pool="${WIF_POOL}" \
-  --location="${WIF_POOL_LOCATION}" \
-  --format="table(name.basename(),state,disabled)"
+fullsend mint enroll "$TARGET" \
+  --project="$GCP_PROJECT" \
+  --region="$MINT_REGION" \
+  --dry-run
 ```
 
-### 4. Copy PEM secrets
+**STOP — show the dry-run output to the operator and wait for explicit
+confirmation before running the actual enrollment.**
 
-For shared apps, copy the PEM from the app set. Pipes directly to
-avoid holding PEM material in shell variables.
+If the preview looks correct and the operator confirms, run the actual
+enrollment:
 
 ```bash
-set -o pipefail
-for ROLE in $(echo "${ROLES}" | tr ',' ' '); do
-  SECRET_ID="fullsend-${ORG}--${ROLE}-app-pem"
-
-  if gcloud secrets describe "${SECRET_ID}" --project="${GCP_PROJECT}" 2>/dev/null; then
-    VERSION_COUNT=$(gcloud secrets versions list "${SECRET_ID}" \
-      --project="${GCP_PROJECT}" --filter="state=ENABLED" \
-      --format="value(name)" 2>/dev/null | wc -l | tr -d ' ')
-    if [ "${VERSION_COUNT}" -gt 0 ]; then
-      echo "SKIP: ${SECRET_ID} already exists with ${VERSION_COUNT} active version(s)"
-      continue
-    fi
-    echo "WARN: ${SECRET_ID} exists but has no active versions — re-adding"
-  fi
-
-  SOURCE_SECRET="fullsend-${APP_SET}--${ROLE}-app-pem"
-
-  if ! gcloud secrets describe "${SOURCE_SECRET}" --project="${GCP_PROJECT}" >/dev/null 2>&1; then
-    echo "ERROR: source secret ${SOURCE_SECRET} not found" >&2
-    exit 1
-  fi
-
-  if ! gcloud secrets describe "${SECRET_ID}" --project="${GCP_PROJECT}" 2>/dev/null; then
-    gcloud secrets create "${SECRET_ID}" \
-      --project="${GCP_PROJECT}" --replication-policy=automatic \
-      || { echo "ERROR: failed to create secret ${SECRET_ID}" >&2; exit 1; }
-  fi
-
-  SOURCE_VERSION_STATE=$(gcloud secrets versions describe latest \
-    --secret="${SOURCE_SECRET}" --project="${GCP_PROJECT}" \
-    --format="value(state)" 2>/dev/null)
-  if [ "${SOURCE_VERSION_STATE}" != "ENABLED" ]; then
-    echo "ERROR: source secret ${SOURCE_SECRET} latest version is not ENABLED (got: ${SOURCE_VERSION_STATE:-empty})" >&2
-    exit 1
-  fi
-
-  gcloud secrets versions access latest \
-    --secret="${SOURCE_SECRET}" --project="${GCP_PROJECT}" \
-    | gcloud secrets versions add "${SECRET_ID}" \
-    --project="${GCP_PROJECT}" --data-file=- \
-    || { echo "ERROR: failed to copy PEM from ${SOURCE_SECRET} to ${SECRET_ID}" >&2; exit 1; }
-
-  gcloud secrets add-iam-policy-binding "${SECRET_ID}" \
-    --project="${GCP_PROJECT}" \
-    --member="serviceAccount:${SA_EMAIL}" \
-    --role="roles/secretmanager.secretAccessor" \
-    || { echo "ERROR: failed to bind IAM policy on ${SECRET_ID}" >&2; exit 1; }
-
-  echo "DONE: ${SECRET_ID}"
-done
-
-# fix role reuses coder app — create fix PEM as a copy of coder PEM
-if echo ",${ROLES}," | grep -Fq ",coder,"; then
-  FIX_SECRET="fullsend-${ORG}--fix-app-pem"
-  CODER_SECRET="fullsend-${ORG}--coder-app-pem"
-  if gcloud secrets describe "${FIX_SECRET}" --project="${GCP_PROJECT}" 2>/dev/null; then
-    FIX_VERSION_COUNT=$(gcloud secrets versions list "${FIX_SECRET}" \
-      --project="${GCP_PROJECT}" --filter="state=ENABLED" \
-      --format="value(name)" 2>/dev/null | wc -l | tr -d ' ')
-    if [ "${FIX_VERSION_COUNT}" -gt 0 ]; then
-      echo "SKIP: ${FIX_SECRET} already exists"
-    else
-      echo "WARN: ${FIX_SECRET} exists but has no active versions — re-adding from coder"
-      gcloud secrets versions access latest \
-        --secret="${CODER_SECRET}" --project="${GCP_PROJECT}" \
-        | gcloud secrets versions add "${FIX_SECRET}" \
-        --project="${GCP_PROJECT}" --data-file=- \
-        || { echo "ERROR: failed to copy PEM to ${FIX_SECRET}" >&2; exit 1; }
-    fi
-  else
-    gcloud secrets create "${FIX_SECRET}" \
-      --project="${GCP_PROJECT}" --replication-policy=automatic \
-      || { echo "ERROR: failed to create secret ${FIX_SECRET}" >&2; exit 1; }
-    gcloud secrets versions access latest \
-      --secret="${CODER_SECRET}" --project="${GCP_PROJECT}" \
-      | gcloud secrets versions add "${FIX_SECRET}" \
-      --project="${GCP_PROJECT}" --data-file=- \
-      || { echo "ERROR: failed to copy PEM to ${FIX_SECRET}" >&2; exit 1; }
-  fi
-  gcloud secrets add-iam-policy-binding "${FIX_SECRET}" \
-    --project="${GCP_PROJECT}" \
-    --member="serviceAccount:${SA_EMAIL}" \
-    --role="roles/secretmanager.secretAccessor" \
-    || { echo "ERROR: failed to bind IAM policy on ${FIX_SECRET}" >&2; exit 1; }
-  echo "DONE: ${FIX_SECRET} (fix role, copied from coder)"
-fi
+fullsend mint enroll "$TARGET" \
+  --project="$GCP_PROJECT" \
+  --region="$MINT_REGION"
 ```
 
-### 5. Update mint env vars
+The CLI performs the following automatically:
 
-Read current values, merge new entries, apply via `gcloud run services update`.
+1. Discovers the existing mint infrastructure and resolves role→app-id mappings
+2. Copies PEM secrets from the app set to the new org's scoped keys
+3. Updates Cloud Run service env vars (ALLOWED_ORGS, ROLE_APP_IDS) using
+   REVISION-pinned traffic routing
+4. Runs post-enrollment verification
+5. Configures WIF provider (shared for per-org, dedicated for per-repo)
+
+**Optional flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--app-set` | `fullsend-ai` | App set to copy PEMs and app IDs from |
+| `--role-app-ids` | | Explicit JSON map of role→app-id (overrides `--app-set`) |
+| `--roles` | `fullsend,triage,coder,review,retro,prioritize` | Comma-separated roles to enroll |
+
+### 4. Verify
+
+The CLI runs post-enrollment verification automatically. Check its output for:
+
+- **Revision state**: confirms which Cloud Run revision is serving traffic
+  and whether it matches the latest template
+- **ALLOWED_ORGS**: confirms the enrolled org is present in the
+  traffic-serving revision's env vars
+- **ROLE_APP_IDS**: confirms all expected role keys are present
+
+If the CLI reports "Post-write verification FAILED", run `mint status` to
+diagnose:
 
 ```bash
-set -o pipefail
-CURRENT_ALLOWED_ORGS=$(gcloud run services describe "${MINT_SERVICE}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-  --format="value(spec.template.spec.containers[0].env.filter(name=ALLOWED_ORGS).value)") \
-  || { echo "ERROR: failed to read ALLOWED_ORGS" >&2; exit 1; }
-
-CURRENT_ROLE_APP_IDS=$(gcloud run services describe "${MINT_SERVICE}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-  --format="value(spec.template.spec.containers[0].env.filter(name=ROLE_APP_IDS).value)") \
-  || { echo "ERROR: failed to read ROLE_APP_IDS" >&2; exit 1; }
-
-# Check if org already in ALLOWED_ORGS
-if echo ",${CURRENT_ALLOWED_ORGS}," | grep -Fq ",${ORG},"; then
-  echo "SKIP: ${ORG} already in ALLOWED_ORGS"
-  NEW_ALLOWED_ORGS="${CURRENT_ALLOWED_ORGS}"
-elif [ -z "${CURRENT_ALLOWED_ORGS}" ]; then
-  NEW_ALLOWED_ORGS="${ORG}"
-else
-  NEW_ALLOWED_ORGS="${CURRENT_ALLOWED_ORGS},${ORG}"
-fi
-
-# Merge new entries into ROLE_APP_IDS (pin lookup to APP_SET)
-NEW_ROLE_APP_IDS=$(echo "${CURRENT_ROLE_APP_IDS}" | \
-  ORG="${ORG}" ROLES="${ROLES}" APP_SET="${APP_SET}" python3 -c "
-import json, sys, os
-raw = sys.stdin.read().strip()
-try:
-    data = json.loads(raw) if raw else {}
-except json.JSONDecodeError as e:
-    print(f'FATAL: ROLE_APP_IDS is not valid JSON: {e}', file=sys.stderr)
-    sys.exit(1)
-org = os.environ['ORG'].lower()
-roles_csv = os.environ['ROLES']
-app_set = os.environ['APP_SET'].lower()
-for role in (r.strip() for r in roles_csv.split(',')):
-    key = f'{org}/{role}'
-    source_key = f'{app_set}/{role}'
-    if key in data:
-        print(f'SKIP: {key} already exists', file=sys.stderr)
-    elif source_key in data:
-        data[key] = data[source_key]
-        print(f'ADDING: {key} = {data[source_key]}', file=sys.stderr)
-    else:
-        print(f'ERROR: no app ID found for {source_key}', file=sys.stderr)
-        sys.exit(1)
-# fix role reuses coder app ID — auto-derive if coder was enrolled
-fix_key = f'{org}/fix'
-coder_key = f'{org}/coder'
-if fix_key not in data and coder_key in data:
-    data[fix_key] = data[coder_key]
-    print(f'ADDING: {fix_key} = {data[coder_key]} (derived from coder)', file=sys.stderr)
-print(json.dumps(data, sort_keys=True))
-") || { echo "ERROR: failed to merge ROLE_APP_IDS — see above" >&2; exit 1; }
-
-# Validate merged JSON
-echo "${NEW_ROLE_APP_IDS}" | python3 -c "import json,sys; json.loads(sys.stdin.read())" \
-  || { echo "ERROR: merged ROLE_APP_IDS is not valid JSON — aborting" >&2; exit 1; }
-
-# Derive ALLOWED_ROLES
-NEW_ALLOWED_ROLES=$(echo "${NEW_ROLE_APP_IDS}" | python3 -c "
-import json, sys
-data = json.loads(sys.stdin.read())
-roles = sorted(set(k.split('/', 1)[1] for k in data if '/' in k))
-print(','.join(roles))
-") || { echo "ERROR: failed to derive ALLOWED_ROLES" >&2; exit 1; }
+fullsend mint status --project="$GCP_PROJECT" --region="$MINT_REGION"
 ```
 
-For per-repo, also add to PER_REPO_WIF_REPOS:
+Common causes of verification failure:
 
-```bash
-if [ -n "${REPO}" ]; then
-  CURRENT_PER_REPO=$(gcloud run services describe "${MINT_SERVICE}" \
-    --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-    --format="value(spec.template.spec.containers[0].env.filter(name=PER_REPO_WIF_REPOS).value)") \
-    || { echo "ERROR: failed to read PER_REPO_WIF_REPOS" >&2; exit 1; }
+- **Template/traffic divergence** — traffic routing step didn't complete.
+  Re-run enrollment to trigger a new revision cycle.
+- **Missing role keys** — the app set doesn't have all roles. Use
+  `--role-app-ids` to provide explicitly.
 
-  REPO_FULL="${ORG}/${REPO}"
-  if echo ",${CURRENT_PER_REPO}," | grep -Fq ",${REPO_FULL},"; then
-    echo "SKIP: ${REPO_FULL} already in PER_REPO_WIF_REPOS"
-    NEW_PER_REPO="${CURRENT_PER_REPO}"
-  elif [ -z "${CURRENT_PER_REPO}" ]; then
-    NEW_PER_REPO="${REPO_FULL}"
-  else
-    NEW_PER_REPO="${CURRENT_PER_REPO},${REPO_FULL}"
-  fi
-fi
-```
-
-Show diff before applying:
-
-```bash
-CURRENT_ALLOWED_ROLES=$(gcloud run services describe "${MINT_SERVICE}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-  --format="value(spec.template.spec.containers[0].env.filter(name=ALLOWED_ROLES).value)" 2>/dev/null)
-
-echo "=== ALLOWED_ORGS ==="
-echo "  OLD: ${CURRENT_ALLOWED_ORGS}"
-echo "  NEW: ${NEW_ALLOWED_ORGS}"
-echo "=== ROLE_APP_IDS ==="
-echo "  OLD: ${CURRENT_ROLE_APP_IDS}"
-echo "  NEW: ${NEW_ROLE_APP_IDS}"
-echo "=== ALLOWED_ROLES ==="
-echo "  OLD: ${CURRENT_ALLOWED_ROLES}"
-echo "  NEW: ${NEW_ALLOWED_ROLES}"
-if [ -n "${REPO}" ]; then
-  echo "=== PER_REPO_WIF_REPOS ==="
-  echo "  OLD: ${CURRENT_PER_REPO}"
-  echo "  NEW: ${NEW_PER_REPO}"
-fi
-```
-
-Abort if any computed value is empty — this prevents wiping existing
-configuration:
-
-```bash
-if [ -z "${NEW_ALLOWED_ORGS}" ]; then
-  echo "ERROR: NEW_ALLOWED_ORGS is empty — aborting to prevent config wipe" >&2
-  exit 1
-fi
-if [ -z "${NEW_ROLE_APP_IDS}" ] || [ "${NEW_ROLE_APP_IDS}" = "{}" ]; then
-  echo "ERROR: NEW_ROLE_APP_IDS is empty or has no entries — aborting" >&2
-  exit 1
-fi
-if [ -z "${NEW_ALLOWED_ROLES}" ]; then
-  echo "ERROR: NEW_ALLOWED_ROLES is empty — aborting to prevent config wipe" >&2
-  exit 1
-fi
-if [ -n "${REPO}" ] && [ -z "${NEW_PER_REPO}" ]; then
-  echo "ERROR: NEW_PER_REPO is empty — aborting to prevent config wipe" >&2
-  exit 1
-fi
-```
-
-Apply using `gcloud run services update` with `^|^` delimiter to avoid
-comma conflicts with JSON in ROLE_APP_IDS:
-
-```bash
-if [ -z "${REPO}" ]; then
-  # Per-org
-  gcloud run services update "${MINT_SERVICE}" \
-    --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-    --update-env-vars="^|^ALLOWED_ORGS=${NEW_ALLOWED_ORGS}|ROLE_APP_IDS=${NEW_ROLE_APP_IDS}|ALLOWED_ROLES=${NEW_ALLOWED_ROLES}" \
-    || { echo "ERROR: failed to update mint env vars" >&2; exit 1; }
-else
-  # Per-repo (also include PER_REPO_WIF_REPOS)
-  gcloud run services update "${MINT_SERVICE}" \
-    --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-    --update-env-vars="^|^ALLOWED_ORGS=${NEW_ALLOWED_ORGS}|ROLE_APP_IDS=${NEW_ROLE_APP_IDS}|ALLOWED_ROLES=${NEW_ALLOWED_ROLES}|PER_REPO_WIF_REPOS=${NEW_PER_REPO}" \
-    || { echo "ERROR: failed to update mint env vars" >&2; exit 1; }
-fi
-```
-
-### 6. Configure WIF provider
-
-Per-repo repos get a dedicated provider. Per-org repos use the shared
-`github-oidc` provider — its `attributeCondition` must include the new org.
-
-```bash
-set -o pipefail
-if [ -z "${REPO}" ]; then
-  # Per-org: update the shared provider's attribute condition to include the new org
-  DEFAULT_PROVIDER="github-oidc"
-  EXISTING_CONDITION=$(gcloud iam workload-identity-pools providers describe "${DEFAULT_PROVIDER}" \
-      --project="${GCP_PROJECT}" \
-      --workload-identity-pool="${WIF_POOL}" \
-      --location="${WIF_POOL_LOCATION}" \
-      --format="value(attributeCondition)") \
-      || { echo "ERROR: shared provider '${DEFAULT_PROVIDER}' not found — run 'mint deploy' first" >&2; exit 1; }
-
-  if echo "${EXISTING_CONDITION}" | grep -qF "'${ORG}'"; then
-    echo "SKIP: ${ORG} already in shared provider condition"
-  else
-    # Parse existing orgs, add new one, rebuild condition (uses python3 for portability)
-    NEW_CONDITION=$(echo "${EXISTING_CONDITION}" | ORG="${ORG}" python3 -c "
-import re, sys, os
-cond = sys.stdin.read().strip()
-orgs = set(re.findall(r\"'([a-z0-9][a-z0-9._-]*?)'\", cond))
-orgs.add(os.environ['ORG'])
-orgs = sorted(orgs)
-if len(orgs) == 1:
-    print(f\"assertion.repository_owner == '{orgs[0]}'\")
-else:
-    quoted = ', '.join(f\"'{o}'\" for o in orgs)
-    print(f'assertion.repository_owner in [{quoted}]')
-") || { echo "ERROR: failed to rebuild WIF condition" >&2; exit 1; }
-    echo "=== WIF Condition ==="
-    echo "  OLD: ${EXISTING_CONDITION}"
-    echo "  NEW: ${NEW_CONDITION}"
-    FULL_IAM_AUDIENCE="https://iam.googleapis.com/projects/${GCP_PROJECT_NUMBER}/locations/${WIF_POOL_LOCATION}/workloadIdentityPools/${WIF_POOL}/providers/${DEFAULT_PROVIDER}"
-    gcloud iam workload-identity-pools providers update-oidc "${DEFAULT_PROVIDER}" \
-      --project="${GCP_PROJECT}" \
-      --workload-identity-pool="${WIF_POOL}" \
-      --location="${WIF_POOL_LOCATION}" \
-      --attribute-condition="${NEW_CONDITION}" \
-      --allowed-audiences="fullsend-mint,${FULL_IAM_AUDIENCE}" \
-      || { echo "ERROR: failed to update shared WIF provider" >&2; exit 1; }
-  fi
-else
-  PROVIDER_ID="gh-${ORG}-${REPO}"
-  # Lowercase, replace non-alphanumeric with hyphens, truncate, strip trailing hyphens
-  PROVIDER_ID=$(echo "${PROVIDER_ID}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-' | cut -c1-32 | sed 's/-*$//')
-  FULL_IAM_AUDIENCE="https://iam.googleapis.com/projects/${GCP_PROJECT_NUMBER}/locations/${WIF_POOL_LOCATION}/workloadIdentityPools/${WIF_POOL}/providers/${PROVIDER_ID}"
-
-  echo "Provider ID: ${PROVIDER_ID} (${#PROVIDER_ID} chars)"
-
-  EXPECTED_CONDITION="assertion.repository == '${ORG}/${REPO}'"
-  DESCRIBE_ERR=$(mktemp)
-  EXISTING_CONDITION=$(gcloud iam workload-identity-pools providers describe "${PROVIDER_ID}" \
-      --project="${GCP_PROJECT}" \
-      --workload-identity-pool="${WIF_POOL}" \
-      --location="${WIF_POOL_LOCATION}" \
-      --format="value(attributeCondition)" 2>"${DESCRIBE_ERR}") || true
-  if [ -s "${DESCRIBE_ERR}" ] && ! grep -q "NOT_FOUND" "${DESCRIBE_ERR}"; then
-    echo "ERROR: failed to describe provider ${PROVIDER_ID}:" >&2
-    cat "${DESCRIBE_ERR}" >&2
-    rm -f "${DESCRIBE_ERR}"
-    exit 1
-  fi
-  rm -f "${DESCRIBE_ERR}"
-
-  if [ -n "${EXISTING_CONDITION}" ]; then
-    if [ "${EXISTING_CONDITION}" != "${EXPECTED_CONDITION}" ]; then
-      echo "ERROR: Provider ID collision — ${PROVIDER_ID} belongs to a different repo:" >&2
-      echo "  Existing: ${EXISTING_CONDITION}" >&2
-      echo "  Expected: ${EXPECTED_CONDITION}" >&2
-      exit 1
-    fi
-    echo "Provider exists for this repo — updating"
-    gcloud iam workload-identity-pools providers update-oidc "${PROVIDER_ID}" \
-      --project="${GCP_PROJECT}" \
-      --workload-identity-pool="${WIF_POOL}" \
-      --location="${WIF_POOL_LOCATION}" \
-      --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner,attribute.actor=assertion.actor" \
-      --attribute-condition="assertion.repository == '${ORG}/${REPO}'" \
-      --allowed-audiences="fullsend-mint,${FULL_IAM_AUDIENCE}" \
-      || { echo "ERROR: failed to update WIF provider ${PROVIDER_ID}" >&2; exit 1; }
-  else
-    gcloud iam workload-identity-pools providers create-oidc "${PROVIDER_ID}" \
-      --project="${GCP_PROJECT}" \
-      --workload-identity-pool="${WIF_POOL}" \
-      --location="${WIF_POOL_LOCATION}" \
-      --issuer-uri="https://token.actions.githubusercontent.com" \
-      --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner,attribute.actor=assertion.actor" \
-      --attribute-condition="assertion.repository == '${ORG}/${REPO}'" \
-      --allowed-audiences="fullsend-mint,${FULL_IAM_AUDIENCE}" \
-      || { echo "ERROR: failed to create WIF provider ${PROVIDER_ID}" >&2; exit 1; }
-  fi
-fi
-```
-
-### 7. Handoff to repo admin
+### 5. Handoff to repo admin
 
 The mint SRE does not configure target repos. Inform the repo admin that
-mint-side enrollment is complete and provide these details:
+mint-side enrollment is complete and provide:
 
-- **Mint URL:** `${MINT_URL}` (resolved in Setup)
+- **Mint URL**: shown in `mint status` output
+- GitHub Actions org variable `FULLSEND_MINT_URL` (set by `fullsend admin install` or manually)
 - `.github/workflows/fullsend.yaml` shim workflow in the target repo
-- GitHub Actions org variable: `FULLSEND_MINT_URL` (set by `fullsend admin install` or manually)
 
 For per-repo enrollments, also provide:
-- **WIF Provider ID:** the computed provider ID from Step 6 (needed for
-  the `google-github-actions/auth` step in the shim workflow)
+
+- **WIF Provider ID**: shown in the enrollment output (needed for the
+  `google-github-actions/auth` step)
 
 For per-org, the `repo-maintenance` workflow in `.fullsend` handles shim
-deployment. For per-repo, the admin runs `fullsend admin install --repo`
-or configures manually.
+deployment. For per-repo, the admin runs
+`fullsend admin install <owner/repo>` or configures manually.
 
 Verify that all required GitHub Apps are installed on the target org
-before the admin triggers a workflow — the mint cannot produce tokens
-for apps that are not installed (see Shared App Model above).
-
-### 8. Verify
-
-Confirm mint infrastructure is ready:
-
-```bash
-set -o pipefail
-VERIFY_FAILED=0
-
-# ALLOWED_WORKFLOW_FILES must not be empty (mint rejects all requests if unset).
-# This is set during mint deploy, not during enrollment — if empty, re-run mint deploy.
-ALLOWED_WF=$(gcloud run services describe "${MINT_SERVICE}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-  --format="value(spec.template.spec.containers[0].env.filter(name=ALLOWED_WORKFLOW_FILES).value)")
-if [ -n "${ALLOWED_WF}" ]; then
-  echo "OK: ALLOWED_WORKFLOW_FILES = ${ALLOWED_WF}"
-else
-  echo "FAIL: ALLOWED_WORKFLOW_FILES is empty — mint will reject ALL token requests (set during 'mint deploy', not enrollment)"
-  VERIFY_FAILED=1
-fi
-
-# Org in ALLOWED_ORGS
-gcloud run services describe "${MINT_SERVICE}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-  --format="value(spec.template.spec.containers[0].env.filter(name=ALLOWED_ORGS).value)" \
-  | tr ',' '\n' | grep -Fxq "${ORG}" \
-  && echo "OK: ${ORG} in ALLOWED_ORGS" || { echo "FAIL: ${ORG} not in ALLOWED_ORGS"; VERIFY_FAILED=1; }
-
-# Org roles in ROLE_APP_IDS
-gcloud run services describe "${MINT_SERVICE}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-  --format="value(spec.template.spec.containers[0].env.filter(name=ROLE_APP_IDS).value)" \
-  | ORG="${ORG}" ROLES="${ROLES}" python3 -c "
-import json, sys, os
-data = json.loads(sys.stdin.read())
-org = os.environ['ORG']
-roles = os.environ['ROLES'].split(',')
-ok = True
-for role in roles:
-    key = f'{org}/{role.strip()}'
-    if key in data:
-        print(f'OK: {key} = {data[key]}')
-    else:
-        print(f'FAIL: {key} not found')
-        ok = False
-# fix role should also be present if coder is enrolled, with matching app ID
-fix_key = f'{org}/fix'
-coder_key = f'{org}/coder'
-if fix_key in data and coder_key in data:
-    if data[fix_key] == data[coder_key]:
-        print(f'OK: {fix_key} = {data[fix_key]} (matches coder)')
-    else:
-        print(f'FAIL: {fix_key} = {data[fix_key]} but coder = {data[coder_key]} — must match')
-        ok = False
-elif fix_key in data:
-    print(f'OK: {fix_key} = {data[fix_key]}')
-elif coder_key in data:
-    print(f'FAIL: {fix_key} not found (should be derived from coder)')
-    ok = False
-sys.exit(0 if ok else 1)
-" || VERIFY_FAILED=1
-
-# ALLOWED_ROLES contains all expected roles
-CURRENT_ALLOWED_ROLES=$(gcloud run services describe "${MINT_SERVICE}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-  --format="value(spec.template.spec.containers[0].env.filter(name=ALLOWED_ROLES).value)" 2>/dev/null)
-for ROLE in $(echo "${ROLES}" | tr ',' ' '); do
-  if echo ",${CURRENT_ALLOWED_ROLES}," | grep -Fq ",${ROLE},"; then
-    echo "OK: ${ROLE} in ALLOWED_ROLES"
-  else
-    echo "FAIL: ${ROLE} not in ALLOWED_ROLES"; VERIFY_FAILED=1
-  fi
-done
-if echo ",${ROLES}," | grep -Fq ",coder,"; then
-  if echo ",${CURRENT_ALLOWED_ROLES}," | grep -Fq ",fix,"; then
-    echo "OK: fix in ALLOWED_ROLES (derived from coder)"
-  else
-    echo "FAIL: fix not in ALLOWED_ROLES (should be derived from coder)"; VERIFY_FAILED=1
-  fi
-fi
-
-# PEM secrets accessible (metadata check — does not read PEM content)
-for ROLE in $(echo "${ROLES}" | tr ',' ' '); do
-  SECRET_ID="fullsend-${ORG}--${ROLE}-app-pem"
-  gcloud secrets versions describe latest \
-    --secret="${SECRET_ID}" \
-    --project="${GCP_PROJECT}" --format="value(state)" 2>/dev/null \
-    | grep -q "ENABLED" \
-    && echo "OK: ${ROLE} secret" || { echo "FAIL: ${ROLE} secret"; VERIFY_FAILED=1; }
-  gcloud secrets get-iam-policy "${SECRET_ID}" --project="${GCP_PROJECT}" \
-    --format="value(bindings.members)" 2>/dev/null \
-    | grep -q "serviceAccount:${SA_EMAIL}" \
-    && echo "OK: ${ROLE} IAM binding" || { echo "FAIL: ${ROLE} IAM binding"; VERIFY_FAILED=1; }
-done
-# fix role PEM (if coder was enrolled)
-if echo ",${ROLES}," | grep -Fq ",coder,"; then
-  FIX_SECRET="fullsend-${ORG}--fix-app-pem"
-  gcloud secrets versions describe latest \
-    --secret="${FIX_SECRET}" \
-    --project="${GCP_PROJECT}" --format="value(state)" 2>/dev/null \
-    | grep -q "ENABLED" \
-    && echo "OK: fix secret" || { echo "FAIL: fix secret"; VERIFY_FAILED=1; }
-  gcloud secrets get-iam-policy "${FIX_SECRET}" --project="${GCP_PROJECT}" \
-    --format="value(bindings.members)" 2>/dev/null \
-    | grep -q "serviceAccount:${SA_EMAIL}" \
-    && echo "OK: fix IAM binding" || { echo "FAIL: fix IAM binding"; VERIFY_FAILED=1; }
-fi
-
-# WIF provider verification
-if [ -z "${REPO}" ]; then
-  # Per-org: verify shared provider condition includes the org
-  DEFAULT_PROVIDER="github-oidc"
-  SHARED_CONDITION=$(gcloud iam workload-identity-pools providers describe "${DEFAULT_PROVIDER}" \
-    --project="${GCP_PROJECT}" \
-    --workload-identity-pool="${WIF_POOL}" \
-    --location="${WIF_POOL_LOCATION}" \
-    --format="value(attributeCondition)" 2>/dev/null) \
-    || { echo "FAIL: shared WIF provider ${DEFAULT_PROVIDER} not found"; VERIFY_FAILED=1; }
-  if [ -n "${SHARED_CONDITION}" ]; then
-    if echo "${SHARED_CONDITION}" | grep -qF "'${ORG}'"; then
-      echo "OK: ${ORG} in shared WIF provider condition"
-    else
-      echo "FAIL: ${ORG} not in shared WIF provider condition"; VERIFY_FAILED=1
-      echo "  Condition: ${SHARED_CONDITION}"
-    fi
-    # Verify audiences on shared provider
-    SHARED_AUDIENCES=$(gcloud iam workload-identity-pools providers describe "${DEFAULT_PROVIDER}" \
-      --project="${GCP_PROJECT}" \
-      --workload-identity-pool="${WIF_POOL}" \
-      --location="${WIF_POOL_LOCATION}" \
-      --format="value(oidc.allowedAudiences)" 2>/dev/null)
-    SHARED_IAM_AUDIENCE="https://iam.googleapis.com/projects/${GCP_PROJECT_NUMBER}/locations/${WIF_POOL_LOCATION}/workloadIdentityPools/${WIF_POOL}/providers/${DEFAULT_PROVIDER}"
-    if echo "${SHARED_AUDIENCES}" | grep -qF "fullsend-mint"; then
-      echo "OK: shared provider has fullsend-mint audience"
-    else
-      echo "FAIL: shared provider missing fullsend-mint audience"; VERIFY_FAILED=1
-    fi
-    if echo "${SHARED_AUDIENCES}" | grep -qF "${SHARED_IAM_AUDIENCE}"; then
-      echo "OK: shared provider has IAM audience URL"
-    else
-      echo "WARN: shared provider missing IAM audience URL"
-    fi
-  fi
-fi
-
-# Per-repo: verify repo in PER_REPO_WIF_REPOS and WIF provider
-if [ -n "${REPO}" ]; then
-  gcloud run services describe "${MINT_SERVICE}" \
-    --project="${GCP_PROJECT}" --region="${MINT_REGION}" \
-    --format="value(spec.template.spec.containers[0].env.filter(name=PER_REPO_WIF_REPOS).value)" \
-    | tr ',' '\n' | grep -Fxq "${ORG}/${REPO}" \
-    && echo "OK: ${ORG}/${REPO} in PER_REPO_WIF_REPOS" \
-    || { echo "FAIL: ${ORG}/${REPO} not in PER_REPO_WIF_REPOS"; VERIFY_FAILED=1; }
-
-  PROVIDER_ID=$(echo "gh-${ORG}-${REPO}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-' | cut -c1-32 | sed 's/-*$//')
-  PROVIDER_JSON=$(gcloud iam workload-identity-pools providers describe "${PROVIDER_ID}" \
-    --project="${GCP_PROJECT}" \
-    --workload-identity-pool="${WIF_POOL}" \
-    --location="${WIF_POOL_LOCATION}" \
-    --format="json(oidc.allowedAudiences,attributeCondition,state)" 2>/dev/null) \
-    || { echo "FAIL: WIF provider ${PROVIDER_ID} not found"; VERIFY_FAILED=1; }
-  if [ -n "${PROVIDER_JSON}" ]; then
-    FULL_IAM_AUDIENCE="https://iam.googleapis.com/projects/${GCP_PROJECT_NUMBER}/locations/${WIF_POOL_LOCATION}/workloadIdentityPools/${WIF_POOL}/providers/${PROVIDER_ID}"
-    echo "${PROVIDER_JSON}" | \
-      EXPECTED_COND="assertion.repository == '${ORG}/${REPO}'" \
-      EXPECTED_IAM_AUD="${FULL_IAM_AUDIENCE}" \
-      python3 -c "
-import json, sys, os
-data = json.loads(sys.stdin.read())
-state = data.get('state', '')
-cond = data.get('attributeCondition', '')
-auds = data.get('oidc', {}).get('allowedAudiences', [])
-expected_cond = os.environ['EXPECTED_COND']
-expected_iam_aud = os.environ['EXPECTED_IAM_AUD']
-ok = True
-if state == 'ACTIVE':
-    print(f'OK: provider state = {state}')
-else:
-    print(f'FAIL: provider state = {state} (expected ACTIVE)')
-    ok = False
-if cond == expected_cond:
-    print(f'OK: attributeCondition matches expected')
-else:
-    print(f'FAIL: attributeCondition mismatch')
-    print(f'  Expected: {expected_cond}')
-    print(f'  Actual:   {cond}')
-    ok = False
-if 'fullsend-mint' in auds:
-    print('OK: audience fullsend-mint present')
-else:
-    print('FAIL: audience fullsend-mint missing')
-    ok = False
-if expected_iam_aud in auds:
-    print('OK: IAM audience URL present')
-else:
-    print(f'WARN: IAM audience URL missing — expected {expected_iam_aud}')
-sys.exit(0 if ok else 1)
-" || VERIFY_FAILED=1
-  fi
-fi
-
-exit "${VERIFY_FAILED}"
-```
-
-After the repo admin triggers a workflow, check mint logs:
-
-```bash
-gcloud functions logs read "${MINT_FUNCTION}" \
-  --project="${GCP_PROJECT}" --region="${MINT_REGION}" --gen2 --limit=50 \
-  --format="table(timecreated,severity,textPayload)" \
-  | grep -i "${ORG}"
-```
+before the admin triggers a workflow.
 
 ## Rollback
 
-Rollback is a **separate deliberate operation** — do not execute without
-explicit approval from the mint service owner. This section is reference
-only; no commands are provided to prevent accidental execution.
+**STOP — unenroll is a destructive operation that removes an org or repo
+from the mint. Always run `--dry-run` first and confirm with the operator
+before proceeding.**
 
-Rollback order (reverse of enrollment):
+Use the CLI to unenroll:
 
-1. **WIF provider** — for per-repo, disable then delete the dedicated
-   provider after confirming no workflows depend on it (deletion is
-   irreversible). For per-org, re-read the shared `github-oidc`
-   provider's `attributeCondition`, remove the org from the list,
-   rebuild the condition, and update with `update-oidc`. Verify other
-   orgs in the condition are preserved.
-2. **PER_REPO_WIF_REPOS** (per-repo only) — remove `{org}/{repo}` from
-   the comma-separated list via `gcloud run services update`.
-3. **Mint env vars** — re-read current values, remove `{org}/*` entries
-   (including `{org}/fix`) from ROLE_APP_IDS, remove `{org}` from
-   ALLOWED_ORGS, re-derive ALLOWED_ROLES, apply with `--update-env-vars`.
-   Verify no other org shares the same app IDs before removing.
-4. **PEM secrets** — disable the latest version (reversible) rather than
-   deleting the secret. Include `fullsend-{org}--fix-app-pem` when
-   rolling back coder. Only delete after a bake period confirms no
-   workflows need the secret.
+```bash
+# Dry-run first
+fullsend mint unenroll "$TARGET" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" --dry-run
+
+# Actual unenroll (after operator confirms dry-run output)
+fullsend mint unenroll "$TARGET" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION"
+```
+
+Unenroll is interactive — it requires typing the target name to confirm.
+Use `--yolo` to skip confirmation in automated contexts.
+
+By default, org-scoped unenroll disables (not deletes) PEM secrets and
+removes the org from the shared WIF provider's attribute condition.
+Repo-scoped unenroll disables the repo-specific WIF provider — it does
+not touch PEM secrets. Both are reversible — re-enrollment will re-enable
+disabled resources and re-add the org to the WIF condition.
+
+To permanently delete instead of disable, add `--delete-secrets` (org only)
+or `--delete-provider` (repo only) to the same unenroll command. These are
+flags on a single invocation, not separate follow-up commands:
+
+```bash
+# Preview permanent secret deletion first
+fullsend mint unenroll "$TARGET" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" --delete-secrets --dry-run
+
+# Permanently delete PEM secrets (org-scoped only, after dry-run confirms)
+fullsend mint unenroll "$TARGET" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" --delete-secrets
+
+# Preview permanent WIF provider deletion first (repo-scoped only)
+fullsend mint unenroll "$TARGET" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" --delete-provider --dry-run
+
+# Permanently delete WIF provider (repo-scoped only, after dry-run confirms)
+fullsend mint unenroll "$TARGET" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" --delete-provider
+```
+
+Only use `--delete-secrets` or `--delete-provider` after confirming no
+workflows depend on the resources.
+
+## Troubleshooting
+
+When the CLI output is insufficient, use `gcloud` to inspect the Cloud Run
+service directly. The commands below are **read-only** — they do not
+modify the mint.
+
+**DANGER — never use `--set-env-vars` to modify the mint service.** The
+`--set-env-vars` flag **replaces all** env vars, wiping out every other
+variable (ALLOWED_ORGS, ROLE_APP_IDS, PEM secret references, etc.). If
+you need to fix an env var manually, use `--update-env-vars` which
+**merges** the provided values into the existing set:
+
+```bash
+# SAFE — merges into existing env vars
+gcloud run services update "$MINT_SERVICE" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" \
+  --update-env-vars="KEY=value"
+
+# DANGEROUS — replaces ALL env vars, destroying every other variable
+# gcloud run services update "$MINT_SERVICE" --set-env-vars="KEY=value"
+```
+
+Prefer `fullsend mint enroll` over manual `gcloud` env var edits — the
+CLI handles read-merge-write with REVISION-pinned traffic routing.
+
+Set these variables for the commands below:
+
+```bash
+MINT_SERVICE="fullsend-mint"
+ORG="<github-org>"           # the org you are troubleshooting
+WIF_POOL="fullsend-pool"
+```
+
+### Read env vars from the traffic-serving revision
+
+The traffic-serving revision may differ from the service template. To see
+what the mint is actually serving:
+
+```bash
+# Get the traffic-serving revision name
+TRAFFIC_REV=$(gcloud run services describe "$MINT_SERVICE" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" \
+  --format="value(status.traffic[0].revisionName)")
+
+# Read its env vars
+gcloud run revisions describe "$TRAFFIC_REV" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" \
+  --format="yaml(spec.containers[0].env)"
+```
+
+### Compare template vs traffic revision
+
+```bash
+# Template env vars (what new revisions would get)
+gcloud run services describe "$MINT_SERVICE" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" \
+  --format="yaml(spec.template.spec.containers[0].env)"
+
+# List recent revisions
+gcloud run revisions list \
+  --service="$MINT_SERVICE" \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" \
+  --limit=5
+```
+
+### Check PEM secrets
+
+```bash
+# List all PEM secrets for the org
+gcloud secrets list --project="$GCP_PROJECT" \
+  --filter="name:fullsend-${ORG}--" \
+  --format="table(name,createTime)"
+
+# Check if a specific secret has an enabled version
+gcloud secrets versions describe latest \
+  --secret="fullsend-${ORG}--coder-app-pem" \
+  --project="$GCP_PROJECT" --format="value(state)"
+```
+
+### Check WIF provider state
+
+```bash
+# List all WIF providers
+gcloud iam workload-identity-pools providers list \
+  --project="$GCP_PROJECT" \
+  --workload-identity-pool="$WIF_POOL" \
+  --location=global \
+  --format="table(name.basename(),state,disabled)"
+
+# Check the shared provider's attribute condition
+gcloud iam workload-identity-pools providers describe github-oidc \
+  --project="$GCP_PROJECT" \
+  --workload-identity-pool="$WIF_POOL" \
+  --location=global \
+  --format="value(attributeCondition)"
+```
+
+### Read mint logs
+
+```bash
+gcloud functions logs read fullsend-mint \
+  --project="$GCP_PROJECT" --region="$MINT_REGION" --gen2 --limit=50 \
+  --format="table(timecreated,severity,textPayload)" \
+  | grep -i "$ORG"
+```
+
+For more troubleshooting scenarios, see the
+[Troubleshooting section](../../docs/guides/infrastructure/mint-administration.md#troubleshooting)
+in the mint administration guide.


### PR DESCRIPTION
## Summary
- **fix(mint):** Handle short revision names from Cloud Run v2 API — the API returns short names (e.g., `fullsend-mint-00114-fm9`) in `trafficStatuses[].revision` and `latestCreatedRevision`, but the code expected fully qualified resource names. This broke `mint enroll`, `mint unenroll`, and `mint status` env var reads.
- **docs(mint):** Update mint-administration.md with post-enrollment verification, REVISION-pinned traffic routing, expanded status section, and troubleshooting guide
- **docs(mint):** Rewrite mint-enroll skill from 835-line gcloud runbook to CLI-based workflow using `fullsend mint` commands

## Bug details

Three failures caused by the Cloud Run v2 API returning short revision names:

1. `GetServiceTrafficEnvVars` rejected the short name as invalid, blocking unenroll and enroll operations
2. `UpdateServiceEnvVars` sent the full resource name in the traffic PATCH payload, but Cloud Run expects a short name there — caused a 400 error and left traffic on the old revision (partial failure)
3. `GetServiceRevisionInfo` silently skipped reading traffic revision env vars when the name didn't match the full pattern

## Test plan
- [x] `go vet ./internal/dispatch/gcf/...` passes
- [x] `go test -race ./internal/dispatch/gcf/...` passes (all 14 revision/traffic tests)
- [x] `make go-build` succeeds
- [x] `make lint` passes
- [x] Verified live: `mint unenroll nonflux/integration-service` + `mint unenroll nonflux` succeeded
- [x] Verified live: `mint enroll nonflux` + `mint enroll nonflux/integration-service` re-enrolled successfully
- [x] Verified live: `mint status` shows healthy, 21 orgs, revision-pinned traffic, template matches
- [x] Verified live: Cloud Run logs show zero request failures on serving revision
- [x] Verify all CLI flag names match current `mint.go` implementation
- [x] Verify no internal identifiers in doc content