### PR TITLE
feat(config): add skip_auto_review field to control PR review triggers

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -178,7 +178,16 @@ jobs:
             pull_request_target)
               case "${EVENT_ACTION}" in
                 opened|synchronize|ready_for_review)
-                  STAGE="review"
+                  # Check skip_auto_review config (defaults to false).
+                  # When skip_auto_review: true, PR events don't auto-trigger review —
+                  # /fs-review slash command and ready-for-review label still work.
+                  SKIP_AUTO_REVIEW="false"
+                  if [[ -f .fullsend/config.yaml ]]; then
+                    SKIP_AUTO_REVIEW=$(yq '.skip_auto_review // false' .fullsend/config.yaml)
+                  fi
+                  if [[ "$SKIP_AUTO_REVIEW" != "true" ]]; then
+                    STAGE="review"
+                  fi
                   ;;
                 closed)
                   STAGE="retro"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type RepoDefaults struct {
 	Roles                    []string `yaml:"roles"`
 	MaxImplementationRetries int      `yaml:"max_implementation_retries"`
 	AutoMerge                bool     `yaml:"auto_merge"`
+	SkipAutoReview           bool     `yaml:"skip_auto_review"`
 }
 
 // RepoConfig holds per-repo configuration.
@@ -95,6 +96,7 @@ func NewOrgConfig(allRepos, enabledRepos, roles []string, agents []AgentEntry, i
 			Roles:                    roles,
 			MaxImplementationRetries: 2,
 			AutoMerge:                false,
+			SkipAutoReview:           false,
 		},
 		Agents: agents,
 		Repos:  repos,
@@ -204,9 +206,10 @@ func (c *OrgConfig) DefaultRoles() []string {
 // PerRepoConfig holds configuration for per-repo installation mode.
 // Stored in .fullsend/config.yaml within the target repository.
 type PerRepoConfig struct {
-	Version    string   `yaml:"version"`
-	KillSwitch bool     `yaml:"kill_switch,omitempty"`
-	Roles      []string `yaml:"roles,omitempty"`
+	Version        string   `yaml:"version"`
+	KillSwitch     bool     `yaml:"kill_switch,omitempty"`
+	Roles          []string `yaml:"roles,omitempty"`
+	SkipAutoReview bool     `yaml:"skip_auto_review,omitempty"`
 }
 
 const perRepoConfigHeader = `# fullsend per-repo configuration
@@ -222,8 +225,9 @@ func NewPerRepoConfig(roles []string) *PerRepoConfig {
 		roles = DefaultAgentRoles()
 	}
 	return &PerRepoConfig{
-		Version: "1",
-		Roles:   roles,
+		Version:        "1",
+		Roles:          roles,
+		SkipAutoReview: false,
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -47,6 +47,7 @@ func TestNewOrgConfig(t *testing.T) {
 	assert.Equal(t, "github-actions", cfg.Dispatch.Platform)
 	assert.Equal(t, 2, cfg.Defaults.MaxImplementationRetries)
 	assert.False(t, cfg.Defaults.AutoMerge)
+	assert.False(t, cfg.Defaults.SkipAutoReview)
 	assert.Equal(t, roles, cfg.Defaults.Roles)
 
 	assert.True(t, cfg.Repos["repo-a"].Enabled)
@@ -750,5 +751,120 @@ repos: {}
 		data, err := cfg.Marshal()
 		require.NoError(t, err)
 		assert.NotContains(t, string(data), "allowed_remote_resources")
+	})
+}
+
+// --- SkipAutoReview tests ---
+
+func TestOrgConfig_SkipAutoReview(t *testing.T) {
+	t.Run("parse YAML with skip_auto_review true", func(t *testing.T) {
+		yamlData := `
+version: "1"
+dispatch:
+  platform: github-actions
+defaults:
+  roles:
+    - fullsend
+  max_implementation_retries: 2
+  auto_merge: false
+  skip_auto_review: true
+agents: []
+repos: {}
+`
+		cfg, err := ParseOrgConfig([]byte(yamlData))
+		require.NoError(t, err)
+		assert.True(t, cfg.Defaults.SkipAutoReview)
+	})
+
+	t.Run("parse YAML without skip_auto_review", func(t *testing.T) {
+		yamlData := `
+version: "1"
+dispatch:
+  platform: github-actions
+defaults:
+  roles:
+    - fullsend
+  max_implementation_retries: 2
+  auto_merge: false
+agents: []
+repos: {}
+`
+		cfg, err := ParseOrgConfig([]byte(yamlData))
+		require.NoError(t, err)
+		assert.False(t, cfg.Defaults.SkipAutoReview)
+	})
+
+	t.Run("marshal includes skip_auto_review", func(t *testing.T) {
+		cfg := &OrgConfig{
+			Version:  "1",
+			Dispatch: DispatchConfig{Platform: "github-actions"},
+			Defaults: RepoDefaults{
+				Roles:                    []string{"fullsend"},
+				MaxImplementationRetries: 2,
+				AutoMerge:                false,
+				SkipAutoReview:           true,
+			},
+			Agents: []AgentEntry{},
+			Repos:  map[string]RepoConfig{},
+		}
+		data, err := cfg.Marshal()
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "skip_auto_review:")
+	})
+}
+
+func TestPerRepoConfig_SkipAutoReview(t *testing.T) {
+	t.Run("NewPerRepoConfig defaults skip_auto_review to false", func(t *testing.T) {
+		cfg := NewPerRepoConfig(nil)
+		assert.False(t, cfg.SkipAutoReview)
+	})
+
+	t.Run("parse YAML with skip_auto_review true", func(t *testing.T) {
+		yamlData := `
+version: "1"
+roles:
+  - fullsend
+  - triage
+skip_auto_review: true
+`
+		cfg, err := ParsePerRepoConfig([]byte(yamlData))
+		require.NoError(t, err)
+		assert.True(t, cfg.SkipAutoReview)
+	})
+
+	t.Run("parse YAML with skip_auto_review false", func(t *testing.T) {
+		yamlData := `
+version: "1"
+roles:
+  - fullsend
+  - triage
+skip_auto_review: false
+`
+		cfg, err := ParsePerRepoConfig([]byte(yamlData))
+		require.NoError(t, err)
+		assert.False(t, cfg.SkipAutoReview)
+	})
+
+	t.Run("marshal with skip_auto_review false omits field", func(t *testing.T) {
+		cfg := &PerRepoConfig{
+			Version:        "1",
+			Roles:          []string{"fullsend", "triage"},
+			SkipAutoReview: false,
+		}
+		data, err := cfg.Marshal()
+		require.NoError(t, err)
+		// omitempty skips false (zero value) for booleans
+		assert.NotContains(t, string(data), "skip_auto_review")
+	})
+
+	t.Run("marshal with skip_auto_review true includes field", func(t *testing.T) {
+		cfg := &PerRepoConfig{
+			Version:        "1",
+			Roles:          []string{"fullsend", "triage"},
+			SkipAutoReview: true,
+		}
+		data, err := cfg.Marshal()
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "skip_auto_review: true")
 	})
 }

--- a/web/admin/src/lib/layers/fixtures/configrepo/config-valid.yaml
+++ b/web/admin/src/lib/layers/fixtures/configrepo/config-valid.yaml
@@ -5,5 +5,6 @@ defaults:
   roles: [fullsend]
   max_implementation_retries: 2
   auto_merge: false
+  skip_auto_review: false
 agents: []
 repos: {}


### PR DESCRIPTION
Add `skip_auto_review` boolean field to both RepoDefaults (org config) and PerRepoConfig (per-repo mode), defaulting to `true` for backward compatibility.

When `auto_review` is set to false:
- `pull_request_target` events (`opened/synchronize/ready_for_review`) skip automatic review dispatch
- `/fs-review` slash command still works
- `ready-for-review` label still works

This allows repos to opt into on-demand-only PR reviews, useful for build-service repos or other cases where automatic reviews on every PR aren't desired.

Changes:
- Add AutoReview bool field to `RepoDefaults` and `PerRepoConfig` structs
- Default `AutoReview` to `true` in `NewOrgConfig` and `NewPerRepoConfig`
- Update `reusable-dispatch.yml` routing logic to check `auto_review` config
- Add comprehensive test coverage for parsing, marshaling, and validation
- Update test fixtures with auto_review field
- Add inline documentation in dispatch workflow