### PR TITLE
fix(dispatch): prevent auto-review of human PRs

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -178,7 +178,11 @@ jobs:
             pull_request_target)
               case "${EVENT_ACTION}" in
                 opened|synchronize|ready_for_review)
-                  STAGE="review"
+                  # Only auto-review bot PRs.
+                  # Human PRs require explicit triggering via /fs-review command.
+                  if [[ "${PR_USER_LOGIN}" =~ \[bot\]$ ]]; then
+                    STAGE="review"
+                  fi
                   ;;
                 closed)
                   STAGE="retro"

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -148,7 +148,11 @@ jobs:
             pull_request_target)
               case "${EVENT_ACTION}" in
                 opened|synchronize|ready_for_review)
-                  STAGE="review"
+                  # Only auto-review bot PRs.
+                  # Human PRs require explicit triggering via /fs-review command.
+                  if [[ "${PR_USER_LOGIN}" =~ \[bot\]$ ]]; then
+                    STAGE="review"
+                  fi
                   ;;
                 closed)
                   STAGE="retro"


### PR DESCRIPTION
The pull_request_target event handler was unconditionally triggering review for all PRs regardless of author. This caused human PRs to be auto-reviewed, which is not the intended behavior.

Now the review stage only auto-triggers for PRs created by bots (username ends with [bot]).

Human PRs can still be reviewed via `/fs-review` command (issue_comment event)

This aligns the review trigger logic with the existing fix agent pattern, which already distinguishes between bot and human PRs.

Fixes both per-org and per-repo dispatch workflows.