### PR TITLE
fix(images/code): run gopls install as sandbox user

### DIFF
--- a/images/code/Containerfile
+++ b/images/code/Containerfile
@@ -71,16 +71,6 @@ RUN case "$TARGETARCH" in \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm /tmp/go.tar.gz
 
-ENV PATH="/usr/local/go/bin:${PATH}" \
-    GOPATH="/sandbox/go" \
-    GOMODCACHE="/sandbox/go/pkg/mod"
-
-# ---------------------------------------------------------------------------
-# gopls — Go language server for Claude Code LSP code intelligence.
-ARG GOPLS_VERSION=0.18.1
-RUN GOBIN=/usr/local/go/bin go install "golang.org/x/tools/gopls@v${GOPLS_VERSION}" \
-    && gopls version
-
 # ---------------------------------------------------------------------------
 # lychee — markdown link checker used by pre-commit hooks (lint-md-links).
 # Baked into the image so pre-commit hooks work without network access.
@@ -122,3 +112,9 @@ COPY scan-secrets /usr/local/bin/scan-secrets
 RUN chmod +x /usr/local/bin/scan-secrets
 
 USER sandbox
+
+# ---------------------------------------------------------------------------
+# gopls — Go language server for Claude Code LSP code intelligence.
+ENV PATH="/sandbox/go/bin:/usr/local/go/bin:${PATH}"
+ARG GOPLS_VERSION=0.18.1
+RUN go install "golang.org/x/tools/gopls@v${GOPLS_VERSION}" && gopls version

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -28,8 +28,8 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/envfile"
 	"github.com/fullsend-ai/fullsend/internal/fetch"
 	"github.com/fullsend-ai/fullsend/internal/harness"
-	agentruntime "github.com/fullsend-ai/fullsend/internal/runtime"
 	"github.com/fullsend-ai/fullsend/internal/resolve"
+	agentruntime "github.com/fullsend-ai/fullsend/internal/runtime"
 	"github.com/fullsend-ai/fullsend/internal/sandbox"
 	"github.com/fullsend-ai/fullsend/internal/scaffold"
 	"github.com/fullsend-ai/fullsend/internal/security"
@@ -872,10 +872,10 @@ func bootstrapEnv(sandboxName, repoDir string, h *harness.Harness, runtimeEnvExp
 
 	// Infrastructure vars.
 	pathExport := fmt.Sprintf("export PATH=%s/bin", sandbox.SandboxWorkspace)
-	if len(h.Plugins) > 0 {
-		pathExport += ":/usr/local/go/bin"
-	}
+	pathExport += ":/usr/local/go/bin"
+	pathExport += ":$HOME/go/bin"
 	pathExport += ":$PATH"
+
 	lines = append(lines, pathExport)
 	lines = append(lines, runtimeEnvExports...)
 	lines = append(lines, fmt.Sprintf("export FULLSEND_OUTPUT_DIR=%s", outputDir))


### PR DESCRIPTION
## Summary

- Moves `go install gopls` after `USER sandbox` in the code agent `Containerfile`
- `go install` now creates `/sandbox/go` owned by `sandbox` instead of `root`
- Removes the explicit `GOPATH`/`GOMODCACHE` env vars set before the user switch — Go's defaults (`$HOME/go`) work correctly once the user is right

## Test plan

- [ ] Build the code agent image and confirm `ls -la /sandbox/go` shows `sandbox` ownership
- [ ] In a sandbox from the new image, run the repro from #1904 — `go build` should succeed without `GOPATH` override
- [ ] Confirm `gopls` still works: `gopls version`

Fixes #1904