### PR TITLE
docs(#1279): add per-repo vs per-org decision point to install guide

### DIFF
--- a/docs/guides/getting-started/installation.md
+++ b/docs/guides/getting-started/installation.md
@@ -1,6 +1,29 @@
-# How to onboard a new organization
+# How to install fullsend
 
-This guide walks through setting up fullsend in a GitHub organization and enrolling your first repository.
+This guide walks through installing fullsend for a GitHub organization or a single repository.
+
+## Choose your installation mode
+
+Before running any install commands, decide whether you need **per-org** or **per-repo** mode:
+
+| Mode | Command format | Best for | Creates `.fullsend` repo? |
+|------|---------------|----------|--------------------------|
+| **Per-org** | `fullsend admin install ORG` | Orgs where one admin manages fullsend for all repos | Yes |
+| **Per-repo** | `fullsend admin install ORG/REPO` | Teams in shared orgs, single-repo onboarding, independent setups | No |
+
+**Use per-repo mode** if any of these apply:
+- Multiple independent teams share the same GitHub organization
+- You only want fullsend on specific repositories without org-wide configuration
+- You do not have (or do not want to use) org-level admin access
+
+→ Skip to [Per-repo installation](#per-repo-installation)
+
+**Use per-org mode** if:
+- A single admin manages fullsend across the entire organization
+- You want centralized configuration via the `.fullsend` config repo
+- You plan to enroll many repositories under unified management
+
+→ Continue below to choose your setup path
 
 ## Choose your setup path
 


### PR DESCRIPTION
## Summary

- Adds a "Choose your installation mode" section at the top of the install guide, before the existing setup path routing
- Presents per-repo vs per-org as a clear decision with a comparison table, criteria for each mode, and links to the relevant section
- Renames the guide title from "How to onboard a new organization" to "How to install fullsend" to reflect both modes

This ensures users in shared-org scenarios see the per-repo option before running any org-level commands that create an unwanted `.fullsend` config repo.

Supersedes #1592 (which targets a file path and structure that no longer exists on main).

Closes #1279

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify all internal links resolve (lint passes)
- [ ] Manual review: a shared-org user reading top-to-bottom finds the per-repo path before any install commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)