### PR TITLE
fix(#1449): use GitHub App bot identity for agent commits

### DIFF
--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -140,6 +140,18 @@ jobs:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
 
+      - name: Resolve bot identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          APP_SLUG=$(gh api /app --jq '.slug')
+          BOT_LOGIN="${APP_SLUG}[bot]"
+          BOT_USER_ID=$(gh api "/users/${BOT_LOGIN}" --jq '.id')
+          GIT_BOT_EMAIL="${BOT_USER_ID}+${BOT_LOGIN}@users.noreply.github.com"
+          echo "Resolved bot identity: ${BOT_LOGIN} (${BOT_USER_ID})"
+          echo "GIT_BOT_EMAIL=${GIT_BOT_EMAIL}" >> "${GITHUB_ENV}"
+
       - name: Setup agent environment
         env:
           AGENT_PREFIX: CODE_

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -129,6 +129,18 @@ jobs:
           repos: ${{ steps.repo-parts.outputs.name }}
           mint_url: ${{ inputs.mint_url }}
 
+      - name: Resolve bot identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          APP_SLUG=$(gh api /app --jq '.slug')
+          BOT_LOGIN="${APP_SLUG}[bot]"
+          BOT_USER_ID=$(gh api "/users/${BOT_LOGIN}" --jq '.id')
+          GIT_BOT_EMAIL="${BOT_USER_ID}+${BOT_LOGIN}@users.noreply.github.com"
+          echo "Resolved bot identity: ${BOT_LOGIN} (${BOT_USER_ID})"
+          echo "GIT_BOT_EMAIL=${GIT_BOT_EMAIL}" >> "${GITHUB_ENV}"
+
       - name: Block fork PRs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,12 @@ chore(ci): update goreleaser to v2
 
 GoReleaser groups changelog entries by type prefix (see `.goreleaser.yml`). Commits without a recognized prefix land under "Others". Commits prefixed `docs:`, `test:`, or `chore:` are excluded from release notes entirely. A wrong prefix means the change shows up in the wrong section — or not at all.
 
+## DCO (Developer Certificate of Origin)
+
+This project uses the [Probot DCO app](https://github.com/apps/dco) to enforce sign-off on human-authored commits. Add `Signed-off-by` to your commits with `git commit -s`.
+
+**Agent commits are exempt.** The DCO is a human attestation — it certifies personhood and legal authority to contribute. An agent cannot meaningfully provide that certification. The code and fix agents commit using the GitHub App's bot identity (`<id>+<slug>[bot]@users.noreply.github.com`), which GitHub recognizes as `author.type: "Bot"`. The Probot DCO app auto-skips bot-authored commits. The human who merges an agent PR accepts responsibility for the contribution.
+
 ## Pull request workflow
 
 ### Opening a PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,11 @@ GoReleaser groups changelog entries by type prefix (see `.goreleaser.yml`). Comm
 
 ## DCO (Developer Certificate of Origin)
 
-This project uses the [Probot DCO app](https://github.com/apps/dco) to enforce sign-off on human-authored commits. Add `Signed-off-by` to your commits with `git commit -s`.
+This project uses the [Probot DCO app](https://github.com/apps/dco) to enforce sign-off on commits. Add `Signed-off-by` to your commits with `git commit -s`.
 
-**Agent commits are exempt.** The DCO is a human attestation — it certifies personhood and legal authority to contribute. An agent cannot meaningfully provide that certification. The code and fix agents commit using the GitHub App's bot identity (`<id>+<slug>[bot]@users.noreply.github.com`), which GitHub recognizes as `author.type: "Bot"`. The Probot DCO app auto-skips bot-authored commits. The human who merges an agent PR accepts responsibility for the contribution.
+**Human-driven agent sessions** (e.g., using Claude Code locally) should sign off — the human directing the session is the one certifying the DCO, just as they would for any other commit.
+
+**Autonomous agent commits are exempt.** The fullsend code and fix agents run without a human in the loop at commit time. The DCO is a human attestation — it certifies personhood and legal authority to contribute. No one is present to make that certification in an autonomous session. These agents commit using the GitHub App's bot identity (`<id>+<slug>[bot]@users.noreply.github.com`), which GitHub recognizes as `author.type: "Bot"`. The Probot DCO app auto-skips bot-authored commits. The human who merges an agent PR accepts responsibility for the contribution.
 
 ## Pull request workflow
 

--- a/internal/scaffold/fullsend-repo/env/code-agent.env
+++ b/internal/scaffold/fullsend-repo/env/code-agent.env
@@ -8,10 +8,14 @@ export GITHUB_ISSUE_URL=${GITHUB_ISSUE_URL}
 # The separate write-enabled PUSH_TOKEN (runner_env) never enters the sandbox.
 export GH_TOKEN=${GH_TOKEN}
 
+# Git identity — uses the GitHub App bot user's noreply email so GitHub
+# links commits to the bot account (author.type === "Bot"). This makes
+# the Probot DCO app auto-exempt agent commits. The GIT_BOT_EMAIL var
+# is resolved at runtime by the "Resolve bot identity" workflow step.
 export GIT_AUTHOR_NAME="fullsend-code"
-export GIT_AUTHOR_EMAIL="fullsend-code@users.noreply.github.com"
+export GIT_AUTHOR_EMAIL="${GIT_BOT_EMAIL}"
 export GIT_COMMITTER_NAME="fullsend-code"
-export GIT_COMMITTER_EMAIL="fullsend-code@users.noreply.github.com"
+export GIT_COMMITTER_EMAIL="${GIT_BOT_EMAIL}"
 
 # Retry budget — the agent re-runs secret scan + tests on failure.
 # Pre-commit is capped at 2 runs total (not per retry) and is NOT

--- a/internal/scaffold/fullsend-repo/env/fix-agent.env
+++ b/internal/scaffold/fullsend-repo/env/fix-agent.env
@@ -12,12 +12,14 @@ export FIX_ITERATION="${FIX_ITERATION}"
 export GH_TOKEN="${GH_TOKEN}"
 
 # Author name is "fullsend-fix" (not "fullsend-code") so fix-agent
-# commits are distinguishable for iteration counting. The email stays
-# fullsend-code@ because both agents share the same GitHub App identity.
+# commits are distinguishable for iteration counting. Both agents share
+# the same GitHub App (coder role), so GIT_BOT_EMAIL resolves to the
+# same bot noreply address. This makes the Probot DCO app auto-exempt
+# agent commits (author.type === "Bot").
 export GIT_AUTHOR_NAME="fullsend-fix"
-export GIT_AUTHOR_EMAIL="fullsend-code@users.noreply.github.com"
+export GIT_AUTHOR_EMAIL="${GIT_BOT_EMAIL}"
 export GIT_COMMITTER_NAME="fullsend-fix"
-export GIT_COMMITTER_EMAIL="fullsend-code@users.noreply.github.com"
+export GIT_COMMITTER_EMAIL="${GIT_BOT_EMAIL}"
 
 # Retry budget — the agent re-runs secret scan + tests on failure.
 # Pre-commit is capped at 2 runs total (not per retry).

--- a/internal/scaffold/fullsend-repo/skills/code-implementation/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/code-implementation/SKILL.md
@@ -639,12 +639,12 @@ Hard-wrap guidelines when a limit is configured:
 - URLs that exceed the limit may remain on one line (gitlint usually
   allows this via `ignore-body-lines`)
 - `Closes #N` and similar trailers: keep on one line
-- **`Signed-off-by:`** — `git commit -s` auto-generates this from
-  `GIT_COMMITTER_NAME` and `GIT_COMMITTER_EMAIL`. If the resulting line
-  exceeds the body-max-line-length, gitlint CI will reject the commit.
-  Before committing, check: if the `Signed-off-by` trailer would exceed
-  the limit, omit the `-s` flag and write a shorter trailer manually, or
-  omit it entirely if the repo does not require DCO sign-off
+- **`Signed-off-by:`** — do NOT use `git commit -s`. The DCO is a
+  human attestation of personhood and legal authority to contribute.
+  An agent cannot meaningfully certify those conditions. Agent commits
+  use the GitHub App bot identity, which the DCO app auto-exempts.
+  The human who merges the PR accepts responsibility for the
+  contribution
 
 The commit body should:
 - Explain **what** changed and **why** (not just "fix bug")
@@ -653,7 +653,7 @@ The commit body should:
 - Note any trade-offs, assumptions, or edge cases
 
 ```bash
-git commit -s -m "<type>(#<number>): <short-description>
+git commit -m "<type>(#<number>): <short-description>
 
 <What changed and why. Hard-wrap at the limit from
 .gitlint if one is configured. Write substantive
@@ -673,16 +673,13 @@ is blocked by `disallowedTools`):
 
 ```bash
 git reset --soft HEAD~1
-git commit -s -m "<fixed title>
+git commit -m "<fixed title>
 
 <fixed body — respect ALL line-length rules>"
 gitlint --commit HEAD
 ```
 
 Common gitlint failures:
-- **B1 body-max-line-length** on `Signed-off-by:` — the auto-generated
-  trailer is too long. Recommit without `-s` and either add a shorter
-  sign-off manually or omit it if the repo doesn't require DCO.
 - **T1 title-max-length** — shorten the title.
 - **B1 body-max-line-length** on prose — re-wrap the offending line.
 

--- a/internal/scaffold/fullsend-repo/skills/code-implementation/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/code-implementation/SKILL.md
@@ -641,10 +641,10 @@ Hard-wrap guidelines when a limit is configured:
 - `Closes #N` and similar trailers: keep on one line
 - **`Signed-off-by:`** — do NOT use `git commit -s`. The DCO is a
   human attestation of personhood and legal authority to contribute.
-  An agent cannot meaningfully certify those conditions. Agent commits
-  use the GitHub App bot identity, which the DCO app auto-exempts.
-  The human who merges the PR accepts responsibility for the
-  contribution
+  No human is present to make that certification in an autonomous
+  agent session. Your commits use the GitHub App bot identity, which
+  the DCO app auto-exempts. The human who merges the PR accepts
+  responsibility for the contribution
 
 The commit body should:
 - Explain **what** changed and **why** (not just "fix bug")

--- a/internal/scaffold/fullsend-repo/skills/fix-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/fix-review/SKILL.md
@@ -355,7 +355,7 @@ The commit message must:
 - Note any disagreements with review feedback.
 
 ```bash
-git commit -s -m "fix: address review feedback on PR #${PR_NUMBER}
+git commit -m "fix: address review feedback on PR #${PR_NUMBER}
 
 <summary of changes per review comment>
 


### PR DESCRIPTION
## Summary

- Use the GitHub App's bot user noreply email for agent commits so GitHub links them to the bot account (`author.type: "Bot"`), which the Probot DCO app auto-exempts
- Resolve the bot user ID dynamically at runtime via `gh api /app` + `/users/{slug}[bot]` — works for any org's app without hardcoding
- Remove `git commit -s` from agent skills since the DCO is a human attestation that agents cannot meaningfully provide

## Changes

| File | What |
|------|------|
| `reusable-code.yml`, `reusable-fix.yml` | New "Resolve bot identity" step sets `GIT_BOT_EMAIL` in `GITHUB_ENV` |
| `code-agent.env`, `fix-agent.env` | Emails changed from hardcoded to `${GIT_BOT_EMAIL}` |
| `code-implementation/SKILL.md` | Removed `-s` flag; explains why DCO doesn't apply to agents |
| `fix-review/SKILL.md` | Removed `-s` from commit example |
| `CONTRIBUTING.md` | New DCO section documenting the exemption policy |

## How it works

1. Workflow mints the coder app token
2. New step calls `gh api /app` → app slug (e.g., `myorg-coder`)
3. Calls `gh api /users/myorg-coder[bot]` → bot user ID (e.g., `278716306`)
4. Sets `GIT_BOT_EMAIL=278716306+myorg-coder[bot]@users.noreply.github.com`
5. Env file expansion substitutes into `GIT_AUTHOR_EMAIL` / `GIT_COMMITTER_EMAIL`
6. GitHub links commit to bot user → DCO app skips it

## Test plan

- [ ] Deploy to a test org and trigger `/fs-code` on an issue — verify the commit author on the resulting PR shows as `<slug>[bot]` and DCO check passes without manual override
- [ ] Verify human PRs still require DCO sign-off (unchanged behavior)
- [ ] Check that fix agent iteration counting still works (author name `fullsend-fix` is preserved)

Closes #1449