### PR TITLE
fix(forge): treat HTTP 500 as transient in retryOnTransient

### DIFF
--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -562,7 +562,7 @@ func (c *LiveClient) retryOnTransient(ctx context.Context, label string, fn func
 		// Retry on transient errors:
 		// - 404: repo not ready (async init)
 		// - 409: branch ref conflict
-		// - 502/503/504: transient server-side errors
+		// - 500/502/503/504: transient server-side errors
 		var apiErr *APIError
 		if !errors.As(lastErr, &apiErr) || !isTransientStatus(apiErr.StatusCode) {
 			return lastErr
@@ -581,11 +581,12 @@ func (c *LiveClient) retryOnTransient(ctx context.Context, label string, fn func
 
 // isTransientStatus returns true for HTTP status codes that indicate a
 // transient error worth retrying: 404 (async repo init), 409 (branch ref
-// conflict), and server-side 502, 503, 504 (GitHub infrastructure errors).
+// conflict), and server-side 500, 502, 503, 504 (GitHub infrastructure errors).
 func isTransientStatus(code int) bool {
 	switch code {
 	case http.StatusNotFound,
 		http.StatusConflict,
+		http.StatusInternalServerError,
 		http.StatusBadGateway,
 		http.StatusServiceUnavailable,
 		http.StatusGatewayTimeout:

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -1152,12 +1152,12 @@ func TestCreateOrUpdateFile_MaxRetriesExceeded(t *testing.T) {
 }
 
 func TestIsTransientStatus(t *testing.T) {
-	transient := []int{404, 409, 502, 503, 504}
+	transient := []int{404, 409, 500, 502, 503, 504}
 	for _, code := range transient {
 		assert.True(t, isTransientStatus(code), "expected %d to be transient", code)
 	}
 
-	nonTransient := []int{200, 201, 400, 401, 403, 422, 500}
+	nonTransient := []int{200, 201, 400, 401, 403, 422}
 	for _, code := range nonTransient {
 		assert.False(t, isTransientStatus(code), "expected %d to not be transient", code)
 	}


### PR DESCRIPTION
## Summary

- Add `http.StatusInternalServerError` (500) to `isTransientStatus` so `retryOnTransient` retries on transient GitHub 500s alongside 502, 503, and 504
- Update `TestIsTransientStatus` to expect 500 as transient

Fixes #1785

## Test plan

- [x] `TestIsTransientStatus` updated and passing
- [x] Full `make go-test` passing
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)