### PR TITLE
chore(mint): log requested and granted token scope

### DIFF
--- a/.github/actions/mint-token/action.yml
+++ b/.github/actions/mint-token/action.yml
@@ -57,12 +57,13 @@ runs:
           -H "Content-Type: application/json" \
           -d "$BODY" \
           "${MINT_URL}/v1/token")
+        echo "::add-mask::$MINT_RESPONSE"
         TOKEN=$(echo "$MINT_RESPONSE" | jq -r '.token')
-        echo "::add-mask::$TOKEN"
         if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
           echo "::error::Token mint returned no token for role=$ROLE"
           exit 1
         fi
+        echo "::add-mask::$TOKEN"
         GRANTED_REPOS=$(echo "$MINT_RESPONSE" | jq -r '.granted_repos | if . then map(strings) | join(",") else empty end')
         GRANTED_PERMS=$(echo "$MINT_RESPONSE" | jq -r '.granted_permissions | if . then to_entries | map("\(.key)=\(.value)") | join(",") else empty end')
         REPO_SELECTION=$(echo "$MINT_RESPONSE" | jq -r '.repository_selection // empty')

--- a/.github/actions/mint-token/action.yml
+++ b/.github/actions/mint-token/action.yml
@@ -51,14 +51,20 @@ runs:
         REPOS_JSON=$(echo "$REPOS" | jq -Rc 'split(",") | map(select(length > 0))')
         BODY=$(jq -nc --arg role "$ROLE" --argjson repos "$REPOS_JSON" \
           '{role: $role, repos: $repos}')
-        TOKEN=$(curl -sSf --retry 5 --retry-delay 5 --retry-all-errors \
+        echo "Requesting token: role=$ROLE repos=$REPOS"
+        MINT_RESPONSE=$(curl -sSf --retry 5 --retry-delay 5 --retry-all-errors \
           -H "Authorization: Bearer $OIDC_TOKEN" \
           -H "Content-Type: application/json" \
           -d "$BODY" \
-          "${MINT_URL}/v1/token" | jq -r '.token')
+          "${MINT_URL}/v1/token")
+        TOKEN=$(echo "$MINT_RESPONSE" | jq -r '.token')
+        echo "::add-mask::$TOKEN"
         if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
           echo "::error::Token mint returned no token for role=$ROLE"
           exit 1
         fi
-        echo "::add-mask::$TOKEN"
+        GRANTED_REPOS=$(echo "$MINT_RESPONSE" | jq -r '.granted_repos | if . then map(strings) | join(",") else empty end')
+        GRANTED_PERMS=$(echo "$MINT_RESPONSE" | jq -r '.granted_permissions | if . then to_entries | map("\(.key)=\(.value)") | join(",") else empty end')
+        REPO_SELECTION=$(echo "$MINT_RESPONSE" | jq -r '.repository_selection // empty')
+        echo "Granted scope: repos=${GRANTED_REPOS:-} permissions=${GRANTED_PERMS:-} repo_selection=${REPO_SELECTION:-}"
         echo "token=$TOKEN" >> "$GITHUB_OUTPUT"

--- a/internal/dispatch/gcf/mintsrc/mintcore/github.go.embed
+++ b/internal/dispatch/gcf/mintsrc/mintcore/github.go.embed
@@ -31,8 +31,23 @@ type installationResponse struct {
 
 // installationTokenResponse is the response from POST /app/installations/{id}/access_tokens.
 type installationTokenResponse struct {
-	Token     string `json:"token"`
-	ExpiresAt string `json:"expires_at"`
+	Token               string                       `json:"token"`
+	ExpiresAt           string                       `json:"expires_at"`
+	Permissions         map[string]string             `json:"permissions,omitempty"`
+	Repositories        []installationTokenRepository `json:"repositories,omitempty"`
+	RepositorySelection string                        `json:"repository_selection,omitempty"`
+}
+
+// installationTokenRepository is a repo entry in the installation token response.
+type installationTokenRepository struct {
+	FullName string `json:"full_name"`
+}
+
+// GrantedScope holds the actual scope GitHub granted for the installation token.
+type GrantedScope struct {
+	Repos         []string
+	Permissions   map[string]string
+	RepoSelection string
 }
 
 // canonicalRolePermissions defines the minimum GitHub App permissions per agent role.
@@ -181,10 +196,10 @@ func FindInstallation(ctx context.Context, httpClient HTTPDoer, githubBaseURL, j
 
 // CreateInstallationToken exchanges a JWT for an installation access token,
 // scoped to the given repos and role-specific permissions.
-func CreateInstallationToken(ctx context.Context, httpClient HTTPDoer, githubBaseURL, jwt string, installationID int64, role string, repos []string) (string, string, error) {
+func CreateInstallationToken(ctx context.Context, httpClient HTTPDoer, githubBaseURL, jwt string, installationID int64, role string, repos []string) (string, string, *GrantedScope, error) {
 	perms := RolePermissionsFor(role)
 	if perms == nil {
-		return "", "", fmt.Errorf("no permissions defined for role %q", role)
+		return "", "", nil, fmt.Errorf("no permissions defined for role %q", role)
 	}
 	tokenReqBody := map[string]interface{}{
 		"repositories": repos,
@@ -193,13 +208,13 @@ func CreateInstallationToken(ctx context.Context, httpClient HTTPDoer, githubBas
 
 	tokenReqBytes, err := json.Marshal(tokenReqBody)
 	if err != nil {
-		return "", "", fmt.Errorf("marshaling token request: %w", err)
+		return "", "", nil, fmt.Errorf("marshaling token request: %w", err)
 	}
 
 	reqURL := fmt.Sprintf("%s/app/installations/%d/access_tokens", githubBaseURL, installationID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(tokenReqBytes))
 	if err != nil {
-		return "", "", fmt.Errorf("creating token request: %w", err)
+		return "", "", nil, fmt.Errorf("creating token request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+jwt)
 	req.Header.Set("Accept", "application/vnd.github+json")
@@ -207,23 +222,31 @@ func CreateInstallationToken(ctx context.Context, httpClient HTTPDoer, githubBas
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", "", fmt.Errorf("creating installation token: %w", err)
+		return "", "", nil, fmt.Errorf("creating installation token: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
 		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
-		return "", "", fmt.Errorf("creating installation token returned status %d", resp.StatusCode)
+		return "", "", nil, fmt.Errorf("creating installation token returned status %d", resp.StatusCode)
 	}
 
 	var tokenResp installationTokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		return "", "", fmt.Errorf("decoding token response: %w", err)
+		return "", "", nil, fmt.Errorf("decoding token response: %w", err)
 	}
 
 	if tokenResp.Token == "" {
-		return "", "", fmt.Errorf("empty installation token returned")
+		return "", "", nil, fmt.Errorf("empty installation token returned")
 	}
 
-	return tokenResp.Token, tokenResp.ExpiresAt, nil
+	granted := &GrantedScope{
+		Permissions:   tokenResp.Permissions,
+		RepoSelection: tokenResp.RepositorySelection,
+	}
+	for _, r := range tokenResp.Repositories {
+		granted.Repos = append(granted.Repos, r.FullName)
+	}
+
+	return tokenResp.Token, tokenResp.ExpiresAt, granted, nil
 }

--- a/internal/dispatch/gcf/mintsrc/mintcore/handler.go.embed
+++ b/internal/dispatch/gcf/mintsrc/mintcore/handler.go.embed
@@ -232,6 +232,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				log.Printf("WARNING: permission level mismatch: %s requested=%s granted=%s", perm, reqLevel, level)
 			}
 		}
+		for perm, reqLevel := range requested {
+			if _, ok := granted.Permissions[perm]; !ok {
+				log.Printf("WARNING: requested permission not granted: %s=%s", perm, reqLevel)
+			}
+		}
 	}
 
 	resp := mintResponse{

--- a/internal/dispatch/gcf/mintsrc/mintcore/handler.go.embed
+++ b/internal/dispatch/gcf/mintsrc/mintcore/handler.go.embed
@@ -24,8 +24,11 @@ type mintRequest struct {
 
 // mintResponse is returned on success.
 type mintResponse struct {
-	Token     string `json:"token"`
-	ExpiresAt string `json:"expires_at"`
+	Token         string            `json:"token"`
+	ExpiresAt     string            `json:"expires_at"`
+	GrantedRepos  []string          `json:"granted_repos,omitempty"`
+	GrantedPerms  map[string]string `json:"granted_permissions,omitempty"`
+	RepoSelection string            `json:"repository_selection,omitempty"`
 }
 
 // statusResponse is returned by the /v1/status diagnostic endpoint.
@@ -201,7 +204,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	org := strings.ToLower(claims.RepositoryOwner)
 
-	token, expiresAt, err := h.mintToken(ctx, org, req.Role, req.Repos)
+	token, expiresAt, granted, err := h.mintToken(ctx, org, req.Role, req.Repos)
 	if err != nil {
 		log.Printf("failed to mint token: org=%s role=%s err=%v", org, req.Role, err)
 		var me *mintError
@@ -213,15 +216,38 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("minted: org=%s role=%s repo_count=%d", org, req.Role, len(req.Repos))
+	log.Printf("minted: org=%s role=%s requested_repos=%v source_repo=%s workflow_ref=%s",
+		org, req.Role, req.Repos, claims.Repository, claims.JobWorkflowRef)
+	if granted != nil {
+		log.Printf("granted scope: repos=%v permissions=%v repo_selection=%s",
+			granted.Repos, granted.Permissions, granted.RepoSelection)
+		if granted.RepoSelection == "all" {
+			log.Printf("WARNING: token granted with repository_selection=all (requested specific repos: %v)", req.Repos)
+		}
+		requested := RolePermissionsFor(req.Role)
+		for perm, level := range granted.Permissions {
+			if reqLevel, ok := requested[perm]; !ok {
+				log.Printf("WARNING: extra permission granted: %s=%s (not requested)", perm, level)
+			} else if level != reqLevel {
+				log.Printf("WARNING: permission level mismatch: %s requested=%s granted=%s", perm, reqLevel, level)
+			}
+		}
+	}
+
+	resp := mintResponse{
+		Token:     token,
+		ExpiresAt: expiresAt,
+	}
+	if granted != nil {
+		resp.GrantedRepos = granted.Repos
+		resp.GrantedPerms = granted.Permissions
+		resp.RepoSelection = granted.RepoSelection
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(mintResponse{
-		Token:     token,
-		ExpiresAt: expiresAt,
-	})
+	json.NewEncoder(w).Encode(resp)
 }
 
 func (h *Handler) handleStatus(w http.ResponseWriter, claims *Claims) {
@@ -248,15 +274,15 @@ func (h *Handler) handleStatus(w http.ResponseWriter, claims *Claims) {
 	}
 }
 
-func (h *Handler) mintToken(ctx context.Context, org, role string, repos []string) (string, string, error) {
+func (h *Handler) mintToken(ctx context.Context, org, role string, repos []string) (string, string, *GrantedScope, error) {
 	appID, err := h.lookupRoleAppID(org, role)
 	if err != nil {
-		return "", "", &mintError{status: http.StatusForbidden, msg: fmt.Sprintf("looking up app ID for role %s: %v", role, err)}
+		return "", "", nil, &mintError{status: http.StatusForbidden, msg: fmt.Sprintf("looking up app ID for role %s: %v", role, err)}
 	}
 
 	pemData, err := h.pemAccessor.AccessPEM(ctx, org, role)
 	if err != nil {
-		return "", "", &mintError{status: http.StatusForbidden, msg: fmt.Sprintf("reading PEM secret for role %s: %v", role, err)}
+		return "", "", nil, &mintError{status: http.StatusForbidden, msg: fmt.Sprintf("reading PEM secret for role %s: %v", role, err)}
 	}
 	defer func() {
 		for i := range pemData {
@@ -266,20 +292,20 @@ func (h *Handler) mintToken(ctx context.Context, org, role string, repos []strin
 
 	jwt, err := GenerateAppJWT(appID, pemData)
 	if err != nil {
-		return "", "", &mintError{status: http.StatusInternalServerError, msg: fmt.Sprintf("generating app JWT: %v", err)}
+		return "", "", nil, &mintError{status: http.StatusInternalServerError, msg: fmt.Sprintf("generating app JWT: %v", err)}
 	}
 
 	installationID, err := FindInstallation(ctx, h.httpClient, h.githubBaseURL, jwt, org, repos[0])
 	if err != nil {
-		return "", "", &mintError{status: http.StatusBadGateway, msg: err.Error()}
+		return "", "", nil, &mintError{status: http.StatusBadGateway, msg: err.Error()}
 	}
 
-	token, expiresAt, err := CreateInstallationToken(ctx, h.httpClient, h.githubBaseURL, jwt, installationID, role, repos)
+	token, expiresAt, granted, err := CreateInstallationToken(ctx, h.httpClient, h.githubBaseURL, jwt, installationID, role, repos)
 	if err != nil {
-		return "", "", &mintError{status: http.StatusBadGateway, msg: err.Error()}
+		return "", "", nil, &mintError{status: http.StatusBadGateway, msg: err.Error()}
 	}
 
-	return token, expiresAt, nil
+	return token, expiresAt, granted, nil
 }
 
 func (h *Handler) checkAllowedRole(role string) bool {

--- a/internal/mintcore/github.go
+++ b/internal/mintcore/github.go
@@ -31,8 +31,23 @@ type installationResponse struct {
 
 // installationTokenResponse is the response from POST /app/installations/{id}/access_tokens.
 type installationTokenResponse struct {
-	Token     string `json:"token"`
-	ExpiresAt string `json:"expires_at"`
+	Token               string                       `json:"token"`
+	ExpiresAt           string                       `json:"expires_at"`
+	Permissions         map[string]string             `json:"permissions,omitempty"`
+	Repositories        []installationTokenRepository `json:"repositories,omitempty"`
+	RepositorySelection string                        `json:"repository_selection,omitempty"`
+}
+
+// installationTokenRepository is a repo entry in the installation token response.
+type installationTokenRepository struct {
+	FullName string `json:"full_name"`
+}
+
+// GrantedScope holds the actual scope GitHub granted for the installation token.
+type GrantedScope struct {
+	Repos         []string
+	Permissions   map[string]string
+	RepoSelection string
 }
 
 // canonicalRolePermissions defines the minimum GitHub App permissions per agent role.
@@ -181,10 +196,10 @@ func FindInstallation(ctx context.Context, httpClient HTTPDoer, githubBaseURL, j
 
 // CreateInstallationToken exchanges a JWT for an installation access token,
 // scoped to the given repos and role-specific permissions.
-func CreateInstallationToken(ctx context.Context, httpClient HTTPDoer, githubBaseURL, jwt string, installationID int64, role string, repos []string) (string, string, error) {
+func CreateInstallationToken(ctx context.Context, httpClient HTTPDoer, githubBaseURL, jwt string, installationID int64, role string, repos []string) (string, string, *GrantedScope, error) {
 	perms := RolePermissionsFor(role)
 	if perms == nil {
-		return "", "", fmt.Errorf("no permissions defined for role %q", role)
+		return "", "", nil, fmt.Errorf("no permissions defined for role %q", role)
 	}
 	tokenReqBody := map[string]interface{}{
 		"repositories": repos,
@@ -193,13 +208,13 @@ func CreateInstallationToken(ctx context.Context, httpClient HTTPDoer, githubBas
 
 	tokenReqBytes, err := json.Marshal(tokenReqBody)
 	if err != nil {
-		return "", "", fmt.Errorf("marshaling token request: %w", err)
+		return "", "", nil, fmt.Errorf("marshaling token request: %w", err)
 	}
 
 	reqURL := fmt.Sprintf("%s/app/installations/%d/access_tokens", githubBaseURL, installationID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(tokenReqBytes))
 	if err != nil {
-		return "", "", fmt.Errorf("creating token request: %w", err)
+		return "", "", nil, fmt.Errorf("creating token request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+jwt)
 	req.Header.Set("Accept", "application/vnd.github+json")
@@ -207,23 +222,31 @@ func CreateInstallationToken(ctx context.Context, httpClient HTTPDoer, githubBas
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", "", fmt.Errorf("creating installation token: %w", err)
+		return "", "", nil, fmt.Errorf("creating installation token: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
 		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
-		return "", "", fmt.Errorf("creating installation token returned status %d", resp.StatusCode)
+		return "", "", nil, fmt.Errorf("creating installation token returned status %d", resp.StatusCode)
 	}
 
 	var tokenResp installationTokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		return "", "", fmt.Errorf("decoding token response: %w", err)
+		return "", "", nil, fmt.Errorf("decoding token response: %w", err)
 	}
 
 	if tokenResp.Token == "" {
-		return "", "", fmt.Errorf("empty installation token returned")
+		return "", "", nil, fmt.Errorf("empty installation token returned")
 	}
 
-	return tokenResp.Token, tokenResp.ExpiresAt, nil
+	granted := &GrantedScope{
+		Permissions:   tokenResp.Permissions,
+		RepoSelection: tokenResp.RepositorySelection,
+	}
+	for _, r := range tokenResp.Repositories {
+		granted.Repos = append(granted.Repos, r.FullName)
+	}
+
+	return tokenResp.Token, tokenResp.ExpiresAt, granted, nil
 }

--- a/internal/mintcore/github_test.go
+++ b/internal/mintcore/github_test.go
@@ -87,14 +87,14 @@ func TestCreateInstallationToken(t *testing.T) {
 	}))
 	defer mockGH.Close()
 
-	token, expiresAt, err := CreateInstallationToken(t.Context(), http.DefaultClient, mockGH.URL, "fake-jwt", 42, "coder", []string{"my-repo"})
+	token, expiresAt, _, err := CreateInstallationToken(t.Context(), http.DefaultClient, mockGH.URL, "fake-jwt", 42, "coder", []string{"my-repo"})
 	require.NoError(t, err)
 	assert.Equal(t, "ghs_test_token", token)
 	assert.Equal(t, "2099-01-01T00:00:00Z", expiresAt)
 }
 
 func TestCreateInstallationToken_UnknownRole(t *testing.T) {
-	_, _, err := CreateInstallationToken(t.Context(), http.DefaultClient, "http://unused", "fake-jwt", 42, "nonexistent", []string{"repo"})
+	_, _, _, err := CreateInstallationToken(t.Context(), http.DefaultClient, "http://unused", "fake-jwt", 42, "nonexistent", []string{"repo"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no permissions defined")
 }

--- a/internal/mintcore/handler.go
+++ b/internal/mintcore/handler.go
@@ -232,6 +232,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				log.Printf("WARNING: permission level mismatch: %s requested=%s granted=%s", perm, reqLevel, level)
 			}
 		}
+		for perm, reqLevel := range requested {
+			if _, ok := granted.Permissions[perm]; !ok {
+				log.Printf("WARNING: requested permission not granted: %s=%s", perm, reqLevel)
+			}
+		}
 	}
 
 	resp := mintResponse{

--- a/internal/mintcore/handler.go
+++ b/internal/mintcore/handler.go
@@ -24,8 +24,11 @@ type mintRequest struct {
 
 // mintResponse is returned on success.
 type mintResponse struct {
-	Token     string `json:"token"`
-	ExpiresAt string `json:"expires_at"`
+	Token         string            `json:"token"`
+	ExpiresAt     string            `json:"expires_at"`
+	GrantedRepos  []string          `json:"granted_repos,omitempty"`
+	GrantedPerms  map[string]string `json:"granted_permissions,omitempty"`
+	RepoSelection string            `json:"repository_selection,omitempty"`
 }
 
 // statusResponse is returned by the /v1/status diagnostic endpoint.
@@ -201,7 +204,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	org := strings.ToLower(claims.RepositoryOwner)
 
-	token, expiresAt, err := h.mintToken(ctx, org, req.Role, req.Repos)
+	token, expiresAt, granted, err := h.mintToken(ctx, org, req.Role, req.Repos)
 	if err != nil {
 		log.Printf("failed to mint token: org=%s role=%s err=%v", org, req.Role, err)
 		var me *mintError
@@ -213,15 +216,38 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("minted: org=%s role=%s repo_count=%d", org, req.Role, len(req.Repos))
+	log.Printf("minted: org=%s role=%s requested_repos=%v source_repo=%s workflow_ref=%s",
+		org, req.Role, req.Repos, claims.Repository, claims.JobWorkflowRef)
+	if granted != nil {
+		log.Printf("granted scope: repos=%v permissions=%v repo_selection=%s",
+			granted.Repos, granted.Permissions, granted.RepoSelection)
+		if granted.RepoSelection == "all" {
+			log.Printf("WARNING: token granted with repository_selection=all (requested specific repos: %v)", req.Repos)
+		}
+		requested := RolePermissionsFor(req.Role)
+		for perm, level := range granted.Permissions {
+			if reqLevel, ok := requested[perm]; !ok {
+				log.Printf("WARNING: extra permission granted: %s=%s (not requested)", perm, level)
+			} else if level != reqLevel {
+				log.Printf("WARNING: permission level mismatch: %s requested=%s granted=%s", perm, reqLevel, level)
+			}
+		}
+	}
+
+	resp := mintResponse{
+		Token:     token,
+		ExpiresAt: expiresAt,
+	}
+	if granted != nil {
+		resp.GrantedRepos = granted.Repos
+		resp.GrantedPerms = granted.Permissions
+		resp.RepoSelection = granted.RepoSelection
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(mintResponse{
-		Token:     token,
-		ExpiresAt: expiresAt,
-	})
+	json.NewEncoder(w).Encode(resp)
 }
 
 func (h *Handler) handleStatus(w http.ResponseWriter, claims *Claims) {
@@ -248,15 +274,15 @@ func (h *Handler) handleStatus(w http.ResponseWriter, claims *Claims) {
 	}
 }
 
-func (h *Handler) mintToken(ctx context.Context, org, role string, repos []string) (string, string, error) {
+func (h *Handler) mintToken(ctx context.Context, org, role string, repos []string) (string, string, *GrantedScope, error) {
 	appID, err := h.lookupRoleAppID(org, role)
 	if err != nil {
-		return "", "", &mintError{status: http.StatusForbidden, msg: fmt.Sprintf("looking up app ID for role %s: %v", role, err)}
+		return "", "", nil, &mintError{status: http.StatusForbidden, msg: fmt.Sprintf("looking up app ID for role %s: %v", role, err)}
 	}
 
 	pemData, err := h.pemAccessor.AccessPEM(ctx, org, role)
 	if err != nil {
-		return "", "", &mintError{status: http.StatusForbidden, msg: fmt.Sprintf("reading PEM secret for role %s: %v", role, err)}
+		return "", "", nil, &mintError{status: http.StatusForbidden, msg: fmt.Sprintf("reading PEM secret for role %s: %v", role, err)}
 	}
 	defer func() {
 		for i := range pemData {
@@ -266,20 +292,20 @@ func (h *Handler) mintToken(ctx context.Context, org, role string, repos []strin
 
 	jwt, err := GenerateAppJWT(appID, pemData)
 	if err != nil {
-		return "", "", &mintError{status: http.StatusInternalServerError, msg: fmt.Sprintf("generating app JWT: %v", err)}
+		return "", "", nil, &mintError{status: http.StatusInternalServerError, msg: fmt.Sprintf("generating app JWT: %v", err)}
 	}
 
 	installationID, err := FindInstallation(ctx, h.httpClient, h.githubBaseURL, jwt, org, repos[0])
 	if err != nil {
-		return "", "", &mintError{status: http.StatusBadGateway, msg: err.Error()}
+		return "", "", nil, &mintError{status: http.StatusBadGateway, msg: err.Error()}
 	}
 
-	token, expiresAt, err := CreateInstallationToken(ctx, h.httpClient, h.githubBaseURL, jwt, installationID, role, repos)
+	token, expiresAt, granted, err := CreateInstallationToken(ctx, h.httpClient, h.githubBaseURL, jwt, installationID, role, repos)
 	if err != nil {
-		return "", "", &mintError{status: http.StatusBadGateway, msg: err.Error()}
+		return "", "", nil, &mintError{status: http.StatusBadGateway, msg: err.Error()}
 	}
 
-	return token, expiresAt, nil
+	return token, expiresAt, granted, nil
 }
 
 func (h *Handler) checkAllowedRole(role string) bool {

--- a/internal/mintcore/handler_test.go
+++ b/internal/mintcore/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"net/http/httptest"
@@ -1842,5 +1843,68 @@ func TestHandler_STSVerifier_PerRepoWIF_RestrictedWorkflows(t *testing.T) {
 
 	if rec2.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401 for disallowed per-repo workflow via STS, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+}
+
+func TestHandler_LogsRequestedPermissionNotGranted(t *testing.T) {
+	t.Setenv("ROLE_APP_IDS", `{"test-org/coder":"200"}`)
+
+	pemData, err := generateTestRSAKey()
+	if err != nil {
+		t.Fatalf("generating test key: %v", err)
+	}
+
+	env := newTestOIDCEnv(t, &fakePEMAccessor{
+		pems: map[string][]byte{"test-org/coder": pemData},
+	})
+	token := env.signToken(t, nil)
+
+	// Simulate GitHub granting only a subset of the coder role's permissions:
+	// contents and metadata are granted, but pull_requests, issues, and checks
+	// are missing.
+	github := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/test-org/test-repo/installation" && r.Method == http.MethodGet:
+			json.NewEncoder(w).Encode(installationResponse{
+				ID: 12345, Account: struct {
+					Login string `json:"login"`
+				}{Login: "test-org"},
+			})
+		case strings.HasPrefix(r.URL.Path, "/app/installations/12345/access_tokens") && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(installationTokenResponse{
+				Token:       "ghs_partial",
+				ExpiresAt:   "2026-05-06T12:00:00Z",
+				Permissions: map[string]string{"contents": "write", "metadata": "read"},
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer github.Close()
+	env.handler.githubBaseURL = github.URL
+
+	// Capture log output.
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(os.Stderr)
+
+	body := `{"role":"coder","repos":["test-repo"]}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/token", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	env.handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	logs := logBuf.String()
+	for _, perm := range []string{"pull_requests", "issues", "checks"} {
+		expected := fmt.Sprintf("WARNING: requested permission not granted: %s=", perm)
+		if !strings.Contains(logs, expected) {
+			t.Errorf("expected log to contain %q, got:\n%s", expected, logs)
+		}
 	}
 }

--- a/internal/mintcore/handler_test.go
+++ b/internal/mintcore/handler_test.go
@@ -657,6 +657,17 @@ func TestHandler_FullFlow(t *testing.T) {
 			json.NewEncoder(w).Encode(installationTokenResponse{
 				Token:     "ghs_test_token",
 				ExpiresAt: "2026-05-06T12:00:00Z",
+				Permissions: map[string]string{
+					"contents":      "write",
+					"pull_requests": "write",
+					"issues":        "write",
+					"checks":        "read",
+					"metadata":      "read",
+				},
+				Repositories: []installationTokenRepository{
+					{FullName: "test-org/test-repo"},
+				},
+				RepositorySelection: "selected",
 			})
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -683,6 +694,80 @@ func TestHandler_FullFlow(t *testing.T) {
 	}
 	if resp.ExpiresAt != "2026-05-06T12:00:00Z" {
 		t.Fatalf("expected expires_at=2026-05-06T12:00:00Z, got %s", resp.ExpiresAt)
+	}
+	if len(resp.GrantedRepos) != 1 || resp.GrantedRepos[0] != "test-org/test-repo" {
+		t.Fatalf("expected granted_repos=[test-org/test-repo], got %v", resp.GrantedRepos)
+	}
+	if resp.RepoSelection != "selected" {
+		t.Fatalf("expected repository_selection=selected, got %s", resp.RepoSelection)
+	}
+	if resp.GrantedPerms["contents"] != "write" {
+		t.Fatalf("expected granted_permissions to include contents=write, got %v", resp.GrantedPerms)
+	}
+}
+
+func TestHandler_FullFlowGrantedScopeAll(t *testing.T) {
+	t.Setenv("ROLE_APP_IDS", `{"test-org/coder":"200"}`)
+
+	pemData, err := generateTestRSAKey()
+	if err != nil {
+		t.Fatalf("generating test key: %v", err)
+	}
+
+	env := newTestOIDCEnv(t, &fakePEMAccessor{
+		pems: map[string][]byte{"test-org/coder": pemData},
+	})
+	token := env.signToken(t, nil)
+
+	github := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/test-org/test-repo/installation" && r.Method == http.MethodGet:
+			json.NewEncoder(w).Encode(installationResponse{
+				ID: 12345, Account: struct {
+					Login string `json:"login"`
+				}{Login: "test-org"},
+			})
+		case strings.HasPrefix(r.URL.Path, "/app/installations/12345/access_tokens") && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			// Simulate GitHub returning repository_selection "all" with no
+			// repositories array — the scenario #1916 is investigating.
+			json.NewEncoder(w).Encode(installationTokenResponse{
+				Token:               "ghs_all_repos_token",
+				ExpiresAt:           "2026-05-06T12:00:00Z",
+				Permissions:         map[string]string{"contents": "read", "issues": "write", "metadata": "read"},
+				RepositorySelection: "all",
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer github.Close()
+	env.handler.githubBaseURL = github.URL
+
+	body := `{"role":"coder","repos":["test-repo"]}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/token", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	env.handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp mintResponse
+	json.NewDecoder(rec.Body).Decode(&resp)
+	if resp.Token != "ghs_all_repos_token" {
+		t.Fatalf("expected token=ghs_all_repos_token, got %s", resp.Token)
+	}
+	if resp.RepoSelection != "all" {
+		t.Fatalf("expected repository_selection=all, got %s", resp.RepoSelection)
+	}
+	if len(resp.GrantedRepos) != 0 {
+		t.Fatalf("expected empty granted_repos for selection=all, got %v", resp.GrantedRepos)
+	}
+	if resp.GrantedPerms["issues"] != "write" {
+		t.Fatalf("expected granted_permissions to include issues=write, got %v", resp.GrantedPerms)
 	}
 }
 

--- a/internal/scaffold/fullsend-repo/.github/actions/mint-token/action.yml
+++ b/internal/scaffold/fullsend-repo/.github/actions/mint-token/action.yml
@@ -57,12 +57,13 @@ runs:
           -H "Content-Type: application/json" \
           -d "$BODY" \
           "${MINT_URL}/v1/token")
+        echo "::add-mask::$MINT_RESPONSE"
         TOKEN=$(echo "$MINT_RESPONSE" | jq -r '.token')
-        echo "::add-mask::$TOKEN"
         if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
           echo "::error::Token mint returned no token for role=$ROLE"
           exit 1
         fi
+        echo "::add-mask::$TOKEN"
         GRANTED_REPOS=$(echo "$MINT_RESPONSE" | jq -r '.granted_repos | if . then map(strings) | join(",") else empty end')
         GRANTED_PERMS=$(echo "$MINT_RESPONSE" | jq -r '.granted_permissions | if . then to_entries | map("\(.key)=\(.value)") | join(",") else empty end')
         REPO_SELECTION=$(echo "$MINT_RESPONSE" | jq -r '.repository_selection // empty')

--- a/internal/scaffold/fullsend-repo/.github/actions/mint-token/action.yml
+++ b/internal/scaffold/fullsend-repo/.github/actions/mint-token/action.yml
@@ -51,14 +51,20 @@ runs:
         REPOS_JSON=$(echo "$REPOS" | jq -Rc 'split(",") | map(select(length > 0))')
         BODY=$(jq -nc --arg role "$ROLE" --argjson repos "$REPOS_JSON" \
           '{role: $role, repos: $repos}')
-        TOKEN=$(curl -sSf --retry 5 --retry-delay 5 --retry-all-errors \
+        echo "Requesting token: role=$ROLE repos=$REPOS"
+        MINT_RESPONSE=$(curl -sSf --retry 5 --retry-delay 5 --retry-all-errors \
           -H "Authorization: Bearer $OIDC_TOKEN" \
           -H "Content-Type: application/json" \
           -d "$BODY" \
-          "${MINT_URL}/v1/token" | jq -r '.token')
+          "${MINT_URL}/v1/token")
+        TOKEN=$(echo "$MINT_RESPONSE" | jq -r '.token')
+        echo "::add-mask::$TOKEN"
         if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
           echo "::error::Token mint returned no token for role=$ROLE"
           exit 1
         fi
-        echo "::add-mask::$TOKEN"
+        GRANTED_REPOS=$(echo "$MINT_RESPONSE" | jq -r '.granted_repos | if . then map(strings) | join(",") else empty end')
+        GRANTED_PERMS=$(echo "$MINT_RESPONSE" | jq -r '.granted_permissions | if . then to_entries | map("\(.key)=\(.value)") | join(",") else empty end')
+        REPO_SELECTION=$(echo "$MINT_RESPONSE" | jq -r '.repository_selection // empty')
+        echo "Granted scope: repos=${GRANTED_REPOS:-} permissions=${GRANTED_PERMS:-} repo_selection=${REPO_SELECTION:-}"
         echo "token=$TOKEN" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Parse `repositories`, `permissions`, and `repository_selection` from GitHub's installation token response (fields we were discarding)
- Log both requested and granted scope on the mint server side
- Return granted scope in the mint response so the `mint-token` action can log it in workflow logs too
- Add OIDC source repo and workflow ref to the mint log line for tracing provenance

Relates to #1916 — gets us the observability needed to investigate how downstream retro runs are posting issues cross-org.

## Test plan

- [x] Existing mint tests pass
- [x] `TestHandler_FullFlow` updated to verify granted scope plumbing end-to-end
- [x] `make go-test` and `make lint` pass
- [ ] Deploy mint, trigger a retro run, check Cloud Function logs for the new `granted scope:` line
- [ ] Check workflow logs for the new `Requesting token:` / `Granted scope:` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)