### PR TITLE
ci: add build to allowed conventional commit types

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -9,4 +9,4 @@ line-length=100
 # Matches the types documented in CONTRIBUTING.md and parsed by
 # GoReleaser for release notes.
 [contrib-title-conventional-commits]
-types=feat,fix,refactor,docs,test,chore,ci,perf
+types=feat,fix,refactor,docs,test,chore,ci,perf,build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,7 @@ changelog:
       - '^docs(\(.*\))?:'
       - '^test(\(.*\))?:'
       - '^chore(\(.*\))?:'
+      - '^build(\(.*\))?:'
   groups:
     - title: Features
       regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ See [CLAUDE.md](CLAUDE.md) for project rules and design decisions.
 
 ## Commit messages
 
-Use [Conventional Commits](https://www.conventionalcommits.org/) format for every commit. The allowed types are: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `perf`. See [CONTRIBUTING.md](CONTRIBUTING.md#commit-messages) for the full specification.
+Use [Conventional Commits](https://www.conventionalcommits.org/) format for every commit. The allowed types are: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `perf`, `build`. See [CONTRIBUTING.md](CONTRIBUTING.md#commit-messages) for the full specification.
 
 This is not optional — GoReleaser parses commit prefixes to build release notes. A missing or wrong prefix produces incorrect changelogs.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/). 
 | `chore` | Maintenance (CI, deps, tooling) | No |
 | `ci` | CI/CD pipeline changes | No |
 | `perf` | Performance improvement | Yes — under **Others** |
+| `build` | Build system or dependency changes | No |
 
 ### Scope
 


### PR DESCRIPTION
Dependabot uses the `build(deps)` prefix for submodule bumps, which is a standard conventional commit type. The `build` type was missing from the allowed list, causing commit-lint failures on every dependabot PR.

**Changes:**

- `.gitlint` — add `build` to allowed types
- `CONTRIBUTING.md` — add `build` row to the types table
- `AGENTS.md` — add `build` to the allowed types list
- `.goreleaser.yml` — exclude `build` commits from release notes (same as `chore`, `ci`, `docs`, `test`)

Fixes commit-lint failure on #1781. Once merged, `@dependabot rebase` on #1781 will pick up the new config.