### PR TITLE
fix(#1449): resolve bot identity with GraphQL viewer instead of /app

### DIFF
--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -145,9 +145,10 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          APP_SLUG=$(gh api /app --jq '.slug')
-          BOT_LOGIN="${APP_SLUG}[bot]"
-          BOT_USER_ID=$(gh api "/users/${BOT_LOGIN}" --jq '.id')
+          read -r BOT_LOGIN BOT_USER_ID < <(
+            gh api graphql -f query='{ viewer { login databaseId } }' \
+              | jq -r '.data.viewer | "\(.login) \(.databaseId)"'
+          )
           GIT_BOT_EMAIL="${BOT_USER_ID}+${BOT_LOGIN}@users.noreply.github.com"
           echo "Resolved bot identity: ${BOT_LOGIN} (${BOT_USER_ID})"
           echo "GIT_BOT_EMAIL=${GIT_BOT_EMAIL}" >> "${GITHUB_ENV}"

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -134,9 +134,10 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          APP_SLUG=$(gh api /app --jq '.slug')
-          BOT_LOGIN="${APP_SLUG}[bot]"
-          BOT_USER_ID=$(gh api "/users/${BOT_LOGIN}" --jq '.id')
+          read -r BOT_LOGIN BOT_USER_ID < <(
+            gh api graphql -f query='{ viewer { login databaseId } }' \
+              | jq -r '.data.viewer | "\(.login) \(.databaseId)"'
+          )
           GIT_BOT_EMAIL="${BOT_USER_ID}+${BOT_LOGIN}@users.noreply.github.com"
           echo "Resolved bot identity: ${BOT_LOGIN} (${BOT_USER_ID})"
           echo "GIT_BOT_EMAIL=${GIT_BOT_EMAIL}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
## Summary

The "Resolve bot identity" step from #1914 called `gh api /app`, which needs App JWT auth — installation tokens can't use it. This broke code and fix agents with `HTTP 401` while triage and review were fine (they don't have the step).

Replacing the two REST calls with a single GraphQL `viewer` query, which works with installation tokens and gives us both the bot login and user ID in one round-trip.

Confirmed working in test workflow run [27026725512](https://github.com/fullsend-ai/fullsend/actions/runs/27026725512) — `viewer` returns `fullsend-ai-coder[bot]` and `databaseId: 278716306`.

## Changes

- `reusable-code.yml`, `reusable-fix.yml`: swap `gh api /app` + `gh api /users/` for `gh api graphql` viewer query
- Carries forward the rest of the original #1914 changes (env files, skill updates, CONTRIBUTING.md)

## Test plan

- [x] Test workflow confirmed GraphQL viewer works with installation tokens
- [ ] Point v0 at this branch, trigger `/fs-code` on a test issue in konflux-ci, confirm the step passes