### PR TITLE
fix(#1960): include disabled repos in repo-maintenance token scope

### DIFF
--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -365,30 +365,8 @@ Files over 64KB save fine if they contain only ASCII characters.`
 
 	// If the run failed, save logs and artifacts for debugging.
 	if finalRun.Conclusion != "success" {
-		runURL := fmt.Sprintf("https://github.com/%s/%s/actions/runs/%d", env.org, forge.ConfigRepoName, finalRun.ID)
-		fmt.Fprintf(os.Stderr, "::notice::Triage workflow run %d failed (conclusion: %s). Downloading debug artifacts. Run URL: %s\n", finalRun.ID, finalRun.Conclusion, runURL)
-
-		debugDir := filepath.Join(env.screenshotDir, fmt.Sprintf("triage-run-%d", finalRun.ID))
-		_ = os.MkdirAll(debugDir, 0o755)
-
-		// Save workflow logs.
-		logs, logErr := env.client.GetWorkflowRunLogs(ctx, env.org, forge.ConfigRepoName, finalRun.ID)
-		if logErr != nil {
-			t.Logf("Could not fetch run logs: %v", logErr)
-		} else {
-			logPath := filepath.Join(debugDir, "workflow-logs.txt")
-			if writeErr := os.WriteFile(logPath, []byte(logs), 0o644); writeErr != nil {
-				t.Logf("Could not write logs to %s: %v", logPath, writeErr)
-			} else {
-				fmt.Fprintf(os.Stderr, "::notice file=%s::Triage run %d workflow logs saved\n", logPath, finalRun.ID)
-			}
-			t.Logf("Workflow run logs:\n%s", logs)
-		}
-
-		// Download run artifacts (transcripts, etc).
-		downloadRunArtifacts(ctx, env.token, env.org, forge.ConfigRepoName, finalRun.ID, debugDir, t)
-
-		t.Fatalf("Triage workflow run %d concluded with %q, expected success. Debug artifacts saved to %s", finalRun.ID, finalRun.Conclusion, debugDir)
+		saveWorkflowRunDebugInfo(t, env, "triage", finalRun)
+		t.Fatalf("Triage workflow run %d concluded with %q, expected success", finalRun.ID, finalRun.Conclusion)
 	}
 
 	// Verify the triage agent posted a comment on the issue.
@@ -440,10 +418,37 @@ Files over 64KB save fine if they contain only ASCII characters.`
 		"issue should have a triage label (needs-info, ready-to-code, duplicate, or blocked), got: %v", labelNames)
 }
 
+// saveWorkflowRunDebugInfo fetches logs and artifacts for a failed workflow run
+// and saves them to the screenshot directory. Use this from any test phase that
+// watches a workflow run and needs to capture debug info on failure.
+func saveWorkflowRunDebugInfo(t *testing.T, env *e2eEnv, label string, run *forge.WorkflowRun) {
+	t.Helper()
+	ctx := context.Background()
+
+	runURL := fmt.Sprintf("https://github.com/%s/%s/actions/runs/%d", env.org, forge.ConfigRepoName, run.ID)
+	fmt.Fprintf(os.Stderr, "::warning::%s workflow run %d failed (conclusion: %s). Run URL: %s\n", label, run.ID, run.Conclusion, runURL)
+
+	debugDir := filepath.Join(env.screenshotDir, fmt.Sprintf("%s-run-%d", label, run.ID))
+	_ = os.MkdirAll(debugDir, 0o755)
+
+	logs, logErr := env.client.GetWorkflowRunLogs(ctx, env.org, forge.ConfigRepoName, run.ID)
+	if logErr != nil {
+		t.Logf("Could not fetch %s run logs: %v", label, logErr)
+	} else {
+		logPath := filepath.Join(debugDir, "workflow-logs.txt")
+		if writeErr := os.WriteFile(logPath, []byte(logs), 0o644); writeErr != nil {
+			t.Logf("Could not write logs to %s: %v", logPath, writeErr)
+		} else {
+			fmt.Fprintf(os.Stderr, "::warning file=%s::%s run %d workflow logs saved\n", logPath, label, run.ID)
+		}
+		t.Logf("%s workflow run logs:\n%s", label, logs)
+	}
+
+	downloadRunArtifacts(ctx, env.token, env.org, forge.ConfigRepoName, run.ID, debugDir, t)
+}
+
 // downloadRunArtifacts fetches all artifacts from a workflow run and extracts
-// them into destDir. Each artifact is extracted into a subdirectory named after
-// the artifact. This captures transcripts, screenshots, and other debug data
-// that the agent run uploads.
+// them into destDir.
 func downloadRunArtifacts(ctx context.Context, token, org, repo string, runID int, destDir string, t *testing.T) {
 	t.Helper()
 
@@ -584,6 +589,22 @@ func runUnenrollmentTest(t *testing.T, env *e2eEnv) {
 		"admin", "disable", "repos", env.org, testRepo, "--yolo")
 	t.Logf("Disable repos output:\n%s", output)
 
+	// Find the most recent repo-maintenance run so we can capture debug info
+	// if it failed. The CLI already watched it to completion, so it should
+	// exist and be completed.
+	var repoMaintRun *forge.WorkflowRun
+	runs, listErr := env.client.ListWorkflowRuns(ctx, env.org, forge.ConfigRepoName, "repo-maintenance.yml")
+	if listErr != nil {
+		t.Logf("Could not list repo-maintenance runs: %v", listErr)
+	} else if len(runs) > 0 {
+		r := runs[0]
+		repoMaintRun = &r
+		t.Logf("repo-maintenance run %d: status=%s conclusion=%s", r.ID, r.Status, r.Conclusion)
+		if r.Conclusion != "" && r.Conclusion != "success" {
+			saveWorkflowRunDebugInfo(t, env, "repo-maintenance", repoMaintRun)
+		}
+	}
+
 	// The CLI waited for repo-maintenance, so the removal PR should exist.
 	// A few retries handle GitHub eventual consistency.
 	var removalPR *forge.ChangeProposal
@@ -607,6 +628,9 @@ func runUnenrollmentTest(t *testing.T, env *e2eEnv) {
 			break
 		}
 		t.Logf("Attempt %d: removal PR not yet visible", attempt+1)
+	}
+	if removalPR == nil && repoMaintRun != nil && repoMaintRun.Conclusion != "success" {
+		t.Fatalf("removal PR not found for %s; repo-maintenance run %d concluded with %q (debug artifacts saved above)", testRepo, repoMaintRun.ID, repoMaintRun.Conclusion)
 	}
 	require.NotNil(t, removalPR, "removal PR should exist for %s", testRepo)
 	t.Logf("Found removal PR #%d: %s", removalPR.Number, removalPR.URL)

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -365,8 +365,8 @@ Files over 64KB save fine if they contain only ASCII characters.`
 
 	// If the run failed, save logs and artifacts for debugging.
 	if finalRun.Conclusion != "success" {
-		saveWorkflowRunDebugInfo(t, env, "triage", finalRun)
-		t.Fatalf("Triage workflow run %d concluded with %q, expected success", finalRun.ID, finalRun.Conclusion)
+		debugDir := saveWorkflowRunDebugInfo(t, env, "triage", finalRun)
+		t.Fatalf("Triage workflow run %d concluded with %q, expected success. Debug artifacts saved to %s", finalRun.ID, finalRun.Conclusion, debugDir)
 	}
 
 	// Verify the triage agent posted a comment on the issue.
@@ -421,7 +421,7 @@ Files over 64KB save fine if they contain only ASCII characters.`
 // saveWorkflowRunDebugInfo fetches logs and artifacts for a workflow run and
 // saves them to the screenshot directory. Called unconditionally so that even
 // successful runs leave a log trail for diagnosing silent-skip problems.
-func saveWorkflowRunDebugInfo(t *testing.T, env *e2eEnv, label string, run *forge.WorkflowRun) {
+func saveWorkflowRunDebugInfo(t *testing.T, env *e2eEnv, label string, run *forge.WorkflowRun) string {
 	t.Helper()
 	ctx := context.Background()
 
@@ -449,6 +449,7 @@ func saveWorkflowRunDebugInfo(t *testing.T, env *e2eEnv, label string, run *forg
 	}
 
 	downloadRunArtifacts(ctx, env.token, env.org, forge.ConfigRepoName, run.ID, debugDir, t)
+	return debugDir
 }
 
 // downloadRunArtifacts fetches all artifacts from a workflow run and extracts
@@ -631,10 +632,13 @@ func runUnenrollmentTest(t *testing.T, env *e2eEnv) {
 		}
 		t.Logf("Attempt %d: removal PR not yet visible", attempt+1)
 	}
-	if removalPR == nil && repoMaintRun != nil && repoMaintRun.Conclusion != "success" {
-		t.Fatalf("removal PR not found for %s; repo-maintenance run %d concluded with %q (debug artifacts saved above)", testRepo, repoMaintRun.ID, repoMaintRun.Conclusion)
+	if removalPR == nil {
+		msg := fmt.Sprintf("removal PR should exist for %s", testRepo)
+		if repoMaintRun != nil {
+			msg += fmt.Sprintf("; repo-maintenance run %d concluded with %q", repoMaintRun.ID, repoMaintRun.Conclusion)
+		}
+		t.Fatal(msg)
 	}
-	require.NotNil(t, removalPR, "removal PR should exist for %s", testRepo)
 	t.Logf("Found removal PR #%d: %s", removalPR.Number, removalPR.URL)
 	err := env.client.MergeChangeProposal(ctx, env.org, testRepo, removalPR.Number)
 	require.NoError(t, err, "merging removal PR")

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -418,15 +418,19 @@ Files over 64KB save fine if they contain only ASCII characters.`
 		"issue should have a triage label (needs-info, ready-to-code, duplicate, or blocked), got: %v", labelNames)
 }
 
-// saveWorkflowRunDebugInfo fetches logs and artifacts for a failed workflow run
-// and saves them to the screenshot directory. Use this from any test phase that
-// watches a workflow run and needs to capture debug info on failure.
+// saveWorkflowRunDebugInfo fetches logs and artifacts for a workflow run and
+// saves them to the screenshot directory. Called unconditionally so that even
+// successful runs leave a log trail for diagnosing silent-skip problems.
 func saveWorkflowRunDebugInfo(t *testing.T, env *e2eEnv, label string, run *forge.WorkflowRun) {
 	t.Helper()
 	ctx := context.Background()
 
 	runURL := fmt.Sprintf("https://github.com/%s/%s/actions/runs/%d", env.org, forge.ConfigRepoName, run.ID)
-	fmt.Fprintf(os.Stderr, "::warning::%s workflow run %d failed (conclusion: %s). Run URL: %s\n", label, run.ID, run.Conclusion, runURL)
+	annotation := "::notice::"
+	if run.Conclusion != "" && run.Conclusion != "success" {
+		annotation = "::warning::"
+	}
+	fmt.Fprintf(os.Stderr, "%s%s workflow run %d (conclusion: %s). Run URL: %s\n", annotation, label, run.ID, run.Conclusion, runURL)
 
 	debugDir := filepath.Join(env.screenshotDir, fmt.Sprintf("%s-run-%d", label, run.ID))
 	_ = os.MkdirAll(debugDir, 0o755)
@@ -439,7 +443,7 @@ func saveWorkflowRunDebugInfo(t *testing.T, env *e2eEnv, label string, run *forg
 		if writeErr := os.WriteFile(logPath, []byte(logs), 0o644); writeErr != nil {
 			t.Logf("Could not write logs to %s: %v", logPath, writeErr)
 		} else {
-			fmt.Fprintf(os.Stderr, "::warning file=%s::%s run %d workflow logs saved\n", logPath, label, run.ID)
+			fmt.Fprintf(os.Stderr, "%sfile=%s::%s run %d workflow logs saved\n", annotation, logPath, label, run.ID)
 		}
 		t.Logf("%s workflow run logs:\n%s", label, logs)
 	}
@@ -589,9 +593,9 @@ func runUnenrollmentTest(t *testing.T, env *e2eEnv) {
 		"admin", "disable", "repos", env.org, testRepo, "--yolo")
 	t.Logf("Disable repos output:\n%s", output)
 
-	// Find the most recent repo-maintenance run so we can capture debug info
-	// if it failed. The CLI already watched it to completion, so it should
-	// exist and be completed.
+	// Always capture the repo-maintenance run's logs. Even when the run
+	// succeeds, the logs reveal whether unenrollment was attempted or silently
+	// skipped (e.g. due to insufficient token scope).
 	var repoMaintRun *forge.WorkflowRun
 	runs, listErr := env.client.ListWorkflowRuns(ctx, env.org, forge.ConfigRepoName, "repo-maintenance.yml")
 	if listErr != nil {
@@ -600,9 +604,7 @@ func runUnenrollmentTest(t *testing.T, env *e2eEnv) {
 		r := runs[0]
 		repoMaintRun = &r
 		t.Logf("repo-maintenance run %d: status=%s conclusion=%s", r.ID, r.Status, r.Conclusion)
-		if r.Conclusion != "" && r.Conclusion != "success" {
-			saveWorkflowRunDebugInfo(t, env, "repo-maintenance", repoMaintRun)
-		}
+		saveWorkflowRunDebugInfo(t, env, "repo-maintenance", repoMaintRun)
 	}
 
 	// The CLI waited for repo-maintenance, so the removal PR should exist.

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -426,11 +426,15 @@ func saveWorkflowRunDebugInfo(t *testing.T, env *e2eEnv, label string, run *forg
 	ctx := context.Background()
 
 	runURL := fmt.Sprintf("https://github.com/%s/%s/actions/runs/%d", env.org, forge.ConfigRepoName, run.ID)
-	annotation := "::notice::"
+	// GitHub Actions annotation commands: "::notice::" for plain messages,
+	// "::notice " (no trailing ::) when followed by file= parameters.
+	annotationMsg := "::notice::"
+	annotationFile := "::notice "
 	if run.Conclusion != "" && run.Conclusion != "success" {
-		annotation = "::warning::"
+		annotationMsg = "::warning::"
+		annotationFile = "::warning "
 	}
-	fmt.Fprintf(os.Stderr, "%s%s workflow run %d (conclusion: %s). Run URL: %s\n", annotation, label, run.ID, run.Conclusion, runURL)
+	fmt.Fprintf(os.Stderr, "%s%s workflow run %d (conclusion: %s). Run URL: %s\n", annotationMsg, label, run.ID, run.Conclusion, runURL)
 
 	debugDir := filepath.Join(env.screenshotDir, fmt.Sprintf("%s-run-%d", label, run.ID))
 	_ = os.MkdirAll(debugDir, 0o755)
@@ -443,7 +447,7 @@ func saveWorkflowRunDebugInfo(t *testing.T, env *e2eEnv, label string, run *forg
 		if writeErr := os.WriteFile(logPath, []byte(logs), 0o644); writeErr != nil {
 			t.Logf("Could not write logs to %s: %v", logPath, writeErr)
 		} else {
-			fmt.Fprintf(os.Stderr, "%sfile=%s::%s run %d workflow logs saved\n", annotation, logPath, label, run.ID)
+			fmt.Fprintf(os.Stderr, "%sfile=%s::%s run %d workflow logs saved\n", annotationFile, logPath, label, run.ID)
 		}
 		t.Logf("%s workflow run logs:\n%s", label, logs)
 	}

--- a/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
@@ -22,25 +22,16 @@ jobs:
       - name: Checkout .fullsend
         uses: actions/checkout@v6
 
-      - name: Extract repo names from config
+      - name: Extract all repo names from config
         id: repo-list
         run: |
           # Collect ALL repos (enabled + disabled) so the minted token has
           # access to disabled repos too. Without this, the reconcile script
           # silently skips unenrollment because API calls to repos outside
           # the token scope fail and get swallowed by error suppression.
-          ENABLED=$(yq '[.repos | to_entries[] | select(.value.enabled == true) | .key] | join(",")' config.yaml)
-          DISABLED=$(yq '[.repos | to_entries[] | select(.value.enabled == false) | .key] | join(",")' config.yaml)
-          ALL=""
-          if [[ -n "$ENABLED" && -n "$DISABLED" ]]; then
-            ALL="$ENABLED,$DISABLED"
-          elif [[ -n "$ENABLED" ]]; then
-            ALL="$ENABLED"
-          elif [[ -n "$DISABLED" ]]; then
-            ALL="$DISABLED"
-          fi
+          ALL=$(yq '[.repos | to_entries[] | select(.value.enabled == true or .value.enabled == false) | .key] | join(",")' config.yaml)
           if [[ -z "$ALL" ]]; then
-            echo "::notice::No repos found in config.yaml — nothing to do"
+            echo "::notice::No enabled or disabled repos found in config.yaml — nothing to do"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
@@ -22,16 +22,29 @@ jobs:
       - name: Checkout .fullsend
         uses: actions/checkout@v6
 
-      - name: Extract enrolled repo names from config
+      - name: Extract repo names from config
         id: repo-list
         run: |
-          REPOS=$(yq '[.repos | to_entries[] | select(.value.enabled == true) | .key] | join(",")' config.yaml)
-          if [[ -z "$REPOS" ]]; then
-            echo "::notice::No enabled repos found in config.yaml — nothing to do"
+          # Collect ALL repos (enabled + disabled) so the minted token has
+          # access to disabled repos too. Without this, the reconcile script
+          # silently skips unenrollment because API calls to repos outside
+          # the token scope fail and get swallowed by error suppression.
+          ENABLED=$(yq '[.repos | to_entries[] | select(.value.enabled == true) | .key] | join(",")' config.yaml)
+          DISABLED=$(yq '[.repos | to_entries[] | select(.value.enabled == false) | .key] | join(",")' config.yaml)
+          ALL=""
+          if [[ -n "$ENABLED" && -n "$DISABLED" ]]; then
+            ALL="$ENABLED,$DISABLED"
+          elif [[ -n "$ENABLED" ]]; then
+            ALL="$ENABLED"
+          elif [[ -n "$DISABLED" ]]; then
+            ALL="$DISABLED"
+          fi
+          if [[ -z "$ALL" ]]; then
+            echo "::notice::No repos found in config.yaml — nothing to do"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "names=$REPOS" >> "$GITHUB_OUTPUT"
+          echo "names=$ALL" >> "$GITHUB_OUTPUT"
 
       - name: Checkout upstream scripts
         if: steps.repo-list.outputs.skip != 'true'

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -679,8 +679,8 @@ func TestRepoMaintenanceTokenCoversAllRepos(t *testing.T) {
 	// script can't check for or remove the shim workflow, and silently skips
 	// unenrollment (gh api fails, 2>/dev/null hides it, script thinks "already
 	// unenrolled").
-	assert.Contains(t, s, "select(.value.enabled == false)",
-		"repo-list step must extract disabled repos so the minted token covers them for unenrollment")
+	assert.Contains(t, s, "select(.value.enabled == true or .value.enabled == false)",
+		"repo-list step must extract both enabled and disabled repos so the minted token covers them for unenrollment")
 }
 
 func TestMintTokenActionContent(t *testing.T) {

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -669,6 +669,20 @@ func TestRepoMaintenanceWorkflowContent(t *testing.T) {
 	assert.NotContains(t, s, "./.github/actions/")
 }
 
+func TestRepoMaintenanceTokenCoversAllRepos(t *testing.T) {
+	content, err := FullsendRepoFile(".github/workflows/repo-maintenance.yml")
+	require.NoError(t, err)
+	s := string(content)
+
+	// The mint-token step must request access to ALL repos (enabled + disabled),
+	// not just enabled ones. Without access to disabled repos, the reconcile
+	// script can't check for or remove the shim workflow, and silently skips
+	// unenrollment (gh api fails, 2>/dev/null hides it, script thinks "already
+	// unenrolled").
+	assert.Contains(t, s, "select(.value.enabled == false)",
+		"repo-list step must extract disabled repos so the minted token covers them for unenrollment")
+}
+
 func TestMintTokenActionContent(t *testing.T) {
 	content, err := FullsendRepoFile(".github/actions/mint-token/action.yml")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- **Root cause fix**: The repo-maintenance workflow only minted tokens for enabled repos. When the reconcile script tried to check/unenroll disabled repos, API calls failed silently (`2>/dev/null`), and the script treated them as "already unenrolled" — skipping removal PR creation entirely while reporting success.
- Extract `saveWorkflowRunDebugInfo` so triage and unenrollment share the same log/artifact capture code
- Capture repo-maintenance workflow logs **unconditionally** (not just on failure) so silent-skip problems leave a debug trail
- Use `::warning::` annotations for failed runs, `::notice::` for successful ones
- Add `TestRepoMaintenanceTokenCoversAllRepos` to prevent regression

## Root cause

`repo-maintenance.yml` step "Extract enrolled repo names from config" only selected `enabled == true` repos:

```yaml
REPOS=$(yq '[... | select(.value.enabled == true) | .key] | join(",")' config.yaml)
```

This meant the minted token had no permissions for disabled repos. The reconcile script's Phase 2 unenrollment tried `gh api repos/$ORG/$REPO/contents/...` on disabled repos, which returned 403 (swallowed by `2>/dev/null`), causing line 530-533 to conclude "no shim on default branch" and skip the repo.

## Fix

The step now collects both enabled and disabled repos for token minting:

```yaml
ENABLED=$(yq '[... | select(.value.enabled == true) | .key] | join(",")' config.yaml)
DISABLED=$(yq '[... | select(.value.enabled == false) | .key] | join(",")' config.yaml)
```

## Test plan

- [x] `TestRepoMaintenanceTokenCoversAllRepos` — asserts disabled repos are included
- [x] `go vet -tags e2e ./e2e/admin/` passes
- [x] `make lint` passes
- [x] All scaffold tests pass
- [ ] E2E run on this branch creates the removal PR successfully

Closes #1960