### PR TITLE
chore: add .playwright-mcp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 _site/
 bin/
 .playwright/
+.playwright-mcp/
 .claude/settings.local.json
 .vscode/
 *.env


### PR DESCRIPTION
## Summary
- Adds `.playwright-mcp/` to `.gitignore` to keep Playwright MCP server artifacts out of the repo.

## Test plan
- [x] Verified `.gitignore` syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)