### PR TITLE
fix(workflows): use fully-qualified paths in reusable-dispatch stage jobs

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -6,9 +6,10 @@
 # Flow: shim (per-repo) → reusable-dispatch.yml → reusable-{stage}.yml
 # Nesting: 3 levels of workflow_call (within GitHub's 4-level limit)
 #
-# Stage workflows are referenced with relative paths (./.github/workflows/...)
-# so a pinned caller (e.g. @v0.10.1) resolves them at that exact tag with
-# no hardcoded version strings.
+# Stage workflows are referenced with fully-qualified paths
+# (fullsend-ai/fullsend/.github/workflows/reusable-{stage}.yml@v0) because
+# relative (./) paths resolve against the *caller's* repo, which breaks
+# per-repo mode where the caller is an external repo.
 #
 # Security: all user-controlled inputs (comment body, labels, usernames)
 # are passed via env: variables, not interpolated in run: blocks.
@@ -338,7 +339,9 @@ jobs:
     name: Triage
     needs: route
     if: needs.route.outputs.stage == 'triage'
-    uses: ./.github/workflows/reusable-triage.yml
+    # @v0 is hardcoded — GHA does not support expressions in uses:.
+    # fullsend_ai_ref controls the ref for composite actions inside stage workflows.
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-triage.yml@v0
     with:
       event_type: ${{ github.event_name }}
       source_repo: ${{ github.repository }}
@@ -356,7 +359,7 @@ jobs:
     name: Code
     needs: route
     if: needs.route.outputs.stage == 'code'
-    uses: ./.github/workflows/reusable-code.yml
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-code.yml@v0
     with:
       event_type: ${{ github.event_name }}
       source_repo: ${{ github.repository }}
@@ -374,7 +377,7 @@ jobs:
     name: Review
     needs: route
     if: needs.route.outputs.stage == 'review'
-    uses: ./.github/workflows/reusable-review.yml
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-review.yml@v0
     with:
       event_type: ${{ github.event_name }}
       source_repo: ${{ github.repository }}
@@ -392,7 +395,7 @@ jobs:
     name: Fix
     needs: route
     if: needs.route.outputs.stage == 'fix'
-    uses: ./.github/workflows/reusable-fix.yml
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-fix.yml@v0
     with:
       event_type: ${{ github.event_name }}
       source_repo: ${{ github.repository }}
@@ -411,7 +414,7 @@ jobs:
     name: Retro
     needs: route
     if: needs.route.outputs.stage == 'retro'
-    uses: ./.github/workflows/reusable-retro.yml
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-retro.yml@v0
     with:
       event_type: ${{ github.event_name }}
       source_repo: ${{ github.repository }}
@@ -429,7 +432,7 @@ jobs:
     name: Prioritize
     needs: route
     if: needs.route.outputs.stage == 'prioritize'
-    uses: ./.github/workflows/reusable-prioritize.yml
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-prioritize.yml@v0
     with:
       event_type: ${{ github.event_name }}
       source_repo: ${{ github.repository }}

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -215,3 +215,29 @@ func TestReusableDispatchProjectNumberInput(t *testing.T) {
 	assert.True(t, strings.Contains(s, "project_number: ${{ inputs.project_number }}"),
 		"prioritize job should thread project_number from dispatch inputs")
 }
+
+// TestReusableDispatchUsesFullyQualifiedPaths validates that reusable-dispatch.yml
+// references stage workflows with fully-qualified paths, not relative (./) paths.
+// Relative paths resolve against the caller's repo, which breaks per-repo mode
+// where the caller is an external repo without these workflow files.
+func TestReusableDispatchUsesFullyQualifiedPaths(t *testing.T) {
+	content, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "reusable-dispatch.yml"))
+	require.NoError(t, err)
+
+	var caller callerWorkflow
+	require.NoError(t, yaml.Unmarshal(content, &caller))
+
+	stages := []string{"triage", "code", "review", "fix", "retro", "prioritize"}
+	for _, stage := range stages {
+		t.Run(stage, func(t *testing.T) {
+			job, ok := caller.Jobs[stage]
+			require.True(t, ok, "job %q not found", stage)
+			assert.True(t, strings.HasPrefix(job.Uses, "fullsend-ai/fullsend/"),
+				"job %q uses: must be fully-qualified (got %q); relative paths break per-repo mode",
+				stage, job.Uses)
+			assert.True(t, strings.Contains(job.Uses, "@"),
+				"job %q uses: must include a @ref suffix (got %q)",
+				stage, job.Uses)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Restore fully-qualified `uses:` paths (`fullsend-ai/fullsend/.github/workflows/reusable-{stage}.yml@v0`) in `reusable-dispatch.yml`, replacing relative `./` paths introduced in #1278
- Add `TestReusableDispatchUsesFullyQualifiedPaths` regression test to prevent re-introduction

## Problem

PR #1278 changed the `uses:` lines in `reusable-dispatch.yml` from fully-qualified to relative (`./`) paths. Relative paths in `uses:` resolve against the **caller's repository**, not the repo that defines the reusable workflow. In per-repo mode, the caller is an external repo (e.g., `konflux-ci/operator-foundry`) that doesn't have the `reusable-{stage}.yml` files, so GitHub Actions fails instantly with "workflow was not found" before any jobs run.

First observed on `konflux-ci/operator-foundry` [run 27046721150](https://github.com/konflux-ci/operator-foundry/actions/runs/27046721150) after the v0 tag was moved to include the change.

## Test plan

- [x] `go test -run TestWorkflowCallInputAlignment` — existing alignment test passes
- [x] `go test -run TestReusableDispatchUsesFullyQualifiedPaths` — new regression test passes
- [x] `go test ./...` in `internal/scaffold` — full suite passes
- [ ] After v0 tag is moved: re-trigger `/fs-review` on `konflux-ci/operator-foundry` PR #3