### PR TITLE
feat(scaffold): add managed-by headers to installed scaffold files

### DIFF
--- a/docs/ADRs/0043-managed-file-headers.md
+++ b/docs/ADRs/0043-managed-file-headers.md
@@ -1,0 +1,52 @@
+---
+title: "43. Add upstream source headers to managed scaffold files"
+status: Accepted
+relates_to:
+  - agent-architecture
+topics:
+  - scaffold
+  - installer
+---
+
+# 43. Add upstream source headers to managed scaffold files
+
+Date: 2026-06-06
+
+## Status
+
+Accepted
+
+## Context
+
+When agents encounter scaffold-generated files in a `.fullsend` config repo
+(workflow definitions, templates), they have no signal that these files are
+managed by fullsend and should not be edited in place. Edits to deployed
+copies are overwritten the next time the installer runs. The correct action
+is to modify the upstream source in
+`internal/scaffold/fullsend-repo/` and let the installer propagate changes.
+
+See [#366](https://github.com/fullsend-ai/fullsend/issues/366) and
+[#857](https://github.com/fullsend-ai/fullsend/issues/857).
+
+## Decision
+
+The installer prepends a managed-by header to scaffold files at install time.
+The header identifies the file as fullsend-managed and links to its upstream
+source in the fullsend repo. Headers are added only to files whose format
+supports comments (YAML, shell); they are never added to user-configurable
+files (`config.yaml`, `customized/` overrides, `AGENTS.md`) or files that
+lack comment syntax (JSON, `.gitkeep`).
+
+The upstream scaffold source files remain header-free so that agents editing
+templates are not confused by self-referential headers.
+
+## Consequences
+
+- Agents encountering a managed file see where the upstream source lives and
+  are directed to edit it there instead.
+- Future scaffold files must follow this convention: managed infrastructure
+  files get headers; user-owned files never do.
+- The `ManagedHeader` function in `internal/scaffold/scaffold.go` is the
+  single point of control for which files get headers and which do not.
+- Header injection is invisible to the scaffold source tree, keeping the
+  embedded templates clean for direct editing and testing.

--- a/internal/layers/workflows.go
+++ b/internal/layers/workflows.go
@@ -84,7 +84,7 @@ func (l *WorkflowsLayer) Install(ctx context.Context) error {
 	err := scaffold.WalkFullsendRepo(func(path string, content []byte) error {
 		files = append(files, forge.TreeFile{
 			Path:    path,
-			Content: content,
+			Content: scaffold.PrependManagedHeader(path, content),
 			Mode:    scaffold.FileMode(path),
 		})
 		return nil

--- a/internal/layers/workflows_test.go
+++ b/internal/layers/workflows_test.go
@@ -73,9 +73,10 @@ func TestWorkflowsLayer_Install_TriageWorkflowContent(t *testing.T) {
 	}
 	require.NotEmpty(t, triageContent, "triage.yml should have been written")
 
-	expected, err := scaffold.FullsendRepoFile(".github/workflows/triage.yml")
+	raw, err := scaffold.FullsendRepoFile(".github/workflows/triage.yml")
 	require.NoError(t, err)
-	assert.Equal(t, string(expected), triageContent)
+	expected := string(scaffold.PrependManagedHeader(".github/workflows/triage.yml", raw))
+	assert.Equal(t, expected, triageContent)
 }
 
 func TestWorkflowsLayer_Install_RepoMaintenanceContent(t *testing.T) {
@@ -94,9 +95,29 @@ func TestWorkflowsLayer_Install_RepoMaintenanceContent(t *testing.T) {
 	}
 	require.NotEmpty(t, maintenanceContent, "repo-maintenance.yml should have been written")
 
-	expected, err := scaffold.FullsendRepoFile(".github/workflows/repo-maintenance.yml")
+	raw, err := scaffold.FullsendRepoFile(".github/workflows/repo-maintenance.yml")
 	require.NoError(t, err)
-	assert.Equal(t, string(expected), maintenanceContent)
+	expected := string(scaffold.PrependManagedHeader(".github/workflows/repo-maintenance.yml", raw))
+	assert.Equal(t, expected, maintenanceContent)
+}
+
+func TestWorkflowsLayer_Install_ManagedHeaders(t *testing.T) {
+	client := forge.NewFakeClient()
+	layer, _ := newWorkflowsLayer(t, client)
+
+	err := layer.Install(context.Background())
+	require.NoError(t, err)
+
+	for _, f := range client.CommittedFiles[0].Files {
+		header := scaffold.ManagedHeader(f.Path)
+		if header != "" {
+			assert.True(t, strings.HasPrefix(string(f.Content), header),
+				"installed file %s should start with managed header", f.Path)
+		} else {
+			assert.False(t, strings.Contains(string(f.Content), "managed by fullsend"),
+				"installed file %s should NOT have a managed header", f.Path)
+		}
+	}
 }
 
 

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"path/filepath"
 	"strings"
 )
 
@@ -129,6 +130,49 @@ func PerRepoCustomizedDirs() []string {
 		dirs = append(dirs, ".fullsend/customized/"+strings.TrimSuffix(d, "/"))
 	}
 	return dirs
+}
+
+const upstreamBase = "https://github.com/fullsend-ai/fullsend/blob/main/internal/scaffold/fullsend-repo/"
+
+// ManagedHeader returns the managed-by header to prepend to a scaffold file
+// at install time, or an empty string if the file should not have one.
+// Files that support # comments (YAML, shell) get a header pointing to the
+// upstream source. Markdown, JSON, and .gitkeep files are skipped.
+func ManagedHeader(path string) string {
+	ext := filepath.Ext(path)
+	switch ext {
+	case ".yml", ".yaml", ".sh", ".env":
+		return fmt.Sprintf(
+			"# This file is managed by fullsend. Do not edit it directly.\n# Upstream: %s%s\n",
+			upstreamBase, path,
+		)
+	default:
+		// Check for extensionless scripts (e.g. scripts/scan-secrets)
+		if strings.HasPrefix(path, "scripts/") && ext == "" {
+			return fmt.Sprintf(
+				"# This file is managed by fullsend. Do not edit it directly.\n# Upstream: %s%s\n",
+				upstreamBase, path,
+			)
+		}
+		return ""
+	}
+}
+
+// PrependManagedHeader prepends the managed-by header to file content.
+// If the file starts with a shebang (#!), the header is inserted after
+// the first line. Returns content unchanged if no header applies.
+func PrependManagedHeader(path string, content []byte) []byte {
+	header := ManagedHeader(path)
+	if header == "" {
+		return content
+	}
+	s := string(content)
+	if strings.HasPrefix(s, "#!") {
+		if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+			return []byte(s[:idx+1] + header + s[idx+1:])
+		}
+	}
+	return []byte(header + s)
 }
 
 func walkFullsendRepo(fn func(path string, content []byte) error, filter bool) error {

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -805,6 +805,56 @@ func TestAllScaffoldYAMLDocumentStartMarker(t *testing.T) {
 	assert.True(t, checked >= 20, "expected at least 20 YAML files, got %d", checked)
 }
 
+func TestManagedHeader(t *testing.T) {
+	tests := []struct {
+		path   string
+		expect string
+	}{
+		// YAML workflow files get a header
+		{
+			path:   ".github/workflows/triage.yml",
+			expect: "# This file is managed by fullsend. Do not edit it directly.\n# Upstream: https://github.com/fullsend-ai/fullsend/blob/main/internal/scaffold/fullsend-repo/.github/workflows/triage.yml\n",
+		},
+		// YAML template files get a header
+		{
+			path:   "templates/shim-per-repo.yaml",
+			expect: "# This file is managed by fullsend. Do not edit it directly.\n# Upstream: https://github.com/fullsend-ai/fullsend/blob/main/internal/scaffold/fullsend-repo/templates/shim-per-repo.yaml\n",
+		},
+		// Markdown files are skipped (user-readable docs)
+		{path: "AGENTS.md", expect: ""},
+		// .gitkeep files are skipped
+		{path: "customized/agents/.gitkeep", expect: ""},
+		// JSON files are skipped (no comment syntax)
+		{path: "schemas/triage-result.schema.json", expect: ""},
+		// Shell scripts get a header
+		{path: "scripts/pre-triage.sh", expect: "# This file is managed by fullsend. Do not edit it directly.\n# Upstream: https://github.com/fullsend-ai/fullsend/blob/main/internal/scaffold/fullsend-repo/scripts/pre-triage.sh\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			got := ManagedHeader(tc.path)
+			assert.Equal(t, tc.expect, got)
+		})
+	}
+}
+
+func TestManagedHeaderPreservesShebang(t *testing.T) {
+	// When content starts with #!, the header should go after the shebang line
+	content := []byte("#!/bin/bash\nset -euo pipefail\n")
+	header := ManagedHeader("scripts/pre-triage.sh")
+	result := PrependManagedHeader("scripts/pre-triage.sh", content)
+
+	assert.True(t, strings.HasPrefix(string(result), "#!/bin/bash\n"))
+	assert.Contains(t, string(result), header)
+	assert.Contains(t, string(result), "set -euo pipefail")
+}
+
+func TestPrependManagedHeaderNoHeader(t *testing.T) {
+	content := []byte("# AGENTS.md\nSome content\n")
+	result := PrependManagedHeader("AGENTS.md", content)
+	assert.Equal(t, content, result, "files without headers should be returned unchanged")
+}
+
 func TestValidateTriageDeleted(t *testing.T) {
 	_, err := FullsendRepoFile("scripts/validate-triage.sh")
 	assert.Error(t, err, "validate-triage.sh should have been deleted")


### PR DESCRIPTION
## Summary

When agents encounter scaffold-generated files in a `.fullsend` config repo, there's no signal that these are managed upstream and shouldn't be edited in place. This adds a header at install time so the provenance is obvious.

- `ManagedHeader` and `PrependManagedHeader` in `scaffold.go` handle comment-prefix selection and shebang-aware insertion
- The `Install` method in `workflows.go` calls `PrependManagedHeader` when writing each file
- YAML, shell, and env files get headers; markdown, JSON, and `.gitkeep` are left alone
- Upstream scaffold sources stay header-free so agents editing templates aren't confused by self-referential headers
- ADR 0043 documents the convention

Installed files now start with:
```yaml
# This file is managed by fullsend. Do not edit it directly.
# Upstream: https://github.com/fullsend-ai/fullsend/blob/main/internal/scaffold/fullsend-repo/.github/workflows/triage.yml
```

Closes #366

## Test plan

- [x] `go test ./internal/scaffold/` — new tests for `ManagedHeader`, `PrependManagedHeader`, shebang preservation
- [x] `go test ./internal/layers/` — updated content-comparison tests, new `TestWorkflowsLayer_Install_ManagedHeaders` integration test
- [x] `go vet` clean
- [x] `make lint` clean