### PR TITLE
ci(e2e): always report status on PRs and merge queue

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,17 +19,7 @@ on:
       - 'Makefile'
       - '.github/workflows/e2e.yml'
   pull_request:
-    paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'e2e/**'
-      - 'internal/scaffold/fullsend-repo/**'
-      - 'internal/security/hooks/**'
-      - 'internal/dispatch/gcf/mintsrc/**'
-      - 'internal/sentencetoken/english.json'
-      - 'Makefile'
-      - '.github/workflows/e2e.yml'
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -41,16 +31,36 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Check for e2e-relevant changes
+        id: changes
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          if echo "$FILES" | grep -qE '\.go$|^go\.(mod|sum)$|^e2e/|^internal/scaffold/fullsend-repo/|^internal/security/hooks/|^internal/dispatch/gcf/mintsrc/|^internal/sentencetoken/english\.json$|^Makefile$|\.github/workflows/e2e\.yml$'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No e2e-relevant files changed — skipping tests"
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.changes.outputs.relevant != 'false'
 
       - uses: actions/setup-go@v5
+        if: steps.changes.outputs.relevant != 'false'
         with:
           go-version-file: go.mod
 
       - name: Install Playwright system dependencies
+        if: steps.changes.outputs.relevant != 'false'
         run: npx playwright install-deps chromium
 
       - name: Check for secrets
+        if: steps.changes.outputs.relevant != 'false'
         id: secrets-check
         run: |
           if [ -z "$E2E_GITHUB_SESSION_B64" ]; then
@@ -63,7 +73,7 @@ jobs:
           E2E_GITHUB_SESSION_B64: ${{ secrets.E2E_GITHUB_SESSION }}
 
       - name: Decode session
-        if: steps.secrets-check.outputs.available == 'true'
+        if: steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
         run: |
           SESSION_FILE="${RUNNER_TEMP}/github-session.json"
           printf '%s' "$E2E_GITHUB_SESSION_B64" | base64 -d > "$SESSION_FILE"
@@ -72,14 +82,14 @@ jobs:
           E2E_GITHUB_SESSION_B64: ${{ secrets.E2E_GITHUB_SESSION }}
 
       - name: Authenticate to GCP
-        if: steps.secrets-check.outputs.available == 'true'
+        if: steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.E2E_GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.E2E_GCP_SERVICE_ACCOUNT }}
 
       - name: Run e2e tests
-        if: steps.secrets-check.outputs.available == 'true'
+        if: steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
         run: make e2e-test
         env:
           E2E_SCREENSHOT_DIR: ${{ runner.temp }}/e2e-screenshots
@@ -89,7 +99,7 @@ jobs:
           E2E_GCP_PROJECT_ID: ${{ secrets.E2E_GCP_PROJECT_ID }}
 
       - name: Upload debug screenshots
-        if: always() && steps.secrets-check.outputs.available == 'true'
+        if: always() && steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-screenshots


### PR DESCRIPTION
## Summary

- Remove `paths` filters from the `pull_request` trigger in `e2e.yml` so the e2e job always runs and reports a status
- Add `merge_group` trigger so e2e can be used as a required check in the merge queue
- When no e2e-relevant files changed on a PR, the job short-circuits after checking the file list via the GitHub API — no checkout, no Go setup, no Playwright install

This unblocks making `e2e` a required status check without blocking docs-only or non-code PRs. Push-to-main keeps its path filters since it doesn't gate the merge queue.

Closes #1987

## Test plan

- [ ] Verify this PR's own e2e check runs and short-circuits (no e2e-relevant files changed)
- [ ] Verify a PR with Go changes still runs the full e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)