### PR TITLE
feat(cli): wire --max-depth and --max-resources flags for transitive resolution

### DIFF
--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -39,6 +39,8 @@ fullsend
 │   ├── --no-post-script                     #   Skip post-script execution
 │   ├── --debug [filter]                     #   Enable Claude Code debug logging
 │   ├── --offline                            #   Reject network fetches
+│   ├── --max-depth <int>                    #   Max transitive dependency depth (0 disables)
+│   ├── --max-resources <int>                #   Max total remote resources per harness
 │   ├── --run-url <url>                      #   CI/CD run URL for status comments
 │   ├── --status-repo <owner/repo>           #   Repository for status comments
 │   ├── --status-number <int>                #   Issue/PR number for status comments

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -230,6 +230,18 @@ fullsend run code \
   --env-file fullsend-code.env
 ```
 
+### Remote resource flags
+
+When your harness references URL-based skills with transitive dependencies
+(see [ADR-0038](../../ADRs/0038-universal-harness-access.md)), you can tune
+resolution limits:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--max-depth` | 10 | Maximum dependency depth for transitive resolution (0 disables) |
+| `--max-resources` | 50 | Maximum total remote resources fetched per harness |
+| `--offline` | false | Reject network fetches; only use cached remote resources |
+
 ### Status notification flags
 
 When running agents locally you can optionally enable status comments on the

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -53,6 +53,13 @@ var agentWorkingDirExcludes = []string{
 	".fullsend-workspace/",
 }
 
+// resolveFlags groups CLI flags that control remote resource resolution.
+type resolveFlags struct {
+	offline      bool
+	maxDepth     int
+	maxResources int
+}
+
 // statusOpts holds the optional status notification parameters for a run.
 type statusOpts struct {
 	runURL      string
@@ -69,8 +76,8 @@ func newRunCmd() *cobra.Command {
 	var envFiles []string
 	var noPostScript bool
 	var debugFilter string
-	var offline bool
 	var keepSandbox bool
+	var rFlags resolveFlags
 	var sOpts statusOpts
 
 	cmd := &cobra.Command{
@@ -81,7 +88,7 @@ func newRunCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agentName := args[0]
 			printer := ui.New(os.Stdout)
-			return runAgent(cmd.Context(), agentName, fullsendDir, outputBase, targetRepo, fullsendBinary, envFiles, noPostScript, debugFilter, offline, sOpts, printer, keepSandbox)
+			return runAgent(cmd.Context(), agentName, fullsendDir, outputBase, targetRepo, fullsendBinary, envFiles, noPostScript, debugFilter, rFlags, sOpts, printer, keepSandbox)
 		},
 	}
 
@@ -94,7 +101,9 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&keepSandbox, "keep-sandbox", false, "skip sandbox deletion after the run (useful for post-failure inspection)")
 	cmd.Flags().StringVar(&debugFilter, "debug", "", `enable Claude Code debug logging with optional category filter (e.g. "api,hooks")`)
 	cmd.Flags().Lookup("debug").NoOptDefVal = "*"
-	cmd.Flags().BoolVar(&offline, "offline", false, "reject network fetches; only use cached remote resources")
+	cmd.Flags().BoolVar(&rFlags.offline, "offline", false, "reject network fetches; only use cached remote resources")
+	cmd.Flags().IntVar(&rFlags.maxDepth, "max-depth", resolve.DefaultMaxDepth, "maximum dependency depth for transitive resolution (0 disables)")
+	cmd.Flags().IntVar(&rFlags.maxResources, "max-resources", resolve.DefaultMaxResources, "maximum total remote resources per harness")
 	cmd.Flags().StringVar(&sOpts.runURL, "run-url", "", "URL of the CI/CD run for status comments")
 	cmd.Flags().StringVar(&sOpts.statusRepo, "status-repo", "", "repository (owner/repo) for status comments")
 	cmd.Flags().IntVar(&sOpts.statusNum, "status-number", 0, "issue/PR number for status comments")
@@ -105,11 +114,18 @@ func newRunCmd() *cobra.Command {
 	return cmd
 }
 
-func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRepo, fullsendBinary string, envFiles []string, noPostScript bool, debug string, offline bool, sOpts statusOpts, printer *ui.Printer, keepSandbox bool) (runErr error) {
+func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRepo, fullsendBinary string, envFiles []string, noPostScript bool, debug string, rFlags resolveFlags, sOpts statusOpts, printer *ui.Printer, keepSandbox bool) (runErr error) {
 	printer.Banner(Version())
 	printer.Blank()
 	printer.Header("Running agent: " + agentName)
 	printer.Blank()
+
+	if rFlags.maxDepth < 0 {
+		return fmt.Errorf("--max-depth must be >= 0, got %d", rFlags.maxDepth)
+	}
+	if rFlags.maxResources < 1 {
+		return fmt.Errorf("--max-resources must be >= 1, got %d", rFlags.maxResources)
+	}
 
 	// 0. Load env files before anything else so vars are available for harness expansion.
 	for _, ef := range envFiles {
@@ -160,12 +176,14 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		}
 
 		policy := fetch.DefaultPolicy
-		policy.Offline = offline
+		policy.Offline = rFlags.offline
 
 		deps, err := resolve.ResolveHarness(ctx, h, resolve.ResolveOpts{
 			WorkspaceRoot: absFullsendDir,
 			FetchPolicy:   policy,
 			AuditLogPath:  filepath.Join(absFullsendDir, ".fullsend-cache", "fetch-audit.jsonl"),
+			MaxDepth:      rFlags.maxDepth,
+			MaxResources:  rFlags.maxResources,
 		})
 		if err != nil {
 			printer.StepFail("Remote resource resolution failed")

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -87,6 +87,55 @@ func TestRunCommand_HasOfflineFlag(t *testing.T) {
 	assert.Equal(t, "false", flag.DefValue)
 }
 
+func TestRunCommand_HasMaxDepthFlag(t *testing.T) {
+	cmd := newRunCmd()
+	flag := cmd.Flags().Lookup("max-depth")
+	require.NotNil(t, flag)
+	assert.Equal(t, "10", flag.DefValue)
+}
+
+func TestRunCommand_HasMaxResourcesFlag(t *testing.T) {
+	cmd := newRunCmd()
+	flag := cmd.Flags().Lookup("max-resources")
+	require.NotNil(t, flag)
+	assert.Equal(t, "50", flag.DefValue)
+}
+
+func TestRunCommand_AcceptsZeroMaxDepth(t *testing.T) {
+	cmd := newRunCmd()
+	cmd.SetArgs([]string{"test-agent", "--fullsend-dir", "/tmp", "--target-repo", "/tmp", "--max-depth", "0"})
+	err := cmd.Execute()
+	// --max-depth 0 is valid (disables transitive resolution); the error
+	// should come from the run flow, not flag validation.
+	if err != nil {
+		assert.NotContains(t, err.Error(), "--max-depth must be >= 0")
+	}
+}
+
+func TestRunCommand_RejectsNegativeMaxDepth(t *testing.T) {
+	cmd := newRunCmd()
+	cmd.SetArgs([]string{"test-agent", "--fullsend-dir", "/tmp", "--target-repo", "/tmp", "--max-depth", "-1"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--max-depth must be >= 0")
+}
+
+func TestRunCommand_RejectsZeroMaxResources(t *testing.T) {
+	cmd := newRunCmd()
+	cmd.SetArgs([]string{"test-agent", "--fullsend-dir", "/tmp", "--target-repo", "/tmp", "--max-resources", "0"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--max-resources must be >= 1")
+}
+
+func TestRunCommand_RejectsNegativeMaxResources(t *testing.T) {
+	cmd := newRunCmd()
+	cmd.SetArgs([]string{"test-agent", "--fullsend-dir", "/tmp", "--target-repo", "/tmp", "--max-resources", "-1"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--max-resources must be >= 1")
+}
+
 func TestBuildScanContextCommand_SourcesEnv(t *testing.T) {
 	traceID := "aabbccdd-1122-4334-8556-aabbccddeeff"
 	cmd := buildScanContextCommand("/tmp/workspace/repo", traceID)


### PR DESCRIPTION
## Summary

Phase 2, PR 3 of ADR-0038 (Universal Harness Access). Wires the transitive dependency resolver (merged in #1923) into the CLI run flow.

- Adds `--max-depth` flag (default 10) to control transitive dependency resolution depth; `--max-depth 0` disables transitive resolution entirely
- Adds `--max-resources` flag (default 50) to cap total remote resources fetched per harness
- Passes both values through `ResolveOpts` to the resolver; previously `MaxDepth` defaulted to Go's zero value (0), which disabled transitive resolution — now it defaults to `DefaultMaxDepth` (10)

**Depends on:** #1923 (merged)

## Changes

| File | Action |
|------|--------|
| `internal/cli/run.go` | Add `--max-depth` / `--max-resources` flags, thread through `runAgent()` signature, pass to `ResolveOpts` |
| `internal/cli/run_test.go` | Add flag registration tests for both new flags |

## Test plan

- [x] `go test ./internal/cli/...` — all tests pass (including new flag registration tests)
- [x] `go test ./internal/resolve/...` — all 28 Phase 1 + Phase 2 tests pass unchanged
- [x] `go vet ./...` — clean
- [x] `make lint` — clean
- [ ] Review: flag defaults match `resolve.DefaultMaxDepth` (10) and `resolve.DefaultMaxResources` (50)
- [ ] Review: `MaxDepth=0` still disables transitive resolution (Phase 1 behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)