### PR TITLE
docs: add contributor issue search link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,8 @@ ADR filenames use a four-digit number (`NNNN-short-description.md`). When multip
 
 When in doubt about whether something warrants a PR, start with an issue. Issues are low-friction and can graduate into PRs, problem docs, or ADRs later.
 
+To find open issues for human contribution, use the [contributor issue search](https://github.com/fullsend-ai/fullsend/issues?q=is%3Aissue%20is%3Aopen%20-author%3Aapp%2Ffullsend-ai-fullsend%20-author%3Aapp%2Ffullsend-ai-triage%20-author%3Aapp%2Ffullsend-ai-review%20-author%3Aapp%2Ffullsend-ai-prioritize%20-author%3Aapp%2Ffullsend-ai-coder%20-author%3Aapp%2Ffullsend-ai-retro%20-label%3Aready-to-code). This search excludes issues reserved for agents.
+
 ## License
 
 All contributions to this project are made under the [Apache License, Version 2.0](LICENSE). By submitting a pull request, you agree that your contributions will be licensed under this license.


### PR DESCRIPTION
## What changed

- Added the contributor issue search link to `CONTRIBUTING.md` under the Issues section.

## Why

This gives human contributors a direct way to find open issues while excluding issues authored by fullsend automation apps and issues reserved for agents.

## Validation

- Ran `git diff --check`.
