### PR TITLE
docs: ADR 0043 — GitLab per-repo support via OIDC/WIF and webhook bridge

### DIFF
--- a/docs/ADRs/0028-gitlab-support.md
+++ b/docs/ADRs/0028-gitlab-support.md
@@ -1,6 +1,7 @@
 ---
 title: "28. GitLab Support Architecture"
-status: Deprecated
+status: Superseded
+superseded_by: "0043-gitlab-per-repo-support"
 relates_to:
   - agent-infrastructure
   - agent-architecture
@@ -17,7 +18,7 @@ Date: 2026-04-29
 
 ## Status
 
-Deprecated
+Superseded by [ADR 0043](0043-gitlab-per-repo-support.md)
 
 ## Context
 

--- a/docs/ADRs/0031-reusable-workflows-for-action-installed-distribution.md
+++ b/docs/ADRs/0031-reusable-workflows-for-action-installed-distribution.md
@@ -141,7 +141,7 @@ caller's perspective.
   inline, which partially mitigates this.
 - **GitHub-specific mechanism:** `workflow_call` and `secrets:` passthrough are
   GitHub Actions primitives with no direct equivalent in other CI systems.
-  Multi-forge support ([ADR 0028](0028-gitlab-support.md)) will need its own
+  Multi-forge support ([ADR 0043](0043-gitlab-per-repo-support.md), supersedes [ADR 0028](0028-gitlab-support.md)) will need its own
   distribution mechanism (e.g., GitLab CI/CD Components or `include:`)
   independent of this ADR.
 - **Scaffold output changes:** `fullsend admin install` will emit thin callers

--- a/docs/ADRs/0036-agent-execution-sandbox.md
+++ b/docs/ADRs/0036-agent-execution-sandbox.md
@@ -21,7 +21,7 @@ Accepted
 
 ## Context
 
-Fullsend agents execute within isolated sandboxes that enforce security boundaries: filesystem access control, network policy enforcement, and credential isolation (ADR-0017, ADR-0025). The current implementation uses OpenShell with per-agent L7 network policies and runs on GitHub Actions runners. With GitLab support proposed (ADR-0028), the execution architecture needs to work on both GitHub Actions and GitLab CI runners.
+Fullsend agents execute within isolated sandboxes that enforce security boundaries: filesystem access control, network policy enforcement, and credential isolation (ADR-0017, ADR-0025). The current implementation uses OpenShell with per-agent L7 network policies and runs on GitHub Actions runners. With GitLab support proposed (ADR-0043, supersedes ADR-0028), the execution architecture needs to work on both GitHub Actions and GitLab CI runners.
 
 The sandbox architecture has multiple concerns that need to be resolved together:
 
@@ -31,7 +31,7 @@ The sandbox architecture has multiple concerns that need to be resolved together
 4. **Resource limits**: CPU, memory, and timeout constraints need platform-independent expression
 5. **OpenShell integration**: The sandbox runtime (OpenShell gateway + L7 policies + providers) must work in all executor environments
 
-The GitLab support design (ADR-0028) explicitly deferred this decision: "The agent execution environment is orthogonal to the CI/CD dispatch architecture. GitLab runner configuration, sandbox isolation, and compute architecture should be documented separately."
+The GitLab support design (ADR-0043, supersedes ADR-0028) explicitly deferred this decision: "The agent execution environment is orthogonal to the CI/CD dispatch architecture. GitLab runner configuration, sandbox isolation, and compute architecture should be documented separately."
 
 The forge abstraction (ADR-0005) keeps dispatch logic platform-neutral. This ADR addresses what happens *after* the dispatch pipeline triggers an agent job: how the agent actually executes.
 
@@ -288,7 +288,7 @@ The implementation document is structured for iterative evolution as the sandbox
 - ADR-0005: Forge abstraction layer (dispatch is platform-neutral, execution must also be)
 - ADR-0017: Credential isolation for sandboxed agents (zero credentials in sandbox)
 - ADR-0025: Provider credential delivery (OpenShell providers for credential injection)
-- [ADR-0028: GitLab Support Architecture](0028-gitlab-support.md) (dispatch pipelines, explicitly deferred agent execution environment)
+- [ADR-0043: GitLab per-repo support](0043-gitlab-per-repo-support.md) (supersedes [ADR-0028](0028-gitlab-support.md); dispatch pipelines, explicitly deferred agent execution environment)
 - ADR-0030: OpenShell sandbox interaction model (defines the agent-harness communication protocol)
 - [agent-infrastructure.md](../problems/agent-infrastructure.md): Infrastructure layer exploration, SIG Agent Sandbox evaluation
 - [OpenShell](https://github.com/NVIDIA/OpenShell): Sandbox runtime with L7 network policy enforcement

--- a/docs/ADRs/0043-gitlab-per-repo-support.md
+++ b/docs/ADRs/0043-gitlab-per-repo-support.md
@@ -1,0 +1,597 @@
+---
+title: "43. GitLab per-repo support via OIDC/WIF and webhook bridge"
+status: Accepted
+relates_to:
+  - agent-infrastructure
+  - agent-architecture
+  - security-threat-model
+topics:
+  - gitlab
+  - forge
+  - ci-cd
+  - per-repo
+  - credentials
+  - webhook
+---
+
+# 43. GitLab per-repo support via OIDC/WIF and webhook bridge
+
+Date: 2026-06-08
+
+## Status
+
+Accepted
+
+Supersedes [ADR 0028](0028-gitlab-support.md).
+
+## Context
+
+ADR 0028 designed GitLab support around a per-org model mirroring GitHub: a central `.fullsend` project per group, per-role Project Access Tokens stored in GCP Secret Manager, and the token mint extended for GitLab OIDC. A design review revealed this was shoehorning GitHub-native architecture into GitLab:
+
+- **No GitHub Apps equivalent**: GitLab has no asymmetric-key token exchange. OAuth Apps are user-interactive only (no client credentials flow). Service accounts use personal access tokens. There is no project-scoped OAuth token.
+- **No sub-day token TTLs**: GitLab access tokens have a minimum ~1 day expiry vs GitHub's 1-hour installation tokens.
+- **`CI_JOB_TOKEN` is insufficient for agent operations**: GitLab's native ephemeral credential cannot authenticate GraphQL requests ([documented limitation](https://docs.gitlab.com/ci/jobs/ci_job_token/)), cannot create merge requests, and provides no bot identity — agent actions appear as the pipeline runner, not a recognizable service account. GitLab is migrating planning features to the GraphQL-only Work Items API (Epic API removal planned for 19.0), making this limitation increasingly acute for triage agents.
+- **Cross-project credential complexity**: Per-org mode requires the agent pipeline to run in a central `.fullsend` project and act on _other_ enrolled projects — creating the cross-project credential problem that drove the mint/token/Secret Manager complexity.
+
+The key insight: **per-repo mode combined with GitLab's native OIDC `id_tokens` enables secretless credential retrieval via GCP Workload Identity Federation (WIF).** The pipeline runs inside the enrolled project on the protected default branch. A GitLab-issued OIDC token exchanges via WIF for GCP credentials, which are used to retrieve a bot project access token from Secret Manager. No credentials are stored as CI/CD variables — the project is secretless from GitLab's perspective.
+
+ADR 0033 established per-repo installation for GitHub. This ADR adapts per-repo for GitLab, making it the _only_ supported mode. GitLab's CI/CD model — each project runs its own pipelines, shared logic via CI/CD Components — is designed for per-repo operation. The OIDC/WIF credential flow reuses infrastructure fullsend already provisions for Vertex AI inference (WIF pool/provider + Secret Manager).
+
+Two architectural gaps remain:
+
+1. **No `pull_request_target` equivalent**: GitLab has no mechanism to run a pipeline from the base branch when an MR event occurs on an untrusted source branch. A webhook bridge Cloud Function translates GitLab webhook events into Pipeline Trigger API calls, hardcoding `ref=main` to ensure the pipeline always runs trusted code.
+
+2. **Agent operations require a bot project access token**: `CI_JOB_TOKEN` cannot create merge requests, cannot authenticate GraphQL requests, and provides no bot identity. A Developer-role project access token stored in GCP Secret Manager (not as a CI/CD variable) fills these gaps. It is retrieved at runtime via OIDC/WIF — no long-lived credentials in the project.
+
+## Options
+
+### Alternative 1: Per-org with central `.fullsend` project
+
+Mirror the GitHub per-org model: a `.fullsend` config project holds dispatch pipelines, per-role project access tokens in Secret Manager, and the token mint extended for GitLab OIDC.
+
+**Rejected**: Requires cross-project tokens (one per role per enrolled project), mint extension for GitLab OIDC claim normalization, and multiple WIF attribute conditions per project. Per-repo mode with OIDC/WIF achieves the same secretless credential retrieval without cross-project configuration. GitLab has no org-level App concept that would make per-org simpler (unlike GitHub, where one PEM per org covers all repos via installation tokens).
+
+### Alternative 2: Both per-org and per-repo
+
+Support both modes for GitLab, letting users choose.
+
+**Rejected**: Per-org adds cross-project credential complexity with no clear benefit. The OIDC/WIF credential flow works per-project — each enrolled project exchanges its own OIDC token for its own bot PAT from Secret Manager. Supporting per-org means building cross-project WIF attribute conditions and shared credential stores for a mode that adds no capability over per-repo. If a user needs centralized config across projects, they can use GitLab CI/CD Components and group-level CI/CD variables without the full per-org machinery.
+
+### Alternative 3: Downstream pipelines instead of webhook bridge
+
+Use GitLab's multi-project or parent-child pipeline features to dispatch agent work without an external bridge.
+
+**Rejected**: Parent-child pipelines (same project) could replace the dispatch-to-stage mechanism — a dispatch pipeline triggers stage-specific child pipelines — but they don't eliminate the bridge. We still need something to convert GitLab webhook events into the initial pipeline trigger, since GitLab has no `pull_request_target` equivalent that runs base-branch code on MR events. Multi-project pipelines (cross-project) would require the enrolled project to have a trigger relationship with another project, reintroducing cross-project configuration that per-repo mode eliminates. Parent-child pipelines remain a viable implementation optimization within Phase 3 (CI/CD templates).
+
+### Alternative 4: Service accounts with personal access tokens
+
+Create GitLab user accounts for each role (fullsend-triage, fullsend-code, etc.) and use their personal access tokens.
+
+**Rejected**: Requires managing user accounts, consumes user licenses, personal access tokens are user-scoped not project-scoped. A project access token stored in Secret Manager and retrieved via OIDC/WIF provides project-scoped credentials without user account overhead.
+
+## Decision
+
+### Overview
+
+GitLab support uses **per-repo installation mode only**. The selection of GitLab as the forge enforces per-repo installation — `fullsend admin install group/project --forge gitlab` is the only valid form; passing just a group name is an error.
+
+The agent pipeline runs inside the enrolled project on the protected default branch, triggered by a webhook bridge Cloud Function. A bot project access token — retrieved at runtime via GitLab OIDC/GCP WIF from Secret Manager — serves as the single credential for all agent operations (REST, GraphQL, MR creation).
+
+```
+GitLab per-repo architecture:
+
+ENROLLED PROJECT                           GCP
+────────────────                           ───
+.gitlab-ci.yml (root pipeline,             WIF pool/provider (validates GitLab OIDC)
+               id_tokens: declared)        Service Account (impersonated by jobs)
+.gitlab/ci/dispatch.yml (routing)    ←──── Bridge Cloud Function (webhook → trigger)
+.gitlab/ci/triage.yml                      Secret Manager:
+.gitlab/ci/code.yml                          - bot PAT per enrolled project
+.gitlab/ci/review.yml                        - webhook secrets per project
+.gitlab/ci/fix.yml                           - trigger tokens per project
+.gitlab/ci/retro.yml
+.fullsend/ (config workspace)
+
+Credential flow:
+  Pipeline job → OIDC token → GCP STS → WIF → impersonate SA → Secret Manager → bot PAT
+```
+
+### 1. Credential model
+
+**Primary credential — bot project access token via OIDC/WIF**: A Developer-role project access token with `api` scope, created during `fullsend admin install` and stored in GCP Secret Manager. Retrieved at runtime via GitLab OIDC → GCP WIF — no credentials are stored as CI/CD variables in the enrolled project.
+
+**OIDC token exchange flow**:
+1. Each stage pipeline declares `id_tokens: { FULLSEND_ID_TOKEN: { aud: "fullsend" } }`
+2. GitLab issues a signed JWT with claims: `project_id`, `project_path`, `namespace_id`, `ref_protected`, `pipeline_source`
+3. The job exchanges the OIDC token at GCP STS (`sts.googleapis.com`)
+4. GCP WIF validates the JWT signature against GitLab's JWKS public keys
+5. GCP WIF validates attribute conditions: enrolled project ID and `ref_protected == "true"`
+6. The job impersonates the fullsend GCP Service Account
+7. The job reads the bot project access token from Secret Manager
+8. The agent uses the bot PAT for all REST and GraphQL API operations
+
+**Why `api` scope**: No narrower project access token scope covers MR creation. GitLab's fine-grained CI/CD job token permissions (GA in GitLab 18.3+) support only `READ_MERGE_REQUESTS`, not write. Fine-grained personal access tokens (beta) support per-resource MR create permissions but are user-scoped (not project-scoped) and not GA. When GitLab makes fine-grained project access tokens available, the bot PAT should be migrated to the narrowest possible scope.
+
+**Bot identity**: The project access token creates a dedicated bot user in GitLab. Agent comments, label changes, and MR operations are attributable to this bot — providing the same recognizable identity that GitHub Apps give fullsend via `fullsend-ai-review[bot]`.
+
+**GraphQL support**: Unlike `CI_JOB_TOKEN` (which [cannot authenticate GraphQL requests](https://docs.gitlab.com/ci/jobs/ci_job_token/)), the bot PAT authenticates both REST and GraphQL APIs. This is required for GitLab's Work Items API (issues, epics, custom fields, health status) which is GraphQL-only.
+
+**Compensating controls for broad scope**:
+- Set project access token expiry to 90 days (shorter than the 1-year maximum) to limit the window of exposure
+- Bot PAT stored in Secret Manager with IAM access controls — only the fullsend Service Account can read it
+- WIF attribute conditions restrict retrieval to pipelines from enrolled projects on protected branches
+- Token is never stored as a CI/CD variable — `CI_DEBUG_TRACE` cannot expose it
+
+**What is NOT needed**:
+- Token mint (no custom credential exchange service — standard GCP WIF handles it)
+- `CI_JOB_TOKEN` for API operations (insufficient for GraphQL and MR creation)
+- Per-project CI/CD variables for credentials (the project is secretless from GitLab's perspective)
+- Per-role tokens (all stages share the same bot PAT; per-role isolation is a future possibility via WIF attribute conditions)
+
+**What IS needed**:
+- GCP WIF pool/provider configured for GitLab OIDC (same one used for inference, or a dedicated one)
+- GCP Service Account for the WIF-authenticated job to impersonate
+- Secret Manager secret per enrolled project (bot PAT value)
+
+### 2. Webhook bridge Cloud Function
+
+GitLab webhooks deliver JSON event payloads, while the Pipeline Trigger API (`/api/v4/projects/:id/trigger/pipeline`) expects form-encoded parameters. These are not wire-compatible. A bridge Cloud Function translates between them.
+
+**Request flow**:
+1. Receive webhook POST from GitLab
+2. Extract `X-Gitlab-Token` header (webhook secret)
+3. Extract `project.path_with_namespace` from JSON payload
+4. Look up project config by `sha256(project_path)` from GCP Secret Manager (with TTL cache)
+5. Validate webhook token using `crypto/subtle.ConstantTimeCompare`
+6. Determine event type from `X-Gitlab-Event` header
+7. Extract minimal event payload, base64-encode it
+8. Call Pipeline Trigger API: `POST /api/v4/projects/{projectID}/trigger/pipeline` with:
+   - `ref=main` (**hardcoded, never from payload**)
+   - `EVENT_TYPE` — mapped event type
+   - `EVENT_PAYLOAD_B64` — base64-encoded minimal payload
+   - `WEBHOOK_VALIDATED=true`
+   - `RESOURCE_KEY` — for concurrency groups (e.g., issue IID or MR IID)
+
+**Per-project config** stored in GCP Secret Manager:
+- `expectedWebhookToken` — the webhook secret for this project
+- `projectID` — GitLab project ID (numeric)
+- `triggerToken` — Pipeline Trigger token for this project
+
+**Deployment**: GCP Cloud Function, deployed alongside but separately from the mint (compromise isolation). The bridge has no access to bot project access tokens or any project credentials — it only holds trigger tokens (which can only trigger pipelines, not access project resources).
+
+**Network connectivity**: The bridge must be able to reach the GitLab instance's Pipeline Trigger API endpoint. For gitlab.com (public API), a standard Cloud Function works. For self-hosted GitLab behind a VPN or firewall, the bridge should be deployed where it can already reach GitLab — not the other way around. Setting up VPN peering from GCP to a corporate network solely to solve a CI trigger limitation is disproportionate infrastructure for the problem.
+
+Deployment options for internal GitLab instances:
+- **On-premise deployment (preferred)**: Deploy the bridge as a standalone container on infrastructure inside the corporate network (OpenShift, Kubernetes, or any container host). The bridge is a self-contained Go binary with no GCP runtime dependency — it only needs outbound HTTPS to the GitLab API. This is the expected default for internal instances like gitlab.cee.
+- **Cloud Run + VPC Connector**: Deploy as a Cloud Run service with a Serverless VPC Access connector peered to the GitLab network. More complex, but keeps all fullsend infrastructure in GCP.
+- **VPN peering**: Peer the GCP VPC hosting the Cloud Function with the corporate network. Highest complexity; only justified if other GCP services also need GitLab connectivity.
+
+**Event type mapping**:
+
+| `X-Gitlab-Event` header | `EVENT_TYPE` variable |
+|---|---|
+| `Issue Hook` | `issues` |
+| `Note Hook` | `note` |
+| `Merge Request Hook` | `merge_request` |
+
+### 3. Pipeline architecture
+
+**Root pipeline** (`.gitlab-ci.yml`):
+```yaml
+include:
+  - local: '.gitlab/ci/dispatch.yml'
+
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $CI_COMMIT_REF_PROTECTED == "true"
+```
+
+The `workflow:rules` ensure the pipeline only runs when triggered via the Pipeline Trigger API (not on push, schedule, or web) AND only on a protected branch. This is defense-in-depth on top of the bridge's `ref=main` hardcoding.
+
+**Dispatch pipeline** (`.gitlab/ci/dispatch.yml`):
+1. Validates `WEBHOOK_VALIDATED == "true"` (set by bridge after token validation)
+2. Validates `CI_COMMIT_REF_PROTECTED == "true"` (redundant with workflow rules, defense-in-depth)
+3. Guards against `CI_DEBUG_TRACE` (aborts if enabled — debug tracing exposes all variables)
+4. Routes event to stage based on `EVENT_TYPE` and payload content (representative routes shown — see Section 4 for the complete event routing table):
+   - `issues` + label `ready-to-code` → code stage
+   - `issues` + label `ready-for-review` → review stage
+   - `note` + `/fs-{stage}` slash commands → corresponding stage
+   - `note` + non-command on issue with `needs-info` label → triage stage
+   - `note` + MR comment with changes-requested marker (same-project) → fix stage
+   - `merge_request` + `open`/`update`/`reopen` → review stage
+   - `merge_request` + `merged` → retro stage
+5. Triggers the matched stage job via GitLab CI `needs:` and `rules:if`
+
+**Stage pipelines** (`.gitlab/ci/triage.yml`, `code.yml`, etc.):
+```yaml
+# fullsend-stage: triage
+
+triage:
+  stage: build
+  image: ghcr.io/fullsend-ai/fullsend:latest
+  id_tokens:
+    FULLSEND_ID_TOKEN:
+      aud: "fullsend"
+  variables:
+    FULLSEND_FORGE: "gitlab"
+  script:
+    - |
+      # CI_DEBUG_TRACE guard
+      if [[ "${CI_DEBUG_TRACE:-}" == "true" ]]; then
+        echo "ERROR: CI_DEBUG_TRACE enabled — aborting to protect secrets"
+        exit 1
+      fi
+
+      # Exchange OIDC token for GCP credentials via WIF
+      gcloud auth login --cred-file=<(cat <<CRED
+      {
+        "type": "external_account",
+        "audience": "//iam.googleapis.com/${FULLSEND_WIF_PROVIDER}",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "token_url": "https://sts.googleapis.com/v1/token",
+        "credential_source": { "file": "${FULLSEND_ID_TOKEN_FILE}" },
+        "service_account_impersonation_url": "https://iam.googleapis.com/v1/projects/-/serviceAccounts/${FULLSEND_SA}:generateAccessToken"
+      }
+      CRED
+      )
+
+      # Read bot PAT from Secret Manager
+      export FULLSEND_FORGE_TOKEN=$(gcloud secrets versions access latest \
+        --secret="${FULLSEND_BOT_TOKEN_SECRET}" \
+        --project="${FULLSEND_GCP_PROJECT_ID}")
+
+      # Decode event payload to temp file
+      EVENT_PAYLOAD_FILE=$(mktemp)
+      trap 'rm -f "${EVENT_PAYLOAD_FILE}"' EXIT
+      echo "${EVENT_PAYLOAD_B64}" | base64 -d > "${EVENT_PAYLOAD_FILE}"
+
+      # Run the agent
+      fullsend run \
+        --stage triage \
+        --source-project "${CI_PROJECT_PATH}" \
+        --event-type "${EVENT_TYPE}" \
+        --event-payload-file "${EVENT_PAYLOAD_FILE}" \
+        --forge gitlab
+  resource_group: "fullsend-triage-${RESOURCE_KEY}"
+  rules:
+    - if: $STAGE == "triage"
+```
+
+All stages use the same credential flow — the bot PAT is the single credential for all operations (REST, GraphQL, MR creation). No stage-specific token handling is needed.
+
+### 4. Event routing
+
+| GitLab Event | Payload Signal | Stage |
+|---|---|---|
+| `Issue Hook` — label added | Label name `ready-to-code` | code |
+| `Issue Hook` — label added | Label name `ready-for-review` | review |
+| `Note Hook` — issue comment | Body starts with `/fs-triage` | triage |
+| `Note Hook` — issue comment | Body starts with `/fs-code` | code |
+| `Note Hook` — issue comment | Body starts with `/fs-review` | review |
+| `Note Hook` — issue comment | Body starts with `/fs-fix` | fix |
+| `Note Hook` — issue comment | Body starts with `/fs-retro` | retro |
+| `Note Hook` — issue comment | Body starts with `/fs-prioritize` | prioritize |
+| `Note Hook` — non-command on issue with `needs-info` | — | triage |
+| `Merge Request Hook` — open/update/reopen | — | review |
+| `Merge Request Hook` — merged | — | retro |
+| `Note Hook` — MR comment with changes-requested marker + same-project MR | — | fix |
+
+**Fork MR protection**: The fix stage is skipped when the MR's `source_project_id != target_project_id`. This prevents fork MRs from triggering fix pipelines that would push commits to the target project.
+
+### 5. Config layering
+
+Same `customized/` convention as GitHub per-repo (ADR 0033, ADR 0035):
+
+```
+fullsend-ai/fullsend defaults  <  .fullsend/customized/  <  AGENTS.md
+(base, fetched at runtime)       (project overrides)       (instructions)
+```
+
+The `.fullsend/` directory in the enrolled project serves as the config workspace. At runtime, the pipeline fetches upstream defaults from `fullsend-ai/fullsend` and copies `customized/` overrides on top — identical layering logic to GitHub per-repo, different CI syntax.
+
+**Config is always read from the protected default branch**, not from MR source branches. The pipeline runs on `ref=main`, so the checkout reflects the default branch. This prevents MR authors from injecting modified agent instructions or policies.
+
+### 6. Repo layout
+
+```
+enrolled-project/
+├── .gitlab-ci.yml                    ← root pipeline
+├── .gitlab/ci/
+│   ├── dispatch.yml                 ← event routing
+│   ├── triage.yml                   ← fullsend-stage: triage
+│   ├── code.yml                     ← fullsend-stage: code
+│   ├── review.yml                   ← fullsend-stage: review
+│   ├── fix.yml                      ← fullsend-stage: fix
+│   ├── retro.yml                    ← fullsend-stage: retro
+│   └── prioritize.yml               ← fullsend-stage: prioritize
+├── .fullsend/                        ← config workspace (optional)
+│   ├── config.yaml                  ← project-level config
+│   └── customized/                  ← user overrides
+│       ├── agents/
+│       ├── harness/
+│       ├── policies/
+│       ├── skills/
+│       └── scripts/
+├── AGENTS.md
+└── ... (source code)
+```
+
+### 7. CLI support
+
+```
+fullsend admin install group/project --forge gitlab
+```
+
+The argument must be `group/project` format. Passing just a group name with `--forge gitlab` is an error: "GitLab installation supports per-repo mode only. Use: fullsend admin install group/project --forge gitlab".
+
+**Flags**:
+- `--forge {github|gitlab}` — auto-detected from remote URL, overridable
+- `--gitlab-url` — GitLab instance URL (default: `https://gitlab.com`)
+- `--inference-project` — GCP project for Vertex AI inference (required)
+- `--inference-region` — GCP region for inference (default: `global`)
+- `--bridge-project` — GCP project for the bridge Cloud Function (defaults to `--inference-project`)
+- `--bridge-region` — GCP region for the bridge (default: `us-central1`)
+- `--skip-bridge-deploy` — skip bridge deployment, reuse existing bridge URL
+- `--bridge-url` — pre-existing bridge URL (requires `--skip-bridge-deploy`)
+- `--dry-run` — preview changes without making them
+
+**Install flow**:
+1. Parse `group/project`, resolve GitLab token (`GL_TOKEN` / `GITLAB_TOKEN` / `glab auth token`)
+2. Create GitLab forge client, validate project exists and user has Maintainer access
+3. Validate default branch is protected (`IsProtectedBranch`)
+4. Validate `CI_DEBUG_TRACE` is not enabled project-wide
+5. Set up WIF pool/provider for GitLab OIDC (if not already configured)
+6. Create Project Access Token (Developer role, `api` scope) → store in Secret Manager
+7. Configure WIF attribute condition for this project: `assertion.project_id == "<id>" && assertion.ref_protected == "true"`
+8. Deploy bridge Cloud Function (if `--skip-bridge-deploy` is not set)
+9. Create pipeline trigger token for the project
+10. Register project with bridge (webhook secret + trigger token + project ID → Secret Manager)
+11. Create project webhook pointing to bridge URL (events: Issue, Note, Merge Request)
+12. Commit CI/CD template files to the project via GitLab API
+13. Set protected CI/CD variables: `FULLSEND_WIF_PROVIDER`, `FULLSEND_SA`, `FULLSEND_BOT_TOKEN_SECRET`, `FULLSEND_GCP_PROJECT_ID`, `FULLSEND_FORGE=gitlab`, `FULLSEND_PER_REPO_INSTALL=true`
+14. Set up inference WIF if `--inference-project` provided
+
+**Uninstall flow** (`fullsend admin uninstall group/project --forge gitlab`):
+1. Delete project webhook
+2. Delete pipeline trigger token
+3. Remove project registration from bridge Secret Manager
+4. Revoke bot project access token, delete Secret Manager secret
+5. Remove WIF attribute condition for this project
+6. Remove CI/CD template files from project
+7. Remove protected CI/CD variables
+8. Optionally tear down bridge Cloud Function (if no other projects use it)
+
+### 8. Forge abstraction compliance
+
+ADR 0005 promises: "Adding a new forge requires implementing `forge.Client` — no changes to layers, CLI, or app setup code."
+
+This ADR adds the following forge-neutral methods to `forge.Client`:
+- `CreateWebhook(ctx, owner, repo, targetURL, secretToken string, events []string) (webhookID string, err error)`
+- `DeleteWebhook(ctx, owner, repo, webhookID string) error`
+- `IsProtectedBranch(ctx, owner, repo, branch string) (bool, error)`
+- `TriggerPipeline(ctx, owner, repo, ref string, variables map[string]string) error`
+
+GitHub-only methods (`ListOrgInstallations`, `GetAppClientID`) move to a `GitHubExtensions` extension interface. Callers type-assert to access them.
+
+A new `ErrNotSupported` sentinel allows forge implementations to reject inapplicable operations (e.g., GitLab returns `ErrNotSupported` for `DispatchWorkflow`; GitHub returns it for `TriggerPipeline`).
+
+The GitLab forge client constructor accepts a single token:
+```go
+func New(token, baseURL string) (*LiveClient, error)
+```
+The bot project access token serves all operations — REST, GraphQL, and MR creation. No dual-token model is needed.
+
+Changes to layers and app setup are limited to calling these new forge-neutral methods and detecting the forge type. The CLI requires forge-specific flags (`--gitlab-url`, `--bridge-project`, etc.) and a GitLab-specific install flow (`runGitLabPerRepoInstall`), but the forge abstraction boundary is preserved — GitLab-specific API logic lives in `internal/forge/gitlab/gitlab.go`, not in shared infrastructure.
+
+## Security Model
+
+### Layer 1: Bridge hardcodes `ref=main`
+
+The bridge Cloud Function always calls the Pipeline Trigger API with the project's protected default branch (typically `main`). This value is read from a per-project config stored in GCP Secret Manager — set at install time and never derived from webhook payload fields. This is the primary control ensuring that MR code cannot modify the pipeline to exfiltrate secrets.
+
+**Threat**: An attacker pushes a malicious branch to the enrolled project with modified `.gitlab-ci.yml` that exfiltrates WIF configuration or attempts OIDC token exchange. If the bridge derived `ref` from the webhook payload, the attacker could trigger a pipeline on the malicious branch. WIF attribute conditions (Layer 4) provide defense-in-depth: even if the pipeline runs on a non-protected branch, `ref_protected == "true"` fails and the token exchange is rejected.
+
+### Layer 2: Protected CI/CD variables
+
+All CI/CD variables in the enrolled project that gate credential retrieval MUST be marked as "protected." GitLab restricts protected variables to pipelines running on protected branches only. No credentials are stored directly as CI/CD variables — the bot PAT lives in Secret Manager — but the WIF configuration variables enable credential retrieval, so protecting them is defense-in-depth on top of WIF attribute conditions (Layer 4).
+
+**Required protected variables**:
+- `FULLSEND_WIF_PROVIDER` — WIF provider resource name (enables OIDC token exchange)
+- `FULLSEND_SA` — GCP Service Account email (impersonated after WIF exchange)
+- `FULLSEND_BOT_TOKEN_SECRET` — Secret Manager secret name for the bot PAT
+- `FULLSEND_GCP_PROJECT_ID` — GCP project for Secret Manager and inference
+
+### Layer 3: Webhook secret validation and replay protection
+
+Each enrolled project has a unique webhook secret. The bridge validates the `X-Gitlab-Token` header against the expected secret using `crypto/subtle.ConstantTimeCompare` to prevent timing side-channel attacks. Invalid tokens are rejected before any processing.
+
+The bridge also deduplicates webhooks using the `X-Gitlab-Event-UUID` header (unique per delivery). A short-lived cache (TTL matching GitLab's retry window) tracks seen delivery IDs and rejects replays. This prevents intercepted valid webhook payloads from being replayed to trigger redundant agent pipelines.
+
+### Layer 4: OIDC/WIF attribute conditions
+
+GCP WIF attribute conditions restrict which GitLab pipelines can exchange OIDC tokens for GCP credentials. The condition for each enrolled project enforces:
+- `assertion.project_id == "<enrolled_project_id>"` — only the specific enrolled project
+- `assertion.ref_protected == "true"` — only pipelines running on protected branches
+
+This provides cryptographic enforcement that the bot PAT can only be retrieved by the correct project on a protected branch. Even if an attacker obtains WIF configuration variables (from `CI_DEBUG_TRACE` or a compromised pipeline on a non-protected branch), the OIDC token exchange fails because the JWT's `ref_protected` claim is `false`.
+
+The OIDC token itself has a short TTL (~5 minutes), limiting the window for replay attacks.
+
+### Layer 5: `CI_DEBUG_TRACE` guard (best-effort)
+
+GitLab's `CI_DEBUG_TRACE` variable, when enabled, prints all CI/CD variables (including protected ones) to job logs. This is a known escape hatch that bypasses variable masking and protection.
+
+Two defenses:
+1. **Install-time**: `fullsend admin install` validates that `CI_DEBUG_TRACE` is not enabled on the project before proceeding.
+2. **Runtime**: Every stage pipeline includes an early guard that aborts if `CI_DEBUG_TRACE` is detected:
+   ```bash
+   if [[ "${CI_DEBUG_TRACE:-}" == "true" ]]; then
+     echo "ERROR: CI_DEBUG_TRACE enabled — aborting to protect secrets"
+     exit 1
+   fi
+   ```
+
+**Reduced risk with OIDC/WIF**: The bot PAT is not stored as a CI/CD variable, so `CI_DEBUG_TRACE` cannot directly expose it. The variables that ARE exposed (WIF provider, Service Account, secret name) are configuration pointers, not credentials. However, the OIDC token itself may be logged, and an attacker with the WIF config + OIDC token could replay the token exchange within its ~5 minute TTL. The runtime guard limits this window, and the install-time check is the stronger control.
+
+**Limitation**: GitLab Runner begins trace-level logging before the script runs, so variable values may already be logged before the guard fires `exit 1`. A sufficiently privileged insider (project Maintainer) can enable `CI_DEBUG_TRACE` at any time — this is an inherent GitLab limitation with no perfect defense.
+
+### Layer 6: Payload encoding
+
+Event payloads are base64-encoded by the bridge before passing as pipeline variables. This prevents YAML injection attacks where attacker-controlled event content (issue titles, MR descriptions containing YAML metacharacters) could break out of the `variables:` block and inject arbitrary pipeline configuration.
+
+### Layer 7: Fork MR protection
+
+The fix stage is skipped when the MR's `source_project_id != target_project_id`. This prevents fork MRs from triggering fix pipelines that would push commits to the target project.
+
+### Known security limitations
+
+1. **Bot PAT scope**: The `api` scope grants full project API access, not just MR creation or GraphQL. GitLab does not offer a narrower project access token scope for these operations. **Migration path**: When GitLab ships fine-grained project access tokens, the bot PAT should be re-created with the narrowest scope that covers MR creation + GraphQL.
+
+   **Post-compromise abuse scenarios** (if a stage is compromised and the attacker obtains the bot PAT from the `FULLSEND_FORGE_TOKEN` environment variable): the `api` scope permits modifying CI/CD variables (including removing the `protected` flag from other variables), altering project webhooks (redirecting events to attacker-controlled endpoints), changing project settings (disabling branch protection), and accessing project-level API endpoints beyond agent operations. **Compensating controls**: 90-day expiry (reduces window of validity), WIF attribute conditions restrict retrieval to enrolled projects on protected branches (Layer 4), Secret Manager IAM controls limit which service accounts can read the bot PAT, and the OIDC token has a ~5 minute TTL (limits replay window).
+
+2. **Token rotation**: The bot PAT expires (max 1 year for project access tokens). GitHub App private keys do not expire. `fullsend admin install` should record the expiration date and warn 30 days before expiry. A `fullsend admin rotate-token` command updates the Secret Manager secret — centralized, no per-project CI/CD variable changes needed.
+
+3. **No per-role credential isolation (initially)**: All stages share the same bot PAT. If the triage stage is compromised, it has the same project access as the code stage (including MR creation). **Future path**: WIF attribute conditions could be extended to select different Secret Manager secrets per stage (e.g., a read-only PAT for triage/review and a write PAT for code/fix), enabling per-role isolation without per-role Apps.
+
+4. **Bridge as external infrastructure**: The webhook bridge is a GCP Cloud Function that must be continuously available. Bridge downtime means webhook events are lost (GitLab retries failed webhooks, but only for a limited time). Bridge compromise could allow triggering pipelines on arbitrary branches (mitigated by Layer 2 — protected variables — and Layer 4 — WIF attribute conditions).
+
+## Comparison with GitHub
+
+This section documents how the GitLab per-repo model differs from GitHub per-repo (ADR 0033). These comparisons are for reference — the GitLab architecture stands independently and should not be evaluated against GitHub as a baseline.
+
+| Concern | GitHub (ADR 0033) | GitLab (this ADR) |
+|---------|-------------------|-------------------|
+| Installation modes | Per-org and per-repo | Per-repo only |
+| Primary credential | GitHub App installation token via mint OIDC | Bot project access token via OIDC/WIF |
+| MR/PR creation | Same App installation token | Same bot project access token |
+| GraphQL support | App installation token authenticates GraphQL | Bot PAT authenticates GraphQL |
+| Bot identity | `fullsend-ai-review[bot]` (App identity) | Bot user from project access token |
+| Credential lifetime | 1 hour (installation token) | Max 1 year (PAT), retrieved per-job via WIF |
+| Token mint | Required (custom Cloud Function) | Not needed (standard GCP WIF) |
+| GCP Secret Manager | PEM keys for all Apps | Bot PAT + webhook secrets |
+| Workload Identity Federation | Required (OIDC → mint) | Required (OIDC → Secret Manager) |
+| Central config repo | Optional (per-repo skips it) | N/A (per-repo only) |
+| Event dispatch | `pull_request_target` + shim workflow | Webhook → bridge → Pipeline Trigger API |
+| Shared logic | Reusable workflows via `workflow_call` | CI/CD Components |
+| Per-role isolation | Separate Apps per role | Single bot PAT (per-role possible via WIF in future) |
+| External infrastructure | Mint Cloud Function | Bridge Cloud Function |
+| Credential rotation | App keys never expire | PAT expires (max 1 year), centralized in Secret Manager |
+| Credential storage | Per-project CI/CD variables | Centralized in GCP Secret Manager (project is secretless) |
+| Secure event trigger | `pull_request_target` (native) | Bridge hardcodes `ref=main` (external) |
+| Debug trace risk | `ACTIONS_STEP_DEBUG` shows step output only | `CI_DEBUG_TRACE` exposes WIF config (not credentials) |
+
+**Where GitLab is simpler**:
+- No App creation dance (no browser-based manifest flow)
+- No custom mint service (standard GCP WIF replaces the mint Cloud Function for credential exchange)
+- No PEM handling (no private key generation, no JWT signing)
+- No installation token exchange (no PEM → JWT → installation token → scoped token chain)
+- No org-level secrets or variables
+- Secretless from the project's perspective (no credentials stored as CI/CD variables)
+
+**Where GitLab is harder**:
+- No `pull_request_target` equivalent (requires external bridge)
+- Review semantics (no native review object — must synthesize from notes and approvals)
+- Project access token rotation (GitHub App keys don't expire; PAT must be rotated in Secret Manager)
+- `CI_DEBUG_TRACE` exposure (though reduced risk since credentials are not CI/CD variables)
+- Subgroup paths (deeply nested namespaces like `org/sub1/sub2/project`)
+
+## Consequences
+
+### Positive
+
+- **Dramatically simpler than per-org**: Eliminates the custom token mint, cross-project credentials, and central `.fullsend` project. Uses standard GCP WIF instead of a custom credential exchange service.
+- **Secretless from the project's perspective**: No credentials stored as CI/CD variables. The bot PAT lives in Secret Manager and is retrieved via OIDC/WIF at runtime. `CI_DEBUG_TRACE` cannot directly expose credentials.
+- **Bot identity**: Agent actions are attributable to a dedicated bot user, providing the same recognizable identity that GitHub Apps offer via `fullsend-ai-review[bot]`.
+- **GraphQL support**: The bot PAT authenticates both REST and GraphQL APIs, supporting GitLab's Work Items API and future GraphQL-only features.
+- **One project access token instead of per-role tokens**: Only one credential to manage and rotate, not four or more.
+- **No mint changes**: GitLab support requires zero changes to the existing token mint infrastructure.
+- **Reuses inference infrastructure**: The WIF pool/provider and Secret Manager are the same GCP services already provisioned for Vertex AI inference.
+- **Pure egress**: The OIDC/WIF credential flow is entirely outbound from GitLab to GCP — no inbound connectivity to the GitLab instance is needed for credential retrieval (the bridge still needs inbound for webhooks).
+- **Same agent workflow**: Triage → Code → Review → Fix stages work identically from the user's perspective.
+
+### Negative
+
+- **Per-repo only**: No centralized config, policies, or credential management across projects. Organizations wanting uniform agent behavior must manage CI/CD Components and group-level variables independently. This creates a user-visible asymmetry with GitHub, which supports both per-org and per-repo modes — teams working across both forges should expect different installation and management workflows.
+- **Bridge Cloud Function required**: External infrastructure that GitHub avoids entirely. Must be deployed, monitored, and maintained.
+- **Token rotation**: The bot PAT expires (max 1 year). Requires renewal automation. GitHub App keys do not expire. Rotation is centralized in Secret Manager (`fullsend admin rotate-token`).
+- **GCP dependency for forge credentials**: Secret Manager + WIF are required for credential retrieval, not just inference. The project cannot operate without GCP infrastructure.
+- **`api` scope is broad**: The bot project access token has full project API access. A narrower scope is not available in GitLab today.
+- **`CI_DEBUG_TRACE` is an escape hatch**: Exposes WIF configuration variables. While the bot PAT itself is not exposed, the OIDC token + WIF config could enable replay within the token's ~5 minute TTL.
+
+### Risks
+
+Ordered by the project's threat priority (external injection > insider > drift > supply chain):
+
+1. **External injection — bridge compromise**: If the bridge is compromised, an attacker could trigger pipelines on arbitrary branches. **Mitigation**: Protected CI/CD variables (Layer 2) prevent secret exposure on non-protected branches. Bridge holds only trigger tokens, not project credentials.
+
+2. **External injection — YAML injection via payloads**: Attacker-controlled event content (issue titles, MR descriptions) could inject YAML if embedded directly in pipeline variables. **Mitigation**: Base64 encoding (Layer 6).
+
+3. **Insider — `CI_DEBUG_TRACE` enablement**: A project maintainer could enable `CI_DEBUG_TRACE` to expose WIF configuration and OIDC tokens. The bot PAT itself is not a CI/CD variable and is not directly exposed, but an attacker could replay the OIDC token exchange within its ~5 minute TTL. **Mitigation**: Runtime guard aborts the pipeline (Layer 5). WIF attribute conditions (Layer 4) provide independent enforcement.
+
+4. **Insider — pipeline modification**: A contributor with write access could modify `.gitlab-ci.yml` or `.gitlab/ci/*.yml` in a PR. Unlike GitHub's `pull_request_target`, there is no mechanism to run the _base branch_ version of the pipeline for MR events — but the pipeline only runs on `ref=main` via the trigger API, so MR branch modifications don't affect the running pipeline until merged. **Mitigation**: CODEOWNERS on `.gitlab-ci.yml`, `.gitlab/ci/`, and `.fullsend/`.
+
+5. **Drift — token expiration**: If the bot PAT expires without renewal, all agent stages fail to authenticate. **Mitigation**: Expiration monitoring and `fullsend admin rotate-token` command (updates Secret Manager secret centrally).
+
+## Implementation Details
+
+Detailed implementation guidance is maintained in a companion document: [docs/plans/gitlab-per-repo-implementation.md](../plans/gitlab-per-repo-implementation.md).
+
+The implementation is organized in six phases:
+
+### Phase 0: Forge interface preparation
+Add `CreateWebhook`, `DeleteWebhook`, `IsProtectedBranch`, `TriggerPipeline` to `forge.Client`. Move GitHub-only methods to `GitHubExtensions` extension interface. Add `ErrNotSupported` sentinel. Create `internal/forge/detect.go` for forge auto-detection.
+
+### Phase 1: GitLab forge client
+Implement `internal/forge/gitlab/gitlab.go` with full `forge.Client` interface using `gitlab.com/gitlab-org/api/client-go`. Single-token constructor for the bot PAT retrieved via OIDC/WIF. Synthesize review semantics from notes and approvals.
+
+### Phase 2: Webhook bridge Cloud Function
+Implement `internal/bridge/main.go` (separate Go module). Webhook → trigger API translation with constant-time token validation, hardcoded `ref=main`, base64-encoded payloads. Per-project configs in Secret Manager.
+
+### Phase 3: GitLab CI/CD templates
+Create `internal/scaffold/fullsend-repo-gitlab/` with dispatch routing and per-stage pipeline templates. OIDC/WIF credential flow in each stage (no mint calls, no CI/CD variable credentials).
+
+### Phase 4: CLI changes
+Add `--forge` and `--gitlab-url` flags to `fullsend admin install`. Implement `runGitLabPerRepoInstall()` with project access token creation, bridge deployment, webhook setup, and scaffold file commit.
+
+### Phase 5: Integration and testing
+Wire forge detection into CLI. Unit tests for GitLab client, bridge, forge detection. Integration tests with mock GitLab API. E2E tests against GitLab.com test project.
+
+### Dependency order
+
+Phases 1 and 2 depend on Phase 0 (forge interface changes). Phase 3 (CI/CD templates) has no code dependency on Phase 0 and can start immediately. Phase 4 depends on Phase 1. Phase 5 depends on all prior phases.
+
+## Open Questions
+
+### Per-role credential isolation via WIF
+
+The current design uses a single bot PAT for all stages. WIF attribute conditions could be extended to select different Secret Manager secrets per stage — for example, a read-only PAT for triage/review and a write PAT for code/fix. This would require per-stage `id_tokens` with different audiences or claims, and corresponding WIF attribute conditions. This is a future optimization that adds complexity (multiple PATs to create and rotate per project) but provides the per-role isolation that GitHub achieves with separate Apps.
+
+### WIF for bridge trigger tokens
+
+The bridge currently stores per-project trigger tokens in Secret Manager. A future optimization could eliminate these by using the bridge's own GCP identity to call the GitLab Pipeline Trigger API via a different mechanism (e.g., a project access token with `api` scope stored centrally). The inbound direction (GitLab → bridge) still requires webhook secrets, as GitLab webhooks authenticate via a shared secret in the `X-Gitlab-Token` header with no OIDC-based alternative.
+
+### Native `merge_request_event` dispatch via `include: project:`
+
+The current design routes all events — including MR events — through the webhook bridge. GitLab's native `merge_request_event` pipeline source could handle MR events directly, using [`include: project: ref: main`](https://docs.gitlab.com/ci/yaml/includes/) to pull trusted dispatch logic from a central templates project. The `ref: main` pin ensures the MR author cannot tamper with dispatch routing, `CI_DEBUG_TRACE` guards, or fork protection — the template is always fetched from the protected branch of the templates project.
+
+This would reduce the bridge's scope to only issue and comment events (which have no native CI trigger), eliminating it from the high-frequency MR path and reducing the blast radius of bridge downtime. Both `merge_request_event` and `include: project:` are available on GitLab Free tier.
+
+**Why deferred**: The bridge is still required for issue/comment events regardless, so it cannot be eliminated — only reduced in scope. Adding a second dispatch path (native for MR events, bridge for issue/comment events) increases operational complexity. The `include: project:` mechanism also introduces a central templates project dependency, and GitLab documents that nested includes execute as a public user — the templates project visibility requirements need investigation. This optimization can be layered on later without changing the credential model or security architecture.
+
+### Parent-child pipelines for stage dispatch
+
+Parent-child pipelines within the enrolled project could replace the current dispatch-to-stage mechanism (dispatch job routes event → triggers stage job). Instead, the dispatch pipeline would trigger child pipelines for each stage. This is an implementation optimization for Phase 3 — it doesn't affect the architecture or credential model.
+
+## References
+
+- [ADR 0005: Forge abstraction layer](0005-forge-abstraction-layer.md) — abstraction boundary preserved
+- [ADR 0007: Per-role GitHub Apps](0007-per-role-github-apps.md) — GitHub authentication model (not replicated for GitLab)
+- [ADR 0028: GitLab Support Architecture](0028-gitlab-support.md) — deprecated, superseded by this ADR
+- [ADR 0029: Central token mint](0029-central-token-mint-secretless-fullsend.md) — not needed for GitLab
+- [ADR 0033: Per-repo installation mode](0033-per-repo-installation-mode.md) — GitHub per-repo (adapted for GitLab)
+- [ADR 0035: Layered content resolution](0035-layered-content-resolution.md) — same `customized/` convention
+- [GitLab OIDC `id_tokens`](https://docs.gitlab.com/ci/secrets/id_token_authentication/) — native OIDC token issuance in CI/CD jobs
+- [GCP Workload Identity Federation for GitLab](https://docs.gitlab.com/ci/cloud_services/google_cloud/) — OIDC → GCP credential exchange
+- [GitLab CI/CD job tokens](https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html) — `CI_JOB_TOKEN` limitations (cannot authenticate GraphQL, cannot create MRs)
+- [GitLab Project Access Tokens](https://docs.gitlab.com/user/project/settings/project_access_tokens/) — scopes and limitations
+- [GitLab Pipeline Triggers](https://docs.gitlab.com/ee/ci/triggers/) — trigger API for the bridge

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,7 +127,7 @@ One concrete implementation option is [`oidcx`](https://github.com/oxidecomputer
 - ~~What identity model fits best — separate bot accounts per agent role, a single bot account with role metadata, GitHub App installations, or something else?~~ Decided in [ADR 0007](ADRs/0007-per-role-github-apps.md).
 - How are credentials rotated and revoked, and who has authority to do that?
 - Does the identity provider integrate with existing secrets management, or is it a new system?
-- How will per-role identity work on GitLab and Forgejo, which lack GitHub's app manifest flow?
+- How will per-role identity work on GitLab and Forgejo, which lack GitHub's app manifest flow? (For GitLab: [ADR 0043](ADRs/0043-gitlab-per-repo-support.md) decided on a single bot project access token retrieved via OIDC/WIF — no per-role isolation initially, but WIF attribute conditions enable future per-role scoping. Forgejo remains open.)
 
 ## Agent Dispatch and Coordination Layer
 
@@ -138,6 +138,7 @@ The existing design principle is that [the repo is the coordinator](problems/age
 **Decided:**
 
 - Event-driven stage dispatch runs synchronously via `workflow_call` to preserve run correlation in the GitHub Actions UI (see [ADR 0041](ADRs/0041-synchronous-workflow-call-event-dispatch.md)).
+- For GitLab: dispatch uses a webhook bridge Cloud Function that translates GitLab webhook events into Pipeline Trigger API calls with `ref=main` hardcoded. The pipeline's dispatch job routes events to stage-specific jobs via dotenv variables (see [ADR 0043](ADRs/0043-gitlab-per-repo-support.md)).
 
 **Open questions:**
 

--- a/docs/plans/agent-execution-environment.md
+++ b/docs/plans/agent-execution-environment.md
@@ -922,7 +922,7 @@ spec:
 - [ADR-0036: Agent Execution Sandbox Architecture](../ADRs/0036-agent-execution-sandbox.md)
 - [ADR-0017: Credential Isolation for Sandboxed Agents](../ADRs/0017-credential-isolation-for-sandboxed-agents.md)
 - [ADR-0025: Provider Credential Delivery](../ADRs/0025-provider-credential-delivery-for-sandboxed-agents.md)
-- [ADR-0028: GitLab Support Architecture](../ADRs/0028-gitlab-support.md)
+- [ADR-0043: GitLab per-repo support](../ADRs/0043-gitlab-per-repo-support.md) (supersedes [ADR-0028](../ADRs/0028-gitlab-support.md))
 - [agent-infrastructure.md](../problems/agent-infrastructure.md): Infrastructure layer exploration
 - [OpenShell Documentation](https://docs.nvidia.com/openshell/)
 - [Sigstore Cosign](https://docs.sigstore.dev/cosign/overview/)

--- a/docs/plans/gitlab-per-repo-implementation.md
+++ b/docs/plans/gitlab-per-repo-implementation.md
@@ -1,0 +1,956 @@
+# GitLab Per-Repo Implementation Details
+
+This document contains implementation details for GitLab per-repo support in fullsend. For the architectural decision and rationale, see [ADR 0043](../ADRs/0043-gitlab-per-repo-support.md).
+
+## Table of Contents
+
+1. [Dependency Graph](#dependency-graph)
+2. [Phase 0: Forge Interface Preparation](#phase-0-forge-interface-preparation)
+3. [Phase 1: GitLab Forge Client](#phase-1-gitlab-forge-client)
+4. [Phase 2: Webhook Bridge Cloud Function](#phase-2-webhook-bridge-cloud-function)
+5. [Phase 3: GitLab CI/CD Templates](#phase-3-gitlab-cicd-templates)
+6. [Phase 4: CLI Changes](#phase-4-cli-changes)
+7. [Phase 5: Integration and Testing](#phase-5-integration-and-testing)
+8. [Security-Critical Code Paths](#security-critical-code-paths)
+9. [Verification Checklist](#verification-checklist)
+
+## Dependency Graph
+
+```
+Phase 0 (forge interface) ──┬──> Phase 1 (GitLab forge client) ──> Phase 4 (CLI changes) ──┐
+                            │                                                                │
+                            └──> Phase 2 (bridge function) ─────────────────────────────────>├──> Phase 5
+                                                                                             │
+Phase 3 (CI/CD templates) ─────────────────────────────────────────────────────────────────>─┘
+```
+
+Phases 1 and 2 depend on Phase 0 (forge interface changes). Phase 3 (CI/CD templates) has no code dependency on Phase 0 and can start immediately. Phase 4 depends on Phase 1. Phase 5 depends on all prior phases.
+
+## Phase 0: Forge Interface Preparation
+
+**Goal**: Prepare `forge.Client` for multi-forge support without breaking GitHub. Pure refactoring — no behavioral changes.
+
+### New methods on `forge.Client`
+
+Add to `internal/forge/forge.go`:
+
+```go
+CreateWebhook(ctx context.Context, owner, repo, targetURL, secretToken string, events []string) (webhookID string, err error)
+DeleteWebhook(ctx context.Context, owner, repo, webhookID string) error
+IsProtectedBranch(ctx context.Context, owner, repo, branch string) (bool, error)
+TriggerPipeline(ctx context.Context, owner, repo, ref string, variables map[string]string) error
+```
+
+### New sentinel error
+
+```go
+var ErrNotSupported = errors.New("operation not supported by this forge")
+```
+
+GitHub returns `ErrNotSupported` for `TriggerPipeline`. GitLab returns it for `DispatchWorkflow`, `ListOrgInstallations`, `GetAppClientID`, and org-level secret/variable methods.
+
+**Caller handling**: All callers of methods that may return `ErrNotSupported` must be audited during Phase 0 via `grep -rn 'MethodName' internal/` to build a complete call-site inventory. The expected handling per call site:
+- `DispatchWorkflow` callers (dispatch layer): check for `ErrNotSupported`, fall back to `TriggerPipeline` for GitLab
+- `CreateOrgSecret`/`OrgSecretExists` callers (secrets layer): skip with a log warning when `ErrNotSupported` — per-repo GitLab does not use org-level secrets
+- `ListOrgInstallations`/`GetAppClientID` callers (appsetup, CLI): already gated behind `GitHubExtensions` type-assertion, so `ErrNotSupported` is never reached
+- `GetLatestWorkflowRun`/`ListWorkflowRuns` callers: skip with a log warning — GitLab uses pipeline status via different mechanisms
+
+### Extension interface
+
+Move GitHub-only methods to an optional extension interface:
+
+```go
+type GitHubExtensions interface {
+    ListOrgInstallations(ctx context.Context, org string) ([]Installation, error)
+    GetAppClientID(ctx context.Context, slug string) (string, error)
+}
+```
+
+Callers in `internal/cli/admin.go` and `internal/appsetup/appsetup.go` type-assert:
+```go
+if ghExt, ok := forgeClient.(forge.GitHubExtensions); ok {
+    installations, err := ghExt.ListOrgInstallations(ctx, org)
+}
+```
+
+### Forge detection
+
+New file `internal/forge/detect.go`:
+
+```go
+func DetectForge(remoteURL string) (string, error) {
+    u, err := url.Parse(remoteURL)
+    if err != nil {
+        return "", fmt.Errorf("invalid remote URL: %w", err)
+    }
+    host := strings.ToLower(u.Hostname())
+
+    switch host {
+    case "github.com":
+        return "github", nil
+    case "gitlab.com":
+        return "gitlab", nil
+    default:
+        return "", fmt.Errorf("unknown forge host %q: use --forge flag for self-hosted instances", host)
+    }
+}
+```
+
+### Files
+
+| Action | Path |
+|--------|------|
+| Modify | `internal/forge/forge.go` — add methods, sentinel, extension interface |
+| Modify | `internal/forge/github/github.go` — implement new methods (webhooks/pipeline → `ErrNotSupported`; `IsProtectedBranch` → branch protection API); move `ListOrgInstallations`/`GetAppClientID` to `GitHubExtensions` |
+| Modify | `internal/forge/fake.go` — implement new methods on FakeClient |
+| Modify | `internal/appsetup/appsetup.go` — update `ListOrgInstallations`/`GetAppClientID` calls to use `GitHubExtensions` type-assertion |
+| Modify | `internal/cli/admin.go` — update `ListOrgInstallations` calls to use `GitHubExtensions` type-assertion |
+| Modify | `internal/cli/github.go` — update `GetAppClientID` calls to use `GitHubExtensions` type-assertion |
+| Create | `internal/forge/detect.go` |
+| Create | `internal/forge/detect_test.go` |
+
+### Verification
+
+`make go-test && make go-vet` — all existing tests pass unchanged.
+
+## Phase 1: GitLab Forge Client
+
+**Goal**: Implement `internal/forge/gitlab/gitlab.go` with the full `forge.Client` interface.
+
+### Library
+
+`gitlab.com/gitlab-org/api/client-go` (official GitLab Go client library).
+
+### Constructor
+
+```go
+type LiveClient struct {
+    client  *gitlab.Client
+    baseURL string
+}
+
+func New(token, baseURL string) (*LiveClient, error)
+```
+
+Single-token model: the bot project access token (retrieved via OIDC/WIF from Secret Manager) serves all operations — REST, GraphQL, and MR creation.
+
+Token resolution outside the client: `GL_TOKEN` / `GITLAB_TOKEN` / `glab auth token` — handled by the CLI for admin operations. At runtime, the bot PAT is retrieved from Secret Manager via OIDC/WIF and passed as `FULLSEND_FORGE_TOKEN`.
+
+### Method mapping
+
+| `forge.Client` method | GitLab API | Notes |
+|---|---|---|
+| `ListOrgRepos` | `Groups.ListGroupProjects` | GitLab groups = GitHub orgs |
+| `GetRepo` | `Projects.GetProject` | |
+| `CreateRepo` | `Projects.CreateProject` | |
+| `DeleteRepo` | `Projects.DeleteProject` | |
+| `CreateFile` | `RepositoryFiles.CreateFile` | |
+| `CreateOrUpdateFile` | `RepositoryFiles.CreateFile` / `UpdateFile` | Check existence first |
+| `GetFileContent` | `RepositoryFiles.GetFile` | |
+| `DeleteFile` | `RepositoryFiles.DeleteFile` | |
+| `CreateBranch` | `Branches.CreateBranch` | |
+| `CommitFiles` | `Commits.CreateCommit` | Multi-file atomic commit with actions |
+| `CreateChangeProposal` | `MergeRequests.CreateMergeRequest` | |
+| `MergeChangeProposal` | `MergeRequests.AcceptMergeRequest` | |
+| `ListRepoPullRequests` | `MergeRequests.ListProjectMergeRequests` | |
+| `CreateIssue` | `Issues.CreateIssue` | |
+| `CloseIssue` | `Issues.UpdateIssue` (state_event=close) | |
+| `ListOpenIssues` | `Issues.ListProjectIssues` | |
+| `CreateIssueComment` | `Notes.CreateIssueNote` | |
+| `ListIssueComments` | `Notes.ListIssueNotes` | |
+| `CreatePullRequestReview(APPROVE)` | `Notes.CreateMergeRequestNote` + `MergeRequestApprovals.ApproveMergeRequest` | |
+| `CreatePullRequestReview(REQUEST_CHANGES)` | `Notes.CreateMergeRequestNote` with `<!-- fullsend:changes-requested -->` prefix | No native GitLab "request changes" |
+| `CreatePullRequestReview(COMMENT)` | `Notes.CreateMergeRequestNote` | |
+| `ListPullRequestReviews` | Synthesize from `Notes` + `MergeRequestApprovals` | Complex — no native review object |
+| `DismissPullRequestReview` | `MergeRequestApprovals.UnapproveMergeRequest` | |
+| `CreateFileOnBranch` | `RepositoryFiles.CreateFile` with branch param | |
+| `CreateOrUpdateFileOnBranch` | `RepositoryFiles.CreateFile` / `UpdateFile` with branch param | |
+| `GetPullRequestHeadSHA` | `MergeRequests.GetMergeRequest` → `SHA` field | |
+| `ListPullRequestFiles` | `MergeRequests.ListMergeRequestDiffs` → file paths | |
+| `ListPullRequestFileDiffs` | `MergeRequests.ListMergeRequestDiffs` → full diff data | |
+| `MergeChangeProposal` | `MergeRequests.AcceptMergeRequest` | |
+| `UpdateIssueComment` | `Notes.UpdateIssueNote` | |
+| `DeleteIssueComment` | `Notes.DeleteIssueNote` | |
+| `CreateRepoSecret` | `ProjectVariables.CreateVariable` (masked=true, protected=true) | |
+| `CreateOrUpdateRepoVariable` | `ProjectVariables.CreateVariable` / `UpdateVariable` | |
+| `RepoSecretExists` | `ProjectVariables.GetVariable` | |
+| `RepoVariableExists` | `ProjectVariables.GetVariable` | |
+| `GetRepoVariable` | `ProjectVariables.GetVariable` | |
+| `DeleteOrgSecret` | Return `ErrNotSupported` | Per-repo only |
+| `GetOrgSecretRepos` | Return `ErrNotSupported` | Per-repo only |
+| `CreateOrUpdateOrgVariable` | Return `ErrNotSupported` | Per-repo only |
+| `OrgVariableExists` | Return `ErrNotSupported` | Per-repo only |
+| `DeleteOrgVariable` | Return `ErrNotSupported` | Per-repo only |
+| `GetOrgVariableRepos` | Return `ErrNotSupported` | Per-repo only |
+| `GetWorkflowRun` | Return `ErrNotSupported` | GitHub Actions-only |
+| `ListWorkflowRuns` | Return `ErrNotSupported` | GitHub Actions-only |
+| `GetWorkflowRunLogs` | Return `ErrNotSupported` | GitHub Actions-only |
+| `GetWorkflowRunAnnotations` | Return `ErrNotSupported` | GitHub Actions-only |
+| `CreateWebhook` | `ProjectHooks.AddProjectHook` | New forge method |
+| `DeleteWebhook` | `ProjectHooks.DeleteProjectHook` | New forge method |
+| `IsProtectedBranch` | `ProtectedBranches.GetProtectedBranch` | New forge method |
+| `TriggerPipeline` | `PipelineTriggers.RunPipelineTrigger` | New forge method |
+| `DispatchWorkflow` | Return `ErrNotSupported` | GitHub-only |
+| `GetLatestWorkflowRun` | Return `ErrNotSupported` | GitHub-only |
+| `ListOrgInstallations` | Moved to `GitHubExtensions` | Not on this client |
+| `GetAppClientID` | Moved to `GitHubExtensions` | Not on this client |
+| `CreateOrgSecret` | Return `ErrNotSupported` | Per-repo only |
+| `OrgSecretExists` | Return `ErrNotSupported` | Per-repo only |
+| `GetOrgPlan` | Return `"unknown", nil` (audit callers during implementation — if any branch on specific plan names, return `ErrNotSupported` instead) | Not needed for per-repo |
+| `GetTokenScopes` | Return `nil, nil` | GitLab PATs don't use OAuth scopes |
+| `MinimizeComment` | Return `nil` | No GitLab equivalent |
+| `GetAuthenticatedUser` | `Users.CurrentUser` | |
+
+### Owner/repo parameter mapping
+
+- `owner` = group path (e.g., `mygroup` or `mygroup/subgroup`)
+- `repo` = project name
+- Full project path = `owner/repo`
+- Internal project ID resolution: `owner/repo` → numeric ID via `Projects.GetProject`, cached
+
+### Review semantics
+
+GitLab has no native review object. The forge client synthesizes reviews:
+
+**Creating reviews**:
+- `APPROVE`: Create a note on the MR with the review body, then call the Approvals API to approve. The note includes a `<!-- fullsend:review:approve -->` marker.
+- `REQUEST_CHANGES`: Create a note with `<!-- fullsend:changes-requested -->` prefix. GitLab has no "request changes" state, so this is tracked by convention.
+- `COMMENT`: Create a note only.
+
+**Listing reviews**: Query MR notes filtered by `<!-- fullsend:review:` markers, plus the Approvals API for approve/unapprove state. Synthesize into `forge.PullRequestReview` structs.
+
+**Inline review comments**: GitLab supports MR discussion notes with position data (file path, line numbers). Map to/from `forge.ReviewComment` structs.
+
+### Files
+
+| Action | Path |
+|--------|------|
+| Create | `internal/forge/gitlab/gitlab.go` (~1500-2000 lines) |
+| Create | `internal/forge/gitlab/gitlab_test.go` |
+
+### What's reusable
+
+- Client structure pattern from `internal/forge/github/github.go` (LiveClient, constructor, HTTP helpers, retry logic)
+- `httptest.NewServer` testing pattern from `internal/forge/github/github_test.go`
+- Error wrapping conventions from existing forge code
+
+### What's net-new
+
+- GitLab API method mapping (all method bodies)
+- Single-token client (all methods use the same `client` — bot project access token retrieved via OIDC/WIF)
+- Review synthesis logic (notes + approvals → reviews)
+- Subgroup path handling
+
+## Phase 2: Webhook Bridge Cloud Function
+
+**Goal**: Translate GitLab webhook JSON into Pipeline Trigger API calls on enrolled projects.
+
+### Module structure
+
+`internal/bridge/` (separate Go module, same pattern as `internal/mint/`):
+
+```
+internal/bridge/
+├── main.go           # Cloud Function entry point
+├── main_test.go      # Tests
+├── go.mod
+└── go.sum
+```
+
+### Bridge configuration
+
+```go
+type ProjectConfig struct {
+    ExpectedWebhookToken string `json:"expectedWebhookToken"`
+    ProjectID            int    `json:"projectID"`
+    TriggerToken         string `json:"triggerToken"`
+    DefaultBranch        string `json:"defaultBranch"` // usually "main"
+    GitLabBaseURL        string `json:"gitlabBaseURL"`  // e.g., "https://gitlab.com"
+}
+```
+
+Per-project configs stored in GCP Secret Manager. Secret name format: `bridge-project-{sha256(project_path)}` (SHA256 is used because GitLab project paths may contain characters like `/`, `.`, and `-` that are invalid in Secret Manager secret names). Bridge reads from Secret Manager with a TTL cache (5-minute refresh).
+
+### Request flow
+
+```go
+func HandleWebhook(w http.ResponseWriter, r *http.Request) {
+    // 1. Extract X-Gitlab-Token header
+    webhookToken := r.Header.Get("X-Gitlab-Token")
+
+    // 2. Parse minimal payload to get project path
+    var payload struct {
+        Project struct {
+            PathWithNamespace string `json:"path_with_namespace"`
+        } `json:"project"`
+    }
+    // ... decode body ...
+
+    // 3. Look up project config
+    projectHash := sha256hex(payload.Project.PathWithNamespace)
+    config, err := lookupProjectConfig(r.Context(), projectHash)
+
+    // 4. Validate webhook token (SECURITY-CRITICAL)
+    if subtle.ConstantTimeCompare(
+        []byte(webhookToken),
+        []byte(config.ExpectedWebhookToken),
+    ) != 1 {
+        http.Error(w, "unauthorized", http.StatusUnauthorized)
+        return
+    }
+
+    // 4b. Replay protection — deduplicate by X-Gitlab-Event-UUID
+    deliveryID := r.Header.Get("X-Gitlab-Event-UUID")
+    if deliveryID != "" && deduplicationCache.Seen(deliveryID) {
+        w.WriteHeader(http.StatusOK) // idempotent — acknowledge but don't re-trigger
+        return
+    }
+    deduplicationCache.Add(deliveryID) // TTL-based, matches GitLab retry window
+    // NOTE: This in-memory cache is per Cloud Function instance. Under horizontal
+    // scaling, concurrent instances will not share dedup state. The downstream
+    // resource_group concurrency control in GitLab CI provides a second layer of
+    // deduplication for most scenarios (only one pipeline per resource group runs
+    // at a time). For strict exactly-once semantics, consider a shared store
+    // (e.g., Firestore or Memorystore) during implementation.
+
+    // 5. Determine event type
+    gitlabEvent := r.Header.Get("X-Gitlab-Event")
+    eventType := mapEventType(gitlabEvent)
+
+    // 6. Extract minimal payload, base64-encode
+    minimalPayload := extractMinimalPayload(body, eventType)
+    payloadB64 := base64.StdEncoding.EncodeToString(minimalPayload)
+
+    // 7. Trigger pipeline (SECURITY-CRITICAL: ref is hardcoded)
+    triggerPipeline(r.Context(), config, TriggerParams{
+        Ref:             config.DefaultBranch, // HARDCODED — never from payload
+        EventType:       eventType,
+        EventPayloadB64: payloadB64,
+        ResourceKey:     extractResourceKey(body, eventType),
+    })
+}
+```
+
+### Minimal payload extraction
+
+The bridge extracts only the fields needed by the dispatch pipeline, not the entire webhook payload. This limits the attack surface for YAML injection (even with base64 encoding, smaller payloads are better).
+
+For `Issue Hook`:
+```json
+{
+  "object_attributes": {"iid": 42, "action": "update", "title": "..."},
+  "labels": [{"title": "ready-to-code"}],
+  "changes": {"labels": {"previous": [...], "current": [...]}}
+}
+```
+
+For `Note Hook`:
+```json
+{
+  "user": {"bot": false},
+  "object_attributes": {"note": "/fs-triage", "noteable_type": "Issue", "noteable_id": 42},
+  "issue": {"iid": 42, "labels": [{"title": "needs-info"}]},
+  "merge_request": {"iid": 10, "source_project_id": 123, "target_project_id": 123}
+}
+```
+
+For `Merge Request Hook`:
+```json
+{
+  "object_attributes": {"iid": 10, "action": "open", "source_project_id": 123, "target_project_id": 123},
+  "labels": [...]
+}
+```
+
+### Event type mapping
+
+```go
+func mapEventType(gitlabEvent string) string {
+    switch gitlabEvent {
+    case "Issue Hook":
+        return "issues"
+    case "Note Hook":
+        return "note"
+    case "Merge Request Hook":
+        return "merge_request"
+    default:
+        return "" // unrecognized — reject
+    }
+}
+```
+
+### Deployment
+
+Extend `internal/dispatch/gcf/provisioner.go` to deploy the bridge as a second Cloud Function. The bridge runs in the same GCP project as the mint but is a separate function (compromise isolation).
+
+New provisioner method:
+```go
+func (p *Provisioner) ProvisionBridge(ctx context.Context) (bridgeURL string, err error)
+```
+
+### Files
+
+| Action | Path |
+|--------|------|
+| Create | `internal/bridge/main.go` (~400-500 lines) |
+| Create | `internal/bridge/main_test.go` |
+| Create | `internal/bridge/go.mod` |
+| Modify | `internal/dispatch/gcf/provisioner.go` — add `ProvisionBridge` |
+| Modify | `internal/dispatch/dispatch.go` — add `ProvisionBridge` to `Dispatcher` interface |
+
+## Phase 3: GitLab CI/CD Templates
+
+**Goal**: Create pipeline YAML templates that are committed to enrolled projects during install.
+
+### Directory structure
+
+```
+internal/scaffold/fullsend-repo-gitlab/
+├── .gitlab-ci.yml
+├── .gitlab/
+│   └── ci/
+│       ├── dispatch.yml
+│       ├── triage.yml
+│       ├── code.yml
+│       ├── review.yml
+│       ├── fix.yml
+│       ├── retro.yml
+│       └── prioritize.yml
+└── .fullsend/
+    ├── config.yaml
+    └── customized/
+        ├── agents/.gitkeep
+        ├── harness/.gitkeep
+        ├── policies/.gitkeep
+        ├── skills/.gitkeep
+        └── scripts/.gitkeep
+```
+
+### Root pipeline (`.gitlab-ci.yml`)
+
+```yaml
+include:
+  - local: '.gitlab/ci/dispatch.yml'
+  - local: '.gitlab/ci/triage.yml'
+  - local: '.gitlab/ci/code.yml'
+  - local: '.gitlab/ci/review.yml'
+  - local: '.gitlab/ci/fix.yml'
+  - local: '.gitlab/ci/retro.yml'
+  - local: '.gitlab/ci/prioritize.yml'
+
+stages:
+  - dispatch
+  - agent
+
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $CI_COMMIT_REF_PROTECTED == "true"
+```
+
+### Dispatch routing (`.gitlab/ci/dispatch.yml`)
+
+The dispatch job receives trigger variables from the bridge and sets the `STAGE` variable for downstream stage jobs.
+
+```yaml
+# fullsend-stage: dispatch
+
+determine-stage:
+  stage: dispatch
+  image: alpine:latest
+  script:
+    - |
+      set -euo pipefail
+
+      # CI_DEBUG_TRACE guard
+      if [ "${CI_DEBUG_TRACE:-}" = "true" ]; then
+        echo "ERROR: CI_DEBUG_TRACE enabled — aborting to protect secrets"
+        exit 1
+      fi
+
+      # Check trigger source marker (set by bridge after webhook secret validation).
+      # NOTE: WEBHOOK_VALIDATED is a pipeline-internal marker, not an independent
+      # security boundary — anyone with a trigger token can set it. The real
+      # security controls are the webhook secret validation in the bridge and
+      # protected CI/CD variables (which prevent secret exposure on non-protected
+      # branches regardless of trigger source).
+      if [ "${WEBHOOK_VALIDATED}" != "true" ]; then
+        echo "ERROR: WEBHOOK_VALIDATED marker not set — this pipeline was not triggered via the webhook bridge dispatch path"
+        exit 1
+      fi
+
+      if [ "${CI_COMMIT_REF_PROTECTED}" != "true" ]; then
+        echo "ERROR: Pipeline not running on protected branch"
+        exit 1
+      fi
+
+      # Decode event payload to temp file (avoids shell expansion of payload content)
+      EVENT_PAYLOAD_FILE=$(mktemp)
+      trap 'rm -f "${EVENT_PAYLOAD_FILE}"' EXIT
+      echo "${EVENT_PAYLOAD_B64}" | base64 -d > "${EVENT_PAYLOAD_FILE}"
+
+      # Route event to stage
+      STAGE=""
+      case "${EVENT_TYPE}" in
+        issues)
+          # Issue routing: only label changes trigger stage dispatch.
+          # Unlike GitHub (where issues.opened/edited triggers auto-triage),
+          # GitLab auto-triage is initiated via /fs-triage slash commands.
+          # This is intentional — GitLab's Issue Hook fires on every edit
+          # (title, description, assignee, weight, etc.), creating excessive
+          # noise for auto-triage. Label-based routing is more precise.
+          # Check changes.labels (newly added labels only), not .labels
+          # (all current labels). GitLab Issue Hook fires for every edit;
+          # without this, any event on an issue with ready-to-code would
+          # re-trigger the code stage.
+          LABEL=$(jq -r '.changes.labels.current[]?.title // empty' "${EVENT_PAYLOAD_FILE}" | grep -E '^ready-(to-code|for-review)$' | head -1)
+          PREV_LABELS=$(jq -r '.changes.labels.previous[]?.title // empty' "${EVENT_PAYLOAD_FILE}")
+          if echo "${PREV_LABELS}" | grep -qxF "${LABEL}" 2>/dev/null; then
+            LABEL=""  # label was already present, not newly added
+          fi
+          case "${LABEL}" in
+            ready-to-code)   STAGE="code" ;;
+            ready-for-review) STAGE="review" ;;
+            *)               STAGE="" ;;
+          esac
+          ;;
+        note)
+          NOTE_BODY=$(jq -r '.object_attributes.note // empty' "${EVENT_PAYLOAD_FILE}")
+          case "${NOTE_BODY}" in
+            /fs-triage*)     STAGE="triage" ;;
+            /fs-code*)       STAGE="code" ;;
+            /fs-review*)     STAGE="review" ;;
+            /fs-fix*)        STAGE="fix" ;;
+            /fs-retro*)      STAGE="retro" ;;
+            /fs-prioritize*) STAGE="prioritize" ;;
+            *)
+              NOTEABLE_TYPE=$(jq -r '.object_attributes.noteable_type // empty' "${EVENT_PAYLOAD_FILE}")
+              if [ "${NOTEABLE_TYPE}" = "MergeRequest" ]; then
+                # MR comment with changes-requested marker → fix stage.
+                # Check this BEFORE the bot filter: the review agent posts via
+                # a bot user (project access token), and its changes-requested
+                # markers must trigger the fix stage.
+                HAS_MARKER=$(echo "${NOTE_BODY}" | grep -cF '<!-- fullsend:changes-requested -->' || true)
+                if [ "${HAS_MARKER}" -gt 0 ]; then
+                  SOURCE_PROJECT=$(jq -r '.merge_request.source_project_id // empty' "${EVENT_PAYLOAD_FILE}")
+                  TARGET_PROJECT=$(jq -r '.merge_request.target_project_id // empty' "${EVENT_PAYLOAD_FILE}")
+                  if [ "${SOURCE_PROJECT}" = "${TARGET_PROJECT}" ]; then
+                    STAGE="fix"
+                  fi
+                fi
+              elif [ "${NOTEABLE_TYPE}" = "Issue" ]; then
+                # Non-command comment on issue with needs-info label.
+                # Guard: skip bot-authored comments to prevent triage
+                # re-triggering on the agent's own replies.
+                IS_BOT=$(jq -r '.user.bot // false' "${EVENT_PAYLOAD_FILE}")
+                if [ "${IS_BOT}" != "true" ]; then
+                  HAS_NEEDS_INFO=$(jq -r '.issue.labels[]?.title // empty' "${EVENT_PAYLOAD_FILE}" | grep -c '^needs-info$' || true)
+                  if [ "${HAS_NEEDS_INFO}" -gt 0 ]; then
+                    STAGE="triage"
+                  fi
+                fi
+              fi
+              ;;
+          esac
+          ;;
+        merge_request)
+          # No fork MR filter here: review runs on fork MRs by design
+          # (read-only — it only posts comments, no code writes).
+          # The fix stage has its own fork MR protection.
+          ACTION=$(jq -r '.object_attributes.action // empty' "${EVENT_PAYLOAD_FILE}")
+          case "${ACTION}" in
+            open|update|reopen) STAGE="review" ;;
+            merge)              STAGE="retro" ;;
+          esac
+          ;;
+      esac
+
+      if [ -z "${STAGE}" ]; then
+        echo "No matching stage for event — skipping"
+        # Write empty dotenv so downstream stage rules don't match any stage.
+        # An empty file means STAGE is undefined (not ""), but stage rules
+        # use `$STAGE == "code"` etc., which won't match either way.
+        touch dispatch.env
+        exit 0
+      fi
+
+      echo "STAGE=${STAGE}" >> dispatch.env
+      echo "Routed to stage: ${STAGE}"
+  artifacts:
+    reports:
+      dotenv: dispatch.env
+  rules:
+    - if: $EVENT_TYPE
+```
+
+### Stage pipeline example (`.gitlab/ci/code.yml`)
+
+```yaml
+# fullsend-stage: code
+
+code:
+  stage: agent
+  image: ghcr.io/fullsend-ai/fullsend:latest
+  needs:
+    - job: determine-stage
+      artifacts: true
+  id_tokens:
+    FULLSEND_ID_TOKEN:
+      aud: "fullsend"
+  variables:
+    FULLSEND_FORGE: "gitlab"
+  script:
+    - |
+      set -euo pipefail
+
+      # CI_DEBUG_TRACE guard
+      if [[ "${CI_DEBUG_TRACE:-}" == "true" ]]; then
+        echo "ERROR: CI_DEBUG_TRACE enabled — aborting to protect secrets"
+        exit 1
+      fi
+
+      # Exchange OIDC token for GCP credentials via WIF
+      gcloud auth login --cred-file=<(cat <<CRED
+      {
+        "type": "external_account",
+        "audience": "//iam.googleapis.com/${FULLSEND_WIF_PROVIDER}",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "token_url": "https://sts.googleapis.com/v1/token",
+        "credential_source": { "file": "${FULLSEND_ID_TOKEN_FILE}" },
+        "service_account_impersonation_url": "https://iam.googleapis.com/v1/projects/-/serviceAccounts/${FULLSEND_SA}:generateAccessToken"
+      }
+      CRED
+      )
+
+      # Read bot PAT from Secret Manager
+      export FULLSEND_FORGE_TOKEN=$(gcloud secrets versions access latest \
+        --secret="${FULLSEND_BOT_TOKEN_SECRET}" \
+        --project="${FULLSEND_GCP_PROJECT_ID}")
+
+      # Decode event payload
+      EVENT_PAYLOAD_FILE=$(mktemp)
+      trap 'rm -f "${EVENT_PAYLOAD_FILE}"' EXIT
+      echo "${EVENT_PAYLOAD_B64}" | base64 -d > "${EVENT_PAYLOAD_FILE}"
+
+      # Prepare workspace (layered content resolution)
+      fullsend workspace prepare \
+        --forge gitlab \
+        --root .fullsend
+
+      # Run the agent
+      fullsend run \
+        --stage code \
+        --source-project "${CI_PROJECT_PATH}" \
+        --event-type "${EVENT_TYPE}" \
+        --event-payload-file "${EVENT_PAYLOAD_FILE}" \
+        --forge gitlab \
+        --fullsend-dir .fullsend
+  resource_group: "fullsend-code-${RESOURCE_KEY}"
+  rules:
+    - if: $STAGE == "code"
+```
+
+### Stage-specific notes
+
+**triage, review, retro, prioritize**: Same structure as `code.yml` — all stages use the same OIDC/WIF credential flow. The bot PAT is the single credential for all operations.
+
+**fix**: Same as `code.yml`. Adds fork MR protection. Note: the fix stage is triggered by a Note Hook (MR comment with changes-requested marker), so MR metadata is under `.merge_request`, not `.object_attributes`:
+```yaml
+    - |
+      # Fork MR protection — fix is triggered by Note Hook, so MR fields
+      # are under .merge_request (not .object_attributes)
+      SOURCE_PROJECT=$(echo "${EVENT_PAYLOAD_B64}" | base64 -d | jq -r '.merge_request.source_project_id // empty')
+      TARGET_PROJECT=$(echo "${EVENT_PAYLOAD_B64}" | base64 -d | jq -r '.merge_request.target_project_id // empty')
+      if [ -n "${SOURCE_PROJECT}" ] && [ -n "${TARGET_PROJECT}" ] && [ "${SOURCE_PROJECT}" != "${TARGET_PROJECT}" ]; then
+        echo "Fork MR detected — skipping fix stage"
+        exit 0
+      fi
+```
+
+### Files
+
+| Action | Path |
+|--------|------|
+| Create | `internal/scaffold/fullsend-repo-gitlab/` (entire tree) |
+| Modify | `internal/scaffold/scaffold.go` — add `GitLabPerRepoScaffold()` function |
+
+## Phase 4: CLI Changes
+
+**Goal**: `fullsend admin install group/project --forge gitlab` works end-to-end.
+
+### New flags
+
+On `fullsend admin install`:
+- `--forge {github|gitlab}` — auto-detected from remote URL, overridable
+- `--gitlab-url` — GitLab instance URL (default: `https://gitlab.com`)
+- `--bridge-project` — GCP project for the bridge Cloud Function (defaults to `--inference-project`)
+- `--bridge-region` — GCP region for the bridge (default: `us-central1`)
+- `--skip-bridge-deploy` — skip bridge deployment, reuse existing bridge URL
+- `--bridge-url` — pre-existing bridge URL (requires `--skip-bridge-deploy`)
+
+### Token resolution
+
+```go
+func resolveGitLabToken() (string, error) {
+    if token := os.Getenv("GL_TOKEN"); token != "" {
+        return token, nil
+    }
+    if token := os.Getenv("GITLAB_TOKEN"); token != "" {
+        return token, nil
+    }
+    out, err := exec.Command("glab", "auth", "token").Output()
+    if err == nil {
+        token := strings.TrimSpace(string(out))
+        if token != "" {
+            return token, nil
+        }
+    }
+    return "", fmt.Errorf("no GitLab token found: set GL_TOKEN, GITLAB_TOKEN, or run 'glab auth login'")
+}
+```
+
+### Per-repo enforcement
+
+```go
+func newInstallCmd() *cobra.Command {
+    // ...
+    RunE: func(cmd *cobra.Command, args []string) error {
+        forgeType := flagForge
+        if forgeType == "" {
+            // Auto-detect: try parsing as URL first (e.g., gitlab.com/group/project),
+            // then fall back to inferring from well-known hosting patterns in the
+            // argument (e.g., "gitlab.com/" prefix → gitlab). DetectForge expects
+            // a URL, so bare "group/project" arguments won't match — --forge flag
+            // is effectively required for non-URL arguments.
+            forgeType, _ = forge.DetectForge(args[0])
+        }
+
+        if forgeType == "gitlab" {
+            if !strings.Contains(args[0], "/") {
+                return fmt.Errorf("GitLab installation supports per-repo mode only. Use: fullsend admin install group/project --forge gitlab")
+            }
+            return runGitLabPerRepoInstall(cmd.Context(), args[0], opts)
+        }
+
+        // existing GitHub logic...
+    }
+}
+```
+
+### GitLab per-repo install flow
+
+```go
+func runGitLabPerRepoInstall(ctx context.Context, target string, opts installOpts) error {
+    // 1. Parse group/project
+    owner, repo := splitOwnerRepo(target)
+
+    // 2. Resolve token
+    token, err := resolveGitLabToken()
+
+    // 3. Create forge client (admin token for setup operations)
+    client, err := gitlab.New(token, opts.gitlabURL)
+
+    // 4. Validate project
+    project, err := client.GetRepo(ctx, owner, repo)
+    // Check user has Maintainer access
+    // Check default branch exists
+
+    // 5. Validate default branch is protected
+    protected, err := client.IsProtectedBranch(ctx, owner, repo, project.DefaultBranch)
+    if !protected {
+        return fmt.Errorf("default branch %q is not protected — protect it before installing fullsend", project.DefaultBranch)
+    }
+
+    // 6. Check CI_DEBUG_TRACE is not enabled
+    // GET /projects/:id/variables/CI_DEBUG_TRACE — if exists and value == "true", fail
+
+    // 7. Create Project Access Token (Developer, api scope)
+    // POST /projects/:id/access_tokens
+    // Store in Secret Manager (not as CI/CD variable)
+
+    // 8. Deploy bridge Cloud Function (if needed)
+    bridgeURL := opts.bridgeURL
+    if bridgeURL == "" && !opts.skipBridgeDeploy {
+        bridgeURL, err = provisioner.ProvisionBridge(ctx)
+    }
+
+    // 9. Create pipeline trigger token
+    // POST /projects/:id/triggers
+
+    // 10. Register project with bridge
+    // Store in Secret Manager: webhook secret + trigger token + project ID
+
+    // 11. Create project webhook
+    webhookSecret := generateWebhookSecret()
+    client.CreateWebhook(ctx, owner, repo, bridgeURL, webhookSecret,
+        []string{"issues", "note", "merge_request"})
+
+    // 12. Commit CI/CD template files
+    scaffoldFiles := scaffold.GitLabPerRepoScaffold()
+    client.CommitFiles(ctx, owner, repo, project.DefaultBranch,
+        "chore: add fullsend CI/CD pipeline", scaffoldFiles)
+
+    // 13. Set protected CI/CD variables (WIF config only — no credentials)
+    client.CreateRepoSecret(ctx, owner, repo, "FULLSEND_WIF_PROVIDER", wifProviderResourceName)
+    client.CreateRepoSecret(ctx, owner, repo, "FULLSEND_SA", serviceAccountEmail)
+    client.CreateRepoSecret(ctx, owner, repo, "FULLSEND_BOT_TOKEN_SECRET", secretManagerSecretName)
+    client.CreateRepoSecret(ctx, owner, repo, "FULLSEND_GCP_PROJECT_ID", opts.inferenceProject)
+    client.CreateOrUpdateRepoVariable(ctx, owner, repo, "FULLSEND_FORGE", "gitlab")
+    client.CreateOrUpdateRepoVariable(ctx, owner, repo, "FULLSEND_PER_REPO_INSTALL", "true")
+
+    // 14. Set up inference WIF (if --inference-project provided)
+    // Same as GitHub per-repo
+}
+```
+
+### Files
+
+| Action | Path |
+|--------|------|
+| Modify | `internal/cli/admin.go` — add flags, `runGitLabPerRepoInstall()`, token resolution |
+| Modify | `internal/config/config.go` — add `Forge` field, validation |
+
+## Phase 5: Integration and Testing
+
+### Integration wiring
+
+- `fullsend run --forge gitlab` constructs a GitLab forge client with the bot PAT from `FULLSEND_FORGE_TOKEN` environment variable (retrieved from Secret Manager via OIDC/WIF in the pipeline script)
+- `internal/dispatch/gcf/provisioner.go` deploys bridge alongside mint
+- Config schema accepts `forge: gitlab` in `config.yaml`
+- Forge detection integrated into CLI argument parsing
+
+### Unit tests
+
+| Component | Test focus |
+|-----------|-----------|
+| GitLab forge client | Mock HTTP responses via `httptest.NewServer`. Cover: MR creation, comment posting, label operations. Review synthesis from notes + approvals. Error handling. Subgroup paths. |
+| Bridge function | Valid webhook acceptance. Invalid token rejection. Malformed payload handling. Event type mapping. `ref` hardcoding verification (assert `ref=main` in all trigger calls). Constant-time comparison. |
+| Forge detection | GitHub URL → `"github"`. GitLab URL → `"gitlab"`. SSH remote → error. Self-hosted → error with flag suggestion. `--forge` override. |
+| CLI | GitLab argument parsing. Per-repo enforcement for GitLab. Token resolution chain. |
+| Config | `forge: gitlab` validation. Unknown forge rejection. |
+
+### Integration tests
+
+Mock GitLab webhook → bridge → mock Pipeline Trigger API:
+1. Bridge receives valid webhook → triggers pipeline with correct variables
+2. Bridge receives invalid token → rejects
+3. Bridge receives unknown project → rejects
+4. Full install flow with mock GitLab API (no real GitLab instance)
+
+### E2E tests
+
+Against GitLab.com:
+1. Create a test project
+2. Run `fullsend admin install group/project --forge gitlab`
+3. Create an issue with `/fs-triage` comment
+4. Verify triage pipeline fires and triage agent runs
+5. Add `ready-to-code` label
+6. Verify code pipeline fires and code agent creates MR
+7. Verify review pipeline fires on MR open
+8. Run `fullsend admin uninstall group/project --forge gitlab`
+9. Verify cleanup (webhook removed, project access token revoked, variables deleted)
+
+Self-hosted testing: Docker-based GitLab CE instance for version compatibility testing. Minimum GitLab version: 17.0+ (stable trigger API, CI/CD variable protection).
+
+### FakeClient updates
+
+Add implementations to `internal/forge/fake.go` for:
+- `CreateWebhook` — record call, return fake webhook ID
+- `DeleteWebhook` — record call
+- `IsProtectedBranch` — configurable return value
+- `TriggerPipeline` — record call with variables
+
+## Security-Critical Code Paths
+
+These paths require extra review attention. A bug here is a security vulnerability, not just a functional failure.
+
+### 1. Bridge `ref` hardcoding
+
+**File**: `internal/bridge/main.go`
+
+The `ref` parameter in the Pipeline Trigger API call MUST be a string literal — never derived from any webhook payload field.
+
+```go
+// CORRECT — hardcoded
+ref: config.DefaultBranch  // set at install time, not from payload
+
+// WRONG — derived from payload
+ref: payload.ObjectAttributes.TargetBranch  // NEVER DO THIS
+```
+
+**Consequence of bug**: Attacker pushes malicious branch, triggers pipeline on it, attempts OIDC token exchange (mitigated by WIF attribute conditions requiring `ref_protected == "true"`).
+
+### 2. Webhook token validation
+
+**File**: `internal/bridge/main.go`
+
+MUST use `crypto/subtle.ConstantTimeCompare`, not `==` or `bytes.Equal`.
+
+```go
+// CORRECT
+if subtle.ConstantTimeCompare([]byte(received), []byte(expected)) != 1 {
+    // reject
+}
+
+// WRONG — timing side-channel
+if received != expected {
+    // reject
+}
+```
+
+**Consequence of bug**: Attacker can determine the webhook secret byte-by-byte via timing analysis.
+
+### 3. Protected variable creation
+
+**File**: `internal/forge/gitlab/gitlab.go`
+
+When creating CI/CD variables for secrets, the `Protected` flag MUST be `true`.
+
+```go
+// CORRECT
+client.CreateVariable(pid, &gitlab.CreateProjectVariableOptions{
+    Key:       gitlab.Ptr("FULLSEND_WIF_PROVIDER"),
+    Value:     gitlab.Ptr(wifProviderResourceName),
+    Masked:    gitlab.Ptr(true),
+    Protected: gitlab.Ptr(true),  // MUST be true
+})
+```
+
+**Consequence of bug**: Any pipeline (including on MR branches with attacker-modified `.gitlab-ci.yml`) can see WIF configuration. With `CI_DEBUG_TRACE`, this could enable OIDC token replay within the ~5 minute TTL. WIF attribute conditions (requiring `ref_protected == "true"`) provide independent defense.
+
+### 4. `CI_DEBUG_TRACE` guard
+
+**Files**: `internal/scaffold/fullsend-repo-gitlab/.gitlab/ci/dispatch.yml`, all stage YAML files, `internal/cli/admin.go`
+
+Every stage pipeline must exit early if debug tracing is detected. The install flow must validate it's not enabled.
+
+**Consequence of bug**: All CI/CD variables (including WIF configuration) are printed to job logs. The bot PAT itself is not a CI/CD variable, but the OIDC token + WIF config could enable replay within the token's ~5 minute TTL.
+
+### 5. Fork MR blocking
+
+**File**: `internal/scaffold/fullsend-repo-gitlab/.gitlab/ci/fix.yml`
+
+The fix stage must skip when `source_project_id != target_project_id`.
+
+**Consequence of bug**: Fork MR triggers fix pipeline that pushes commits to the target project.
+
+### 6. Payload base64 encoding
+
+**File**: `internal/bridge/main.go`
+
+Event payloads MUST be base64-encoded before passing as pipeline trigger variables.
+
+**Consequence of bug**: YAML injection via issue titles or MR descriptions containing YAML metacharacters.
+
+## Verification Checklist
+
+- [ ] `make go-test` — all unit tests pass (existing + new)
+- [ ] `make go-vet` — no issues
+- [ ] `make lint` — passes
+- [ ] Bridge unit test asserts `ref=main` in all trigger API calls
+- [ ] Bridge unit test asserts `crypto/subtle.ConstantTimeCompare` usage
+- [ ] GitLab client unit test asserts `Protected: true` on secret variable creation
+- [ ] All stage YAML files contain `CI_DEBUG_TRACE` guard
+- [ ] Fix stage YAML contains fork MR protection
+- [ ] `fullsend admin install --dry-run testgroup/testproject --forge gitlab` shows correct plan
+- [ ] `fullsend admin install testgroup --forge gitlab` returns per-repo enforcement error
+- [ ] E2E: Install on GitLab.com test project → create issue → triage pipeline fires → code agent creates MR → review pipeline fires → uninstall cleans up

--- a/docs/problems/gitlab-implementation.md
+++ b/docs/problems/gitlab-implementation.md
@@ -1,6 +1,8 @@
 # GitLab Support Implementation Details
 
-This document contains implementation details for GitLab support in fullsend. For the architectural decision and rationale, see [ADR-0028](../ADRs/0028-gitlab-support.md).
+> **Note**: ADR-0028 has been superseded by [ADR-0043](../ADRs/0043-gitlab-per-repo-support.md) (per-repo-only GitLab support via OIDC/WIF and bot project access token). This document reflects the earlier per-org design. For the current implementation plan, see [docs/plans/gitlab-per-repo-implementation.md](../plans/gitlab-per-repo-implementation.md).
+
+This document contains implementation details for the original GitLab support design in fullsend. For the superseded architectural decision, see [ADR-0028](../ADRs/0028-gitlab-support.md) (deprecated).
 
 ## Table of Contents
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -75,7 +75,7 @@ Problems we are actively thinking about but not yet building. These are informed
 
 ### GitLab support
 
-GitHub is the starting point, not the boundary. GitLab support requires solving webhook-to-pipeline translation, MR-event security models, and forge interface abstraction. The architectural groundwork is laid in [ADR-0028](ADRs/0028-gitlab-support.md).
+GitHub is the starting point, not the boundary. GitLab support requires solving webhook-to-pipeline translation, MR-event security models, and forge interface abstraction. The architectural design is complete — [ADR-0043](ADRs/0043-gitlab-per-repo-support.md) (supersedes [ADR-0028](ADRs/0028-gitlab-support.md)) covers the per-repo credential model, webhook bridge, and security layers — but implementation work has not started. It will move to **Next** once the current secretless deployment and per-repo work for GitHub stabilizes.
 
 - Related: [gitlab-implementation](problems/gitlab-implementation.md)
 


### PR DESCRIPTION
> [!NOTE]
> Supersedes #1816 (GitLab support via webhook bridge — per-org model). This PR redesigns GitLab support around per-repo-only installation based on review feedback from ifireball and waynesun09.

## Summary

- Adds ADR 0043 which supersedes ADR 0028 (GitLab Support Architecture)
- Redesigns GitLab support around **per-repo-only installation**, using GitLab OIDC `id_tokens` with GCP Workload Identity Federation to retrieve a bot project access token from Secret Manager
- **Secretless from the project perspective** — no credentials stored as CI/CD variables, no custom token mint
- Bot project access token with `api` scope provides REST + GraphQL API access and bot identity
- Webhook bridge Cloud Function translates GitLab events to Pipeline Trigger API calls (on-premise container deployment recommended for internal GitLab instances)
- 7-layer security model with WIF attribute conditions, protected CI/CD variables, and explicit post-compromise abuse scenarios
- Companion implementation plan (`docs/plans/gitlab-per-repo-implementation.md`) with 6-phase build-out, security-critical path analysis, and verification checklist

## Test plan

- [x] `make lint` passes (ADR status, numbers, frontmatter, markdown links all clean)
- [ ] Review ADR content for architectural soundness
- [ ] Review implementation plan for completeness and correct dependency ordering
- [ ] Verify security model covers the project's threat priority order (external injection > insider > drift > supply chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)