### PR TITLE
ci: add codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,31 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...80"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+
+ignore:
+  - "**/*_test.go"
+  - "**/*__data__*/*.ts"
+  - "docs/**"
+  - "hack/**"
+  - "experiments/**"
+  - "images/**"
+  - "**/*.md"
+  - "**/*.sh"
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary

- Adds `.codecov.yml` with standard coverage settings
- Project coverage target: `auto` (threshold: `1%`)
- Patch coverage target: `80%` (threshold: `5%`)
- Ignores non-code files: docs, hack, experiments, images, markdown, shell scripts

## Reference

Based on [konflux-ui/.codecov.yml](https://github.com/konflux-ci/konflux-ui/blob/main/.codecov.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)