### PR TITLE
ci: add codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,31 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...80"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+
+ignore:
+  - "**/*_test.go"
+  - "**/*__data__*/*.ts"
+  - "docs/**"
+  - "hack/**"
+  - "experiments/**"
+  - "images/**"
+  - "**/*.md"
+  - "**/*.sh"
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,7 +17,7 @@ coverage:
 
 ignore:
   - "**/*_test.go"
-  - "**/*__data__*/*.ts"
+  - "**/testdata/**"
   - "docs/**"
   - "hack/**"
   - "experiments/**"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,10 @@ jobs:
       - run: make test
 
       - name: Generate coverage profile
-        run: GH_TOKEN= GITHUB_TOKEN= go test -race -coverprofile=coverage.out ./...
+        run: go test -race -coverprofile=coverage.out ./...
+        env:
+          GH_TOKEN: ""
+          GITHUB_TOKEN: ""
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,13 +36,15 @@ jobs:
           echo "1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a  /tmp/lychee.tar.gz" | sha256sum -c
           tar xzf /tmp/lychee.tar.gz -C /usr/local/bin --strip-components=1 lychee-x86_64-unknown-linux-gnu/lychee
 
-      - run: make test
+      - run: make lint-all
 
-      - name: Generate coverage profile
+      - name: Run Go tests with coverage
         run: go test -race -coverprofile=coverage.out ./...
         env:
           GH_TOKEN: ""
           GITHUB_TOKEN: ""
+
+      - run: make script-test
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,6 +38,14 @@ jobs:
 
       - run: make test
 
+      - name: Generate coverage profile
+        run: GH_TOKEN= GITHUB_TOKEN= go test -race -coverprofile=coverage.out ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+
   commit-lint:
     # On pull_request: lint the PR title (which becomes the merge commit
     # subject on squash-merge). On push/merge_group: lint each commit.


### PR DESCRIPTION
## Summary

- Adds `.codecov.yml` with standard coverage settings
- Project coverage target: `auto` (threshold: `1%`)
- Patch coverage target: `80%` (threshold: `5%`)
- Ignores non-code files: docs, hack, experiments, images, markdown, shell scripts, test files, testdata
- Adds coverage profile generation and Codecov upload step to CI workflow

Supersedes #2064 (rebased from fork to upstream with fixes applied).

Original PR by @eedri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)