### PR TITLE
chore: consolidate commit message guidance into COMMITS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,7 @@ See [CLAUDE.md](CLAUDE.md) for project rules and design decisions.
 
 ## Commit messages
 
-Use [Conventional Commits](https://www.conventionalcommits.org/) format for every commit. The allowed types are: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `perf`, `build`. See [CONTRIBUTING.md](CONTRIBUTING.md#commit-messages) for the full specification.
-
-This is not optional — GoReleaser parses commit prefixes to build release notes. A missing or wrong prefix produces incorrect changelogs.
-
-When reviewing PRs, check that commit messages and PR titles follow this format. Flag violations as a required change — they are not cosmetic.
+You **must** read and follow [COMMITS.md](COMMITS.md) when writing or reviewing commit messages. Getting the prefix right is not optional — GoReleaser uses it to build release notes.
 
 ## Forge abstraction
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Fullsend is a platform for fully autonomous agentic development for GitHub-hoste
 - Keep core problem documents organization-agnostic. Organization-specific details belong in `docs/problems/applied/<org-name>/`.
 - The target audience is any contributor community considering autonomous agents — keep language accessible, avoid presuming solutions.
 - Always run `make lint` before submitting changes and fix any failures.
-- Use [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages. See [CONTRIBUTING.md](CONTRIBUTING.md#commit-messages) for the full specification. This is critical — GoReleaser uses commit prefixes to generate release notes.
+- You **must** read and follow [COMMITS.md](COMMITS.md) when writing or reviewing commit messages. Getting the prefix right is not optional — GoReleaser uses it to build release notes.
 - Never commit secrets (tokens, API keys, PEM keys, gcloud credentials) or sensitive data (GCP project names, service account identifiers, Model Armor template names, internal hostnames). Use environment variables with no defaults for sensitive values.
 
 ## Go code

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -1,0 +1,73 @@
+# Commit Messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/). Every commit on `main` feeds the auto-generated release notes (via GoReleaser), so getting the prefix right matters. You **must** consult this file when writing or reviewing commit messages.
+
+## Format
+
+```
+<type>(<scope>): <short description>
+
+<optional body>
+
+<optional trailers>
+```
+
+## Types
+
+| Type | Purpose | Appears in release notes? |
+|---|---|---|
+| `feat` | New user-facing functionality | Yes — under **Features** |
+| `fix` | Bug fix visible to users | Yes — under **Bug Fixes** |
+| `refactor` | Code restructuring (no behavior change) | Yes — under **Refactoring** |
+| `docs` | Documentation only | No |
+| `test` | Adding or updating tests | No |
+| `chore` | Maintenance (CI, deps, tooling) | No |
+| `ci` | CI/CD pipeline changes | No |
+| `perf` | Performance improvement | Yes — under **Others** |
+| `build` | Build system or dependency changes | No |
+
+## `feat` is for end users
+
+The `feat` prefix populates the **Features** section of our release notes. End users read that list to decide whether to upgrade. Reserve `feat` for changes an end user would recognize as new capability:
+
+- A new CLI command or flag they can invoke
+- A new behavior they interact with (e.g., the agent now comments on their PR with a new kind of analysis)
+- A new integration or platform they can target
+
+**`feat` is wrong for:**
+
+- Restructuring internals (extracting a sub-agent, splitting a package) → `refactor`
+- Adding internal packages, helpers, or abstractions that don't change user-visible behavior → `refactor`
+- Upgrading a dependency or vendored tool version → `chore`
+- Tightening internal heuristics, adjusting prompts, or tuning agent behavior that users don't directly control → `refactor` or `fix` depending on whether it corrects a defect
+- Addressing review feedback on an existing PR → `fix` or `refactor`, not `feat`
+
+Apply the same discipline to `fix` — bumping a dependency version is `chore`, not `fix`, unless it corrects a user-visible bug. Removing a trailing blank line is `chore`, not `fix`.
+
+**When in doubt, prefer `refactor` or `chore` over `feat` or `fix`.** A change miscategorized as `refactor` is harmless — it shows up in a lower section of the release notes. A change miscategorized as `feat` erodes the signal of the Features list.
+
+## Scope
+
+The parenthesized scope is optional but encouraged. Use it to identify the subsystem: `feat(appsetup)`, `fix(mint)`, `docs(adr)`, `chore(ci)`. When fixing a specific issue, prefer the issue number as scope: `fix(#123): ...`.
+
+## Breaking changes
+
+Append `!` after the type/scope to flag a breaking change: `feat(cli)!: rename --gcp flags to --inference`. Include a `BREAKING CHANGE:` trailer in the body explaining migration steps.
+
+## Examples
+
+```
+feat(review-agent): add outcome labels to post-review.sh
+
+fix(#933): use .yaml extension for shim workflow path
+
+refactor(#1797): extract challenger pass into dedicated sub-agent
+
+chore(sandbox): bump gopls from 0.18.1 to 0.22.0
+
+docs: add mint URL stability note to installation guide
+```
+
+## Reviewing commit messages
+
+When reviewing PRs, check that commit messages and PR titles use the correct type prefix. Flag violations as a required change — they are not cosmetic. Pay particular attention to `feat` — challenge it if the change is not user-facing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,55 +4,7 @@ Thank you for your interest in contributing! This document covers the social nor
 
 ## Commit messages
 
-This project uses [Conventional Commits](https://www.conventionalcommits.org/). Every commit on `main` feeds the auto-generated release notes (via GoReleaser), so getting the format right matters.
-
-### Format
-
-```
-<type>(<scope>): <short description>
-
-<optional body>
-
-<optional trailers>
-```
-
-### Types
-
-| Type | Purpose | Appears in release notes? |
-|---|---|---|
-| `feat` | New functionality | Yes — under **Features** |
-| `fix` | Bug fix | Yes — under **Bug Fixes** |
-| `refactor` | Code restructuring (no behavior change) | Yes — under **Refactoring** |
-| `docs` | Documentation only | No |
-| `test` | Adding or updating tests | No |
-| `chore` | Maintenance (CI, deps, tooling) | No |
-| `ci` | CI/CD pipeline changes | No |
-| `perf` | Performance improvement | Yes — under **Others** |
-| `build` | Build system or dependency changes | No |
-
-### Scope
-
-The parenthesized scope is optional but encouraged. Use it to identify the subsystem: `feat(appsetup)`, `fix(mint)`, `docs(adr)`, `chore(ci)`. When fixing a specific issue, prefer the issue number as scope: `fix(#123): ...`.
-
-### Breaking changes
-
-Append `!` after the type/scope to flag a breaking change: `feat(cli)!: rename --gcp flags to --inference`. Include a `BREAKING CHANGE:` trailer in the body explaining migration steps. Breaking changes trigger a major version bump.
-
-### Examples
-
-```
-feat(review-agent): add outcome labels to post-review.sh
-
-fix(#933): use .yaml extension for shim workflow path
-
-docs: add mint URL stability note to installation guide
-
-chore(ci): update goreleaser to v2
-```
-
-### Why this matters
-
-GoReleaser groups changelog entries by type prefix (see `.goreleaser.yml`). Commits without a recognized prefix land under "Others". Commits prefixed `docs:`, `test:`, `chore:`, `ci:`, or `build:` are excluded from release notes entirely. A wrong prefix means the change shows up in the wrong section — or not at all.
+This project uses [Conventional Commits](https://www.conventionalcommits.org/). See [COMMITS.md](COMMITS.md) for the full specification, type selection rules, and examples.
 
 ## DCO (Developer Certificate of Origin)
 


### PR DESCRIPTION
## Summary

- Adds `COMMITS.md` as the single source of truth for commit message rules, including new guidance that `feat` is reserved for user-facing features (not internal refactors, dep bumps, or prompt tuning)
- Replaces duplicated commit message specs in CLAUDE.md, AGENTS.md, and CONTRIBUTING.md with pointers to COMMITS.md
- Goal: future release notes should only list things under "Features" that an end user would recognize as new capability

Refs #2088

## Test plan

- [ ] Verify `make lint` passes
- [ ] Review COMMITS.md for completeness and tone
- [ ] Confirm CLAUDE.md, AGENTS.md, and CONTRIBUTING.md all point to COMMITS.md consistently