### PR TITLE
ci: expand merge-queue skill with monitoring scripts

### DIFF
--- a/skills/merge-queue/SKILL.md
+++ b/skills/merge-queue/SKILL.md
@@ -1,24 +1,41 @@
 ---
 name: merge-queue
 description: >-
-  Use when you need to add a PR to a GitHub merge queue. The gh CLI has no
-  built-in merge-queue command, so this skill provides a script that uses the
+  Use when you need to add a PR to a GitHub merge queue, check what's currently
+  queued, or find out why a PR was removed from the queue. The gh CLI has no
+  built-in merge-queue commands, so this skill provides scripts that use the
   GraphQL API.
-allowed-tools: Bash(bash skills/merge-queue/scripts/enqueue-pr.sh:*)
+allowed-tools: Bash(bash skills/merge-queue/scripts/*:*)
 ---
 
 # Merge Queue
 
+## Enqueue a PR
+
 Run `bash skills/merge-queue/scripts/enqueue-pr.sh [PR_NUMBER_OR_URL]` to enqueue a PR.
 Omit the argument to enqueue the current branch's PR.
 
-## Accepted input formats
+### Accepted input formats
 
 - **PR number:** `652` (uses the current repo context from `gh`)
 - **PR URL:** `https://github.com/owner/repo/pull/652`
 - **Omitted:** uses the current branch's PR
 
 The `owner/repo#number` format is **not supported** — use a URL or number instead.
+
+## Check queue status
+
+Run `bash skills/merge-queue/scripts/queue-status.sh [OWNER/REPO] [BRANCH]` to list PRs currently in the merge queue.
+
+Both arguments are optional — defaults to the current repo and `main` branch.
+
+Shows each entry's position, state, PR title/URL, author, enqueuer, and estimated time to merge.
+
+## Investigate dequeue reasons
+
+Run `bash skills/merge-queue/scripts/dequeue-reason.sh <PR_NUMBER_OR_URL>` to find out why a PR was removed from the merge queue.
+
+Shows each removal event's timestamp, reason (e.g. `failed_checks`, `merge_conflict`), and the commit SHA at the time of removal.
 
 ## Prerequisites
 

--- a/skills/merge-queue/scripts/dequeue-reason.sh
+++ b/skills/merge-queue/scripts/dequeue-reason.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Shows why a PR was removed from the merge queue.
+# Usage: dequeue-reason.sh <PR_NUMBER_OR_URL>
+#
+# Queries the PR timeline for RemovedFromMergeQueueEvent entries and
+# prints the reason, timestamp, and commit SHA for each removal.
+# Requires: gh CLI authenticated, jq.
+
+set -euo pipefail
+
+pr="${1:?Usage: dequeue-reason.sh <PR_NUMBER_OR_URL>}"
+
+# Resolve to owner/repo and PR number
+if [[ "$pr" =~ ^https://github.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+  repo="${BASH_REMATCH[1]}"
+  number="${BASH_REMATCH[2]}"
+elif [[ "$pr" =~ ^[0-9]+$ ]]; then
+  repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+  number="$pr"
+else
+  echo "Error: provide a PR number or URL" >&2
+  exit 1
+fi
+
+owner="${repo%%/*}"
+name="${repo##*/}"
+
+result="$(gh api graphql -f query='
+  query($owner: String!, $name: String!, $number: Int!) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        title
+        url
+        timelineItems(last: 20, itemTypes: [REMOVED_FROM_MERGE_QUEUE_EVENT]) {
+          nodes {
+            ... on RemovedFromMergeQueueEvent {
+              createdAt
+              reason
+              beforeCommit { abbreviatedOid }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner="$owner" -f name="$name" -F number="$number")"
+
+title="$(echo "$result" | jq -r '.data.repository.pullRequest.title')"
+url="$(echo "$result" | jq -r '.data.repository.pullRequest.url')"
+count="$(echo "$result" | jq '.data.repository.pullRequest.timelineItems.nodes | length')"
+
+if [[ "$count" -eq 0 ]]; then
+  echo "${url}  ${title}"
+  echo "  No merge queue removals found."
+  exit 0
+fi
+
+echo "${url}  ${title}"
+echo "${count} removal(s):"
+echo ""
+echo "$result" | jq -r '
+  .data.repository.pullRequest.timelineItems.nodes[] |
+  "  \(.createdAt)  reason: \(.reason)  commit: \(.beforeCommit.abbreviatedOid // "unknown")"
+'

--- a/skills/merge-queue/scripts/queue-status.sh
+++ b/skills/merge-queue/scripts/queue-status.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Lists PRs currently in the merge queue for a branch.
+# Usage: queue-status.sh [OWNER/REPO] [BRANCH]
+#
+# Defaults: OWNER/REPO from current gh repo context, BRANCH=main
+# Requires: gh CLI authenticated, jq.
+
+set -euo pipefail
+
+repo="${1:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+branch="${2:-main}"
+owner="${repo%%/*}"
+name="${repo##*/}"
+
+result="$(gh api graphql -f query='
+  query($owner: String!, $name: String!, $branch: String!) {
+    repository(owner: $owner, name: $name) {
+      mergeQueue(branch: $branch) {
+        entries(first: 50) {
+          nodes {
+            position
+            state
+            estimatedTimeToMerge
+            enqueuedAt
+            enqueuer { login }
+            pullRequest {
+              number
+              title
+              url
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner="$owner" -f name="$name" -f branch="$branch")"
+
+count="$(echo "$result" | jq '.data.repository.mergeQueue.entries.nodes | length')"
+
+if [[ "$count" -eq 0 ]]; then
+  echo "Merge queue for ${repo}:${branch} is empty."
+  exit 0
+fi
+
+echo "Merge queue for ${repo}:${branch} — ${count} enqueued:"
+echo ""
+echo "$result" | jq -r '
+  .data.repository.mergeQueue.entries.nodes[] |
+  "  #\(.position) [\(.state)] \(.pullRequest.url)  \(.pullRequest.title)\n      by \(.pullRequest.author.login), enqueued \(.enqueuedAt) by \(.enqueuer.login)  ETA: \(.estimatedTimeToMerge // "unknown")s"
+'


### PR DESCRIPTION
## Summary

- Add `queue-status.sh` — lists PRs currently in the merge queue via GraphQL
- Add `dequeue-reason.sh` — shows why a PR was removed from the queue (reason, timestamp, commit)
- Update SKILL.md with usage docs for both new scripts

## Test plan

- [x] `queue-status.sh` tested against live repo (empty queue + populated queue)
- [x] `dequeue-reason.sh` tested against PR #1698 (3 historical removals)
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)