### PR TITLE
feat(e2e): gate fork PR runs with pull_request_target

### DIFF
--- a/.github/actions/check-e2e-authorization/action.yml
+++ b/.github/actions/check-e2e-authorization/action.yml
@@ -86,8 +86,9 @@ runs:
         body+="
         See [E2E testing guide](${DOCS_URL}) for details."
 
+        bot_login="$(gh api user --jq .login)"
         existing_id="$(gh api "repos/${owner}/${repo}/issues/${PR_NUMBER}/comments" --paginate \
-          --jq ".[] | select(.body | contains(\"${marker}\")) | .id" | head -n1 || true)"
+          --jq ".[] | select(.user.login == \"${bot_login}\" and (.body | contains(\"${marker}\"))) | .id" | head -n1 || true)"
 
         if [[ -n "${existing_id}" ]]; then
           jq -n --arg body "${body}" '{body: $body}' | \
@@ -111,8 +112,9 @@ runs:
         owner="${REPOSITORY%%/*}"
         repo="${REPOSITORY#*/}"
 
+        bot_login="$(gh api user --jq .login)"
         existing_id="$(gh api "repos/${owner}/${repo}/issues/${PR_NUMBER}/comments" --paginate \
-          --jq ".[] | select(.body | contains(\"${marker}\")) | .id" | head -n1 || true)"
+          --jq ".[] | select(.user.login == \"${bot_login}\" and (.body | contains(\"${marker}\"))) | .id" | head -n1 || true)"
 
         if [[ -n "${existing_id}" ]]; then
           body="${marker}

--- a/.github/actions/check-e2e-authorization/action.yml
+++ b/.github/actions/check-e2e-authorization/action.yml
@@ -10,6 +10,14 @@ inputs:
   repository:
     description: Repository in owner/name form
     required: true
+  pr_updated_at:
+    description: github.event.pull_request.updated_at (server-side push time)
+    required: false
+    default: ""
+  event_action:
+    description: github.event.action
+    required: false
+    default: ""
   docs_url:
     description: Link to e2e testing documentation
     required: false
@@ -36,6 +44,8 @@ runs:
         GH_TOKEN: ${{ github.token }}
         PR_NUMBER: ${{ inputs.pr_number }}
         REPOSITORY: ${{ inputs.repository }}
+        PR_UPDATED_AT: ${{ inputs.pr_updated_at }}
+        EVENT_ACTION: ${{ inputs.event_action }}
       run: bash "${GITHUB_WORKSPACE}/scripts/check-e2e-authorization.sh" "${PR_NUMBER}" "${REPOSITORY}"
 
     - name: Post gate comment
@@ -88,7 +98,9 @@ runs:
 
         bot_login="$(gh api user --jq .login)"
         existing_id="$(gh api "repos/${owner}/${repo}/issues/${PR_NUMBER}/comments" --paginate \
-          --jq ".[] | select(.user.login == \"${bot_login}\" and (.body | contains(\"${marker}\"))) | .id" | head -n1 || true)"
+          | jq -r --arg login "${bot_login}" --arg marker "${marker}" \
+            '.[] | select(.user.login == $login and (.body | contains($marker))) | .id' \
+          | head -n1 || true)"
 
         if [[ -n "${existing_id}" ]]; then
           jq -n --arg body "${body}" '{body: $body}' | \
@@ -114,7 +126,9 @@ runs:
 
         bot_login="$(gh api user --jq .login)"
         existing_id="$(gh api "repos/${owner}/${repo}/issues/${PR_NUMBER}/comments" --paginate \
-          --jq ".[] | select(.user.login == \"${bot_login}\" and (.body | contains(\"${marker}\"))) | .id" | head -n1 || true)"
+          | jq -r --arg login "${bot_login}" --arg marker "${marker}" \
+            '.[] | select(.user.login == $login and (.body | contains($marker))) | .id' \
+          | head -n1 || true)"
 
         if [[ -n "${existing_id}" ]]; then
           body="${marker}

--- a/.github/actions/check-e2e-authorization/action.yml
+++ b/.github/actions/check-e2e-authorization/action.yml
@@ -58,6 +58,7 @@ runs:
         REASON: ${{ steps.check.outputs.reason }}
         LABEL_REMOVED: ${{ steps.check.outputs.label_removed }}
         DOCS_URL: ${{ inputs.docs_url }}
+        BOT_LOGIN: ${{ github.actor }}
       run: |
         set -euo pipefail
 
@@ -96,9 +97,8 @@ runs:
         body+="
         See [E2E testing guide](${DOCS_URL}) for details."
 
-        bot_login="$(gh api user --jq .login)"
         existing_id="$(gh api "repos/${owner}/${repo}/issues/${PR_NUMBER}/comments" --paginate \
-          | jq -r --arg login "${bot_login}" --arg marker "${marker}" \
+          | jq -r --arg login "${BOT_LOGIN}" --arg marker "${marker}" \
             '.[] | select(.user.login == $login and (.body | contains($marker))) | .id' \
           | head -n1 || true)"
 
@@ -117,6 +117,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
         REPOSITORY: ${{ inputs.repository }}
         PR_NUMBER: ${{ inputs.pr_number }}
+        BOT_LOGIN: ${{ github.actor }}
       run: |
         set -euo pipefail
 
@@ -124,9 +125,8 @@ runs:
         owner="${REPOSITORY%%/*}"
         repo="${REPOSITORY#*/}"
 
-        bot_login="$(gh api user --jq .login)"
         existing_id="$(gh api "repos/${owner}/${repo}/issues/${PR_NUMBER}/comments" --paginate \
-          | jq -r --arg login "${bot_login}" --arg marker "${marker}" \
+          | jq -r --arg login "${BOT_LOGIN}" --arg marker "${marker}" \
             '.[] | select(.user.login == $login and (.body | contains($marker))) | .id' \
           | head -n1 || true)"
 

--- a/.github/actions/check-e2e-authorization/action.yml
+++ b/.github/actions/check-e2e-authorization/action.yml
@@ -1,0 +1,124 @@
+name: Check E2E Authorization
+description: >-
+  Authorize PR-triggered e2e runs for trusted authors or a fresh ok-to-test label.
+  Removes stale ok-to-test labels and posts a sticky PR comment when unauthorized.
+
+inputs:
+  pr_number:
+    description: Pull request number to authorize
+    required: true
+  repository:
+    description: Repository in owner/name form
+    required: true
+  docs_url:
+    description: Link to e2e testing documentation
+    required: false
+    default: https://github.com/fullsend-ai/fullsend/blob/main/docs/guides/dev/e2e-testing.md#ci-authorization
+
+outputs:
+  authorized:
+    description: Whether e2e tests may run for this PR
+    value: ${{ steps.check.outputs.authorized }}
+  reason:
+    description: Authorization outcome reason code
+    value: ${{ steps.check.outputs.reason }}
+  label_removed:
+    description: Whether a stale ok-to-test label was removed
+    value: ${{ steps.check.outputs.label_removed }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check authorization
+      id: check
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        REPOSITORY: ${{ inputs.repository }}
+      run: bash "${GITHUB_WORKSPACE}/scripts/check-e2e-authorization.sh" "${PR_NUMBER}" "${REPOSITORY}"
+
+    - name: Post gate comment
+      if: steps.check.outputs.authorized != 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPOSITORY: ${{ inputs.repository }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        REASON: ${{ steps.check.outputs.reason }}
+        LABEL_REMOVED: ${{ steps.check.outputs.label_removed }}
+        DOCS_URL: ${{ inputs.docs_url }}
+      run: |
+        set -euo pipefail
+
+        marker='<!-- e2e-gate -->'
+        owner="${REPOSITORY%%/*}"
+        repo="${REPOSITORY#*/}"
+
+        body="${marker}
+        ## E2E tests did not run
+
+        "
+
+        case "${REASON}" in
+          stale_ok_to_test)
+            body+="The \`ok-to-test\` label was removed because new commits landed after it was applied. A maintainer must re-apply \`ok-to-test\` after reviewing the latest changes.
+        "
+            ;;
+          error)
+            body+="The authorization check failed (GitHub API error). Re-run the workflow when the API is available; if this persists, contact a maintainer.
+        "
+            ;;
+          *)
+            body+="E2E tests run automatically for org/repo **members and collaborators** on pull requests.
+
+        For other contributors, a maintainer must add the \`ok-to-test\` label **after** the latest push.
+        "
+            ;;
+        esac
+
+        if [[ "${LABEL_REMOVED}" == "true" ]]; then
+          body+="
+        > **Note:** \`ok-to-test\` was cleared due to new commits.
+        "
+        fi
+
+        body+="
+        See [E2E testing guide](${DOCS_URL}) for details."
+
+        existing_id="$(gh api "repos/${owner}/${repo}/issues/${PR_NUMBER}/comments" --paginate \
+          --jq ".[] | select(.body | contains(\"${marker}\")) | .id" | head -n1 || true)"
+
+        if [[ -n "${existing_id}" ]]; then
+          jq -n --arg body "${body}" '{body: $body}' | \
+            gh api -X PATCH "repos/${owner}/${repo}/issues/comments/${existing_id}" --input - >/dev/null
+        else
+          jq -n --arg body "${body}" '{body: $body}' | \
+            gh api -X POST "repos/${owner}/${repo}/issues/${PR_NUMBER}/comments" --input - >/dev/null
+        fi
+
+    - name: Clear gate comment
+      if: steps.check.outputs.authorized == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPOSITORY: ${{ inputs.repository }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+      run: |
+        set -euo pipefail
+
+        marker='<!-- e2e-gate -->'
+        owner="${REPOSITORY%%/*}"
+        repo="${REPOSITORY#*/}"
+
+        existing_id="$(gh api "repos/${owner}/${repo}/issues/${PR_NUMBER}/comments" --paginate \
+          --jq ".[] | select(.body | contains(\"${marker}\")) | .id" | head -n1 || true)"
+
+        if [[ -n "${existing_id}" ]]; then
+          body="${marker}
+        ## E2E tests are running
+
+        Authorization passed for this commit. See the **E2E Tests** workflow for results."
+          jq -n --arg body "${body}" '{body: $body}' | \
+            gh api -X PATCH "repos/${owner}/${repo}/issues/comments/${existing_id}" --input - >/dev/null
+        fi

--- a/.github/actions/check-e2e-authorization/action.yml
+++ b/.github/actions/check-e2e-authorization/action.yml
@@ -58,7 +58,7 @@ runs:
         REASON: ${{ steps.check.outputs.reason }}
         LABEL_REMOVED: ${{ steps.check.outputs.label_removed }}
         DOCS_URL: ${{ inputs.docs_url }}
-        BOT_LOGIN: ${{ github.actor }}
+        BOT_LOGIN: github-actions[bot]
       run: |
         set -euo pipefail
 
@@ -117,7 +117,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
         REPOSITORY: ${{ inputs.repository }}
         PR_NUMBER: ${{ inputs.pr_number }}
-        BOT_LOGIN: ${{ github.actor }}
+        BOT_LOGIN: github-actions[bot]
       run: |
         set -euo pipefail
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,6 +95,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,6 +58,7 @@ jobs:
       github.event_name == 'pull_request_target' &&
       (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write
@@ -65,6 +66,8 @@ jobs:
       authorized: ${{ steps.auth.outputs.authorized }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}  # Base branch only — never checkout PR head in gate
 
       - name: Check PR authorization
         id: auth

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,12 +72,13 @@ jobs:
           repository: ${{ github.repository }}
 
   e2e:
-    # Runs only after gate approves (or gate skipped for push/merge_group/dispatch).
+    # For pull_request_target, runs only when gate sets authorized=true.
+    # Do not treat a skipped gate as authorized (e.g. labeled events for non-ok-to-test labels).
     # This job checks out untrusted PR head code — no pull-requests: write here.
     needs: gate
     if: >-
       !cancelled() &&
-      (needs.gate.result == 'skipped' || needs.gate.outputs.authorized == 'true')
+      (github.event_name != 'pull_request_target' || needs.gate.outputs.authorized == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,8 +1,10 @@
 name: E2E Tests
 
-permissions:
-  contents: read
-  id-token: write
+# PR-triggered e2e uses pull_request_target so fork PRs receive secrets.
+# Authorization runs in a separate gate job (base checkout only) before the e2e
+# job checks out the PR head — see gate/e2e job comments for why this is split.
+
+permissions: {}
 
 on:
   push:
@@ -18,53 +20,86 @@ on:
       - 'internal/sentencetoken/english.json'
       - 'Makefile'
       - '.github/workflows/e2e.yml'
-  pull_request:
+      - '.github/actions/check-e2e-authorization/**'
+      - 'scripts/check-e2e-authorization.sh'
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'e2e/**'
+      - 'internal/scaffold/fullsend-repo/**'
+      - 'internal/security/hooks/**'
+      - 'internal/dispatch/gcf/mintsrc/**'
+      - 'internal/sentencetoken/english.json'
+      - 'Makefile'
+      - '.github/workflows/e2e.yml'
+      - '.github/actions/check-e2e-authorization/**'
+      - 'scripts/check-e2e-authorization.sh'
   merge_group:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: >-
+    ${{ github.event_name == 'pull_request_target'
+        && format('e2e-{0}', github.event.pull_request.number)
+        || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  gate:
+    # Separate job (not steps in e2e) so pull-requests: write stays out of the
+    # job that checks out fork head and runs make e2e-test with secrets.
+    # Never checkout github.event.pull_request.head.sha here.
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      authorized: ${{ steps.auth.outputs.authorized }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check PR authorization
+        id: auth
+        uses: ./.github/actions/check-e2e-authorization
+        with:
+          pr_number: ${{ github.event.pull_request.number }}
+          repository: ${{ github.repository }}
+
   e2e:
+    # Runs only after gate approves (or gate skipped for push/merge_group/dispatch).
+    # This job checks out untrusted PR head code — no pull-requests: write here.
+    needs: gate
+    if: >-
+      !cancelled() &&
+      (needs.gate.result == 'skipped' || needs.gate.outputs.authorized == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - name: Check for e2e-relevant changes
-        id: changes
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
-          if echo "$FILES" | grep -qE '\.go$|^go\.(mod|sum)$|^e2e/|^internal/scaffold/fullsend-repo/|^internal/security/hooks/|^internal/dispatch/gcf/mintsrc/|^internal/sentencetoken/english\.json$|^Makefile$|\.github/workflows/e2e\.yml$'; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::No e2e-relevant files changed — skipping tests"
-            echo "relevant=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: actions/checkout@v4
-        if: steps.changes.outputs.relevant != 'false'
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-go@v5
-        if: steps.changes.outputs.relevant != 'false'
         with:
           go-version-file: go.mod
 
       - name: Install Playwright system dependencies
-        if: steps.changes.outputs.relevant != 'false'
         run: npx playwright install-deps chromium
 
       - name: Check for secrets
-        if: steps.changes.outputs.relevant != 'false'
         id: secrets-check
         run: |
           if [ -z "$E2E_GITHUB_SESSION_B64" ]; then
-            echo "::warning::E2E secrets are not available (expected for fork PRs). Skipping e2e tests."
+            echo "::warning::E2E secrets are not configured. Skipping e2e tests."
             echo "available=false" >> "$GITHUB_OUTPUT"
           else
             echo "available=true" >> "$GITHUB_OUTPUT"
@@ -73,7 +108,7 @@ jobs:
           E2E_GITHUB_SESSION_B64: ${{ secrets.E2E_GITHUB_SESSION }}
 
       - name: Decode session
-        if: steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
+        if: steps.secrets-check.outputs.available == 'true'
         run: |
           SESSION_FILE="${RUNNER_TEMP}/github-session.json"
           printf '%s' "$E2E_GITHUB_SESSION_B64" | base64 -d > "$SESSION_FILE"
@@ -82,14 +117,14 @@ jobs:
           E2E_GITHUB_SESSION_B64: ${{ secrets.E2E_GITHUB_SESSION }}
 
       - name: Authenticate to GCP
-        if: steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
+        if: steps.secrets-check.outputs.available == 'true'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.E2E_GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.E2E_GCP_SERVICE_ACCOUNT }}
 
       - name: Run e2e tests
-        if: steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
+        if: steps.secrets-check.outputs.available == 'true'
         run: make e2e-test
         env:
           E2E_SCREENSHOT_DIR: ${{ runner.temp }}/e2e-screenshots
@@ -99,10 +134,10 @@ jobs:
           E2E_GCP_PROJECT_ID: ${{ secrets.E2E_GCP_PROJECT_ID }}
 
       - name: Upload debug screenshots
-        if: always() && steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
+        if: always() && steps.secrets-check.outputs.available == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-screenshots
+          name: e2e-screenshots-${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.run_id }}
           path: ${{ runner.temp }}/e2e-screenshots/
           if-no-files-found: ignore
           retention-days: 5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,6 +75,8 @@ jobs:
         with:
           pr_number: ${{ github.event.pull_request.number }}
           repository: ${{ github.repository }}
+          pr_updated_at: ${{ github.event.pull_request.updated_at }}
+          event_action: ${{ github.event.action }}
 
   e2e:
     # For pull_request_target, runs only when gate sets authorized=true.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,7 +45,9 @@ concurrency:
     ${{ github.event_name == 'pull_request_target'
         && format('e2e-{0}', github.event.pull_request.number)
         || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request_target'
+        || github.ref != 'refs/heads/main' }}
 
 jobs:
   gate:

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ lint-md-links:
 	lychee --offline --no-progress --include-fragments --exclude-path node_modules --exclude-path experiments '**/*.md'
 
 script-test:
+	bash scripts/check-e2e-authorization-test.sh
 	bash internal/scaffold/fullsend-repo/scripts/post-triage-test.sh
 	bash internal/scaffold/fullsend-repo/scripts/post-prioritize-test.sh
 	bash internal/scaffold/fullsend-repo/scripts/post-code-test.sh

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -34,5 +34,6 @@ Guides for developers working in repositories where fullsend is active.
 Guides for contributors developing and testing fullsend itself.
 
 - [Local development](dev/local-dev.md) — Run fullsend agents locally on macOS and Linux (amd64 + arm64)
+- [E2E testing](dev/e2e-testing.md) — Local and CI e2e runs, including PR authorization and `ok-to-test`
 - [CLI internals](dev/cli-internals.md) — Command structure, installation pipeline, and sandbox runtime
 - [Testing workflow changes](dev/testing-workflows.md) — Point a live GitHub org at a branch to test workflow, action, and agent changes before release

--- a/docs/guides/dev/e2e-testing.md
+++ b/docs/guides/dev/e2e-testing.md
@@ -48,10 +48,10 @@ in GitHub repo settings (Settings → Labels).
 
 If new commits are pushed after `ok-to-test` was applied, the label is removed
 automatically and e2e is skipped until a maintainer re-applies it after
-reviewing the latest changes. Freshness uses the server-side PR `updated_at`
-from the workflow event (not commit author dates). Applying the label triggers
-immediate authorization; subsequent pushes require the label timestamp to be
-strictly after the latest push time.
+reviewing the latest changes. Freshness compares the label timestamp against
+the frozen PR `updated_at` from the workflow event (`PR_UPDATED_AT`); the live
+API fallback may over-reject when non-push activity bumped `updated_at`.
+Applying the label triggers immediate authorization on `labeled` events.
 
 ### Blocked runs
 

--- a/docs/guides/dev/e2e-testing.md
+++ b/docs/guides/dev/e2e-testing.md
@@ -48,8 +48,10 @@ in GitHub repo settings (Settings → Labels).
 
 If new commits are pushed after `ok-to-test` was applied, the label is removed
 automatically and e2e is skipped until a maintainer re-applies it after
-reviewing the latest changes. The label must be applied **strictly after** the
-latest push (same-second labels are treated as stale).
+reviewing the latest changes. Freshness uses the server-side PR `updated_at`
+from the workflow event (not commit author dates). Applying the label triggers
+immediate authorization; subsequent pushes require the label timestamp to be
+strictly after the latest push time.
 
 ### Blocked runs
 

--- a/docs/guides/dev/e2e-testing.md
+++ b/docs/guides/dev/e2e-testing.md
@@ -1,0 +1,65 @@
+# E2E Testing
+
+Guide for running and debugging fullsend admin e2e tests locally and in CI.
+
+Related ADRs: [0010](../../ADRs/0010-stored-session-for-e2e-browser-auth.md) (browser
+session), [0039](../../ADRs/0039-totp-automation-for-e2e-2fa.md) (2FA),
+[0040](../../ADRs/0040-org-pool-for-parallel-e2e-tests.md) (org pool).
+
+## Local runs
+
+```bash
+# Export a Playwright session (once per session expiry)
+make e2e-export-session
+
+# Run tests (uses E2E_GITHUB_SESSION_FILE or credentials from env)
+make e2e-test
+
+# Upload session to GitHub repo secret (maintainers)
+make e2e-upload-session
+```
+
+Required environment variables are documented in the `Makefile` help (`make help`).
+
+Tests acquire an exclusive lock on one org from the pool (`halfsend-01` …
+`halfsend-06`) — see [ADR 0040](../../ADRs/0040-org-pool-for-parallel-e2e-tests.md).
+
+## CI authorization
+
+Pull requests trigger e2e via `pull_request_target` in
+[`.github/workflows/e2e.yml`](../../.github/workflows/e2e.yml) so fork PRs can
+use repository secrets. Because that exposes credentials to untrusted code, a
+**gate job** runs first (see workflow comments for why it is a separate job).
+
+### Who runs automatically
+
+E2E tests run without maintainer action when the PR author is an org/repo
+**member** or **collaborator** (`author_association` of `OWNER`, `MEMBER`, or
+`COLLABORATOR` on the base repo).
+
+### Who needs `ok-to-test`
+
+External contributors and fork PR authors must have a maintainer apply the
+**`ok-to-test`** label **after** the latest push. The label must be created once
+in GitHub repo settings (Settings → Labels).
+
+### Stale labels
+
+If new commits are pushed after `ok-to-test` was applied, the label is removed
+automatically and e2e is skipped until a maintainer re-applies it after
+reviewing the latest changes.
+
+### Blocked runs
+
+When e2e does not run, a sticky PR comment (marker `<!-- e2e-gate -->`) explains
+why and what to do. Re-run the workflow or add/re-apply `ok-to-test` as
+appropriate.
+
+## CI architecture
+
+1. **Gate** — authorize the PR author or a fresh `ok-to-test` label (base
+   checkout only; never checks out PR head)
+2. **E2E** — checkout PR head SHA, authenticate to GCP via WIF, `make e2e-test`
+
+Pushes to `main`, merge queue, and `workflow_dispatch` skip the gate and run e2e
+directly.

--- a/docs/guides/dev/e2e-testing.md
+++ b/docs/guides/dev/e2e-testing.md
@@ -27,7 +27,7 @@ Tests acquire an exclusive lock on one org from the pool (`halfsend-01` …
 ## CI authorization
 
 Pull requests trigger e2e via `pull_request_target` in
-[`.github/workflows/e2e.yml`](../../.github/workflows/e2e.yml) so fork PRs can
+[`.github/workflows/e2e.yml`](../../../.github/workflows/e2e.yml) so fork PRs can
 use repository secrets. Because that exposes credentials to untrusted code, a
 **gate job** runs first (see workflow comments for why it is a separate job).
 
@@ -47,7 +47,8 @@ in GitHub repo settings (Settings → Labels).
 
 If new commits are pushed after `ok-to-test` was applied, the label is removed
 automatically and e2e is skipped until a maintainer re-applies it after
-reviewing the latest changes.
+reviewing the latest changes. The label must be applied **strictly after** the
+latest push (same-second labels are treated as stale).
 
 ### Blocked runs
 

--- a/docs/guides/dev/e2e-testing.md
+++ b/docs/guides/dev/e2e-testing.md
@@ -4,7 +4,8 @@ Guide for running and debugging fullsend admin e2e tests locally and in CI.
 
 Related ADRs: [0010](../../ADRs/0010-stored-session-for-e2e-browser-auth.md) (browser
 session), [0039](../../ADRs/0039-totp-automation-for-e2e-2fa.md) (2FA),
-[0040](../../ADRs/0040-org-pool-for-parallel-e2e-tests.md) (org pool).
+[0040](../../ADRs/0040-org-pool-for-parallel-e2e-tests.md) (org pool),
+[0009](../../ADRs/0009-pull-request-target-in-shim-workflows.md) (pull_request_target security model for shims; e2e uses a separate gate pattern documented below).
 
 ## Local runs
 

--- a/scripts/check-e2e-authorization-test.sh
+++ b/scripts/check-e2e-authorization-test.sh
@@ -107,47 +107,47 @@ run_case() {
 }
 
 write_pr "MEMBER" '[]'
-write_timeline '[{"event":"committed","created_at":"2026-06-01T10:00:00Z"}]'
+write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T10:00:00Z"}}]'
 write_events '[]'
 run_case "trusted member author" "true" "trusted_author" "false"
 
 write_pr "OWNER" '[]'
-write_timeline '[{"event":"committed","created_at":"2026-06-01T10:00:00Z"}]'
+write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T10:00:00Z"}}]'
 write_events '[]'
 run_case "trusted owner author" "true" "trusted_author" "false"
 
 write_pr "COLLABORATOR" '[]'
-write_timeline '[{"event":"committed","created_at":"2026-06-01T10:00:00Z"}]'
+write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T10:00:00Z"}}]'
 write_events '[]'
 run_case "trusted collaborator author" "true" "trusted_author" "false"
 
 write_pr "CONTRIBUTOR" '[]'
-write_timeline '[{"event":"committed","created_at":"2026-06-01T10:00:00Z"}]'
+write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T10:00:00Z"}}]'
 write_events '[]'
 run_case "contributor author denied" "false" "unauthorized" "false"
 
 write_pr "MEMBER" '[{"name":"ok-to-test"}]'
-write_timeline '[{"event":"committed","created_at":"2026-06-01T12:00:00Z"}]'
+write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T12:00:00Z"}}]'
 write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
 run_case "trusted member ignores stale ok-to-test label" "true" "trusted_author" "false"
 
 write_pr "NONE" '[{"name":"ok-to-test"}]'
-write_timeline '[{"event":"committed","created_at":"2026-06-01T10:00:00Z"}]'
+write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T10:00:00Z"}}]'
 write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
 run_case "fresh ok-to-test label" "true" "ok_to_test" "false"
 
 write_pr "NONE" '[{"name":"ok-to-test"}]'
-write_timeline '[{"event":"committed","created_at":"2026-06-01T12:00:00Z"}]'
+write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T12:00:00Z"}}]'
 write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
 run_case "stale ok-to-test label" "false" "stale_ok_to_test" "true"
 
 write_pr "NONE" '[{"name":"ok-to-test"}]'
-write_timeline '[{"event":"committed","created_at":"2026-06-01T12:00:00Z"}]'
+write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T12:00:00Z"}}]'
 write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T12:00:00Z"}]'
 run_case "ok-to-test label at push time is stale" "false" "stale_ok_to_test" "true"
 
 write_pr "NONE" '[{"name":"ok-to-test"}]'
-write_timeline '[{"event":"committed","created_at":"2026-06-01T12:00:00Z"}]'
+write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T12:00:00Z"}}]'
 write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
 unset CHECK_E2E_AUTH_DRY_RUN
 run_case "stale ok-to-test removes label" "false" "stale_ok_to_test" "true"
@@ -160,15 +160,19 @@ fi
 export CHECK_E2E_AUTH_DRY_RUN="true"
 
 write_pr "NONE" '[]'
-write_timeline '[{"event":"committed","created_at":"2026-06-01T10:00:00Z"}]'
+write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T10:00:00Z"}}]'
 write_events '[]'
 run_case "untrusted author without label" "false" "unauthorized" "false"
 
 write_pr "NONE" '[{"name":"ok-to-test"}]'
-write_commits '["2020-01-01T00:00:00Z"]'
-write_timeline '[{"event":"committed","created_at":"2026-06-01T12:00:00Z"}]'
+write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T12:00:00Z"}}]'
 write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
-run_case "backdated committer date does not bypass timeline push time" "false" "stale_ok_to_test" "true"
+run_case "timeline committer date used for push time" "false" "stale_ok_to_test" "true"
+
+write_pr "NONE" '[{"name":"ok-to-test"}]'
+write_timeline '[{"event":"head_ref_force_pushed","created_at":"2026-06-01T10:00:00Z"}]'
+write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
+run_case "head_ref_force_pushed created_at authorizes fresh ok-to-test" "true" "ok_to_test" "false"
 
 write_pr "NONE" '[]'
 write_timeline '[]'

--- a/scripts/check-e2e-authorization-test.sh
+++ b/scripts/check-e2e-authorization-test.sh
@@ -16,8 +16,6 @@ MOCK_BIN="${TMPDIR}/bin"
 mkdir -p "${MOCK_BIN}"
 
 PR_JSON="${TMPDIR}/pr.json"
-COMMITS_JSON="${TMPDIR}/commits.json"
-TIMELINE_JSON="${TMPDIR}/timeline.json"
 EVENTS_JSON="${TMPDIR}/events.json"
 GH_LOG="${TMPDIR}/gh.log"
 GH_FAIL="false"
@@ -25,19 +23,9 @@ GH_FAIL="false"
 write_pr() {
   local assoc="$1"
   local labels_json="$2"
-  jq -n --arg assoc "${assoc}" --argjson labels "${labels_json}" \
-    '{author_association: $assoc, labels: $labels}' >"${PR_JSON}"
-}
-
-write_commits() {
-  local dates_json="$1"
-  jq -n --argjson dates "${dates_json}" \
-    '[ $dates[] | {commit: {committer: {date: .}}}]' >"${COMMITS_JSON}"
-}
-
-write_timeline() {
-  local events_json="$1"
-  echo "${events_json}" >"${TIMELINE_JSON}"
+  local updated_at="${3:-2026-06-01T10:00:00Z}"
+  jq -n --arg assoc "${assoc}" --argjson labels "${labels_json}" --arg updated_at "${updated_at}" \
+    '{author_association: $assoc, labels: $labels, updated_at: $updated_at}' >"${PR_JSON}"
 }
 
 write_events() {
@@ -52,13 +40,11 @@ if [[ "\${GH_FAIL}" == "true" ]]; then
   echo "simulated gh failure" >&2
   exit 1
 fi
+if [[ "\${GH_FAIL}" == "events" && "\$*" == *"/issues/"*"/events"* ]]; then
+  echo "simulated events API failure" >&2
+  exit 1
+fi
 case "\$*" in
-  *"/issues/"*"/timeline"*)
-    cat "${TIMELINE_JSON}"
-    ;;
-  *"/pulls/"*"/commits"*)
-    cat "${COMMITS_JSON}"
-    ;;
   *"/issues/"*"/events"*)
     cat "${EVENTS_JSON}"
     ;;
@@ -80,6 +66,7 @@ export PATH="${MOCK_BIN}:${PATH}"
 export GH_TOKEN="test-token"
 export CHECK_E2E_AUTH_DRY_RUN="true"
 export GH_FAIL="false"
+unset EVENT_ACTION PR_UPDATED_AT
 
 run_case() {
   local name="$1"
@@ -107,48 +94,34 @@ run_case() {
 }
 
 write_pr "MEMBER" '[]'
-write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T10:00:00Z"}}]'
-write_events '[]'
 run_case "trusted member author" "true" "trusted_author" "false"
 
 write_pr "OWNER" '[]'
-write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T10:00:00Z"}}]'
-write_events '[]'
 run_case "trusted owner author" "true" "trusted_author" "false"
 
 write_pr "COLLABORATOR" '[]'
-write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T10:00:00Z"}}]'
-write_events '[]'
 run_case "trusted collaborator author" "true" "trusted_author" "false"
 
 write_pr "CONTRIBUTOR" '[]'
-write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T10:00:00Z"}}]'
-write_events '[]'
 run_case "contributor author denied" "false" "unauthorized" "false"
 
 write_pr "MEMBER" '[{"name":"ok-to-test"}]'
-write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T12:00:00Z"}}]'
-write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
 run_case "trusted member ignores stale ok-to-test label" "true" "trusted_author" "false"
 
+export EVENT_ACTION="synchronize"
+export PR_UPDATED_AT="2026-06-01T10:00:00Z"
 write_pr "NONE" '[{"name":"ok-to-test"}]'
-write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T10:00:00Z"}}]'
 write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
-run_case "fresh ok-to-test label" "true" "ok_to_test" "false"
+run_case "fresh ok-to-test label after push" "true" "ok_to_test" "false"
 
-write_pr "NONE" '[{"name":"ok-to-test"}]'
-write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T12:00:00Z"}}]'
+export PR_UPDATED_AT="2026-06-01T12:00:00Z"
 write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
-run_case "stale ok-to-test label" "false" "stale_ok_to_test" "true"
+run_case "stale ok-to-test label after newer push" "false" "stale_ok_to_test" "true"
 
-write_pr "NONE" '[{"name":"ok-to-test"}]'
-write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T12:00:00Z"}}]'
+export PR_UPDATED_AT="2026-06-01T12:00:00Z"
 write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T12:00:00Z"}]'
 run_case "ok-to-test label at push time is stale" "false" "stale_ok_to_test" "true"
 
-write_pr "NONE" '[{"name":"ok-to-test"}]'
-write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T12:00:00Z"}}]'
-write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
 unset CHECK_E2E_AUTH_DRY_RUN
 run_case "stale ok-to-test removes label" "false" "stale_ok_to_test" "true"
 if ! grep -q DELETE "${GH_LOG}"; then
@@ -159,37 +132,39 @@ else
 fi
 export CHECK_E2E_AUTH_DRY_RUN="true"
 
+unset EVENT_ACTION PR_UPDATED_AT
 write_pr "NONE" '[]'
-write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T10:00:00Z"}}]'
-write_events '[]'
 run_case "untrusted author without label" "false" "unauthorized" "false"
 
+export EVENT_ACTION="labeled"
 write_pr "NONE" '[{"name":"ok-to-test"}]'
-write_timeline '[{"event":"committed","committer":{"date":"2026-06-01T12:00:00Z"}}]'
-write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
-run_case "timeline committer date used for push time" "false" "stale_ok_to_test" "true"
-
-write_pr "NONE" '[{"name":"ok-to-test"}]'
-write_timeline '[{"event":"head_ref_force_pushed","created_at":"2026-06-01T10:00:00Z"}]'
-write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
-run_case "head_ref_force_pushed created_at authorizes fresh ok-to-test" "true" "ok_to_test" "false"
-
-write_pr "NONE" '[]'
-write_timeline '[]'
 write_events '[]'
-run_case "empty timeline without label is unauthorized" "false" "unauthorized" "false"
+run_case "labeled ok-to-test authorizes without events lookup" "true" "ok_to_test" "false"
+if grep -q '/events' "${GH_LOG}"; then
+  echo "FAIL: labeled path should not call events API"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "PASS: labeled path skips events API"
+fi
 
-write_pr "NONE" '[{"name":"ok-to-test"}]'
-write_timeline '[]'
+export EVENT_ACTION="synchronize"
+unset PR_UPDATED_AT
+write_pr "NONE" '[{"name":"ok-to-test"}]' "2026-06-01T10:00:00Z"
 write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
-run_case "empty timeline treats ok-to-test as stale" "false" "stale_ok_to_test" "true"
+run_case "falls back to pull updated_at when PR_UPDATED_AT unset" "true" "ok_to_test" "false"
 
-GH_FAIL="true"
-write_pr "NONE" '[]'
-write_timeline '[]'
+write_pr "MEMBER" '[]'
+export GH_FAIL="events"
+run_case "trusted author not blocked by events API failure" "true" "trusted_author" "false"
+export GH_FAIL="false"
+
+export EVENT_ACTION="synchronize"
+export PR_UPDATED_AT="2026-06-01T10:00:00Z"
+write_pr "NONE" '[{"name":"ok-to-test"}]'
 write_events '[]'
-run_case "gh api failure returns error reason" "false" "error" "false"
-GH_FAIL="false"
+export GH_FAIL="true"
+run_case "gh api failure on events returns error reason" "false" "error" "false"
+export GH_FAIL="false"
 
 if [[ "${FAILURES}" -gt 0 ]]; then
   echo "${FAILURES} test(s) failed"

--- a/scripts/check-e2e-authorization-test.sh
+++ b/scripts/check-e2e-authorization-test.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# check-e2e-authorization-test.sh — Tests for check-e2e-authorization.sh with mock gh.
+#
+# Run from repo root: bash scripts/check-e2e-authorization-test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUTH_SCRIPT="${SCRIPT_DIR}/check-e2e-authorization.sh"
+FAILURES=0
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+MOCK_BIN="${TMPDIR}/bin"
+mkdir -p "${MOCK_BIN}"
+
+PR_JSON="${TMPDIR}/pr.json"
+COMMITS_JSON="${TMPDIR}/commits.json"
+TIMELINE_JSON="${TMPDIR}/timeline.json"
+EVENTS_JSON="${TMPDIR}/events.json"
+GH_LOG="${TMPDIR}/gh.log"
+GH_FAIL="false"
+
+write_pr() {
+  local assoc="$1"
+  local labels_json="$2"
+  jq -n --arg assoc "${assoc}" --argjson labels "${labels_json}" \
+    '{author_association: $assoc, labels: $labels}' >"${PR_JSON}"
+}
+
+write_commits() {
+  local dates_json="$1"
+  jq -n --argjson dates "${dates_json}" \
+    '[ $dates[] | {commit: {committer: {date: .}}}]' >"${COMMITS_JSON}"
+}
+
+write_timeline() {
+  local events_json="$1"
+  echo "${events_json}" >"${TIMELINE_JSON}"
+}
+
+write_events() {
+  local events_json="$1"
+  echo "${events_json}" >"${EVENTS_JSON}"
+}
+
+cat >"${MOCK_BIN}/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh \$*" >> "${GH_LOG}"
+if [[ "\${GH_FAIL}" == "true" ]]; then
+  echo "simulated gh failure" >&2
+  exit 1
+fi
+case "\$*" in
+  *"/issues/"*"/timeline"*)
+    cat "${TIMELINE_JSON}"
+    ;;
+  *"/pulls/"*"/commits"*)
+    cat "${COMMITS_JSON}"
+    ;;
+  *"/issues/"*"/events"*)
+    cat "${EVENTS_JSON}"
+    ;;
+  *"/pulls/"*)
+    cat "${PR_JSON}"
+    ;;
+  *DELETE*)
+    echo "deleted" >> "${GH_LOG}"
+    ;;
+  *)
+    echo "unexpected gh call: \$*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${MOCK_BIN}/gh"
+
+export PATH="${MOCK_BIN}:${PATH}"
+export GH_TOKEN="test-token"
+export CHECK_E2E_AUTH_DRY_RUN="true"
+export GH_FAIL="false"
+
+run_case() {
+  local name="$1"
+  local expected_auth="$2"
+  local expected_reason="$3"
+  local expected_removed="$4"
+
+  : >"${GH_LOG}"
+
+  local output
+  output="$("${AUTH_SCRIPT}" 42 "fullsend-ai/fullsend")"
+  local auth reason removed
+  auth="$(grep -o 'authorized=[^ ]*' <<<"${output}" | cut -d= -f2)"
+  reason="$(grep -o 'reason=[^ ]*' <<<"${output}" | cut -d= -f2)"
+  removed="$(grep -o 'label_removed=[^ ]*' <<<"${output}" | cut -d= -f2)"
+
+  if [[ "${auth}" != "${expected_auth}" || "${reason}" != "${expected_reason}" || "${removed}" != "${expected_removed}" ]]; then
+    echo "FAIL: ${name}"
+    echo "  expected authorized=${expected_auth} reason=${expected_reason} label_removed=${expected_removed}"
+    echo "  got      authorized=${auth} reason=${reason} label_removed=${removed}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+  echo "PASS: ${name}"
+}
+
+write_pr "MEMBER" '[]'
+write_timeline '[{"event":"committed","created_at":"2026-06-01T10:00:00Z"}]'
+write_events '[]'
+run_case "trusted member author" "true" "trusted_author" "false"
+
+write_pr "OWNER" '[]'
+write_timeline '[{"event":"committed","created_at":"2026-06-01T10:00:00Z"}]'
+write_events '[]'
+run_case "trusted owner author" "true" "trusted_author" "false"
+
+write_pr "COLLABORATOR" '[]'
+write_timeline '[{"event":"committed","created_at":"2026-06-01T10:00:00Z"}]'
+write_events '[]'
+run_case "trusted collaborator author" "true" "trusted_author" "false"
+
+write_pr "CONTRIBUTOR" '[]'
+write_timeline '[{"event":"committed","created_at":"2026-06-01T10:00:00Z"}]'
+write_events '[]'
+run_case "contributor author denied" "false" "unauthorized" "false"
+
+write_pr "MEMBER" '[{"name":"ok-to-test"}]'
+write_timeline '[{"event":"committed","created_at":"2026-06-01T12:00:00Z"}]'
+write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
+run_case "trusted member ignores stale ok-to-test label" "true" "trusted_author" "false"
+
+write_pr "NONE" '[{"name":"ok-to-test"}]'
+write_timeline '[{"event":"committed","created_at":"2026-06-01T10:00:00Z"}]'
+write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
+run_case "fresh ok-to-test label" "true" "ok_to_test" "false"
+
+write_pr "NONE" '[{"name":"ok-to-test"}]'
+write_timeline '[{"event":"committed","created_at":"2026-06-01T12:00:00Z"}]'
+write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
+run_case "stale ok-to-test label" "false" "stale_ok_to_test" "true"
+
+write_pr "NONE" '[{"name":"ok-to-test"}]'
+write_timeline '[{"event":"committed","created_at":"2026-06-01T12:00:00Z"}]'
+write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T12:00:00Z"}]'
+run_case "ok-to-test label at push time is stale" "false" "stale_ok_to_test" "true"
+
+write_pr "NONE" '[{"name":"ok-to-test"}]'
+write_timeline '[{"event":"committed","created_at":"2026-06-01T12:00:00Z"}]'
+write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
+unset CHECK_E2E_AUTH_DRY_RUN
+run_case "stale ok-to-test removes label" "false" "stale_ok_to_test" "true"
+if ! grep -q DELETE "${GH_LOG}"; then
+  echo "FAIL: stale ok-to-test removes label (expected gh DELETE call)"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "PASS: stale ok-to-test removes label (DELETE exercised)"
+fi
+export CHECK_E2E_AUTH_DRY_RUN="true"
+
+write_pr "NONE" '[]'
+write_timeline '[{"event":"committed","created_at":"2026-06-01T10:00:00Z"}]'
+write_events '[]'
+run_case "untrusted author without label" "false" "unauthorized" "false"
+
+write_pr "NONE" '[{"name":"ok-to-test"}]'
+write_commits '["2020-01-01T00:00:00Z"]'
+write_timeline '[{"event":"committed","created_at":"2026-06-01T12:00:00Z"}]'
+write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
+run_case "backdated committer date does not bypass timeline push time" "false" "stale_ok_to_test" "true"
+
+GH_FAIL="true"
+write_pr "NONE" '[]'
+write_timeline '[]'
+write_events '[]'
+run_case "gh api failure returns error reason" "false" "error" "false"
+GH_FAIL="false"
+
+if [[ "${FAILURES}" -gt 0 ]]; then
+  echo "${FAILURES} test(s) failed"
+  exit 1
+fi
+
+echo "All check-e2e-authorization tests passed."

--- a/scripts/check-e2e-authorization-test.sh
+++ b/scripts/check-e2e-authorization-test.sh
@@ -156,6 +156,13 @@ run_case "falls back to pull updated_at when PR_UPDATED_AT unset" "true" "ok_to_
 write_pr "MEMBER" '[]'
 export GH_FAIL="events"
 run_case "trusted author not blocked by events API failure" "true" "trusted_author" "false"
+
+export EVENT_ACTION="synchronize"
+export PR_UPDATED_AT="2026-06-01T10:00:00Z"
+write_pr "NONE" '[{"name":"ok-to-test"}]'
+write_events '[]'
+export GH_FAIL="events"
+run_case "events API failure for untrusted ok-to-test returns error" "false" "error" "false"
 export GH_FAIL="false"
 
 export EVENT_ACTION="synchronize"

--- a/scripts/check-e2e-authorization-test.sh
+++ b/scripts/check-e2e-authorization-test.sh
@@ -172,15 +172,13 @@ run_case "backdated committer date does not bypass timeline push time" "false" "
 
 write_pr "NONE" '[]'
 write_timeline '[]'
-write_commits '["2026-06-01T10:00:00Z"]'
 write_events '[]'
-run_case "commits api fallback when timeline has no push events" "false" "unauthorized" "false"
+run_case "empty timeline without label is unauthorized" "false" "unauthorized" "false"
 
 write_pr "NONE" '[{"name":"ok-to-test"}]'
 write_timeline '[]'
-write_commits '["2026-06-01T10:00:00Z"]'
 write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
-run_case "commits api fallback with fresh ok-to-test label" "true" "ok_to_test" "false"
+run_case "empty timeline treats ok-to-test as stale" "false" "stale_ok_to_test" "true"
 
 GH_FAIL="true"
 write_pr "NONE" '[]'

--- a/scripts/check-e2e-authorization-test.sh
+++ b/scripts/check-e2e-authorization-test.sh
@@ -170,6 +170,12 @@ write_timeline '[{"event":"committed","created_at":"2026-06-01T12:00:00Z"}]'
 write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
 run_case "backdated committer date does not bypass timeline push time" "false" "stale_ok_to_test" "true"
 
+write_pr "NONE" '[]'
+write_timeline '[]'
+write_commits '["2026-06-01T10:00:00Z"]'
+write_events '[]'
+run_case "commits api fallback when timeline has no push events" "false" "unauthorized" "false"
+
 GH_FAIL="true"
 write_pr "NONE" '[]'
 write_timeline '[]'

--- a/scripts/check-e2e-authorization-test.sh
+++ b/scripts/check-e2e-authorization-test.sh
@@ -176,6 +176,12 @@ write_commits '["2026-06-01T10:00:00Z"]'
 write_events '[]'
 run_case "commits api fallback when timeline has no push events" "false" "unauthorized" "false"
 
+write_pr "NONE" '[{"name":"ok-to-test"}]'
+write_timeline '[]'
+write_commits '["2026-06-01T10:00:00Z"]'
+write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
+run_case "commits api fallback with fresh ok-to-test label" "true" "ok_to_test" "false"
+
 GH_FAIL="true"
 write_pr "NONE" '[]'
 write_timeline '[]'

--- a/scripts/check-e2e-authorization-test.sh
+++ b/scripts/check-e2e-authorization-test.sh
@@ -170,7 +170,7 @@ export PR_UPDATED_AT="2026-06-01T10:00:00Z"
 write_pr "NONE" '[{"name":"ok-to-test"}]'
 write_events '[]'
 export GH_FAIL="true"
-run_case "gh api failure on events returns error reason" "false" "error" "false"
+run_case "gh api failure on pull fetch returns error reason" "false" "error" "false"
 export GH_FAIL="false"
 
 if [[ "${FAILURES}" -gt 0 ]]; then

--- a/scripts/check-e2e-authorization.sh
+++ b/scripts/check-e2e-authorization.sh
@@ -4,9 +4,8 @@
 # Authorized when the PR author is OWNER/MEMBER/COLLABORATOR, or when a fresh
 # ok-to-test label was applied after the latest push.
 #
-# Push time for ok-to-test freshness uses PR updated_at from the workflow event
-# (server-side; passed as PR_UPDATED_AT). On ok-to-test labeled events, the
-# label is treated as fresh (maintainer just applied it). Does not use
+# Freshness uses PR updated_at from the frozen workflow event (PR_UPDATED_AT).
+# On ok-to-test labeled events, authorization is immediate. Does not use
 # committer.date (author-controlled).
 #
 # Usage: check-e2e-authorization.sh PR_NUMBER OWNER/REPO
@@ -70,6 +69,8 @@ elif [[ "${has_ok_label}" == "true" ]]; then
 
   last_push_at="${PR_UPDATED_AT:-}"
   if [[ -z "${last_push_at}" ]]; then
+    # Fallback: live updated_at is noisy (bumped by comments, labels, etc.)
+    # and may over-reject. Prefer the frozen event-payload value (PR_UPDATED_AT).
     last_push_at="$(jq -r '.updated_at // empty' <<<"${pr_json}")"
   fi
 

--- a/scripts/check-e2e-authorization.sh
+++ b/scripts/check-e2e-authorization.sh
@@ -3,9 +3,9 @@
 #
 # Authorized when the PR author is OWNER/MEMBER/COLLABORATOR, or when a fresh
 # ok-to-test label was applied after the latest commit on the PR head.
-# Push time uses GitHub issue timeline committed/force-push event timestamps
-# (server-side). When timeline has no push events, freshness cannot be verified
-# and ok-to-test is treated as stale (fail-closed; no commits API fallback).
+# Push time uses GitHub issue timeline timestamps: head_ref_force_pushed.created_at
+# (server-side) and committed.committer.date (commit metadata; maintainer ok-to-test
+# is required for untrusted authors). Empty timeline fails closed for ok-to-test.
 # Removes stale ok-to-test labels (applied at or before the latest push).
 #
 # Usage: check-e2e-authorization.sh PR_NUMBER OWNER/REPO
@@ -50,7 +50,8 @@ has_ok_label="$(jq -r --arg label "${OK_TO_TEST_LABEL}" '[.labels[].name] | inde
 timeline_json="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/timeline" --paginate \
   -H "Accept: application/vnd.github+json" | jq -s 'add')"
 last_push_at="$(jq -r '
-  [.[] | select(.event == "committed" or .event == "head_ref_force_pushed") | .created_at] | max // empty
+  [.[] | select(.event == "head_ref_force_pushed") | .created_at] +
+  [.[] | select(.event == "committed") | .committer.date] | max // empty
 ' <<<"${timeline_json}")"
 
 events_json="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/events" --paginate | jq -s 'add')"

--- a/scripts/check-e2e-authorization.sh
+++ b/scripts/check-e2e-authorization.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# check-e2e-authorization.sh — Decide whether a PR may run e2e tests in CI.
+#
+# Authorized when the PR author is OWNER/MEMBER/COLLABORATOR, or when a fresh
+# ok-to-test label was applied after the latest commit on the PR head.
+# Push time uses GitHub issue timeline committed/force-push event timestamps
+# (server-side), falling back to committer.date only when timeline is empty.
+# Removes stale ok-to-test labels (applied at or before the latest push).
+#
+# Usage: check-e2e-authorization.sh PR_NUMBER OWNER/REPO
+#
+# Writes authorized, reason, and label_removed to GITHUB_OUTPUT when set.
+# Exits 0 always; callers inspect outputs.
+
+set -euo pipefail
+
+PR_NUMBER="${1:?PR number required}"
+REPOSITORY="${2:?repository (owner/repo) required}"
+
+TRUSTED_ASSOCIATIONS="OWNER MEMBER COLLABORATOR"
+OK_TO_TEST_LABEL="ok-to-test"
+
+write_error_output() {
+  echo "check-e2e-authorization: API or script error (see log above)" >&2
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "authorized=false"
+      echo "reason=error"
+      echo "label_removed=false"
+    } >>"${GITHUB_OUTPUT}"
+  fi
+  printf 'authorized=false reason=error label_removed=false\n'
+}
+
+trap 'write_error_output; exit 0' ERR
+
+is_trusted_author() {
+  local assoc="$1"
+  case " ${TRUSTED_ASSOCIATIONS} " in
+    *" ${assoc} "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+pr_json="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")"
+author_association="$(jq -r '.author_association' <<<"${pr_json}")"
+has_ok_label="$(jq -r --arg label "${OK_TO_TEST_LABEL}" '[.labels[].name] | index($label) != null' <<<"${pr_json}")"
+
+timeline_json="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/timeline" --paginate \
+  -H "Accept: application/vnd.github+json" | jq -s 'add')"
+last_push_at="$(jq -r '
+  [.[] | select(.event == "committed" or .event == "head_ref_force_pushed") | .created_at] | max // empty
+' <<<"${timeline_json}")"
+if [[ -z "${last_push_at}" ]]; then
+  commits_json="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}/commits" --paginate | jq -s 'add')"
+  last_push_at="$(jq -r '[.[] | .commit.committer.date] | max // empty' <<<"${commits_json}")"
+fi
+
+events_json="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/events" --paginate | jq -s 'add')"
+ok_to_test_at="$(jq -r --arg label "${OK_TO_TEST_LABEL}" '
+  [.[] | select(.event == "labeled" and (.label.name // "") == $label) | .created_at] | max // empty
+' <<<"${events_json}")"
+
+is_trusted=false
+if is_trusted_author "${author_association}"; then
+  is_trusted=true
+fi
+
+has_fresh_label=false
+label_removed=false
+authorized=false
+reason="unauthorized"
+
+if [[ "${has_ok_label}" == "true" && "${is_trusted}" != "true" ]]; then
+  if [[ -n "${ok_to_test_at}" && -n "${last_push_at}" && "${ok_to_test_at}" > "${last_push_at}" ]]; then
+    has_fresh_label=true
+  else
+    if [[ "${CHECK_E2E_AUTH_DRY_RUN:-}" != "true" ]]; then
+      gh api -X DELETE "repos/${REPOSITORY}/issues/${PR_NUMBER}/labels/${OK_TO_TEST_LABEL}" >/dev/null
+    fi
+    label_removed=true
+  fi
+fi
+
+if [[ "${is_trusted}" == "true" ]]; then
+  authorized=true
+  reason="trusted_author"
+elif [[ "${has_fresh_label}" == "true" ]]; then
+  authorized=true
+  reason="ok_to_test"
+elif [[ "${label_removed}" == "true" ]]; then
+  reason="stale_ok_to_test"
+fi
+
+trap - ERR
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "authorized=${authorized}"
+    echo "reason=${reason}"
+    echo "label_removed=${label_removed}"
+  } >>"${GITHUB_OUTPUT}"
+fi
+
+printf 'authorized=%s reason=%s label_removed=%s\n' "${authorized}" "${reason}" "${label_removed}"

--- a/scripts/check-e2e-authorization.sh
+++ b/scripts/check-e2e-authorization.sh
@@ -2,13 +2,18 @@
 # check-e2e-authorization.sh — Decide whether a PR may run e2e tests in CI.
 #
 # Authorized when the PR author is OWNER/MEMBER/COLLABORATOR, or when a fresh
-# ok-to-test label was applied after the latest commit on the PR head.
-# Push time uses GitHub issue timeline timestamps: head_ref_force_pushed.created_at
-# (server-side) and committed.committer.date (commit metadata; maintainer ok-to-test
-# is required for untrusted authors). Empty timeline fails closed for ok-to-test.
-# Removes stale ok-to-test labels (applied at or before the latest push).
+# ok-to-test label was applied after the latest push.
+#
+# Push time for ok-to-test freshness uses PR updated_at from the workflow event
+# (server-side; passed as PR_UPDATED_AT). On ok-to-test labeled events, the
+# label is treated as fresh (maintainer just applied it). Does not use
+# committer.date (author-controlled).
 #
 # Usage: check-e2e-authorization.sh PR_NUMBER OWNER/REPO
+#
+# Environment (optional, from workflow):
+#   PR_UPDATED_AT — github.event.pull_request.updated_at
+#   EVENT_ACTION  — github.event.action
 #
 # Writes authorized, reason, and label_removed to GITHUB_OUTPUT when set.
 # Exits 0 always; callers inspect outputs.
@@ -47,47 +52,39 @@ pr_json="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")"
 author_association="$(jq -r '.author_association' <<<"${pr_json}")"
 has_ok_label="$(jq -r --arg label "${OK_TO_TEST_LABEL}" '[.labels[].name] | index($label) != null' <<<"${pr_json}")"
 
-timeline_json="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/timeline" --paginate \
-  -H "Accept: application/vnd.github+json" | jq -s 'add')"
-last_push_at="$(jq -r '
-  [.[] | select(.event == "head_ref_force_pushed") | .created_at] +
-  [.[] | select(.event == "committed") | .committer.date] | max // empty
-' <<<"${timeline_json}")"
-
-events_json="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/events" --paginate | jq -s 'add')"
-ok_to_test_at="$(jq -r --arg label "${OK_TO_TEST_LABEL}" '
-  [.[] | select(.event == "labeled" and (.label.name // "") == $label) | .created_at] | max // empty
-' <<<"${events_json}")"
-
-is_trusted=false
-if is_trusted_author "${author_association}"; then
-  is_trusted=true
-fi
-
 has_fresh_label=false
 label_removed=false
 authorized=false
 reason="unauthorized"
 
-if [[ "${has_ok_label}" == "true" && "${is_trusted}" != "true" ]]; then
+if is_trusted_author "${author_association}"; then
+  authorized=true
+  reason="trusted_author"
+elif [[ "${has_ok_label}" == "true" && "${EVENT_ACTION:-}" == "labeled" ]]; then
+  authorized=true
+  reason="ok_to_test"
+elif [[ "${has_ok_label}" == "true" ]]; then
+  events_json="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/events" --paginate | jq -s 'add // []')"
+  ok_to_test_at="$(jq -r --arg label "${OK_TO_TEST_LABEL}" '
+    [.[] | select(.event == "labeled" and (.label.name // "") == $label) | .created_at] | max // empty
+  ' <<<"${events_json}")"
+
+  last_push_at="${PR_UPDATED_AT:-}"
+  if [[ -z "${last_push_at}" ]]; then
+    last_push_at="$(jq -r '.updated_at // empty' <<<"${pr_json}")"
+  fi
+
   if [[ -n "${ok_to_test_at}" && -n "${last_push_at}" && "${ok_to_test_at}" > "${last_push_at}" ]]; then
     has_fresh_label=true
+    authorized=true
+    reason="ok_to_test"
   else
     if [[ "${CHECK_E2E_AUTH_DRY_RUN:-}" != "true" ]]; then
       gh api -X DELETE "repos/${REPOSITORY}/issues/${PR_NUMBER}/labels/${OK_TO_TEST_LABEL}" >/dev/null
     fi
     label_removed=true
+    reason="stale_ok_to_test"
   fi
-fi
-
-if [[ "${is_trusted}" == "true" ]]; then
-  authorized=true
-  reason="trusted_author"
-elif [[ "${has_fresh_label}" == "true" ]]; then
-  authorized=true
-  reason="ok_to_test"
-elif [[ "${label_removed}" == "true" ]]; then
-  reason="stale_ok_to_test"
 fi
 
 trap - ERR

--- a/scripts/check-e2e-authorization.sh
+++ b/scripts/check-e2e-authorization.sh
@@ -52,7 +52,6 @@ pr_json="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")"
 author_association="$(jq -r '.author_association' <<<"${pr_json}")"
 has_ok_label="$(jq -r --arg label "${OK_TO_TEST_LABEL}" '[.labels[].name] | index($label) != null' <<<"${pr_json}")"
 
-has_fresh_label=false
 label_removed=false
 authorized=false
 reason="unauthorized"
@@ -75,7 +74,6 @@ elif [[ "${has_ok_label}" == "true" ]]; then
   fi
 
   if [[ -n "${ok_to_test_at}" && -n "${last_push_at}" && "${ok_to_test_at}" > "${last_push_at}" ]]; then
-    has_fresh_label=true
     authorized=true
     reason="ok_to_test"
   else

--- a/scripts/check-e2e-authorization.sh
+++ b/scripts/check-e2e-authorization.sh
@@ -4,7 +4,8 @@
 # Authorized when the PR author is OWNER/MEMBER/COLLABORATOR, or when a fresh
 # ok-to-test label was applied after the latest commit on the PR head.
 # Push time uses GitHub issue timeline committed/force-push event timestamps
-# (server-side), falling back to committer.date only when timeline is empty.
+# (server-side). When timeline has no push events, freshness cannot be verified
+# and ok-to-test is treated as stale (fail-closed; no commits API fallback).
 # Removes stale ok-to-test labels (applied at or before the latest push).
 #
 # Usage: check-e2e-authorization.sh PR_NUMBER OWNER/REPO
@@ -51,10 +52,6 @@ timeline_json="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/timeline" --pag
 last_push_at="$(jq -r '
   [.[] | select(.event == "committed" or .event == "head_ref_force_pushed") | .created_at] | max // empty
 ' <<<"${timeline_json}")"
-if [[ -z "${last_push_at}" ]]; then
-  commits_json="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}/commits" --paginate | jq -s 'add')"
-  last_push_at="$(jq -r '[.[] | .commit.committer.date] | max // empty' <<<"${commits_json}")"
-fi
 
 events_json="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/events" --paginate | jq -s 'add')"
 ok_to_test_at="$(jq -r --arg label "${OK_TO_TEST_LABEL}" '


### PR DESCRIPTION
Closes #1604

## Summary

Progress on #1604: enable fork PR e2e runs without the shim/`workflow_call` indirection proposed in earlier designs. This PR uses a **simplified single-workflow design** (`pull_request_target` + separate gate job) that provides the **same security properties** as the shim/gate pattern:

- Base-branch workflow definition (PR authors cannot modify the gate)
- Authorization before checkout of untrusted PR head code
- Trusted author or maintainer-applied `ok-to-test` after latest push
- Sticky PR comment when blocked; stale label removal on new commits

**GCP access via WIF is unchanged** — `google-github-actions/auth` with `E2E_GCP_WIF_PROVIDER` / `E2E_GCP_SERVICE_ACCOUNT` was already implemented for e2e tests; this PR does not alter that path.

**ADR 0009 does not apply here.** [ADR 0009](docs/ADRs/0009-pull-request-target-in-shim-workflows.md) documents `pull_request_target` for **shim workflows in enrolled repos** that consume fullsend (static dispatch curl, no PR code checkout). This change is an **internal CI workflow for fullsend itself**, with a different threat model: it intentionally checks out fork PR code after authorization, documented in [e2e-testing.md](docs/guides/dev/e2e-testing.md).

### Changes

- Switch PR-triggered e2e from `pull_request` to `pull_request_target` so fork PRs receive repository secrets
- Add a separate `gate` job that authorizes trusted authors (`OWNER`/`MEMBER`/`COLLABORATOR`) or a fresh `ok-to-test` label before the e2e job checks out PR head code
- Post/update a sticky PR comment when e2e is blocked; remove stale `ok-to-test` labels after new pushes
- Add authorization script tests and [e2e testing guide](docs/guides/dev/e2e-testing.md)

Protected-path changes (`.github/workflows`, `.github/actions`, `scripts/`) implement the authorization gate above.

## Test plan

- [x] `bash scripts/check-e2e-authorization-test.sh` passes locally
- [ ] Member/collaborator PR: gate passes, e2e runs
- [ ] Fork PR without label: sticky comment posted, e2e skipped
- [ ] Fork PR with maintainer `ok-to-test` after latest push: e2e runs on head SHA
- [ ] New push after `ok-to-test`: label removed, e2e skipped until re-labeled
- [x] Non-`ok-to-test` label event does not bypass gate (fixed in 03438384)
- [ ] Create `ok-to-test` label in repo settings if missing