### PR TITLE
feat(harness): add optional role and slug fields (ADR-0045 PR 2)

### DIFF
--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -16,6 +16,9 @@ var (
 	validAgentName  = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 	validModelName  = regexp.MustCompile(`^[a-zA-Z0-9_.@-]+$`)
 	validPluginName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	// validRoleName mirrors mintcore.RolePattern — duplicated to avoid coupling harness→mintcore.
+	validRoleName   = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+	validSlugName   = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
 	envVarRef      = regexp.MustCompile(`\$\{([^}]+)\}`)
 )
 
@@ -193,6 +196,8 @@ type Harness struct {
 	Agent          string            `yaml:"agent"`
 	Doc            string            `yaml:"doc,omitempty"` // source-repo-only; not resolved at runtime, used by lint-agent-docs
 	Description    string            `yaml:"description,omitempty"`
+	Role           string            `yaml:"role,omitempty"`
+	Slug           string            `yaml:"slug,omitempty"`
 	Image          string            `yaml:"image,omitempty"`
 	Policy         string            `yaml:"policy,omitempty"`
 	Skills         []string          `yaml:"skills,omitempty"`
@@ -247,6 +252,17 @@ func (h *Harness) Validate() error {
 	}
 	if h.Model != "" && !validModelName.MatchString(h.Model) {
 		return fmt.Errorf("model %q contains invalid characters (allowed: a-z, A-Z, 0-9, _, -, ., @)", h.Model)
+	}
+	if h.Role != "" {
+		if !validRoleName.MatchString(h.Role) {
+			return fmt.Errorf("role %q contains invalid characters (allowed: a-z, 0-9, _, -; must start with a lowercase letter)", h.Role)
+		}
+		if strings.Contains(h.Role, "--") {
+			return fmt.Errorf("role %q must not contain double hyphens", h.Role)
+		}
+	}
+	if h.Slug != "" && !validSlugName.MatchString(h.Slug) {
+		return fmt.Errorf("slug %q contains invalid characters (allowed: a-z, A-Z, 0-9, _, -; must start with a letter or digit)", h.Slug)
 	}
 	for i, p := range h.Plugins {
 		pluginBase := filepath.Base(p)

--- a/internal/harness/harness_test.go
+++ b/internal/harness/harness_test.go
@@ -1073,3 +1073,74 @@ func TestMatchingAllowedPrefix(t *testing.T) {
 		assert.Equal(t, "https://Example.Com/Skills/", h2.MatchingAllowedPrefix("https://example.com/skills/test.md"))
 	})
 }
+
+// --- Role and slug field tests ---
+
+func TestLoad_RoleAndSlug(t *testing.T) {
+	content := `
+agent: agents/triage.md
+role: triage
+slug: fullsend-ai-triage
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "triage.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	h, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "triage", h.Role)
+	assert.Equal(t, "fullsend-ai-triage", h.Slug)
+}
+
+func TestLoad_RoleAndSlugAbsent(t *testing.T) {
+	content := `
+agent: agents/test.md
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	h, err := Load(path)
+	require.NoError(t, err)
+	assert.Empty(t, h.Role)
+	assert.Empty(t, h.Slug)
+}
+
+func TestValidate_RoleValid(t *testing.T) {
+	for _, role := range []string{"triage", "code-reviewer", "bug_triage", "a"} {
+		h := &Harness{Agent: "agents/test.md", Role: role}
+		require.NoError(t, h.Validate(), "role %q should be valid", role)
+	}
+}
+
+func TestValidate_RoleInvalid(t *testing.T) {
+	for _, role := range []string{"Triage", "1role", "role!"} {
+		h := &Harness{Agent: "agents/test.md", Role: role}
+		err := h.Validate()
+		require.Error(t, err, "role %q should be invalid", role)
+		assert.Contains(t, err.Error(), "contains invalid characters")
+	}
+}
+
+func TestValidate_RoleDoubleHyphen(t *testing.T) {
+	h := &Harness{Agent: "agents/test.md", Role: "my--role"}
+	err := h.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "double hyphens")
+}
+
+func TestValidate_SlugValid(t *testing.T) {
+	for _, slug := range []string{"fullsend-ai-triage", "Custom_App", "a1"} {
+		h := &Harness{Agent: "agents/test.md", Slug: slug}
+		require.NoError(t, h.Validate(), "slug %q should be valid", slug)
+	}
+}
+
+func TestValidate_SlugInvalid(t *testing.T) {
+	for _, slug := range []string{"-slug", "slug!name", "my slug"} {
+		h := &Harness{Agent: "agents/test.md", Slug: slug}
+		err := h.Validate()
+		require.Error(t, err, "slug %q should be invalid", slug)
+		assert.Contains(t, err.Error(), "slug")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds optional `role` and `slug` fields to the `Harness` struct with validation
- `role` uses the same lowercase pattern as `mintcore.RolePattern` (`^[a-z][a-z0-9_-]*$`, no double hyphens) without importing it to avoid coupling `harness` → `mintcore`
- `slug` accepts GitHub App slug format (`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
- Both fields are optional in Phase 1 — validated only when present

Part of the [ADR-0045 implementation plan](https://github.com/fullsend-ai/fullsend/pull/2100) (PR 2 of 7). No dependencies on other PRs.

## Test plan

- [x] `go test ./internal/harness/...` — all 84 tests pass (6 new)
- [x] `TestHarnessesLoadAndValidate` — scaffold templates still load
- [x] `make go-vet` — clean
- [x] `make lint` — passes
- [x] Backward compat: harness without role/slug loads with empty strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)