### PR TITLE
feat(scaffold): add role and slug to harness templates (ADR-0045 PR 6)

### DIFF
--- a/internal/scaffold/fullsend-repo/harness/code.yaml
+++ b/internal/scaffold/fullsend-repo/harness/code.yaml
@@ -14,6 +14,9 @@ model: opus
 image: ghcr.io/fullsend-ai/fullsend-code:latest
 policy: policies/code.yaml
 
+role: coder
+slug: fullsend-ai-coder
+
 pre_script: scripts/pre-code.sh
 post_script: scripts/post-code.sh
 

--- a/internal/scaffold/fullsend-repo/harness/fix.yaml
+++ b/internal/scaffold/fullsend-repo/harness/fix.yaml
@@ -14,6 +14,9 @@ model: opus
 image: ghcr.io/fullsend-ai/fullsend-code:latest
 policy: policies/fix.yaml
 
+role: coder
+slug: fullsend-ai-coder
+
 pre_script: scripts/pre-fix.sh
 
 validation_loop:

--- a/internal/scaffold/fullsend-repo/harness/prioritize.yaml
+++ b/internal/scaffold/fullsend-repo/harness/prioritize.yaml
@@ -5,6 +5,9 @@ model: opus
 image: ghcr.io/fullsend-ai/fullsend-sandbox:latest
 policy: policies/prioritize.yaml
 
+role: prioritize
+slug: fullsend-ai-prioritize
+
 host_files:
   - src: env/gcp-vertex.env
     dest: /sandbox/workspace/.env.d/gcp-vertex.env

--- a/internal/scaffold/fullsend-repo/harness/retro.yaml
+++ b/internal/scaffold/fullsend-repo/harness/retro.yaml
@@ -5,6 +5,9 @@ model: opus
 image: ghcr.io/fullsend-ai/fullsend-sandbox:latest
 policy: policies/retro.yaml
 
+role: retro
+slug: fullsend-ai-retro
+
 host_files:
   - src: env/gcp-vertex.env
     dest: /sandbox/workspace/.env.d/gcp-vertex.env

--- a/internal/scaffold/fullsend-repo/harness/review.yaml
+++ b/internal/scaffold/fullsend-repo/harness/review.yaml
@@ -5,6 +5,9 @@ model: opus
 image: ghcr.io/fullsend-ai/fullsend-code:latest
 policy: policies/review.yaml
 
+role: review
+slug: fullsend-ai-review
+
 skills:
   - skills/pr-review
   - skills/code-review

--- a/internal/scaffold/fullsend-repo/harness/triage.yaml
+++ b/internal/scaffold/fullsend-repo/harness/triage.yaml
@@ -5,6 +5,9 @@ model: opus
 image: ghcr.io/fullsend-ai/fullsend-sandbox:latest
 policy: policies/triage.yaml
 
+role: triage
+slug: fullsend-ai-triage
+
 host_files:
   - src: env/gcp-vertex.env
     dest: /sandbox/workspace/.env.d/gcp-vertex.env


### PR DESCRIPTION
## Summary

- Adds `role` and `slug` fields to all 6 scaffold harness templates in `internal/scaffold/fullsend-repo/harness/`
- Part of ADR-0045 Phase 1 ([implementation plan](docs/plans/adr-0045-forge-portable-harness-schema.md), PR 6)
- Depends on PR 2 (#2128, merged) which added optional `role`/`slug` fields to the `Harness` struct

### Harness → role/slug mapping

| Harness | Role | Slug |
|---------|------|------|
| `triage.yaml` | `triage` | `fullsend-ai-triage` |
| `code.yaml` | `coder` | `fullsend-ai-coder` |
| `review.yaml` | `review` | `fullsend-ai-review` |
| `fix.yaml` | `coder` | `fullsend-ai-coder` |
| `retro.yaml` | `retro` | `fullsend-ai-retro` |
| `prioritize.yaml` | `prioritize` | `fullsend-ai-prioritize` |

Note: `fix.yaml` reuses the coder app (same role/slug as `code.yaml`).

## Test plan

- [x] `make go-test` — all tests pass, including `TestHarnessesLoadAndValidate`
- [x] `make lint` — passes
- [x] Backward compatible — fields are `omitempty`, existing harnesses without role/slug continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)