### PR TITLE
fix: update status comment on cancellation instead of orphaning it

### DIFF
--- a/cmd/fullsend/main.go
+++ b/cmd/fullsend/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/fullsend-ai/fullsend/internal/cli"
 )
@@ -16,7 +19,10 @@ type exitCoder interface {
 }
 
 func main() {
-	if err := cli.Execute(); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := cli.Execute(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		var ec exitCoder
 		if errors.As(err, &ec) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +34,7 @@ func newRootCmd() *cobra.Command {
 	return cmd
 }
 
-// Execute runs the root command.
-func Execute() error {
-	return newRootCmd().Execute()
+// Execute runs the root command with the given context.
+func Execute(ctx context.Context) error {
+	return newRootCmd().ExecuteContext(ctx)
 }

--- a/internal/statuscomment/statuscomment.go
+++ b/internal/statuscomment/statuscomment.go
@@ -4,8 +4,8 @@
 // Unlike internal/sticky, which manages persistent bot comments that
 // accumulate history across multiple runs (e.g. review output),
 // statuscomment manages transient lifecycle markers: a start comment
-// created when the agent begins, updated or replaced on completion,
-// and deleted on cancellation. The two packages share the HTML-marker
+// created when the agent begins, then updated or replaced on
+// completion (including cancellation). The two packages share the HTML-marker
 // convention but have different lifecycles and placement heuristics.
 package statuscomment
 
@@ -83,10 +83,7 @@ func (n *Notifier) PostStart(ctx context.Context, description string) error {
 // PostCompletion posts or edits a completion comment.
 // status should be "success", "failure", or "cancelled".
 //
-// Cancellation deletes the start comment (if one exists), leaving no
-// trace on the timeline. No completion comment is posted.
-//
-// For success/failure, placement follows three rules:
+// Placement follows three rules:
 //  1. If the agent posted output after the start comment (a bot-authored
 //     comment that is not a status marker), the start comment is updated
 //     in place — the agent's output is the visible forward signal and a
@@ -97,10 +94,6 @@ func (n *Notifier) PostStart(ctx context.Context, description string) error {
 //     output), a new completion comment is posted so the user sees the
 //     result while reading forward.
 func (n *Notifier) PostCompletion(ctx context.Context, description, status string) error {
-	if status == "cancelled" {
-		return n.handleCancelled(ctx)
-	}
-
 	completionTime := n.now().UTC()
 
 	if !commentEnabled(n.cfg.Comment.Completion) {
@@ -138,15 +131,6 @@ func (n *Notifier) PostCompletion(ctx context.Context, description, status strin
 		}
 	}
 
-	return nil
-}
-
-func (n *Notifier) handleCancelled(ctx context.Context) error {
-	if n.startCommentID != 0 {
-		if err := n.client.DeleteIssueComment(ctx, n.owner, n.repo, n.startCommentID); err != nil {
-			n.warnf("failed to delete start comment on cancellation: %v", err)
-		}
-	}
 	return nil
 }
 

--- a/internal/statuscomment/statuscomment_test.go
+++ b/internal/statuscomment/statuscomment_test.go
@@ -185,11 +185,17 @@ func TestPostCompletion_Cancelled(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, fc.IssueComments["org/repo/7"], 1)
 
+	completionTime := fixedTime().Add(2 * time.Minute)
+	n.now = func() time.Time { return completionTime }
+
 	err = n.PostCompletion(context.Background(), "Working", "cancelled")
 	require.NoError(t, err)
 
-	require.Len(t, fc.DeletedComments, 1)
-	assert.Equal(t, 1, fc.DeletedComments[0])
+	assert.Empty(t, fc.DeletedComments, "should update, not delete")
+	require.Len(t, fc.UpdatedComments, 1)
+	assert.Equal(t, 1, fc.UpdatedComments[0].CommentID)
+	assert.Contains(t, fc.UpdatedComments[0].Body, "Finished Working")
+	assert.Contains(t, fc.UpdatedComments[0].Body, "⚠️ Cancelled")
 }
 
 func TestAllDisabled_NoAPICalls(t *testing.T) {
@@ -332,6 +338,27 @@ func TestPostCompletion_CompletionDisabled_CleansUpStartComment(t *testing.T) {
 
 	n.now = func() time.Time { return fixedTime().Add(time.Minute) }
 	err = n.PostCompletion(context.Background(), "Working", "success")
+	require.NoError(t, err)
+
+	assert.Empty(t, fc.UpdatedComments, "should not update start comment")
+	require.Len(t, fc.DeletedComments, 1, "should delete orphaned start comment")
+	assert.Equal(t, 1, fc.DeletedComments[0])
+	assert.Empty(t, fc.IssueComments["org/repo/7"], "start comment should be removed")
+}
+
+func TestPostCompletion_CancelledWithCompletionDisabled(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "disabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+	require.Equal(t, 1, n.startCommentID)
+
+	n.now = func() time.Time { return fixedTime().Add(time.Minute) }
+	err = n.PostCompletion(context.Background(), "Working", "cancelled")
 	require.NoError(t, err)
 
 	assert.Empty(t, fc.UpdatedComments, "should not update start comment")
@@ -484,11 +511,14 @@ func TestPostCompletion_CancelledWithNoStartComment(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, n.startCommentID)
 
+	n.now = func() time.Time { return fixedTime().Add(time.Minute) }
 	err = n.PostCompletion(context.Background(), "Working", "cancelled")
 	require.NoError(t, err)
 
 	assert.Empty(t, fc.DeletedComments, "should not attempt deletion when no start comment exists")
-	assert.Empty(t, fc.IssueComments, "should not post any comment")
+	comments := fc.IssueComments["org/repo/7"]
+	require.Len(t, comments, 1, "should post a completion comment")
+	assert.Contains(t, comments[0].Body, "⚠️ Cancelled")
 }
 
 func TestPostCompletion_AnalyzeTimelineError_UpdatesStartInPlace(t *testing.T) {


### PR DESCRIPTION
## Summary

- Wire `signal.NotifyContext` into `main.go` and `ExecuteContext` into the root command so SIGINT/SIGTERM cancel the context and deferred cleanup runs (previously `os.Exit(2)` skipped defers entirely)
- Thread the signal-aware context through Cobra so `ctx.Err()` in `run.go`'s defer correctly detects cancellation
- Change cancelled status from deleting the start comment to updating it in-place with "⚠️ Cancelled", matching the success/failure update path

Fixes #2147

## Test plan

- [x] `go test ./internal/statuscomment/...` — all 28 tests pass (added `TestPostCompletion_CancelledWithCompletionDisabled`)
- [x] `go vet` clean on all changed packages
- [ ] Deploy to staging and cancel a running review to verify the comment updates to "⚠️ Cancelled"

🤖 Generated with [Claude Code](https://claude.com/claude-code)