### PR TITLE
feat(cli): download from sandbox into different directory

### DIFF
--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -378,6 +378,10 @@ Vendoring commit messages use title + body (upload and stale delete). `admin ana
 │             ▼                                                   │
 │  ┌──────────────────┐                                           │
 │  │ Post-script       │ Run harness.post_script (host-side)      │
+│  │                   │ Env includes REPO_DIR pointing to        │
+│  │                   │ /tmp/fullsend-downloads/<sandbox>/       │
+│  │                   │ iteration-N/ (persists until OS clears   │
+│  │                   │ /tmp; not explicitly cleaned up)         │
 │  └──────┬───────────┘                                           │
 │         ▼                                                       │
 │  ┌──────────────────┐                                           │

--- a/docs/guides/user/customizing-agents.md
+++ b/docs/guides/user/customizing-agents.md
@@ -43,8 +43,12 @@ validation_loop:
 runner_env:
   PUSH_TOKEN: "${PUSH_TOKEN}"
   REPO_FULL_NAME: "${REPO_FULL_NAME}"
-  REPO_DIR: "${GITHUB_WORKSPACE}/target-repo"
+  REPO_DIR: "${GITHUB_WORKSPACE}/target-repo"  # sandbox-side path seen by the agent
 ```
+
+> **Note:** `REPO_DIR` in `runner_env` sets the path the agent sees inside the sandbox.
+> The post-script receives a separate `REPO_DIR` injected by the runner, pointing to
+> the extracted copy of the repo on the host (`/tmp/fullsend-downloads/<sandbox>/iteration-N/`).
 
 **Optional fields** (all have secure defaults and can be omitted):
 
@@ -283,7 +287,7 @@ validation_loop:
 runner_env:
   PUSH_TOKEN: "${PUSH_TOKEN}"
   REPO_FULL_NAME: "${REPO_FULL_NAME}"
-  REPO_DIR: "${GITHUB_WORKSPACE}/target-repo"
+  REPO_DIR: "${GITHUB_WORKSPACE}/target-repo"  # sandbox-side path seen by the agent
 ```
 
 Then create your custom skill at `.fullsend/customized/skills/my-custom-linting/SKILL.md`.

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -172,9 +172,8 @@ PUSH_TOKEN_SOURCE=github-app
 GITHUB_ISSUE_URL=https://github.com/{org}/{repo}/issues/{issue_num}
 REPO_FULL_NAME={org}/{repo}
 ISSUE_NUMBER={issue_num}
+TARGET_BRANCH=main
 CODE_ALLOWED_TARGET_BRANCHES=main
-REPO_DIR=/tmp/repo-dir
-GITHUB_WORKSPACE=/tmp/
 ```
 
 ```bash

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -524,10 +524,12 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	}
 	runDir := filepath.Join(outputBase, sandboxName)
 
-	// hostDownloadDir is outside outputBase because outputBase is uploaded
-	// as artifact in action.yml, we don't want to upload the source code as
-	// an artifact
+	// hostDownloadDir is separate from outputBase so the downloaded source
+	// code is not included when outputBase is collected as a build artifact.
 	hostDownloadDir := filepath.Join(os.TempDir(), "fullsend-downloads", sandboxName)
+	// lastDownloadDir represents the latest path, within hostDownloadDir, where
+	// fullsend download the repository within the sandbox to the host. Defined
+	// here so the defer can act on it, set later.
 	var lastDownloadDir string
 
 	// validationPassed is declared here (before the post-script defer) so the
@@ -561,7 +563,10 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 			postCmd := exec.Command(h.PostScript)
 			postCmd.Dir = runDir
 			postCmd.Env = append(os.Environ(), envToList(h.RunnerEnv)...)
-			postCmd.Env = append(postCmd.Env, fmt.Sprintf("REPO_DIR=%s", lastDownloadDir))
+			postCmd.Env = append(postCmd.Env,
+				fmt.Sprintf("REPO_DIR=%s", lastDownloadDir),
+				fmt.Sprintf("TARGET_REPO_DIR=%s", lastDownloadDir),
+			)
 			postCmd.Stdout = os.Stdout
 			postCmd.Stderr = os.Stderr
 			if err := postCmd.Run(); err != nil {
@@ -948,10 +953,16 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 			}
 		}
 
-		// 9d. Extract target repo back to host. SafeDownload removes dangerous
+		// 9d. Extract target repo from sandbox. SafeDownload removes dangerous
 		// symlinks (absolute or repo-escaping) and .git/hooks/ to prevent sandbox escape.
 		iterDownloadDir := filepath.Join(hostDownloadDir, fmt.Sprintf("iteration-%d", iteration))
+		if lastDownloadDir != "" {
+			os.RemoveAll(lastDownloadDir)
+		}
 		lastDownloadDir = iterDownloadDir
+		if err := os.MkdirAll(iterDownloadDir, 0o755); err != nil {
+			return fmt.Errorf("creating download dir: %w", err)
+		}
 		repoExtractStart := time.Now()
 		printer.StepStart("Extracting target repo")
 		if err := sandbox.SafeDownload(sandboxName, remoteRepositoryDir, iterDownloadDir); err != nil {
@@ -1015,6 +1026,9 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		if err := scanOutputFiles(runDir, traceID, printer); err != nil {
 			printer.StepWarn("Output scan error: " + err.Error())
 		}
+		if err := scanOutputFiles(hostDownloadDir, traceID, printer); err != nil {
+			printer.StepWarn("Output scan error (download dir): " + err.Error())
+		}
 
 		// Extract sandbox-side security findings for audit trail.
 		findingsDir := filepath.Join(runDir, "security")
@@ -1045,7 +1059,7 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	printer.Blank()
 	printer.Header("Results")
 	printer.KeyValue("Run directory", runDir)
-	printer.KeyValue("Download directory", hostDownloadDir)
+	printer.KeyValue("Extracted repo", hostDownloadDir)
 	printer.KeyValue("Agent exit code", fmt.Sprintf("%d", lastExitCode))
 	printer.KeyValue("Agent runs", fmt.Sprintf("%d", runCount))
 	printer.KeyValue("Trace ID", traceID)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -524,6 +524,12 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	}
 	runDir := filepath.Join(outputBase, sandboxName)
 
+	// hostDownloadDir is outside outputBase because outputBase is uploaded
+	// as artifact in action.yml, we don't want to upload the source code as
+	// an artifact
+	hostDownloadDir := filepath.Join(os.TempDir(), "fullsend-downloads", sandboxName)
+	var lastDownloadDir string
+
 	// validationPassed is declared here (before the post-script defer) so the
 	// defer closure can guard on it. The post-script must only run when
 	// validation has passed — running it on unvalidated output would violate
@@ -555,6 +561,7 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 			postCmd := exec.Command(h.PostScript)
 			postCmd.Dir = runDir
 			postCmd.Env = append(os.Environ(), envToList(h.RunnerEnv)...)
+			postCmd.Env = append(postCmd.Env, fmt.Sprintf("REPO_DIR=%s", lastDownloadDir))
 			postCmd.Stdout = os.Stdout
 			postCmd.Stderr = os.Stderr
 			if err := postCmd.Run(); err != nil {
@@ -943,18 +950,17 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 
 		// 9d. Extract target repo back to host. SafeDownload removes dangerous
 		// symlinks (absolute or repo-escaping) and .git/hooks/ to prevent sandbox escape.
-		if clearErr := os.RemoveAll(hostRepositoryDir); clearErr != nil {
-			return fmt.Errorf("clearing local repo %s before extraction: %w", hostRepositoryDir, clearErr)
-		}
+		iterDownloadDir := filepath.Join(hostDownloadDir, fmt.Sprintf("iteration-%d", iteration))
+		lastDownloadDir = iterDownloadDir
 		repoExtractStart := time.Now()
 		printer.StepStart("Extracting target repo")
-		if err := sandbox.SafeDownload(sandboxName, remoteRepositoryDir, hostRepositoryDir); err != nil {
+		if err := sandbox.SafeDownload(sandboxName, remoteRepositoryDir, iterDownloadDir); err != nil {
 			if es := tx.ParseTranscriptErrors(iterTranscriptDir); len(es) > 0 {
 				tx.EmitTranscriptErrors(os.Stderr, es)
 			}
 			return fmt.Errorf("extracting target repo (iteration %d): %w", iteration, err)
 		}
-		printer.StepDone(fmt.Sprintf("Target repo extracted to %s (%.1fs)", hostRepositoryDir, time.Since(repoExtractStart).Seconds()))
+		printer.StepDone(fmt.Sprintf("Target repo extracted to %s (%.1fs)", iterDownloadDir, time.Since(repoExtractStart).Seconds()))
 
 		// 9e. Run validation.
 		if h.ValidationLoop == nil {
@@ -967,7 +973,7 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		valCmd.Dir = iterDir
 		valCmd.Env = append(os.Environ(),
 			append(envToList(h.RunnerEnv),
-				fmt.Sprintf("TARGET_REPO_DIR=%s", hostRepositoryDir),
+				fmt.Sprintf("TARGET_REPO_DIR=%s", iterDownloadDir),
 				fmt.Sprintf("FULLSEND_RUN_DIR=%s", runDir),
 			)...,
 		)
@@ -1039,6 +1045,7 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	printer.Blank()
 	printer.Header("Results")
 	printer.KeyValue("Run directory", runDir)
+	printer.KeyValue("Download directory", hostDownloadDir)
 	printer.KeyValue("Agent exit code", fmt.Sprintf("%d", lastExitCode))
 	printer.KeyValue("Agent runs", fmt.Sprintf("%d", runCount))
 	printer.KeyValue("Trace ID", traceID)

--- a/internal/scaffold/fullsend-repo/scripts/post-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-code.sh
@@ -20,7 +20,9 @@
 #                       (GitHub App installation token or PAT)
 #   REPO_FULL_NAME    — owner/repo (e.g. my-org/my-repo)
 #   ISSUE_NUMBER      — GitHub issue number
-#   REPO_DIR          — path to extracted repo (default: current directory)
+#   REPO_DIR          — path to extracted repo; injected by the runner to
+#                       /tmp/fullsend-downloads/<sandbox>/iteration-N/
+#                       (persists until OS clears /tmp; always set in production)
 #
 # Optional environment variables:
 #   PUSH_TOKEN_SOURCE — "github-app" (for logging; default: unknown)
@@ -48,7 +50,7 @@ UV_SHA256="f3b623eb0e6141a7053d571d59a0bdc341e0f238ea8f5f0b4815ddbec9a2a296"
 # ---------------------------------------------------------------------------
 # Setup
 # ---------------------------------------------------------------------------
-REPO_DIR="${REPO_DIR:-repo}"
+REPO_DIR="${REPO_DIR:-.}"
 RUN_DIR="$(pwd)"
 
 if [ "${REPO_DIR}" != "." ]; then

--- a/internal/scaffold/fullsend-repo/scripts/post-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-fix.sh
@@ -34,7 +34,9 @@
 #   PUSH_TOKEN        — token with contents:write + pull-requests:write
 #   REPO_FULL_NAME    — owner/repo
 #   PR_NUMBER         — PR number
-#   REPO_DIR          — path to extracted repo (default: current directory)
+#   REPO_DIR          — path to extracted repo; injected by the runner to
+#                       /tmp/fullsend-downloads/<sandbox>/iteration-N/
+#                       (persists until OS clears /tmp; always set in production)
 #   TRIGGER_SOURCE    — GitHub username that triggered the fix (usernames ending in [bot] are bot triggers)
 #
 # Optional environment variables:
@@ -68,7 +70,7 @@ UV_SHA256="f3b623eb0e6141a7053d571d59a0bdc341e0f238ea8f5f0b4815ddbec9a2a296"
 # ---------------------------------------------------------------------------
 # Setup
 # ---------------------------------------------------------------------------
-REPO_DIR="${REPO_DIR:-repo}"
+REPO_DIR="${REPO_DIR:-.}"
 RUN_DIR="$(pwd)"
 
 if [ "${REPO_DIR}" != "." ]; then


### PR DESCRIPTION
`fullsend run` was wiping out `--target-repo` and downloading the sandbox target repo into it. On the workflows, this was OK, but locally this meant wiping out the target directory. If someone used a valuable target repository that would mean that they could lose local information (in case the agent decided to wipe out branches within the sandbox, or something similar). Because of that this PR introduces `hostDownloadDir` to download the sandbox contents and prevent wiping out the host `--target-repo`. This is not configurable, so overriding the `--target-repo` is not possible, users that want their contents modified will need to manually copy changes into their `--target-repo`.

Closes #2075 