### PR TITLE
fix(e2e): use event author_association for trusted member gate

### DIFF
--- a/.github/actions/check-e2e-authorization/action.yml
+++ b/.github/actions/check-e2e-authorization/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: github.event.action
     required: false
     default: ""
+  pr_author_association:
+    description: github.event.pull_request.author_association (frozen event payload)
+    required: false
+    default: ""
   docs_url:
     description: Link to e2e testing documentation
     required: false
@@ -46,6 +50,7 @@ runs:
         REPOSITORY: ${{ inputs.repository }}
         PR_UPDATED_AT: ${{ inputs.pr_updated_at }}
         EVENT_ACTION: ${{ inputs.event_action }}
+        PR_AUTHOR_ASSOCIATION: ${{ inputs.pr_author_association }}
       run: bash "${GITHUB_WORKSPACE}/scripts/check-e2e-authorization.sh" "${PR_NUMBER}" "${REPOSITORY}"
 
     - name: Post gate comment

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,6 +77,7 @@ jobs:
           repository: ${{ github.repository }}
           pr_updated_at: ${{ github.event.pull_request.updated_at }}
           event_action: ${{ github.event.action }}
+          pr_author_association: ${{ github.event.pull_request.author_association }}
 
   e2e:
     # For pull_request_target, runs only when gate sets authorized=true.

--- a/docs/guides/dev/e2e-testing.md
+++ b/docs/guides/dev/e2e-testing.md
@@ -36,7 +36,10 @@ use repository secrets. Because that exposes credentials to untrusted code, a
 
 E2E tests run without maintainer action when the PR author is an org/repo
 **member** or **collaborator** (`author_association` of `OWNER`, `MEMBER`, or
-`COLLABORATOR` on the base repo).
+`COLLABORATOR` on the base repo). The gate uses the frozen
+`github.event.pull_request.author_association` from the workflow event — not a
+live REST lookup — because `GITHUB_TOKEN` lacks `read:org` and cannot see org
+membership for members with private visibility.
 
 ### Who needs `ok-to-test`
 

--- a/scripts/check-e2e-authorization-test.sh
+++ b/scripts/check-e2e-authorization-test.sh
@@ -107,6 +107,20 @@ else
 fi
 unset PR_AUTHOR_ASSOCIATION
 
+export PR_AUTHOR_ASSOCIATION="CONTRIBUTOR"
+export EVENT_ACTION="synchronize"
+export PR_UPDATED_AT="2026-06-01T10:00:00Z"
+write_pr "NONE" '[{"name":"ok-to-test"}]'
+write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
+run_case "untrusted event payload falls through to ok-to-test label check" "true" "ok_to_test" "false"
+if ! grep -q '/pulls/' "${GH_LOG}"; then
+  echo "FAIL: untrusted event payload should fetch pulls API for labels"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "PASS: untrusted event payload fetches pulls API for labels"
+fi
+unset PR_AUTHOR_ASSOCIATION EVENT_ACTION PR_UPDATED_AT
+
 write_pr "OWNER" '[]'
 run_case "trusted owner author" "true" "trusted_author" "false"
 

--- a/scripts/check-e2e-authorization-test.sh
+++ b/scripts/check-e2e-authorization-test.sh
@@ -96,6 +96,17 @@ run_case() {
 write_pr "MEMBER" '[]'
 run_case "trusted member author" "true" "trusted_author" "false"
 
+export PR_AUTHOR_ASSOCIATION="MEMBER"
+write_pr "NONE" '[]'
+run_case "event payload trusted author overrides API NONE" "true" "trusted_author" "false"
+if grep -q '/pulls/' "${GH_LOG}"; then
+  echo "FAIL: trusted event payload should not call pulls API"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "PASS: trusted event payload skips pulls API"
+fi
+unset PR_AUTHOR_ASSOCIATION
+
 write_pr "OWNER" '[]'
 run_case "trusted owner author" "true" "trusted_author" "false"
 

--- a/scripts/check-e2e-authorization.sh
+++ b/scripts/check-e2e-authorization.sh
@@ -11,6 +11,7 @@
 # Usage: check-e2e-authorization.sh PR_NUMBER OWNER/REPO
 #
 # Environment (optional, from workflow):
+#   PR_AUTHOR_ASSOCIATION — github.event.pull_request.author_association
 #   PR_UPDATED_AT — github.event.pull_request.updated_at
 #   EVENT_ACTION  — github.event.action
 #
@@ -47,42 +48,53 @@ is_trusted_author() {
   esac
 }
 
-pr_json="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")"
-author_association="$(jq -r '.author_association' <<<"${pr_json}")"
-has_ok_label="$(jq -r --arg label "${OK_TO_TEST_LABEL}" '[.labels[].name] | index($label) != null' <<<"${pr_json}")"
-
 label_removed=false
 authorized=false
 reason="unauthorized"
 
+# Prefer the frozen workflow event payload. GITHUB_TOKEN cannot see org
+# membership (read:org), so pulls.get often returns NONE/CONTRIBUTOR for
+# org members — especially when membership visibility is private.
+if [[ -n "${PR_AUTHOR_ASSOCIATION:-}" ]]; then
+  author_association="${PR_AUTHOR_ASSOCIATION}"
+else
+  pr_json="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")"
+  author_association="$(jq -r '.author_association' <<<"${pr_json}")"
+fi
+
 if is_trusted_author "${author_association}"; then
   authorized=true
   reason="trusted_author"
-elif [[ "${has_ok_label}" == "true" && "${EVENT_ACTION:-}" == "labeled" ]]; then
-  authorized=true
-  reason="ok_to_test"
-elif [[ "${has_ok_label}" == "true" ]]; then
-  events_json="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/events" --paginate | jq -s 'add // []')"
-  ok_to_test_at="$(jq -r --arg label "${OK_TO_TEST_LABEL}" '
-    [.[] | select(.event == "labeled" and (.label.name // "") == $label) | .created_at] | max // empty
-  ' <<<"${events_json}")"
+else
+  pr_json="${pr_json:-$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")}"
+  has_ok_label="$(jq -r --arg label "${OK_TO_TEST_LABEL}" '[.labels[].name] | index($label) != null' <<<"${pr_json}")"
 
-  last_push_at="${PR_UPDATED_AT:-}"
-  if [[ -z "${last_push_at}" ]]; then
-    # Fallback: live updated_at is noisy (bumped by comments, labels, etc.)
-    # and may over-reject. Prefer the frozen event-payload value (PR_UPDATED_AT).
-    last_push_at="$(jq -r '.updated_at // empty' <<<"${pr_json}")"
-  fi
-
-  if [[ -n "${ok_to_test_at}" && -n "${last_push_at}" && "${ok_to_test_at}" > "${last_push_at}" ]]; then
+  if [[ "${has_ok_label}" == "true" && "${EVENT_ACTION:-}" == "labeled" ]]; then
     authorized=true
     reason="ok_to_test"
-  else
-    if [[ "${CHECK_E2E_AUTH_DRY_RUN:-}" != "true" ]]; then
-      gh api -X DELETE "repos/${REPOSITORY}/issues/${PR_NUMBER}/labels/${OK_TO_TEST_LABEL}" >/dev/null
+  elif [[ "${has_ok_label}" == "true" ]]; then
+    events_json="$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/events" --paginate | jq -s 'add // []')"
+    ok_to_test_at="$(jq -r --arg label "${OK_TO_TEST_LABEL}" '
+      [.[] | select(.event == "labeled" and (.label.name // "") == $label) | .created_at] | max // empty
+    ' <<<"${events_json}")"
+
+    last_push_at="${PR_UPDATED_AT:-}"
+    if [[ -z "${last_push_at}" ]]; then
+      # Fallback: live updated_at is noisy (bumped by comments, labels, etc.)
+      # and may over-reject. Prefer the frozen event-payload value (PR_UPDATED_AT).
+      last_push_at="$(jq -r '.updated_at // empty' <<<"${pr_json}")"
     fi
-    label_removed=true
-    reason="stale_ok_to_test"
+
+    if [[ -n "${ok_to_test_at}" && -n "${last_push_at}" && "${ok_to_test_at}" > "${last_push_at}" ]]; then
+      authorized=true
+      reason="ok_to_test"
+    else
+      if [[ "${CHECK_E2E_AUTH_DRY_RUN:-}" != "true" ]]; then
+        gh api -X DELETE "repos/${REPOSITORY}/issues/${PR_NUMBER}/labels/${OK_TO_TEST_LABEL}" >/dev/null
+      fi
+      label_removed=true
+      reason="stale_ok_to_test"
+    fi
   fi
 fi
 


### PR DESCRIPTION
Fixes #2157

## Summary

- Pass `github.event.pull_request.author_association` into the e2e gate and prefer it for trusted-author checks
- Keep REST API lookups for `ok-to-test` label freshness (labels/events)
- Document why the event payload is required (`GITHUB_TOKEN` lacks `read:org`)

## Problem

PR #2106 authorized trusted authors via `gh api .../pulls/...` with `GITHUB_TOKEN`. That token cannot see org membership, so members (including fork PR authors like #1954) were misclassified as `unauthorized` and e2e was skipped despite the gate job succeeding.

## Test plan

- [x] `bash scripts/check-e2e-authorization-test.sh`
- [ ] Merge and re-run E2E Tests on PR #1954 — gate should set `authorized=true`, e2e job should run


Made with [Cursor](https://cursor.com)