### PR TITLE
feat(review): use "Looks good to me" when no findings

### DIFF
--- a/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
@@ -693,8 +693,8 @@ where `[open]` = `<` + `!--` and `[close]` = `--` + `>`.
   there are no critical findings, omit the `#### Critical` heading
   entirely. If the only findings are medium/low/info, only show that
   section. If there are no findings at all, set the body to
-  "Looks good to me" — omit the `## Review` header and
-  `### Findings` section entirely.
+  the hidden SHA comment followed by a newline and "Looks good to me"
+  — omit the `## Review` header and `### Findings` section entirely.
 - **No footer.** Do not repeat the outcome or include boilerplate
   about pushes clearing the review.
 
@@ -711,7 +711,7 @@ The table below lists the **additional** required fields per action:
 
 | Outcome         | Action            | Required fields                                                                               |
 |-----------------|-------------------|-----------------------------------------------------------------------------------------------|
-| approve         | `approve`         | `head_sha`; `body` defaults to "Looks good to me" when there are no findings; include `findings[]` when low/info findings are actionable follow-up work |
+| approve         | `approve`         | `body`, `head_sha`; set `body` to "Looks good to me" (preceded by the hidden SHA comment) when there are no findings; include `findings[]` when low/info findings are actionable follow-up work |
 | request-changes | `request-changes` | `body`, `head_sha`, `findings[]`                                                              |
 | comment-only    | `comment`         | `body`, `head_sha`                                                                            |
 | failure         | `failure`         | `reason` (body optional)                                                                      |

--- a/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
@@ -692,8 +692,9 @@ where `[open]` = `<` + `!--` and `[close]` = `--` + `>`.
 - **Only include finding severity sections that have findings.** If
   there are no critical findings, omit the `#### Critical` heading
   entirely. If the only findings are medium/low/info, only show that
-  section. If there are no findings at all, state "No findings." in
-  place of the findings section.
+  section. If there are no findings at all, set the body to
+  "Looks good to me" — omit the `## Review` header and
+  `### Findings` section entirely.
 - **No footer.** Do not repeat the outcome or include boilerplate
   about pushes clearing the review.
 
@@ -710,7 +711,7 @@ The table below lists the **additional** required fields per action:
 
 | Outcome         | Action            | Required fields                                                                               |
 |-----------------|-------------------|-----------------------------------------------------------------------------------------------|
-| approve         | `approve`         | `body`, `head_sha`; include `findings[]` when low/info findings are actionable follow-up work |
+| approve         | `approve`         | `head_sha`; `body` defaults to "Looks good to me" when there are no findings; include `findings[]` when low/info findings are actionable follow-up work |
 | request-changes | `request-changes` | `body`, `head_sha`, `findings[]`                                                              |
 | comment-only    | `comment`         | `body`, `head_sha`                                                                            |
 | failure         | `failure`         | `reason` (body optional)                                                                      |


### PR DESCRIPTION
## Summary

- When the review agent finds no issues, it now sets the comment body to "Looks good to me" instead of posting a structured `## Review / ### Findings / No findings.` block
- Omits the `## Review` header and `### Findings` section entirely in the zero-findings case
- Updates the outcome table to clarify that `body` defaults to "Looks good to me" for `approve` with no findings

Closes #1499

## Test plan

- [ ] Trigger a review agent run on a clean PR with no findings — confirm sticky comment reads "Looks good to me" with no structured block
- [ ] Trigger a review agent run on a PR with low/info findings — confirm full structured comment still appears
- [ ] Confirm approval is still submitted via GitHub's formal review mechanism in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)