### PR TITLE
fix(dispatch): strip CRLF \r from comment body before command matching

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -124,7 +124,7 @@ jobs:
 
           COMMAND=""
           if [[ -n "${COMMENT_BODY:-}" ]]; then
-            COMMAND="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | awk '{print $1}')"
+            COMMAND="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | tr -d '\r' | awk '{print $1}')"
           fi
 
           case "${EVENT_NAME}" in
@@ -152,7 +152,7 @@ jobs:
                 /fs-retro|/fullsend)
                   if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                     if [[ "${COMMAND}" == "/fullsend" ]]; then
-                      SECOND_WORD="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | awk '{print $2}')"
+                      SECOND_WORD="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | tr -d '\r' | awk '{print $2}')"
                       if [[ "${SECOND_WORD}" == "retro" ]]; then
                         STAGE="retro"
                       fi

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -79,7 +79,7 @@ jobs:
           # Extract the first word of the comment as the command
           COMMAND=""
           if [[ -n "${COMMENT_BODY:-}" ]]; then
-            COMMAND="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | awk '{print $1}')"
+            COMMAND="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | tr -d '\r' | awk '{print $1}')"
           fi
 
           case "${EVENT_NAME}" in
@@ -107,7 +107,7 @@ jobs:
                 /fs-retro|/fullsend)
                   if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
                     if [[ "${COMMAND}" == "/fullsend" ]]; then
-                      SECOND_WORD="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | awk '{print $2}')"
+                      SECOND_WORD="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | tr -d '\r' | awk '{print $2}')"
                       if [[ "${SECOND_WORD}" == "retro" ]]; then
                         STAGE="retro"
                       fi


### PR DESCRIPTION
## Summary

- Strip `\r` from GitHub comment bodies in the dispatch command extraction pipeline so slash commands match correctly when the comment has multiple lines
- Fixes all four `head -1 | awk` pipelines across both dispatch routers (`reusable-dispatch.yml` and scaffold `dispatch.yml`)
- Root cause: GitHub delivers comment bodies with `\r\n` (CRLF) line endings; `head -1` strips `\n` but keeps `\r`, so `COMMAND` becomes `/fs-fix\r` which silently fails the exact-match `case` statement

## Evidence

| What | Link |
|------|------|
| Original failure (`/fs-fix` on PR #2136) | [Workflow run 27298310530](https://github.com/fullsend-ai/fullsend/actions/runs/27298310530) |
| Reproduced on `/fs-triage` (node-api #2) | [Workflow run 27301834754](https://github.com/fullsend-playground/node-api/actions/runs/27301834754) |
| Issue with full analysis | #2137 |

## Change

One-token insertion in each of 4 pipelines — `tr -d '\r'` between `head -1` and `awk`:

```bash
# Before:
COMMAND="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | awk '{print $1}')"
# After:
COMMAND="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | tr -d '\r' | awk '{print $1}')"
```

## Files changed

- `.github/workflows/reusable-dispatch.yml` — COMMAND (line 127) and SECOND_WORD (line 155)
- `internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml` — COMMAND (line 82) and SECOND_WORD (line 110)

Both routers are kept in sync per repo conventions.

## Test plan

- [ ] Verify CI passes (actionlint, shellcheck, YAML lint)
- [ ] Post `/fs-triage` with a multi-line body on a test issue and confirm triage agent triggers
- [ ] Post bare `/fs-fix` (no body) on a test PR and confirm it still works (regression check)
- [ ] Note: already-scaffolded repos retain old dispatch.yml until re-scaffolded

Closes #2137

Made with [Cursor](https://cursor.com)