### PR TITLE
feat(harness): add base composition for harness inheritance (ADR-0045 PR 4/7)

### DIFF
--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -1,0 +1,549 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fullsend-ai/fullsend/internal/fetch"
+	"gopkg.in/yaml.v3"
+)
+
+// MaxBaseDepth is the maximum depth of base chain inheritance.
+// This prevents runaway recursion from circular or pathologically deep chains.
+const MaxBaseDepth = 5
+
+// Dependency records a single URL that was resolved to a local cache path.
+// This mirrors resolve.Dependency but lives here to avoid circular imports.
+type Dependency struct {
+	Field     string
+	URL       string
+	LocalPath string
+	SHA256    string
+	FetchedAt time.Time
+	CacheHit  bool
+	Type      string // "file" for base harnesses
+}
+
+// ComposeOpts controls base composition behavior.
+type ComposeOpts struct {
+	// WorkspaceRoot is the root directory for cache paths (typically the repo root).
+	WorkspaceRoot string
+
+	// FetchPolicy controls SSRF protection, offline mode, and size limits.
+	FetchPolicy fetch.FetchPolicy
+
+	// TraceID is a correlation ID for audit log entries.
+	TraceID string
+
+	// AuditLogPath is the path to the fetch audit log (JSONL).
+	// If empty, audit logging is skipped.
+	AuditLogPath string
+
+	// ForgePlatform is the platform to resolve after base merging (e.g., "github").
+	// If empty, ResolveForge is a no-op.
+	ForgePlatform string
+
+	// OrgAllowlist is the org-level allowed_remote_resources from config.yaml.
+	// Base URLs must match a prefix in this list.
+	OrgAllowlist []string
+
+	// allowSelfAllowlist permits using the child harness's own AllowedRemoteResources
+	// when OrgAllowlist is empty. This is for testing only; production callers should
+	// always provide OrgAllowlist from config.yaml. Unexported to prevent misuse.
+	allowSelfAllowlist bool
+}
+
+// LoadWithBase loads a harness with base composition and forge resolution.
+// If the harness has a `base` field, the base chain is recursively loaded
+// and merged before forge resolution. Returns the merged harness and a list
+// of dependencies for any URL bases that were fetched.
+//
+// Pipeline:
+//  1. LoadRaw(path) — preserves forge map
+//  2. If base absent: ResolveForge → Validate → return
+//  3. If base present: loadBaseChain recursively, then mergeBaseIntoChild
+//  4. ResolveForge once on final merged result
+//  5. Validate
+//
+// When base is absent, this behaves identically to LoadWithOpts.
+func LoadWithBase(ctx context.Context, path string, opts ComposeOpts) (*Harness, []Dependency, error) {
+	childDir := filepath.Dir(path)
+
+	child, err := LoadRaw(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if child.Base == "" {
+		// No base — same as LoadWithOpts
+		if err := child.validateForge(); err != nil {
+			return nil, nil, fmt.Errorf("invalid harness: %w", err)
+		}
+		if err := child.ResolveForge(opts.ForgePlatform); err != nil {
+			return nil, nil, fmt.Errorf("resolving forge config: %w", err)
+		}
+		if err := child.Validate(); err != nil {
+			return nil, nil, fmt.Errorf("invalid harness: %w", err)
+		}
+		return child, nil, nil
+	}
+
+	// Org allowlist is the authority for URL bases.
+	// Reject URL bases when no org allowlist is configured to prevent
+	// self-authorization (child harness declaring its own allowed URLs).
+	allowlist := opts.OrgAllowlist
+	if len(allowlist) == 0 && IsURL(child.Base) && !opts.allowSelfAllowlist {
+		return nil, nil, fmt.Errorf("URL base requires org-level allowed_remote_resources")
+	}
+	// For testing, allowSelfAllowlist permits using the child's own list.
+	if opts.allowSelfAllowlist && len(allowlist) == 0 {
+		allowlist = child.AllowedRemoteResources
+	}
+
+	visited := make(map[string]bool)
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving absolute path: %w", err)
+	}
+	visited[absPath] = true // Mark child as visited to detect self-reference
+
+	base, deps, err := loadBaseChain(ctx, child.Base, childDir, allowlist, opts, visited, 1)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading base chain: %w", err)
+	}
+
+	// Merge base into child (child overrides base)
+	mergeBaseIntoChild(base, child)
+
+	// Clear the base field (consumed)
+	child.Base = ""
+
+	// ResolveForge once on the merged result
+	if err := child.validateForge(); err != nil {
+		return nil, nil, fmt.Errorf("invalid harness: %w", err)
+	}
+	if err := child.ResolveForge(opts.ForgePlatform); err != nil {
+		return nil, nil, fmt.Errorf("resolving forge config: %w", err)
+	}
+	if err := child.Validate(); err != nil {
+		return nil, nil, fmt.Errorf("invalid harness: %w", err)
+	}
+
+	return child, deps, nil
+}
+
+// loadBaseChain recursively loads a base harness and its ancestors.
+// Returns the fully-merged base harness and any URL dependencies.
+func loadBaseChain(
+	ctx context.Context,
+	baseRef string,
+	childDir string,
+	allowlist []string,
+	opts ComposeOpts,
+	visited map[string]bool,
+	depth int,
+) (*Harness, []Dependency, error) {
+	if depth > MaxBaseDepth {
+		return nil, nil, fmt.Errorf("exceeded maximum base depth of %d", MaxBaseDepth)
+	}
+
+	var base *Harness
+	var deps []Dependency
+	var baseDir string
+
+	// Reject non-HTTPS URLs before they get treated as local paths
+	if strings.HasPrefix(baseRef, "http://") {
+		return nil, nil, fmt.Errorf("base URL scheme must be https, got http://")
+	}
+
+	if IsURL(baseRef) {
+		// Check for cycle before fetching to avoid wasted network round-trips
+		cleanURL, _, _ := ParseIntegrityHash(baseRef)
+		if visited[cleanURL] {
+			return nil, nil, fmt.Errorf("circular base reference: %s", cleanURL)
+		}
+		visited[cleanURL] = true
+
+		// URL base — fetch, verify, cache
+		dep, content, err := fetchBaseURL(ctx, baseRef, allowlist, opts)
+		if err != nil {
+			return nil, nil, err
+		}
+		deps = append(deps, dep)
+
+		// Parse the fetched content
+		base, err = parseHarnessContent(content)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parsing base harness from %s: %w", cleanURL, err)
+		}
+
+		// For URL bases, relative paths in the base resolve against the child's directory
+		// (scripts are always local per ADR-0038's "no remote executables" rule)
+		baseDir = childDir
+	} else {
+		// Local path base
+		basePath := baseRef
+		if !filepath.IsAbs(basePath) {
+			basePath = filepath.Join(childDir, basePath)
+		}
+
+		// Canonicalize for cycle detection
+		absBasePath, err := filepath.Abs(basePath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving base path: %w", err)
+		}
+		absBasePath = filepath.Clean(absBasePath)
+
+		// Directory containment check: base must be within workspace root.
+		// Default to child's directory if WorkspaceRoot is not set.
+		containmentRoot := opts.WorkspaceRoot
+		if containmentRoot == "" {
+			containmentRoot = childDir
+		}
+		absWorkspace, err := filepath.Abs(containmentRoot)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving containment root: %w", err)
+		}
+		absWorkspace = filepath.Clean(absWorkspace)
+		rel, err := filepath.Rel(absWorkspace, absBasePath)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return nil, nil, fmt.Errorf("base path %q escapes workspace root", baseRef)
+		}
+
+		if visited[absBasePath] {
+			return nil, nil, fmt.Errorf("circular base reference: %s", absBasePath)
+		}
+		visited[absBasePath] = true
+
+		base, err = LoadRaw(basePath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("loading base harness %s: %w", basePath, err)
+		}
+
+		baseDir = filepath.Dir(absBasePath)
+	}
+
+	// If base has its own base, recurse
+	if base.Base != "" {
+		ancestorBase, ancestorDeps, err := loadBaseChain(ctx, base.Base, baseDir, allowlist, opts, visited, depth+1)
+		if err != nil {
+			return nil, nil, err
+		}
+		deps = append(deps, ancestorDeps...)
+
+		// Merge ancestor into base
+		mergeBaseIntoChild(ancestorBase, base)
+		base.Base = ""
+	}
+
+	return base, deps, nil
+}
+
+// fetchBaseURL fetches a URL-referenced base harness using the ADR-0038 infrastructure.
+func fetchBaseURL(ctx context.Context, rawURL string, allowlist []string, opts ComposeOpts) (Dependency, []byte, error) {
+	cleanURL, expectedHash, hasHash := ParseIntegrityHash(rawURL)
+	if !hasHash {
+		return Dependency{}, nil, fmt.Errorf("base URL must include #sha256=... integrity hash: %s", cleanURL)
+	}
+	if !strings.HasPrefix(cleanURL, "https://") {
+		return Dependency{}, nil, fmt.Errorf("base URL scheme must be https: %s", cleanURL)
+	}
+
+	// Check allowlist
+	allowedBy := matchingAllowedPrefix(cleanURL, allowlist)
+	if allowedBy == "" {
+		return Dependency{}, nil, fmt.Errorf("base URL %q is not in allowed_remote_resources", cleanURL)
+	}
+
+	// Check cache
+	content, entry, err := fetch.CacheGet(opts.WorkspaceRoot, expectedHash)
+	if err != nil {
+		return Dependency{}, nil, fmt.Errorf("cache lookup for base: %w", err)
+	}
+
+	cacheHit := content != nil
+	fetchedAt := time.Now().UTC()
+
+	if content == nil {
+		// Offline mode check
+		if opts.FetchPolicy.Offline {
+			return Dependency{}, nil, fmt.Errorf("base URL %s not in cache and offline mode is enabled", cleanURL)
+		}
+
+		// Fetch
+		content, err = fetch.FetchURL(ctx, cleanURL, opts.FetchPolicy)
+		if err != nil {
+			return Dependency{}, nil, fmt.Errorf("fetching base from %s: %w", cleanURL, err)
+		}
+
+		// Verify integrity
+		actualHash := fetch.ComputeSHA256(content)
+		if actualHash != expectedHash {
+			return Dependency{}, nil, fmt.Errorf("base integrity check failed for %s: expected %s, got %s", cleanURL, expectedHash, actualHash)
+		}
+
+		// Cache
+		if err := fetch.CachePut(opts.WorkspaceRoot, cleanURL, content); err != nil {
+			return Dependency{}, nil, fmt.Errorf("caching base: %w", err)
+		}
+	} else {
+		fetchedAt = entry.FetchTime
+	}
+
+	// Audit log
+	if opts.AuditLogPath != "" {
+		if err := fetch.AppendFetchAudit(opts.AuditLogPath, fetch.FetchAuditEntry{
+			TraceID:   opts.TraceID,
+			FetchTime: fetchedAt,
+			URL:       cleanURL,
+			SHA256:    expectedHash,
+			FetchType: "static",
+			AllowedBy: allowedBy,
+			CacheHit:  cacheHit,
+		}); err != nil {
+			return Dependency{}, nil, fmt.Errorf("writing fetch audit log: %w", err)
+		}
+	}
+
+	// Compute local path
+	cachePath, err := fetch.CachePath(opts.WorkspaceRoot, expectedHash)
+	if err != nil {
+		return Dependency{}, nil, fmt.Errorf("computing cache path: %w", err)
+	}
+	localPath := filepath.Join(cachePath, "content")
+
+	dep := Dependency{
+		Field:     "base",
+		URL:       cleanURL,
+		LocalPath: localPath,
+		SHA256:    expectedHash,
+		FetchedAt: fetchedAt,
+		CacheHit:  cacheHit,
+		Type:      "file",
+	}
+
+	return dep, content, nil
+}
+
+// parseHarnessContent parses harness YAML content without validation.
+func parseHarnessContent(content []byte) (*Harness, error) {
+	var h Harness
+	if err := yaml.Unmarshal(content, &h); err != nil {
+		return nil, err
+	}
+	return &h, nil
+}
+
+// matchingAllowedPrefix checks if a URL matches any prefix in the allowlist.
+// Returns the matching prefix or "" if none match.
+func matchingAllowedPrefix(rawURL string, allowlist []string) string {
+	return MatchingAllowedPrefixInList(rawURL, allowlist)
+}
+
+// mergeBaseIntoChild merges base harness fields into child harness.
+// Child values override base values following ADR-0045 merge rules:
+//   - Scalars: child overrides if non-zero
+//   - Slices (skills, plugins, providers, api_servers): base + child (concatenated)
+//   - Maps (runner_env): base merged with child; child keys win
+//   - Pointer structs (validation_loop, security): child replaces if non-nil
+//   - host_files: concatenated with last-writer-wins dedup by Dest
+//   - forge: key-by-key merge; per-platform uses same rules
+//   - allowed_remote_resources: NOT merged (security; child must declare its own)
+func mergeBaseIntoChild(base, child *Harness) {
+	// Scalars: child overrides if non-zero
+	if child.Agent == "" {
+		child.Agent = base.Agent
+	}
+	if child.Doc == "" {
+		child.Doc = base.Doc
+	}
+	if child.Description == "" {
+		child.Description = base.Description
+	}
+	if child.Role == "" {
+		child.Role = base.Role
+	}
+	if child.Slug == "" {
+		child.Slug = base.Slug
+	}
+	if child.Image == "" {
+		child.Image = base.Image
+	}
+	if child.Policy == "" {
+		child.Policy = base.Policy
+	}
+	if child.Model == "" {
+		child.Model = base.Model
+	}
+	if child.PreScript == "" {
+		child.PreScript = base.PreScript
+	}
+	if child.PostScript == "" {
+		child.PostScript = base.PostScript
+	}
+	if child.AgentInput == "" {
+		child.AgentInput = base.AgentInput
+	}
+	if child.TimeoutMinutes == 0 {
+		child.TimeoutMinutes = base.TimeoutMinutes
+	}
+	if child.SandboxTimeoutSeconds == 0 {
+		child.SandboxTimeoutSeconds = base.SandboxTimeoutSeconds
+	}
+
+	// Concatenated slices: base + child.
+	// Pre-allocate new slices to avoid mutating base's backing array.
+	if base.Skills != nil {
+		merged := make([]string, 0, len(base.Skills)+len(child.Skills))
+		merged = append(merged, base.Skills...)
+		merged = append(merged, child.Skills...)
+		child.Skills = merged
+	}
+	if base.Plugins != nil {
+		merged := make([]string, 0, len(base.Plugins)+len(child.Plugins))
+		merged = append(merged, base.Plugins...)
+		merged = append(merged, child.Plugins...)
+		child.Plugins = merged
+	}
+	if base.Providers != nil {
+		merged := make([]string, 0, len(base.Providers)+len(child.Providers))
+		merged = append(merged, base.Providers...)
+		merged = append(merged, child.Providers...)
+		child.Providers = merged
+	}
+	// AllowedRemoteResources is NOT merged from base harnesses to prevent
+	// privilege escalation: a base cannot inject arbitrary URL prefixes
+	// into the child's allowlist. The child must declare its own allowlist
+	// which is validated against the org-level allowlist.
+	if base.APIServers != nil {
+		merged := make([]APIServer, 0, len(base.APIServers)+len(child.APIServers))
+		merged = append(merged, base.APIServers...)
+		merged = append(merged, child.APIServers...)
+		child.APIServers = merged
+	}
+
+	// HostFiles: concatenated with last-writer-wins dedup by Dest
+	if base.HostFiles != nil {
+		child.HostFiles = mergeHostFiles(base.HostFiles, child.HostFiles)
+	}
+
+	// RunnerEnv: merge maps, child keys win
+	if base.RunnerEnv != nil {
+		merged := make(map[string]string, len(base.RunnerEnv)+len(child.RunnerEnv))
+		for k, v := range base.RunnerEnv {
+			merged[k] = v
+		}
+		for k, v := range child.RunnerEnv {
+			merged[k] = v
+		}
+		child.RunnerEnv = merged
+	}
+
+	// Pointer structs: child replaces if non-nil
+	if child.ValidationLoop == nil {
+		child.ValidationLoop = base.ValidationLoop
+	}
+	// Security: child inherits base's config if nil. Note that a base harness
+	// (even integrity-pinned) could set fail_mode: open. Child authors must
+	// explicitly set their own security block to prevent inheriting a weaker posture.
+	if child.Security == nil {
+		child.Security = base.Security
+	}
+
+	// Forge: key-by-key merge
+	if base.Forge != nil {
+		child.Forge = mergeForgeBlocks(base.Forge, child.Forge)
+	}
+}
+
+// mergeHostFiles concatenates base and child host files, with child entries
+// overriding base entries that have the same Dest path.
+func mergeHostFiles(base, child []HostFile) []HostFile {
+	destIndex := make(map[string]int)
+	result := make([]HostFile, 0, len(base)+len(child))
+
+	// Add base entries
+	for _, hf := range base {
+		destIndex[hf.Dest] = len(result)
+		result = append(result, hf)
+	}
+
+	// Add/override with child entries
+	for _, hf := range child {
+		if idx, exists := destIndex[hf.Dest]; exists {
+			result[idx] = hf // override
+		} else {
+			destIndex[hf.Dest] = len(result)
+			result = append(result, hf)
+		}
+	}
+
+	return result
+}
+
+// mergeForgeBlocks merges forge maps key-by-key.
+// For each platform key present in both, the ForgeConfig fields are merged
+// using the same rules as mergeForgeConfig.
+func mergeForgeBlocks(base, child map[string]*ForgeConfig) map[string]*ForgeConfig {
+	if child == nil {
+		child = make(map[string]*ForgeConfig)
+	}
+
+	for key, baseFC := range base {
+		if childFC, exists := child[key]; exists && childFC != nil {
+			// Merge per-platform ForgeConfig
+			mergeForgeConfigInto(baseFC, childFC)
+		} else if !exists {
+			// Child doesn't have this platform — inherit from base
+			child[key] = baseFC
+		}
+		// If child[key] exists but is nil, child explicitly nulls out this platform
+	}
+
+	return child
+}
+
+// mergeForgeConfigInto merges base ForgeConfig fields into child.
+// Similar to mergeForgeConfig in forge.go but prepends base skills
+// (base + child order) rather than appending forge skills to harness skills.
+func mergeForgeConfigInto(base, child *ForgeConfig) {
+	if base == nil {
+		return
+	}
+
+	// Scalars: child overrides if non-empty
+	if child.PreScript == "" {
+		child.PreScript = base.PreScript
+	}
+	if child.PostScript == "" {
+		child.PostScript = base.PostScript
+	}
+
+	// Skills: concatenate (pre-allocate to avoid mutating base's backing array)
+	if base.Skills != nil {
+		merged := make([]string, 0, len(base.Skills)+len(child.Skills))
+		merged = append(merged, base.Skills...)
+		merged = append(merged, child.Skills...)
+		child.Skills = merged
+	}
+
+	// RunnerEnv: merge, child keys win
+	if base.RunnerEnv != nil {
+		if child.RunnerEnv == nil {
+			child.RunnerEnv = make(map[string]string, len(base.RunnerEnv))
+		}
+		for k, v := range base.RunnerEnv {
+			if _, exists := child.RunnerEnv[k]; !exists {
+				child.RunnerEnv[k] = v
+			}
+		}
+	}
+
+	// ValidationLoop: child replaces if non-nil
+	if child.ValidationLoop == nil {
+		child.ValidationLoop = base.ValidationLoop
+	}
+}

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -1,0 +1,1099 @@
+package harness
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fullsend-ai/fullsend/internal/fetch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func computeHash(content []byte) string {
+	h := sha256.Sum256(content)
+	return hex.EncodeToString(h[:])
+}
+
+func writeTestHarness(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	return path
+}
+
+func TestLoadWithBase_NoBase(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/test.md
+model: opus
+`)
+
+	h, deps, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+	assert.Equal(t, "agents/test.md", h.Agent)
+	assert.Equal(t, "opus", h.Model)
+	assert.Empty(t, deps)
+	assert.Empty(t, h.Base)
+}
+
+func TestLoadWithBase_LocalBase_ScalarOverride(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/base.md
+model: sonnet
+image: base-image
+timeout_minutes: 30
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+agent: agents/child.md
+model: opus
+`)
+
+	h, deps, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	// Child overrides base
+	assert.Equal(t, "agents/child.md", h.Agent)
+	assert.Equal(t, "opus", h.Model)
+	// Base values inherited
+	assert.Equal(t, "base-image", h.Image)
+	assert.Equal(t, 30, h.TimeoutMinutes)
+	// No URL deps
+	assert.Empty(t, deps)
+	// Base field consumed
+	assert.Empty(t, h.Base)
+}
+
+func TestLoadWithBase_LocalBase_SkillsConcat(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/test.md
+skills:
+  - skill-a
+  - skill-b
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+skills:
+  - skill-c
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	// Skills concatenated: base + child
+	assert.Equal(t, []string{"skill-a", "skill-b", "skill-c"}, h.Skills)
+}
+
+func TestLoadWithBase_LocalBase_RunnerEnvMerge(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/test.md
+runner_env:
+  KEY1: base-value1
+  KEY2: base-value2
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+runner_env:
+  KEY2: child-value2
+  KEY3: child-value3
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	// RunnerEnv merged: base + child, child wins on conflict
+	assert.Equal(t, map[string]string{
+		"KEY1": "base-value1",
+		"KEY2": "child-value2",
+		"KEY3": "child-value3",
+	}, h.RunnerEnv)
+}
+
+func TestLoadWithBase_LocalBase_HostFilesDedup(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/test.md
+host_files:
+  - src: base-src1
+    dest: /dest1
+  - src: base-src2
+    dest: /dest2
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+host_files:
+  - src: child-src2
+    dest: /dest2
+  - src: child-src3
+    dest: /dest3
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	// HostFiles: base + child, child overrides same Dest
+	require.Len(t, h.HostFiles, 3)
+	assert.Equal(t, "base-src1", h.HostFiles[0].Src)
+	assert.Equal(t, "/dest1", h.HostFiles[0].Dest)
+	assert.Equal(t, "child-src2", h.HostFiles[1].Src) // overridden
+	assert.Equal(t, "/dest2", h.HostFiles[1].Dest)
+	assert.Equal(t, "child-src3", h.HostFiles[2].Src)
+	assert.Equal(t, "/dest3", h.HostFiles[2].Dest)
+}
+
+func TestLoadWithBase_LocalBase_ValidationLoopReplace(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/test.md
+validation_loop:
+  script: base-script.sh
+  max_iterations: 5
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+validation_loop:
+  script: child-script.sh
+  max_iterations: 3
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	// ValidationLoop: child replaces entirely
+	require.NotNil(t, h.ValidationLoop)
+	assert.Equal(t, "child-script.sh", h.ValidationLoop.Script)
+	assert.Equal(t, 3, h.ValidationLoop.MaxIterations)
+}
+
+func TestLoadWithBase_LocalBase_ValidationLoopInherit(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/test.md
+validation_loop:
+  script: base-script.sh
+  max_iterations: 5
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+model: opus
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	// ValidationLoop: inherited from base when child is nil
+	require.NotNil(t, h.ValidationLoop)
+	assert.Equal(t, "base-script.sh", h.ValidationLoop.Script)
+	assert.Equal(t, 5, h.ValidationLoop.MaxIterations)
+}
+
+func TestLoadWithBase_ChainedBases(t *testing.T) {
+	dir := t.TempDir()
+
+	// A → B → C: C is the root, B extends C, A extends B
+	writeTestHarness(t, dir, "c.yaml", `
+agent: agents/c.md
+model: c-model
+image: c-image
+skills:
+  - skill-c
+`)
+
+	writeTestHarness(t, dir, "b.yaml", `
+base: c.yaml
+model: b-model
+skills:
+  - skill-b
+`)
+
+	path := writeTestHarness(t, dir, "a.yaml", `
+base: b.yaml
+agent: agents/a.md
+skills:
+  - skill-a
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	// A overrides agent
+	assert.Equal(t, "agents/a.md", h.Agent)
+	// B overrides model
+	assert.Equal(t, "b-model", h.Model)
+	// C provides image (inherited through B to A)
+	assert.Equal(t, "c-image", h.Image)
+	// Skills concatenated: c + b + a
+	assert.Equal(t, []string{"skill-c", "skill-b", "skill-a"}, h.Skills)
+}
+
+func TestLoadWithBase_CycleDetection(t *testing.T) {
+	dir := t.TempDir()
+
+	// A → B → A (cycle)
+	writeTestHarness(t, dir, "a.yaml", `
+agent: agents/a.md
+base: b.yaml
+`)
+
+	writeTestHarness(t, dir, "b.yaml", `
+agent: agents/b.md
+base: a.yaml
+`)
+
+	path := filepath.Join(dir, "a.yaml")
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "circular base reference")
+}
+
+func TestLoadWithBase_SelfReference(t *testing.T) {
+	dir := t.TempDir()
+
+	// A → A (self-reference)
+	path := writeTestHarness(t, dir, "a.yaml", `
+agent: agents/a.md
+base: a.yaml
+`)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "circular base reference")
+}
+
+func TestLoadWithBase_LocalBase_PathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "subdir")
+	require.NoError(t, os.MkdirAll(subdir, 0755))
+
+	// Child in subdir tries to reference base outside workspace root via ../
+	path := writeTestHarness(t, subdir, "child.yaml", `
+agent: agents/child.md
+base: ../../../etc/passwd
+`)
+
+	// WorkspaceRoot is subdir, so ../../../etc/passwd escapes it
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot: subdir,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes workspace root")
+}
+
+func TestLoadWithBase_LocalBase_PathTraversal_NoWorkspaceRoot(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "subdir")
+	require.NoError(t, os.MkdirAll(subdir, 0755))
+
+	// Child in subdir tries to reference base outside via ../
+	path := writeTestHarness(t, subdir, "child.yaml", `
+agent: agents/child.md
+base: ../outside.yaml
+`)
+
+	// No WorkspaceRoot set, so childDir is used as containment root
+	// ../outside.yaml escapes subdir
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes workspace root")
+}
+
+func TestLoadWithBase_DepthExceeded(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a chain deeper than MaxBaseDepth
+	for i := MaxBaseDepth + 2; i >= 0; i-- {
+		var content string
+		if i == MaxBaseDepth+2 {
+			content = `agent: agents/root.md`
+		} else {
+			content = fmt.Sprintf("agent: agents/test.md\nbase: h%d.yaml", i+1)
+		}
+		writeTestHarness(t, dir, fmt.Sprintf("h%d.yaml", i), content)
+	}
+
+	path := filepath.Join(dir, "h0.yaml")
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeded maximum base depth")
+}
+
+func TestLoadWithBase_ForgeBlockMerge(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/test.md
+forge:
+  github:
+    pre_script: base-pre.sh
+    skills:
+      - gh-skill-base
+    runner_env:
+      GH_KEY1: base-value1
+  gitlab:
+    pre_script: gitlab-pre.sh
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+forge:
+  github:
+    post_script: child-post.sh
+    skills:
+      - gh-skill-child
+    runner_env:
+      GH_KEY2: child-value2
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		ForgePlatform: "github",
+	})
+	require.NoError(t, err)
+
+	// GitHub forge merged, then resolved
+	assert.Equal(t, "base-pre.sh", h.PreScript)       // from base forge
+	assert.Equal(t, "child-post.sh", h.PostScript)    // from child forge
+	assert.Contains(t, h.Skills, "gh-skill-base")     // base skills
+	assert.Contains(t, h.Skills, "gh-skill-child")    // child skills
+	assert.Equal(t, "base-value1", h.RunnerEnv["GH_KEY1"])
+	assert.Equal(t, "child-value2", h.RunnerEnv["GH_KEY2"])
+
+	// Forge map consumed after ResolveForge
+	assert.Nil(t, h.Forge)
+}
+
+func TestLoadWithBase_ForgeInheritPlatform(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/test.md
+forge:
+  github:
+    pre_script: gh-pre.sh
+  gitlab:
+    pre_script: gl-pre.sh
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+model: opus
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		ForgePlatform: "gitlab",
+	})
+	require.NoError(t, err)
+
+	// GitLab forge inherited from base
+	assert.Equal(t, "gl-pre.sh", h.PreScript)
+}
+
+func TestLoadWithBase_URLBase(t *testing.T) {
+	baseContent := []byte(`
+agent: agents/remote.md
+model: sonnet
+skills:
+  - remote-skill
+`)
+	hash := computeHash(baseContent)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(baseContent)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	baseURL := server.URL + "/base.yaml#sha256=" + hash
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/child.md
+base: `+baseURL+`
+allowed_remote_resources:
+  - `+server.URL+`/
+`)
+
+	policy := fetch.NewTestPolicy(
+		server.Client().Transport.(*http.Transport).TLSClientConfig,
+		[]string{"127.0.0.1"},
+		[]string{server.Listener.Addr().String()[len("127.0.0.1:"):]},
+	)
+
+	h, deps, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot: cacheDir,
+		FetchPolicy:   policy,
+		OrgAllowlist:  []string{server.URL + "/"},
+	})
+	require.NoError(t, err)
+
+	// Child overrides agent
+	assert.Equal(t, "agents/child.md", h.Agent)
+	// Base provides model and skills
+	assert.Equal(t, "sonnet", h.Model)
+	assert.Contains(t, h.Skills, "remote-skill")
+
+	// One dependency for the URL base
+	require.Len(t, deps, 1)
+	assert.Equal(t, "base", deps[0].Field)
+	assert.Equal(t, server.URL+"/base.yaml", deps[0].URL)
+	assert.Equal(t, hash, deps[0].SHA256)
+}
+
+func TestLoadWithBase_ChainedURLBases(t *testing.T) {
+	// Test URL base whose own base is also a URL
+	grandparentContent := []byte(`
+agent: agents/grandparent.md
+model: opus
+`)
+	grandparentHash := computeHash(grandparentContent)
+
+	parentContent := []byte(`
+agent: agents/parent.md
+skills:
+  - parent-skill
+`)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/grandparent.yaml" {
+			w.WriteHeader(http.StatusOK)
+			w.Write(grandparentContent)
+		} else if r.URL.Path == "/parent.yaml" {
+			// Parent's base field will be set dynamically
+			w.WriteHeader(http.StatusOK)
+			w.Write(parentContent)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	// Now create parent content with base pointing to grandparent
+	parentContentWithBase := []byte(fmt.Sprintf(`
+agent: agents/parent.md
+base: %s/grandparent.yaml#sha256=%s
+skills:
+  - parent-skill
+`, server.URL, grandparentHash))
+	parentHash := computeHash(parentContentWithBase)
+
+	// Update server to serve the correct parent content
+	server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/grandparent.yaml" {
+			w.WriteHeader(http.StatusOK)
+			w.Write(grandparentContent)
+		} else if r.URL.Path == "/parent.yaml" {
+			w.WriteHeader(http.StatusOK)
+			w.Write(parentContentWithBase)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	parentURL := server.URL + "/parent.yaml#sha256=" + parentHash
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/child.md
+base: `+parentURL+`
+skills:
+  - child-skill
+`)
+
+	policy := fetch.NewTestPolicy(
+		server.Client().Transport.(*http.Transport).TLSClientConfig,
+		[]string{"127.0.0.1"},
+		[]string{server.Listener.Addr().String()[len("127.0.0.1:"):]},
+	)
+
+	h, deps, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot: cacheDir,
+		FetchPolicy:   policy,
+		OrgAllowlist:  []string{server.URL + "/"},
+	})
+	require.NoError(t, err)
+
+	// Child overrides agent
+	assert.Equal(t, "agents/child.md", h.Agent)
+	// Grandparent provides model
+	assert.Equal(t, "opus", h.Model)
+	// Skills concatenated: grandparent (none) + parent + child
+	assert.Contains(t, h.Skills, "parent-skill")
+	assert.Contains(t, h.Skills, "child-skill")
+
+	// Two dependencies for the chained URL bases
+	require.Len(t, deps, 2)
+}
+
+func TestLoadWithBase_URLBase_HashMismatch(t *testing.T) {
+	baseContent := []byte(`agent: agents/remote.md`)
+	wrongHash := "0000000000000000000000000000000000000000000000000000000000000000"
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(baseContent)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	baseURL := server.URL + "/base.yaml#sha256=" + wrongHash
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/child.md
+base: `+baseURL+`
+allowed_remote_resources:
+  - `+server.URL+`/
+`)
+
+	policy := fetch.NewTestPolicy(
+		server.Client().Transport.(*http.Transport).TLSClientConfig,
+		[]string{"127.0.0.1"},
+		[]string{server.Listener.Addr().String()[len("127.0.0.1:"):]},
+	)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot: cacheDir,
+		FetchPolicy:   policy,
+		OrgAllowlist:  []string{server.URL + "/"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "integrity check failed")
+}
+
+func TestLoadWithBase_URLBase_NotInAllowlist(t *testing.T) {
+	baseContent := []byte(`agent: agents/remote.md`)
+	hash := computeHash(baseContent)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(baseContent)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	baseURL := server.URL + "/base.yaml#sha256=" + hash
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/child.md
+base: `+baseURL+`
+allowed_remote_resources:
+  - https://other.example.com/
+`)
+
+	policy := fetch.NewTestPolicy(
+		server.Client().Transport.(*http.Transport).TLSClientConfig,
+		[]string{"127.0.0.1"},
+		[]string{server.Listener.Addr().String()[len("127.0.0.1:"):]},
+	)
+
+	// allowSelfAllowlist lets us use child's list, but base URL doesn't match it
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot:      cacheDir,
+		FetchPolicy:        policy,
+		allowSelfAllowlist: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not in allowed_remote_resources")
+}
+
+func TestLoadWithBase_URLBase_NoOrgAllowlist(t *testing.T) {
+	dir := t.TempDir()
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/child.md
+base: https://example.com/base.yaml#sha256=0000000000000000000000000000000000000000000000000000000000000000
+`)
+
+	// No OrgAllowlist and allowSelfAllowlist is false (default)
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "URL base requires org-level allowed_remote_resources")
+}
+
+func TestLoadWithBase_URLBase_MissingHash(t *testing.T) {
+	dir := t.TempDir()
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/child.md
+base: https://example.com/base.yaml
+allowed_remote_resources:
+  - https://example.com/
+`)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		OrgAllowlist: []string{"https://example.com/"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must include #sha256=")
+}
+
+func TestLoadWithBase_URLBase_OfflineMode_CacheMiss(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/child.md
+base: https://example.com/base.yaml#sha256=0000000000000000000000000000000000000000000000000000000000000000
+allowed_remote_resources:
+  - https://example.com/
+`)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot: cacheDir,
+		FetchPolicy: fetch.FetchPolicy{
+			Offline: true,
+		},
+		OrgAllowlist: []string{"https://example.com/"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "offline mode is enabled")
+}
+
+func TestLoadWithBase_URLBase_OfflineMode_CacheHit(t *testing.T) {
+	baseContent := []byte(`
+agent: agents/remote.md
+model: sonnet
+`)
+	hash := computeHash(baseContent)
+
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	// Pre-populate cache
+	require.NoError(t, fetch.CachePut(cacheDir, "https://example.com/base.yaml", baseContent))
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/child.md
+base: https://example.com/base.yaml#sha256=`+hash+`
+allowed_remote_resources:
+  - https://example.com/
+`)
+
+	h, deps, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		WorkspaceRoot: cacheDir,
+		FetchPolicy: fetch.FetchPolicy{
+			Offline: true,
+		},
+		OrgAllowlist: []string{"https://example.com/"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "agents/child.md", h.Agent)
+	assert.Equal(t, "sonnet", h.Model)
+
+	// Dependency shows cache hit
+	require.Len(t, deps, 1)
+	assert.True(t, deps[0].CacheHit)
+}
+
+func TestLoadWithBase_RoleSlugInheritance(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/base.md
+role: triage
+slug: fullsend-ai-triage
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+agent: agents/child.md
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	// Role and slug inherited from base
+	assert.Equal(t, "triage", h.Role)
+	assert.Equal(t, "fullsend-ai-triage", h.Slug)
+}
+
+func TestLoadWithBase_AllowedRemoteResourcesNotMerged(t *testing.T) {
+	// AllowedRemoteResources is NOT merged from base to prevent privilege escalation
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/base.md
+allowed_remote_resources:
+  - https://example.com/base/
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+allowed_remote_resources:
+  - https://example.com/child/
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	// Only child's AllowedRemoteResources, not merged with base
+	assert.Equal(t, []string{"https://example.com/child/"}, h.AllowedRemoteResources)
+}
+
+func TestMergeHostFiles(t *testing.T) {
+	base := []HostFile{
+		{Src: "base1", Dest: "/dest1"},
+		{Src: "base2", Dest: "/dest2"},
+	}
+	child := []HostFile{
+		{Src: "child2", Dest: "/dest2"}, // override
+		{Src: "child3", Dest: "/dest3"}, // new
+	}
+
+	result := mergeHostFiles(base, child)
+
+	require.Len(t, result, 3)
+	assert.Equal(t, "base1", result[0].Src)
+	assert.Equal(t, "/dest1", result[0].Dest)
+	assert.Equal(t, "child2", result[1].Src) // overridden
+	assert.Equal(t, "/dest2", result[1].Dest)
+	assert.Equal(t, "child3", result[2].Src)
+	assert.Equal(t, "/dest3", result[2].Dest)
+}
+
+func TestMergeForgeBlocks(t *testing.T) {
+	base := map[string]*ForgeConfig{
+		"github": {
+			PreScript: "base-pre.sh",
+			Skills:    []string{"base-skill"},
+			RunnerEnv: map[string]string{"KEY1": "base1"},
+		},
+		"gitlab": {
+			PreScript: "gitlab-pre.sh",
+		},
+	}
+	child := map[string]*ForgeConfig{
+		"github": {
+			PostScript: "child-post.sh",
+			Skills:     []string{"child-skill"},
+			RunnerEnv:  map[string]string{"KEY2": "child2"},
+		},
+	}
+
+	result := mergeForgeBlocks(base, child)
+
+	// GitHub merged
+	gh := result["github"]
+	require.NotNil(t, gh)
+	assert.Equal(t, "base-pre.sh", gh.PreScript)   // inherited
+	assert.Equal(t, "child-post.sh", gh.PostScript) // from child
+	assert.Equal(t, []string{"base-skill", "child-skill"}, gh.Skills)
+	assert.Equal(t, "base1", gh.RunnerEnv["KEY1"])  // inherited
+	assert.Equal(t, "child2", gh.RunnerEnv["KEY2"]) // from child
+
+	// GitLab inherited
+	gl := result["gitlab"]
+	require.NotNil(t, gl)
+	assert.Equal(t, "gitlab-pre.sh", gl.PreScript)
+}
+
+func TestMergeForgeBlocks_NilChild(t *testing.T) {
+	base := map[string]*ForgeConfig{
+		"github": {
+			PreScript: "base-pre.sh",
+		},
+	}
+
+	result := mergeForgeBlocks(base, nil)
+
+	require.NotNil(t, result)
+	assert.Equal(t, "base-pre.sh", result["github"].PreScript)
+}
+
+func TestMergeForgeBlocks_NilChildPlatform(t *testing.T) {
+	base := map[string]*ForgeConfig{
+		"github": {
+			PreScript: "base-pre.sh",
+		},
+	}
+	child := map[string]*ForgeConfig{
+		"github": nil, // explicitly nil — should NOT inherit from base
+	}
+
+	result := mergeForgeBlocks(base, child)
+
+	// Child explicitly nulled github, so it stays nil
+	assert.Nil(t, result["github"])
+}
+
+func TestMergeForgeConfigInto_NilBase(t *testing.T) {
+	child := &ForgeConfig{
+		PreScript: "child-pre.sh",
+	}
+
+	// Should not panic with nil base
+	mergeForgeConfigInto(nil, child)
+
+	assert.Equal(t, "child-pre.sh", child.PreScript)
+}
+
+func TestMergeForgeConfigInto_ValidationLoop(t *testing.T) {
+	base := &ForgeConfig{
+		ValidationLoop: &ValidationLoop{
+			Script:        "base-validate.sh",
+			MaxIterations: 5,
+		},
+	}
+	child := &ForgeConfig{
+		PreScript: "child-pre.sh",
+		// No ValidationLoop — should inherit from base
+	}
+
+	mergeForgeConfigInto(base, child)
+
+	require.NotNil(t, child.ValidationLoop)
+	assert.Equal(t, "base-validate.sh", child.ValidationLoop.Script)
+	assert.Equal(t, 5, child.ValidationLoop.MaxIterations)
+}
+
+func TestLoadWithBase_InvalidForgeAfterMerge(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/base.md
+forge:
+  invalid_platform:
+    pre_script: test.sh
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+model: opus
+`)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid harness")
+}
+
+func TestLoadWithBase_ValidationErrorAfterMerge(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/base.md
+`)
+
+	// Child clears the agent field (empty string doesn't override)
+	// but then the merged result is invalid because agent is required
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+agent: ""
+`)
+
+	// This should work because empty string doesn't override
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+	assert.Equal(t, "agents/base.md", h.Agent)
+}
+
+func TestLoadWithBase_BaseFileNotFound(t *testing.T) {
+	dir := t.TempDir()
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/child.md
+base: nonexistent.yaml
+`)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "loading base chain")
+}
+
+func TestLoadWithBase_URLBase_NonHTTPS(t *testing.T) {
+	dir := t.TempDir()
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+agent: agents/child.md
+base: http://example.com/base.yaml#sha256=0000000000000000000000000000000000000000000000000000000000000000
+allowed_remote_resources:
+  - http://example.com/
+`)
+
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{
+		OrgAllowlist: []string{"http://example.com/"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "https")
+}
+
+func TestLoadWithBase_SecurityInheritance(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/base.md
+security:
+  fail_mode: closed
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+model: opus
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	require.NotNil(t, h.Security)
+	assert.Equal(t, "closed", h.Security.FailMode)
+}
+
+func TestLoadWithBase_SecurityChildOverrides(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/base.md
+security:
+  fail_mode: closed
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+security:
+  fail_mode: open
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	require.NotNil(t, h.Security)
+	assert.Equal(t, "open", h.Security.FailMode)
+}
+
+func TestLoadWithBase_APIServersConcat(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/base.md
+api_servers:
+  - name: base-api
+    script: base-api.sh
+    port: 8080
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+api_servers:
+  - name: child-api
+    script: child-api.sh
+    port: 9090
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	require.Len(t, h.APIServers, 2)
+	assert.Equal(t, "base-api", h.APIServers[0].Name)
+	assert.Equal(t, "child-api", h.APIServers[1].Name)
+}
+
+func TestLoadWithBase_PluginsConcat(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/base.md
+plugins:
+  - plugin-a
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+plugins:
+  - plugin-b
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"plugin-a", "plugin-b"}, h.Plugins)
+}
+
+func TestLoadWithBase_ProvidersConcat(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/base.md
+providers:
+  - provider-a
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+providers:
+  - provider-b
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"provider-a", "provider-b"}, h.Providers)
+}
+
+func TestLoadWithBase_TimeoutInheritance(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/base.md
+timeout_minutes: 30
+sandbox_timeout_seconds: 600
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+model: opus
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 30, h.TimeoutMinutes)
+	assert.Equal(t, 600, h.SandboxTimeoutSeconds)
+}
+
+func TestLoadWithBase_RunnerEnvNilBase(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestHarness(t, dir, "base.yaml", `
+agent: agents/base.md
+`)
+
+	path := writeTestHarness(t, dir, "child.yaml", `
+base: base.yaml
+runner_env:
+  KEY1: value1
+`)
+
+	h, _, err := LoadWithBase(context.Background(), path, ComposeOpts{})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"KEY1": "value1"}, h.RunnerEnv)
+}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -200,6 +200,7 @@ type Harness struct {
 	Description    string            `yaml:"description,omitempty"`
 	Role           string            `yaml:"role,omitempty"`
 	Slug           string            `yaml:"slug,omitempty"`
+	Base           string            `yaml:"base,omitempty"`
 	Image          string            `yaml:"image,omitempty"`
 	Policy         string            `yaml:"policy,omitempty"`
 	Skills         []string          `yaml:"skills,omitempty"`
@@ -290,6 +291,12 @@ func LoadRaw(path string) (*Harness, error) {
 
 // Validate checks that required fields are present.
 func (h *Harness) Validate() error {
+	// Base field must be consumed by LoadWithBase before validation.
+	// If it's still set, the harness was loaded via Load/LoadWithOpts which
+	// don't process base composition — a silent misconfiguration.
+	if h.Base != "" {
+		return fmt.Errorf("base field is set but harness was not loaded with LoadWithBase; use LoadWithBase to enable base composition")
+	}
 	if h.Agent == "" {
 		return fmt.Errorf("agent field is required")
 	}
@@ -658,12 +665,18 @@ func (h *Harness) ValidateResourceTypes() error {
 	}
 
 	// Declarative fields: if a URL, must include integrity hash.
+	// Check URL fields require integrity hashes.
+	// Note: "base" is included as defense-in-depth. In normal flow, Validate()
+	// rejects non-empty base before reaching here, and LoadWithBase clears base
+	// before calling Validate. This check catches edge cases where
+	// ValidateResourceTypes is called standalone.
 	declFields := []struct {
 		name  string
 		value string
 	}{
 		{"agent", h.Agent},
 		{"policy", h.Policy},
+		{"base", h.Base},
 	}
 	for _, f := range declFields {
 		if f.value != "" && IsURL(f.value) {
@@ -736,6 +749,29 @@ func (h *Harness) MatchingAllowedPrefix(rawURL string) string {
 		return ""
 	}
 	for _, prefix := range h.AllowedRemoteResources {
+		normPrefix, prefixOK := normalizeURLPath(strings.ToLower(prefix))
+		if !prefixOK {
+			continue
+		}
+		if strings.HasPrefix(normalized, normPrefix) {
+			return prefix
+		}
+	}
+	return ""
+}
+
+// MatchingAllowedPrefixInList checks if a URL matches any prefix in the given allowlist.
+// Returns the matching prefix or "" if none match. Standalone version of MatchingAllowedPrefix.
+func MatchingAllowedPrefixInList(rawURL string, allowlist []string) string {
+	lower := strings.ToLower(rawURL)
+	if strings.Contains(lower, "%25") {
+		return ""
+	}
+	normalized, ok := normalizeURLPath(lower)
+	if !ok {
+		return ""
+	}
+	for _, prefix := range allowlist {
 		normPrefix, prefixOK := normalizeURLPath(strings.ToLower(prefix))
 		if !prefixOK {
 			continue


### PR DESCRIPTION
## Summary

- Add `base` field to harness YAML schema for harness-to-harness inheritance
- Implement `LoadWithBase()` for recursive base chain merging with cycle detection
- URL bases use ADR-0038's SSRF-hardened fetch infrastructure with mandatory integrity hashes
- Return base dependencies for lock file integration (wired in PR 5)

## Test plan

- [x] `make go-test` — all tests pass including 24 new compose tests
- [x] `make go-vet` — no issues
- [x] `make lint` — passes
- [ ] PR 5 will wire `LoadWithBase` into CLI for end-to-end verification

🤖 Generated with [Claude Code](https://claude.ai/code)