### PR TITLE
feat(mint): add mint-token CLI command and mintclient package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ Fullsend is a platform for fully autonomous agentic development for GitHub-hoste
 
 When changing `internal/mint/main.go`, always copy it to `internal/dispatch/gcf/mintsrc/main.go.embed`. If `go.mod` or `go.sum` changed, sync those to `go.mod.embed` and `go.sum.embed` too.
 
+**Mint client:** `internal/mintclient/` is the Go client for calling the mint service at runtime. It exchanges a GitHub Actions OIDC JWT for a role-scoped installation token. Unlike `internal/mint/` and `internal/mintcore/`, it has no embedded copies or sync requirements.
+
 The `internal/mintcore/` module is shared between the mint and devmint. Its files are also embedded for Cloud Function deployment at `internal/dispatch/gcf/mintsrc/mintcore/*.embed`. When changing any file in `internal/mintcore/`, sync it to the corresponding `.embed` file under `mintsrc/mintcore/`. Note: the mint's `go.mod.embed` uses `replace mintcore => ./mintcore` (not `../mintcore`), because `provisioner.go` rewrites the replace directive at bundle time to match the deployed directory layout.
 
 **Dispatch workflows:** The scaffold `dispatch.yml` (at `internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml`) and the repo's `reusable-dispatch.yml` (at `.github/workflows/reusable-dispatch.yml`) share identical routing logic for different installation modes (per-org vs per-repo). When changing the jq payload construction, stage routing, or input/secret threading in one, apply the same change to the other.

--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -14,11 +14,16 @@ fullsend
 │   │   └── repos    <org> [repo...]         # Enable agent on repos
 │   └── disable
 │       └── repos    <org> [repo...]         # Disable agent on repos
-├── mint                                     # GCP: token mint management
+├── mint                                     # Token mint management
 │   ├── deploy                               # Deploy/update mint Cloud Function
 │   ├── enroll       <org|owner/repo>        # Register org/repo in mint
 │   ├── unenroll     <org|owner/repo>        # Remove org/repo from mint
-│   └── status       [org]                   # Inspect mint state and PEM health
+│   ├── status       [org]                   # Inspect mint state and PEM health
+│   └── token                                # Mint a short-lived token via OIDC
+│       ├── --role <name>                    #   Agent role (triage, coder, review)
+│       ├── --repos <list>                   #   Comma-separated repo names
+│       ├── --mint-url <url>                 #   Mint service URL ($FULLSEND_MINT_URL)
+│       └── --audience <string>              #   OIDC audience (default: fullsend-mint)
 ├── inference                                # GCP: inference WIF management
 │   ├── provision    <org|owner/repo>        # Create WIF pool/provider for Agent Platform
 │   ├── deprovision  <org|owner/repo>        # Remove WIF access for org or repo

--- a/docs/guides/infrastructure/infrastructure-reference.md
+++ b/docs/guides/infrastructure/infrastructure-reference.md
@@ -4,7 +4,7 @@ This guide provides implementation details for fullsend's infrastructure compone
 
 ## Token Mint (OIDC) — GCF Cloud Function
 
-> Managed by: `fullsend mint deploy`, `fullsend mint enroll`, `fullsend mint unenroll`, `fullsend mint status`
+> Managed by: `fullsend mint deploy`, `fullsend mint enroll`, `fullsend mint unenroll`, `fullsend mint status`, `fullsend mint token`
 
 The mint is a GCP Cloud Function that exchanges GitHub OIDC tokens for scoped GitHub App installation tokens. This eliminates long-lived PATs from the system.
 

--- a/docs/guides/infrastructure/mint-administration.md
+++ b/docs/guides/infrastructure/mint-administration.md
@@ -234,6 +234,22 @@ The status command reports overall health as one of:
 | `degraded` | No enrolled orgs, OR template diverges from traffic-serving revision |
 | `not-installed` | Mint function not found in the specified project/region |
 
+## Minting tokens at runtime
+
+`fullsend mint token` exchanges a GitHub Actions OIDC JWT for a short-lived, role-scoped GitHub App installation token. This is a runtime operation intended for use inside GitHub Actions workflows (not infrastructure management).
+
+```bash
+# Mint a token for the triage role scoped to a specific repo
+fullsend mint token --role triage --repos my-repo --mint-url "$FULLSEND_MINT_URL"
+
+# Mint a token scoped to multiple repos
+fullsend mint token --role coder --repos repo-a,repo-b --mint-url "$FULLSEND_MINT_URL"
+```
+
+The command prints the token to stdout for shell capture. When running in GitHub Actions (`GITHUB_ACTIONS=true`), it also emits `::add-mask::` to stderr to prevent the token from appearing in logs.
+
+**Required environment:** The calling GitHub Actions job must declare `id-token: write` permission so that `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` are available.
+
 ## Multi-org setup
 
 A single token mint can serve multiple GitHub organizations. The first org deploys the mint infrastructure and creates **public unlisted** GitHub Apps; additional orgs reuse the existing mint and install the same apps.

--- a/internal/cli/mint.go
+++ b/internal/cli/mint.go
@@ -304,16 +304,18 @@ func loadAppSetPEMs(ctx context.Context, pemDir, appSet string) (map[string][]by
 func newMintCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mint",
-		Short: "Manage token mint infrastructure (requires GCP access)",
-		Long: `Manage the GCP Cloud Function that mints GitHub App installation tokens.
+		Short: "Manage token mint infrastructure and mint tokens",
+		Long: `Manage the GCP Cloud Function that mints GitHub App installation tokens,
+and mint short-lived tokens via OIDC.
 
-These commands require GCP project access but do NOT require a GitHub token.
-Use 'fullsend github setup' for GitHub-side setup.`,
+Infrastructure subcommands (deploy, enroll, unenroll, status) require GCP
+project access. The 'token' subcommand requires only GitHub Actions OIDC.`,
 	}
 	cmd.AddCommand(newMintDeployCmd())
 	cmd.AddCommand(newMintEnrollCmd())
 	cmd.AddCommand(newMintUnenrollCmd())
 	cmd.AddCommand(newMintStatusCmd())
+	cmd.AddCommand(newMintTokenCmd())
 	return cmd
 }
 

--- a/internal/cli/mint_test.go
+++ b/internal/cli/mint_test.go
@@ -47,6 +47,7 @@ func TestMintCommand_HasSubcommands(t *testing.T) {
 	assert.True(t, names["enroll <org|owner/repo>"], "expected enroll subcommand")
 	assert.True(t, names["unenroll <org|owner/repo>"], "expected unenroll subcommand")
 	assert.True(t, names["status [org]"], "expected status subcommand")
+	assert.True(t, names["token"], "expected token subcommand")
 }
 
 func TestMintCommand_RegisteredInRoot(t *testing.T) {

--- a/internal/cli/minttoken.go
+++ b/internal/cli/minttoken.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/fullsend-ai/fullsend/internal/mintclient"
+	"github.com/fullsend-ai/fullsend/internal/mintcore"
+)
+
+var mintTokenPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+func newMintTokenCmd() *cobra.Command {
+	var (
+		role     string
+		repos    string
+		mintURL  string
+		audience string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "token",
+		Short: "Mint a short-lived GitHub installation token via OIDC",
+		Long: `Exchange a GitHub Actions OIDC token for a role-scoped installation token
+via the fullsend token mint service. Requires id-token: write permission
+on the calling GitHub Actions job (no GCP access needed).
+
+Prints the token to stdout for capture in shell scripts.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if mintURL == "" {
+				mintURL = os.Getenv("FULLSEND_MINT_URL")
+			}
+			if mintURL == "" {
+				return fmt.Errorf("--mint-url or FULLSEND_MINT_URL required")
+			}
+
+			repoList := strings.Split(repos, ",")
+			var filtered []string
+			for _, r := range repoList {
+				if trimmed := strings.TrimSpace(r); trimmed != "" {
+					filtered = append(filtered, trimmed)
+				}
+			}
+			if len(filtered) == 0 {
+				return fmt.Errorf("--repos must contain at least one repo name")
+			}
+			for _, r := range filtered {
+				if !mintcore.RepoNamePattern.MatchString(r) {
+					return fmt.Errorf("invalid repo name %q: must match %s", r, mintcore.RepoNamePattern.String())
+				}
+			}
+
+			role = resolveRole(role)
+			if err := mintcore.ValidateRoleName(role); err != nil {
+				return fmt.Errorf("invalid role: %w", err)
+			}
+
+			result, err := mintclient.MintToken(cmd.Context(), mintclient.MintRequest{
+				MintURL:  mintURL,
+				Role:     role,
+				Repos:    filtered,
+				Audience: audience,
+			})
+			if err != nil {
+				return fmt.Errorf("minting token: %w", err)
+			}
+
+			if !mintTokenPattern.MatchString(result.Token) {
+				return fmt.Errorf("mint returned token with unexpected characters")
+			}
+
+			if os.Getenv("GITHUB_ACTIONS") == "true" {
+				fmt.Fprintf(os.Stderr, "::add-mask::%s\n", result.Token)
+			}
+
+			fmt.Fprint(cmd.OutOrStdout(), result.Token)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&role, "role", "", "agent role name (e.g. triage, coder, review)")
+	cmd.Flags().StringVar(&repos, "repos", "", "comma-separated repo names to scope the token to")
+	cmd.Flags().StringVar(&mintURL, "mint-url", "", "mint service URL (default: $FULLSEND_MINT_URL)")
+	cmd.Flags().StringVar(&audience, "audience", "fullsend-mint", "OIDC audience claim")
+	_ = cmd.MarkFlagRequired("role")
+	_ = cmd.MarkFlagRequired("repos")
+
+	return cmd
+}

--- a/internal/cli/minttoken_test.go
+++ b/internal/cli/minttoken_test.go
@@ -1,0 +1,252 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/fullsend-ai/fullsend/internal/mintclient"
+)
+
+func TestMintTokenCmd_RequiredFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			"missing role",
+			[]string{"--repos", "my-repo", "--mint-url", "http://mint"},
+			`required flag(s) "role" not set`,
+		},
+		{
+			"missing repos",
+			[]string{"--role", "triage", "--mint-url", "http://mint"},
+			`required flag(s) "repos" not set`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newMintTokenCmd()
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if got := err.Error(); got != tt.wantErr {
+				t.Errorf("error = %q, want %q", got, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMintTokenCmd_MintURLFallback(t *testing.T) {
+	t.Setenv("FULLSEND_MINT_URL", "")
+	cmd := newMintTokenCmd()
+	cmd.SetArgs([]string{"--role", "triage", "--repos", "my-repo"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	want := "--mint-url or FULLSEND_MINT_URL required"
+	if got := err.Error(); got != want {
+		t.Errorf("error = %q, want %q", got, want)
+	}
+}
+
+func TestMintTokenCmd_EmptyRepos(t *testing.T) {
+	cmd := newMintTokenCmd()
+	cmd.SetArgs([]string{"--role", "triage", "--repos", ",,,", "--mint-url", "http://mint"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	want := "--repos must contain at least one repo name"
+	if got := err.Error(); got != want {
+		t.Errorf("error = %q, want %q", got, want)
+	}
+}
+
+func TestMintTokenCmd_InvalidRepoName(t *testing.T) {
+	cmd := newMintTokenCmd()
+	cmd.SetArgs([]string{"--role", "triage", "--repos", "valid-repo,bad repo!", "--mint-url", "https://mint.example.com"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid repo name") {
+		t.Errorf("error = %q, want to contain 'invalid repo name'", err.Error())
+	}
+}
+
+func TestMintTokenCmd_InvalidRole(t *testing.T) {
+	cmd := newMintTokenCmd()
+	cmd.SetArgs([]string{"--role", "UPPER", "--repos", "r", "--mint-url", "https://mint.example.com"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid role") {
+		t.Errorf("error = %q, want to contain 'invalid role'", err.Error())
+	}
+}
+
+func TestMintTokenCmd_RoleAliasResolved(t *testing.T) {
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(struct {
+			Value string `json:"value"`
+		}{Value: "oidc-jwt"})
+	}))
+	defer oidcServer.Close()
+
+	var gotRole string
+	mintServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Role string `json:"role"`
+		}
+		json.NewDecoder(r.Body).Decode(&body)
+		gotRole = body.Role
+		json.NewEncoder(w).Encode(mintclient.MintResult{
+			Token:     "ghu_test",
+			ExpiresAt: "2026-06-11T23:30:00Z",
+		})
+	}))
+	defer mintServer.Close()
+
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", oidcServer.URL+"?d=1")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "tok")
+
+	var stdout bytes.Buffer
+	cmd := newMintTokenCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--role", "fix", "--repos", "r", "--mint-url", mintServer.URL})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotRole != "coder" {
+		t.Errorf("role sent to mint = %q, want %q (alias 'fix' should resolve to 'coder')", gotRole, "coder")
+	}
+}
+
+func TestMintTokenCmd_SuccessPath(t *testing.T) {
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(struct {
+			Value string `json:"value"`
+		}{Value: "oidc-jwt"})
+	}))
+	defer oidcServer.Close()
+
+	mintServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(mintclient.MintResult{
+			Token:     "ghu_cli_test_token",
+			ExpiresAt: "2026-06-11T23:30:00Z",
+		})
+	}))
+	defer mintServer.Close()
+
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", oidcServer.URL+"?d=1")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "tok")
+
+	var stdout bytes.Buffer
+	cmd := newMintTokenCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--role", "triage", "--repos", "my-repo,other-repo", "--mint-url", mintServer.URL})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := stdout.String(); got != "ghu_cli_test_token" {
+		t.Errorf("stdout = %q, want %q", got, "ghu_cli_test_token")
+	}
+}
+
+func TestMintTokenCmd_ReposTrimsWhitespace(t *testing.T) {
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(struct {
+			Value string `json:"value"`
+		}{Value: "jwt"})
+	}))
+	defer oidcServer.Close()
+
+	var gotRepos []string
+	mintServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Repos []string `json:"repos"`
+		}
+		json.NewDecoder(r.Body).Decode(&body)
+		gotRepos = body.Repos
+		json.NewEncoder(w).Encode(mintclient.MintResult{
+			Token:     "tok",
+			ExpiresAt: "2026-01-01T00:00:00Z",
+		})
+	}))
+	defer mintServer.Close()
+
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", oidcServer.URL+"?d=1")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "tok")
+
+	var stdout bytes.Buffer
+	cmd := newMintTokenCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--role", "triage", "--repos", " repo-a , repo-b ", "--mint-url", mintServer.URL})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gotRepos) != 2 || gotRepos[0] != "repo-a" || gotRepos[1] != "repo-b" {
+		t.Errorf("repos = %v, want [repo-a repo-b]", gotRepos)
+	}
+}
+
+func TestMintTokenCmd_RejectsInvalidTokenChars(t *testing.T) {
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(struct {
+			Value string `json:"value"`
+		}{Value: "jwt"})
+	}))
+	defer oidcServer.Close()
+
+	mintServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(mintclient.MintResult{
+			Token:     "bad\ntoken::set-env name=FOO::bar",
+			ExpiresAt: "2026-01-01T00:00:00Z",
+		})
+	}))
+	defer mintServer.Close()
+
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", oidcServer.URL+"?d=1")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "tok")
+
+	cmd := newMintTokenCmd()
+	cmd.SetArgs([]string{"--role", "triage", "--repos", "r", "--mint-url", mintServer.URL})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for token with invalid characters")
+	}
+	if !strings.Contains(err.Error(), "unexpected characters") {
+		t.Errorf("error = %q, want to contain 'unexpected characters'", err.Error())
+	}
+}
+
+func TestMintTokenCmd_MintTokenError(t *testing.T) {
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "")
+
+	cmd := newMintTokenCmd()
+	cmd.SetArgs([]string{"--role", "triage", "--repos", "r", "--mint-url", "https://mint.example.com"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "ACTIONS_ID_TOKEN_REQUEST_URL") {
+		t.Errorf("error = %q, want to contain ACTIONS_ID_TOKEN_REQUEST_URL", err.Error())
+	}
+}

--- a/internal/mintclient/mintclient.go
+++ b/internal/mintclient/mintclient.go
@@ -1,0 +1,257 @@
+package mintclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+var httpClient HTTPDoer = &http.Client{Timeout: 30 * time.Second}
+
+// HTTPDoer abstracts http.Client for testability.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+const defaultAudience = "fullsend-mint"
+
+// MintRequest holds the parameters for minting a token via the fullsend mint service.
+type MintRequest struct {
+	MintURL  string
+	Role     string
+	Repos    []string
+	Audience string
+}
+
+// MintResult holds the minted token and its expiry.
+type MintResult struct {
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+// envLookup is overridden in tests.
+var envLookup = os.Getenv
+
+// MintToken obtains a fresh GitHub App installation token by exchanging a
+// GitHub Actions OIDC JWT with the fullsend token mint service.
+//
+// It reads ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN
+// from the environment. These are set automatically by GitHub Actions when
+// the job declares id-token: write permission.
+func MintToken(ctx context.Context, req MintRequest) (*MintResult, error) {
+	if req.MintURL == "" {
+		return nil, fmt.Errorf("mint URL is required")
+	}
+	parsed, err := url.Parse(req.MintURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid mint URL: %w", err)
+	}
+	isLocalhost := parsed.Hostname() == "localhost" || parsed.Hostname() == "127.0.0.1"
+	if parsed.Scheme != "https" && !isLocalhost {
+		return nil, fmt.Errorf("mint URL must use HTTPS")
+	}
+	if req.Role == "" {
+		return nil, fmt.Errorf("role is required")
+	}
+	if len(req.Repos) == 0 {
+		return nil, fmt.Errorf("at least one repo is required")
+	}
+
+	audience := req.Audience
+	if audience == "" {
+		audience = defaultAudience
+	}
+
+	oidcJWT, err := fetchOIDCJWT(ctx, audience)
+	if err != nil {
+		return nil, fmt.Errorf("fetching OIDC JWT: %w", err)
+	}
+
+	result, err := callMint(ctx, req.MintURL, oidcJWT, req.Role, req.Repos)
+	if err != nil {
+		return nil, fmt.Errorf("calling mint service: %w", err)
+	}
+
+	return result, nil
+}
+
+type oidcTokenResponse struct {
+	Value string `json:"value"`
+}
+
+func fetchOIDCJWT(ctx context.Context, audience string) (string, error) {
+	requestURL := envLookup("ACTIONS_ID_TOKEN_REQUEST_URL")
+	if requestURL == "" {
+		return "", fmt.Errorf("ACTIONS_ID_TOKEN_REQUEST_URL not set (is this running in GitHub Actions with id-token: write?)")
+	}
+
+	requestToken := envLookup("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+	if requestToken == "" {
+		return "", fmt.Errorf("ACTIONS_ID_TOKEN_REQUEST_TOKEN not set")
+	}
+
+	parsedOIDC, err := url.Parse(requestURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing OIDC URL: %w", err)
+	}
+	q := parsedOIDC.Query()
+	q.Set("audience", audience)
+	parsedOIDC.RawQuery = q.Encode()
+	oidcURL := parsedOIDC.String()
+
+	var body []byte
+	var statusCode int
+	err = doWithRetry(ctx, 3, func() error {
+		httpReq, rerr := http.NewRequestWithContext(ctx, http.MethodGet, oidcURL, nil)
+		if rerr != nil {
+			return fmt.Errorf("creating request: %w", rerr)
+		}
+		httpReq.Header.Set("Authorization", "bearer "+requestToken)
+
+		resp, rerr := httpClient.Do(httpReq)
+		if rerr != nil {
+			return &retryableError{fmt.Errorf("requesting OIDC token: %w", rerr)}
+		}
+		defer resp.Body.Close()
+
+		body, rerr = io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+		if rerr != nil {
+			return fmt.Errorf("reading response: %w", rerr)
+		}
+		statusCode = resp.StatusCode
+
+		if statusCode >= 500 {
+			return &retryableError{fmt.Errorf("OIDC endpoint returned HTTP %d: %s", statusCode, truncateBody(body, 200))}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if statusCode != http.StatusOK {
+		excerpt := truncateBody(body, 200)
+		return "", fmt.Errorf("OIDC endpoint returned HTTP %d: %s", statusCode, excerpt)
+	}
+
+	var tokenResp oidcTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("parsing response: %w", err)
+	}
+
+	if tokenResp.Value == "" {
+		return "", fmt.Errorf("OIDC endpoint returned empty token")
+	}
+
+	return tokenResp.Value, nil
+}
+
+type mintRequestBody struct {
+	Role  string   `json:"role"`
+	Repos []string `json:"repos"`
+}
+
+func callMint(ctx context.Context, mintURL, oidcJWT, role string, repos []string) (*MintResult, error) {
+	reqBody := mintRequestBody{
+		Role:  role,
+		Repos: repos,
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+
+	mintEndpoint, err := url.JoinPath(mintURL, "/v1/token")
+	if err != nil {
+		return nil, fmt.Errorf("constructing mint URL: %w", err)
+	}
+
+	var body []byte
+	var statusCode int
+	err = doWithRetry(ctx, 5, func() error {
+		httpReq, rerr := http.NewRequestWithContext(ctx, http.MethodPost, mintEndpoint, bytes.NewReader(bodyBytes))
+		if rerr != nil {
+			return fmt.Errorf("creating request: %w", rerr)
+		}
+		httpReq.Header.Set("Authorization", "Bearer "+oidcJWT)
+		httpReq.Header.Set("Content-Type", "application/json")
+
+		resp, rerr := httpClient.Do(httpReq)
+		if rerr != nil {
+			return &retryableError{fmt.Errorf("requesting token: %w", rerr)}
+		}
+		defer resp.Body.Close()
+
+		body, rerr = io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+		if rerr != nil {
+			return fmt.Errorf("reading response: %w", rerr)
+		}
+		statusCode = resp.StatusCode
+
+		if statusCode >= 500 {
+			return &retryableError{fmt.Errorf("mint returned HTTP %d: %s", statusCode, truncateBody(body, 200))}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode != http.StatusOK {
+		excerpt := truncateBody(body, 200)
+		return nil, fmt.Errorf("mint returned HTTP %d: %s", statusCode, excerpt)
+	}
+
+	var result MintResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+
+	if result.Token == "" {
+		return nil, fmt.Errorf("mint returned empty token")
+	}
+
+	return &result, nil
+}
+
+type retryableError struct{ error }
+
+var retryBaseDelay = time.Second
+
+func doWithRetry(ctx context.Context, maxAttempts int, fn func() error) error {
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+		if _, ok := lastErr.(*retryableError); !ok {
+			return lastErr
+		}
+		if attempt < maxAttempts-1 {
+			delay := time.Duration(1<<uint(attempt)) * retryBaseDelay
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+	}
+	return lastErr
+}
+
+func truncateBody(b []byte, max int) string {
+	s := strings.TrimSpace(string(b))
+	if len([]rune(s)) <= max {
+		return s
+	}
+	return string([]rune(s)[:max]) + "..."
+}

--- a/internal/mintclient/mintclient_test.go
+++ b/internal/mintclient/mintclient_test.go
@@ -1,0 +1,551 @@
+package mintclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func init() {
+	retryBaseDelay = 0
+}
+
+func TestMintToken_HappyPath(t *testing.T) {
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "bearer test-request-token" {
+			t.Errorf("OIDC auth header = %q, want %q", got, "bearer test-request-token")
+		}
+		if got := r.URL.Query().Get("audience"); got != "fullsend-mint" {
+			t.Errorf("audience = %q, want %q", got, "fullsend-mint")
+		}
+		json.NewEncoder(w).Encode(oidcTokenResponse{Value: "oidc-jwt-value"})
+	}))
+	defer oidcServer.Close()
+
+	mintServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/token" {
+			t.Errorf("path = %q, want /v1/token", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer oidc-jwt-value" {
+			t.Errorf("mint auth header = %q, want %q", got, "Bearer oidc-jwt-value")
+		}
+
+		var body mintRequestBody
+		json.NewDecoder(r.Body).Decode(&body)
+		if body.Role != "triage" {
+			t.Errorf("role = %q, want %q", body.Role, "triage")
+		}
+		if len(body.Repos) != 1 || body.Repos[0] != "my-repo" {
+			t.Errorf("repos = %v, want [my-repo]", body.Repos)
+		}
+
+		json.NewEncoder(w).Encode(MintResult{
+			Token:     "ghu_test_token",
+			ExpiresAt: "2026-06-11T23:30:00Z",
+		})
+	}))
+	defer mintServer.Close()
+
+	origEnv := envLookup
+	envLookup = func(key string) string {
+		switch key {
+		case "ACTIONS_ID_TOKEN_REQUEST_URL":
+			return oidcServer.URL + "?dummy=1"
+		case "ACTIONS_ID_TOKEN_REQUEST_TOKEN":
+			return "test-request-token"
+		default:
+			return ""
+		}
+	}
+	defer func() { envLookup = origEnv }()
+
+	result, err := MintToken(context.Background(), MintRequest{
+		MintURL: mintServer.URL,
+		Role:    "triage",
+		Repos:   []string{"my-repo"},
+	})
+	if err != nil {
+		t.Fatalf("MintToken() error = %v", err)
+	}
+	if result.Token != "ghu_test_token" {
+		t.Errorf("token = %q, want %q", result.Token, "ghu_test_token")
+	}
+	if result.ExpiresAt != "2026-06-11T23:30:00Z" {
+		t.Errorf("expires_at = %q, want %q", result.ExpiresAt, "2026-06-11T23:30:00Z")
+	}
+}
+
+func TestMintToken_CustomAudience(t *testing.T) {
+	var gotAudience string
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAudience = r.URL.Query().Get("audience")
+		json.NewEncoder(w).Encode(oidcTokenResponse{Value: "jwt"})
+	}))
+	defer oidcServer.Close()
+
+	mintServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(MintResult{Token: "tok", ExpiresAt: "2026-01-01T00:00:00Z"})
+	}))
+	defer mintServer.Close()
+
+	origEnv := envLookup
+	envLookup = func(key string) string {
+		switch key {
+		case "ACTIONS_ID_TOKEN_REQUEST_URL":
+			return oidcServer.URL + "?dummy=1"
+		case "ACTIONS_ID_TOKEN_REQUEST_TOKEN":
+			return "tok"
+		default:
+			return ""
+		}
+	}
+	defer func() { envLookup = origEnv }()
+
+	_, err := MintToken(context.Background(), MintRequest{
+		MintURL:  mintServer.URL,
+		Role:     "triage",
+		Repos:    []string{"repo"},
+		Audience: "custom-aud",
+	})
+	if err != nil {
+		t.Fatalf("MintToken() error = %v", err)
+	}
+	if gotAudience != "custom-aud" {
+		t.Errorf("audience = %q, want %q", gotAudience, "custom-aud")
+	}
+}
+
+func TestMintToken_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		req  MintRequest
+		want string
+	}{
+		{"empty mint URL", MintRequest{Role: "triage", Repos: []string{"r"}}, "mint URL is required"},
+		{"non-HTTPS mint URL", MintRequest{MintURL: "http://example.com", Role: "triage", Repos: []string{"r"}}, "mint URL must use HTTPS"},
+		{"empty role", MintRequest{MintURL: "https://mint.example.com", Repos: []string{"r"}}, "role is required"},
+		{"no repos", MintRequest{MintURL: "https://mint.example.com", Role: "triage"}, "at least one repo is required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := MintToken(context.Background(), tt.req)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if got := err.Error(); got != tt.want {
+				t.Errorf("error = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMintToken_MissingOIDCEnvVars(t *testing.T) {
+	origEnv := envLookup
+	defer func() { envLookup = origEnv }()
+
+	t.Run("missing request URL", func(t *testing.T) {
+		envLookup = func(key string) string { return "" }
+		_, err := MintToken(context.Background(), MintRequest{
+			MintURL: "https://mint.example.com",
+			Role:    "triage",
+			Repos:   []string{"r"},
+		})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "ACTIONS_ID_TOKEN_REQUEST_URL not set") {
+			t.Errorf("error = %q, want to contain ACTIONS_ID_TOKEN_REQUEST_URL", err.Error())
+		}
+	})
+
+	t.Run("missing request token", func(t *testing.T) {
+		envLookup = func(key string) string {
+			if key == "ACTIONS_ID_TOKEN_REQUEST_URL" {
+				return "http://oidc"
+			}
+			return ""
+		}
+		_, err := MintToken(context.Background(), MintRequest{
+			MintURL: "https://mint.example.com",
+			Role:    "triage",
+			Repos:   []string{"r"},
+		})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "ACTIONS_ID_TOKEN_REQUEST_TOKEN not set") {
+			t.Errorf("error = %q, want to contain ACTIONS_ID_TOKEN_REQUEST_TOKEN", err.Error())
+		}
+	})
+}
+
+func TestMintToken_OIDCEndpointFailure(t *testing.T) {
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer oidcServer.Close()
+
+	origEnv := envLookup
+	envLookup = func(key string) string {
+		switch key {
+		case "ACTIONS_ID_TOKEN_REQUEST_URL":
+			return oidcServer.URL + "?d=1"
+		case "ACTIONS_ID_TOKEN_REQUEST_TOKEN":
+			return "tok"
+		default:
+			return ""
+		}
+	}
+	defer func() { envLookup = origEnv }()
+
+	_, err := MintToken(context.Background(), MintRequest{
+		MintURL: "https://mint.example.com",
+		Role:    "triage",
+		Repos:   []string{"r"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("error = %q, want to contain HTTP 500", err.Error())
+	}
+}
+
+func TestMintToken_OIDCEmptyToken(t *testing.T) {
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(oidcTokenResponse{Value: ""})
+	}))
+	defer oidcServer.Close()
+
+	origEnv := envLookup
+	envLookup = func(key string) string {
+		switch key {
+		case "ACTIONS_ID_TOKEN_REQUEST_URL":
+			return oidcServer.URL + "?d=1"
+		case "ACTIONS_ID_TOKEN_REQUEST_TOKEN":
+			return "tok"
+		default:
+			return ""
+		}
+	}
+	defer func() { envLookup = origEnv }()
+
+	_, err := MintToken(context.Background(), MintRequest{
+		MintURL: "https://mint.example.com",
+		Role:    "triage",
+		Repos:   []string{"r"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "empty token") {
+		t.Errorf("error = %q, want to contain 'empty token'", err.Error())
+	}
+}
+
+func TestMintToken_OIDCNetworkError(t *testing.T) {
+	origEnv := envLookup
+	envLookup = func(key string) string {
+		switch key {
+		case "ACTIONS_ID_TOKEN_REQUEST_URL":
+			return "http://127.0.0.1:1?d=1"
+		case "ACTIONS_ID_TOKEN_REQUEST_TOKEN":
+			return "tok"
+		default:
+			return ""
+		}
+	}
+	defer func() { envLookup = origEnv }()
+
+	_, err := MintToken(context.Background(), MintRequest{
+		MintURL: "https://mint.example.com",
+		Role:    "triage",
+		Repos:   []string{"r"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "requesting OIDC token") {
+		t.Errorf("error = %q, want to contain 'requesting OIDC token'", err.Error())
+	}
+}
+
+func TestMintToken_OIDCInvalidJSON(t *testing.T) {
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer oidcServer.Close()
+
+	origEnv := envLookup
+	envLookup = func(key string) string {
+		switch key {
+		case "ACTIONS_ID_TOKEN_REQUEST_URL":
+			return oidcServer.URL + "?d=1"
+		case "ACTIONS_ID_TOKEN_REQUEST_TOKEN":
+			return "tok"
+		default:
+			return ""
+		}
+	}
+	defer func() { envLookup = origEnv }()
+
+	_, err := MintToken(context.Background(), MintRequest{
+		MintURL: "https://mint.example.com",
+		Role:    "triage",
+		Repos:   []string{"r"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "parsing response") {
+		t.Errorf("error = %q, want to contain 'parsing response'", err.Error())
+	}
+}
+
+func TestMintToken_MintNetworkError(t *testing.T) {
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(oidcTokenResponse{Value: "jwt"})
+	}))
+	defer oidcServer.Close()
+
+	origEnv := envLookup
+	envLookup = func(key string) string {
+		switch key {
+		case "ACTIONS_ID_TOKEN_REQUEST_URL":
+			return oidcServer.URL + "?d=1"
+		case "ACTIONS_ID_TOKEN_REQUEST_TOKEN":
+			return "tok"
+		default:
+			return ""
+		}
+	}
+	defer func() { envLookup = origEnv }()
+
+	_, err := MintToken(context.Background(), MintRequest{
+		MintURL: "http://127.0.0.1:1",
+		Role:    "triage",
+		Repos:   []string{"r"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "requesting token") {
+		t.Errorf("error = %q, want to contain 'requesting token'", err.Error())
+	}
+}
+
+func TestMintToken_MintServiceFailure(t *testing.T) {
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(oidcTokenResponse{Value: "jwt"})
+	}))
+	defer oidcServer.Close()
+
+	tests := []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantSubstr string
+	}{
+		{
+			"401 unauthorized",
+			func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusUnauthorized) },
+			"HTTP 401",
+		},
+		{
+			"500 internal error",
+			func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusInternalServerError) },
+			"HTTP 500",
+		},
+		{
+			"empty token in response",
+			func(w http.ResponseWriter, r *http.Request) {
+				json.NewEncoder(w).Encode(MintResult{Token: ""})
+			},
+			"empty token",
+		},
+		{
+			"invalid JSON",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("not json"))
+			},
+			"parsing response",
+		},
+	}
+
+	origEnv := envLookup
+	envLookup = func(key string) string {
+		switch key {
+		case "ACTIONS_ID_TOKEN_REQUEST_URL":
+			return oidcServer.URL + "?d=1"
+		case "ACTIONS_ID_TOKEN_REQUEST_TOKEN":
+			return "tok"
+		default:
+			return ""
+		}
+	}
+	defer func() { envLookup = origEnv }()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mintServer := httptest.NewServer(tt.handler)
+			defer mintServer.Close()
+
+			_, err := MintToken(context.Background(), MintRequest{
+				MintURL: mintServer.URL,
+				Role:    "triage",
+				Repos:   []string{"r"},
+			})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestMintToken_RetriesOn500(t *testing.T) {
+	var attempts int
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(oidcTokenResponse{Value: "jwt"})
+	}))
+	defer oidcServer.Close()
+
+	mintServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		json.NewEncoder(w).Encode(MintResult{Token: "tok", ExpiresAt: "2026-01-01T00:00:00Z"})
+	}))
+	defer mintServer.Close()
+
+	origEnv := envLookup
+	envLookup = func(key string) string {
+		switch key {
+		case "ACTIONS_ID_TOKEN_REQUEST_URL":
+			return oidcServer.URL + "?d=1"
+		case "ACTIONS_ID_TOKEN_REQUEST_TOKEN":
+			return "tok"
+		default:
+			return ""
+		}
+	}
+	defer func() { envLookup = origEnv }()
+
+	result, err := MintToken(context.Background(), MintRequest{
+		MintURL: mintServer.URL,
+		Role:    "triage",
+		Repos:   []string{"r"},
+	})
+	if err != nil {
+		t.Fatalf("expected success after retries, got: %v", err)
+	}
+	if result.Token != "tok" {
+		t.Errorf("token = %q, want %q", result.Token, "tok")
+	}
+	if attempts != 3 {
+		t.Errorf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestMintToken_RetryRespectsContextCancel(t *testing.T) {
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(oidcTokenResponse{Value: "jwt"})
+	}))
+	defer oidcServer.Close()
+
+	mintServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer mintServer.Close()
+
+	origEnv := envLookup
+	envLookup = func(key string) string {
+		switch key {
+		case "ACTIONS_ID_TOKEN_REQUEST_URL":
+			return oidcServer.URL + "?d=1"
+		case "ACTIONS_ID_TOKEN_REQUEST_TOKEN":
+			return "tok"
+		default:
+			return ""
+		}
+	}
+	defer func() { envLookup = origEnv }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := MintToken(ctx, MintRequest{
+		MintURL: mintServer.URL,
+		Role:    "triage",
+		Repos:   []string{"r"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestMintToken_DoesNotRetryOn4xx(t *testing.T) {
+	var attempts int
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(oidcTokenResponse{Value: "jwt"})
+	}))
+	defer oidcServer.Close()
+
+	mintServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer mintServer.Close()
+
+	origEnv := envLookup
+	envLookup = func(key string) string {
+		switch key {
+		case "ACTIONS_ID_TOKEN_REQUEST_URL":
+			return oidcServer.URL + "?d=1"
+		case "ACTIONS_ID_TOKEN_REQUEST_TOKEN":
+			return "tok"
+		default:
+			return ""
+		}
+	}
+	defer func() { envLookup = origEnv }()
+
+	_, err := MintToken(context.Background(), MintRequest{
+		MintURL: mintServer.URL,
+		Role:    "triage",
+		Repos:   []string{"r"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if attempts != 1 {
+		t.Errorf("4xx should not retry: attempts = %d, want 1", attempts)
+	}
+}
+
+func TestMintToken_LocalhostHTTPAllowed(t *testing.T) {
+	origEnv := envLookup
+	envLookup = func(key string) string { return "" }
+	defer func() { envLookup = origEnv }()
+
+	_, err := MintToken(context.Background(), MintRequest{
+		MintURL: "http://localhost:8080",
+		Role:    "triage",
+		Repos:   []string{"r"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), "HTTPS") {
+		t.Errorf("localhost HTTP should be allowed, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/mintclient` package with a `MintToken()` function that exchanges a GitHub Actions OIDC JWT for a role-scoped installation token via the fullsend token mint service
- Adds `fullsend mint token` CLI subcommand (under the existing `mint` parent) wrapping the library for use in post-scripts
- Includes retry with exponential backoff (3 retries for OIDC, 5 for mint) matching the shell action's resilience
- Enables the status comment infrastructure to mint fresh tokens on demand rather than depending on the agent's pre-minted token, which may expire before PostCompletion runs

Part of #2130 (provides the building block; status comment integration is a follow-up PR)

## Test plan

- [x] `go build ./cmd/fullsend/` compiles
- [x] `go test ./internal/mintclient/` — unit tests covering happy path, custom audience, validation errors, missing env vars, OIDC failures, mint service errors, retry on 500, no retry on 4xx, context cancellation
- [x] `go test ./internal/cli/ -run TestMintToken` — CLI flag validation, success path, token format rejection
- [x] `go vet ./...` passes
- [x] `make lint` passes
- [ ] Manual: `fullsend mint token --help` shows expected flags/usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)