### PR TITLE
feat: review agent applies contextual labels via issue-labels skill (#1706)

### DIFF
--- a/docs/agents/review.md
+++ b/docs/agents/review.md
@@ -48,7 +48,24 @@ applied — the `pull_request_review` event triggers the [fix agent](fix.md) dir
 Stale outcome labels from prior review runs are removed before the new one is
 applied.
 
+The `issue-labels` skill may also apply contextual labels (e.g., `area/api`,
+`priority/high`) but these are informational -- they do not control agent
+behavior.
+
 ## Configuration and extension
+
+### Skill: `issue-labels`
+
+The review agent includes the `issue-labels` skill to discover your repo's
+labels and apply them to PRs during review. This is the same skill used by the
+[triage agent](triage.md) -- overloading it affects both agents.
+
+To overload the built-in skill, create your own `issue-labels` skill in
+`.agents/skills/issue-labels/SKILL.md` and symlink `.claude/skills` to
+`.agents/skills` so it's discoverable by both fullsend and local agent tooling.
+You can also overload it at the org level in your `.fullsend` config repo at
+`customized/skills/issue-labels/SKILL.md`. At runtime, your version replaces
+the upstream default -- no other configuration needed.
 
 See [Customizing with AGENTS.md](../guides/user/customizing-with-agents-md.md) and
 [Customizing with Skills](../guides/user/customizing-with-skills.md).

--- a/docs/agents/triage.md
+++ b/docs/agents/triage.md
@@ -100,17 +100,17 @@ Here's an example that encodes domain-specific labeling rules:
 ---
 name: issue-labels
 description: >-
-  Apply contextual labels to issues and pull requests using team labeling conventions.
+  Apply contextual labels to triaged issues using team labeling conventions.
 ---
 
 # Issue Labels
 
-Apply labels to the issue or pull request being processed. Use the conventions below — do not
+Apply labels to the issue being triaged. Use the conventions below — do not
 invent labels or apply labels not listed here.
 
 ## Control labels (never recommend these)
 
-These are managed by agent pipelines. Never include them in `label_actions`:
+These are managed by the triage pipeline. Never include them in `label_actions`:
 `needs-info`, `ready-to-code`, `duplicate`, `blocked`, `triaged`, `question`.
 
 ## Area labels

--- a/docs/agents/triage.md
+++ b/docs/agents/triage.md
@@ -100,17 +100,17 @@ Here's an example that encodes domain-specific labeling rules:
 ---
 name: issue-labels
 description: >-
-  Apply contextual labels to triaged issues using team labeling conventions.
+  Apply contextual labels to issues and pull requests using team labeling conventions.
 ---
 
 # Issue Labels
 
-Apply labels to the issue being triaged. Use the conventions below — do not
+Apply labels to the issue or pull request being processed. Use the conventions below — do not
 invent labels or apply labels not listed here.
 
 ## Control labels (never recommend these)
 
-These are managed by the triage pipeline. Never include them in `label_actions`:
+These are managed by agent pipelines. Never include them in `label_actions`:
 `needs-info`, `ready-to-code`, `duplicate`, `blocked`, `triaged`, `question`.
 
 ## Area labels

--- a/docs/guides/user/customizing-with-skills.md
+++ b/docs/guides/user/customizing-with-skills.md
@@ -108,7 +108,7 @@ These skills ship with fullsend and can be overloaded:
 |-------|-------|---------|
 | [Triage](../../agents/triage.md) | `issue-labels` | Label discovery and application during triage |
 | [Code](../../agents/code.md) | `code-implementation` | Step-by-step implementation procedure |
-| [Review](../../agents/review.md) | `code-review`, `pr-review`, `docs-review` | Review evaluation across dimensions |
+| [Review](../../agents/review.md) | `code-review`, `pr-review`, `docs-review`, `issue-labels` | Review evaluation across dimensions |
 | [Fix](../../agents/fix.md) | `fix-review` | Review feedback interpretation and fix strategy |
 | [Prioritize](../../agents/prioritize.md) | `customer-research` | Customer data gathering for RICE scoring (extension point) |
 | [Retro](../../agents/retro.md) | `retro-analysis`, `finding-agent-runs` | Workflow analysis and proposal generation |

--- a/docs/superpowers/plans/2026-06-11-review-agent-contextual-labels.md
+++ b/docs/superpowers/plans/2026-06-11-review-agent-contextual-labels.md
@@ -1,0 +1,829 @@
+# Review Agent Contextual Labels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable the review agent to apply contextual labels (e.g., `area/api`, `priority/high`) to PRs using the same `issue-labels` skill as the triage agent.
+
+**Architecture:** Generalize the existing `issue-labels` skill to be agent-agnostic, add it to the review agent's harness/definition, extend the review result schema with an optional `label_actions` field, and add label processing to the review post-script mirroring the triage post-script's implementation.
+
+**Tech Stack:** Bash (post-scripts), JSON Schema, Markdown (agent definitions, skills, docs)
+
+---
+
+### Task 1: Generalize the issue-labels skill
+
+**Files:**
+- Modify: `internal/scaffold/fullsend-repo/skills/issue-labels/SKILL.md`
+
+- [ ] **Step 1: Read the current skill file**
+
+Read `internal/scaffold/fullsend-repo/skills/issue-labels/SKILL.md` to confirm current contents match expectations.
+
+- [ ] **Step 2: Update the skill**
+
+Replace the file with the generalized version. Changes:
+- Description: "triaged issues" → "issues and pull requests"
+- Remove the entire "Control labels (do NOT recommend these)" section (lines 14-24). Post-scripts enforce this server-side.
+- Title area: "issue being triaged" → "issue or pull request"
+- Step 2: add a note to skip for PRs
+
+```markdown
+---
+name: issue-labels
+description: >-
+  Discover repository labels and recommend contextual labels to add or remove
+  on issues and pull requests. Produces label_actions in the agent result JSON.
+---
+
+# Issue Labels
+
+Recommend contextual labels for the issue or pull request being processed.
+These are labels that describe the domain, area, priority, or other
+team-specific dimensions -- NOT control labels used by agent pipelines.
+
+Control labels are managed by each agent's post-script and will be refused
+server-side if recommended. You do not need to track which labels are
+control labels -- just recommend what fits and the pipeline will filter.
+
+## Step 1: Discover available labels
+
+```
+gh label list --repo OWNER/REPO --json name,description --limit 100
+```
+
+If the repo has no labels beyond those used by agent pipelines, skip labeling
+entirely -- do not emit `label_actions`.
+
+## Step 2: Check for GitHub issue types
+
+GitHub issue types (Bug, Feature, Task, etc.) classify issues at a higher level
+than labels. **Skip this step when labeling a pull request** -- GitHub issue
+types do not apply to PRs.
+
+If the repo uses issue types, do **not** recommend labels that
+duplicate the issue type -- e.g., do not add `bug` or `type/bug` when the issue
+already has the Bug type.
+
+Query the current issue to check for an issue type:
+```
+gh issue view NUMBER --repo OWNER/REPO --json type
+```
+
+If the `.type` field is non-null, the repo uses issue types. In that case:
+- Do not recommend labels whose names match or overlap with the issue type
+  (e.g., `bug`, `type/bug`, `enhancement`, `feature`, `type/feature`).
+- Area, priority, component, and other non-type labels are still appropriate.
+
+## Step 3: Research labeling conventions
+
+Spawn a sub-agent to investigate how labels have been applied to recent issues.
+The sub-agent should:
+
+1. Query recent closed and open issues:
+   ```
+   gh issue list --repo OWNER/REPO --state all --json number,title,labels --limit 50
+   ```
+2. Analyze which labels appear together and in what contexts.
+3. Return a short summary (under 500 characters) describing the labeling
+   conventions observed -- which labels are commonly used and any patterns in
+   how they are applied.
+
+Do not dump raw issue data into the parent context. Only use the sub-agent's
+summary to inform your recommendations.
+
+## Step 4: Recommend labels
+
+Based on the content, the available labels, and the observed conventions:
+
+- Recommend labels to **add** if they clearly apply.
+- Recommend labels to **remove** if stale labels from a prior run no longer
+  apply.
+- If no labels clearly apply, do not emit `label_actions` at all. Silence is
+  better than noise.
+- Only recommend labels that exist in `gh label list`. Do not invent labels.
+
+## Output
+
+Include your recommendations in the `label_actions` field of the agent result
+JSON:
+
+```json
+"label_actions": {
+  "reason": "Single sentence explaining the label choices for the whole batch.",
+  "actions": [
+    { "action": "add", "label": "area/api" },
+    { "action": "remove", "label": "area/cli" }
+  ]
+}
+```
+
+Write one concise sentence for `reason` that justifies the batch. Do not
+include label justifications in the `comment` field -- the pipeline appends the
+reason automatically.
+```
+
+- [ ] **Step 3: Run the linter**
+
+Run: `make lint`
+Expected: PASS (no lint failures from the skill file change)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/scaffold/fullsend-repo/skills/issue-labels/SKILL.md
+git commit -S -s -m "feat(skill): generalize issue-labels for issues and PRs (#1706)
+
+Remove hardcoded control-label exclusion list (post-scripts enforce
+this server-side) and reword triage-specific language to be
+agent-agnostic. Add note to skip issue-type check for PRs.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add label_actions to the review result schema
+
+**Files:**
+- Modify: `internal/scaffold/fullsend-repo/schemas/review-result.schema.json`
+
+- [ ] **Step 1: Write a test to validate the schema accepts label_actions**
+
+Create a quick validation script. This tests that the schema accepts a review result with `label_actions` and also one without.
+
+Create file `internal/scaffold/fullsend-repo/schemas/review-result-label-actions-test.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Test that review-result.schema.json accepts label_actions correctly.
+# Requires: ajv-cli (npx ajv) or python3 with jsonschema.
+set -euo pipefail
+
+SCHEMA="$(dirname "$0")/review-result.schema.json"
+FAILURES=0
+
+fail() {
+  echo "FAIL: $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+# Use python3 jsonschema for validation (available in CI images).
+validate() {
+  local desc="$1"
+  local json="$2"
+  local expect_pass="$3"
+
+  if echo "${json}" | python3 -c "
+import sys, json
+try:
+    from jsonschema import validate, ValidationError, Draft202012Validator
+    schema = json.load(open('${SCHEMA}'))
+    instance = json.load(sys.stdin)
+    Draft202012Validator(schema).validate(instance)
+    sys.exit(0)
+except ValidationError as e:
+    print(str(e)[:200], file=sys.stderr)
+    sys.exit(1)
+" 2>/dev/null; then
+    if [ "${expect_pass}" = "true" ]; then
+      echo "PASS: ${desc}"
+    else
+      fail "${desc} (expected rejection but schema accepted it)"
+    fi
+  else
+    if [ "${expect_pass}" = "false" ]; then
+      echo "PASS: ${desc}"
+    else
+      fail "${desc} (expected acceptance but schema rejected it)"
+    fi
+  fi
+}
+
+# --- approve without label_actions (baseline) ---
+validate "approve-without-label-actions" '{
+  "action": "approve",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "LGTM"
+}' "true"
+
+# --- approve with valid label_actions ---
+validate "approve-with-label-actions" '{
+  "action": "approve",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "LGTM",
+  "label_actions": {
+    "reason": "PR modifies API surface",
+    "actions": [
+      { "action": "add", "label": "area/api" }
+    ]
+  }
+}' "true"
+
+# --- request-changes with label_actions ---
+validate "request-changes-with-label-actions" '{
+  "action": "request-changes",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "Found issues",
+  "findings": [{"severity":"high","category":"bug","file":"main.go","description":"nil deref"}],
+  "label_actions": {
+    "reason": "Touches CI config",
+    "actions": [
+      { "action": "add", "label": "area/ci" },
+      { "action": "remove", "label": "area/api" }
+    ]
+  }
+}' "true"
+
+# --- failure action with label_actions (should still be valid — optional field) ---
+validate "failure-with-label-actions" '{
+  "action": "failure",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "reason": "tool-failure",
+  "label_actions": {
+    "reason": "Would have labeled area/api",
+    "actions": [{ "action": "add", "label": "area/api" }]
+  }
+}' "true"
+
+# --- invalid: label_actions missing reason ---
+validate "label-actions-missing-reason" '{
+  "action": "approve",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "LGTM",
+  "label_actions": {
+    "actions": [{ "action": "add", "label": "area/api" }]
+  }
+}' "false"
+
+# --- invalid: label_actions with empty actions array ---
+validate "label-actions-empty-actions" '{
+  "action": "approve",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "LGTM",
+  "label_actions": {
+    "reason": "No labels",
+    "actions": []
+  }
+}' "false"
+
+# --- invalid: label action with unknown action verb ---
+validate "label-actions-invalid-verb" '{
+  "action": "approve",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "LGTM",
+  "label_actions": {
+    "reason": "Test",
+    "actions": [{ "action": "replace", "label": "area/api" }]
+  }
+}' "false"
+
+# --- invalid: extra property in label_actions ---
+validate "label-actions-extra-property" '{
+  "action": "approve",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "LGTM",
+  "label_actions": {
+    "reason": "Test",
+    "actions": [{ "action": "add", "label": "area/api" }],
+    "extra": "should fail"
+  }
+}' "false"
+
+echo ""
+if [ "${FAILURES}" -gt 0 ]; then
+  echo "${FAILURES} test(s) failed"
+  exit 1
+fi
+echo "All tests passed"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bash internal/scaffold/fullsend-repo/schemas/review-result-label-actions-test.sh`
+Expected: FAIL — the schema doesn't have `label_actions` yet, so the "approve-with-label-actions" test should fail (schema rejects the unknown property due to `additionalProperties: false`).
+
+- [ ] **Step 3: Add label_actions to the schema**
+
+Edit `internal/scaffold/fullsend-repo/schemas/review-result.schema.json`. Add the `label_actions` property to the `properties` object (after `reason`) and add the `$defs/label_actions` definition.
+
+Add to `properties` (after line 26, the `reason` property):
+
+```json
+    "label_actions": {
+      "$ref": "#/$defs/label_actions"
+    }
+```
+
+Add to `$defs` (after the `finding` definition, before the closing `}`):
+
+```json
+    "label_actions": {
+      "type": "object",
+      "required": ["reason", "actions"],
+      "properties": {
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Single sentence explaining why these labels are being applied or removed"
+        },
+        "actions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {
+            "type": "object",
+            "required": ["action", "label"],
+            "properties": {
+              "action": { "type": "string", "enum": ["add", "remove"] },
+              "label": { "type": "string", "minLength": 1, "pattern": "^[a-zA-Z0-9._/: +-]+$" }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bash internal/scaffold/fullsend-repo/schemas/review-result-label-actions-test.sh`
+Expected: All tests passed
+
+- [ ] **Step 5: Run make lint**
+
+Run: `make lint`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/scaffold/fullsend-repo/schemas/review-result.schema.json \
+       internal/scaffold/fullsend-repo/schemas/review-result-label-actions-test.sh
+git commit -S -s -m "feat(schema): add optional label_actions to review result (#1706)
+
+Same shape as triage-result.schema.json. The field is optional --
+when omitted the post-script skips label processing.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Add label_actions processing to the review post-script
+
+**Files:**
+- Modify: `internal/scaffold/fullsend-repo/scripts/post-review.sh`
+- Modify: `internal/scaffold/fullsend-repo/scripts/post-review-test.sh`
+
+The post-script flow requires label_actions to be processed in two phases:
+
+1. **Before** `fullsend post-review` (line 139): validate label_actions and append the reason to the result JSON body (same pattern as the protected-path downgrade at lines 122-128).
+2. **After** `fullsend post-review` (after line 218, alongside outcome labels): apply the validated label mutations via the GitHub labels API.
+
+- [ ] **Step 1: Write failing tests for label_actions processing**
+
+Edit `internal/scaffold/fullsend-repo/scripts/post-review-test.sh`. Add an `is_control_label` function and tests for it after the existing outcome-label tests.
+
+Append before the `# --- Summary ---` section (before line 102):
+
+```bash
+# ---------------------------------------------------------------------------
+# Control-label guard tests
+# ---------------------------------------------------------------------------
+
+REVIEW_CONTROL_LABELS=(
+  "ready-for-merge" "requires-manual-review" "rejected"
+  "ready-for-review" "fullsend-no-fix" "fullsend-fix"
+)
+
+is_control_label() {
+  local label="$1"
+  for cl in "${REVIEW_CONTROL_LABELS[@]}"; do
+    if [[ "${cl}" == "${label}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_control_label_test() {
+  local test_name="$1"
+  local label="$2"
+  local expected_control="$3"  # "true" or "false"
+
+  if is_control_label "${label}"; then
+    local actual="true"
+  else
+    local actual="false"
+  fi
+
+  if [ "${actual}" != "${expected_control}" ]; then
+    echo "FAIL: ${test_name}"
+    echo "  label:    '${label}'"
+    echo "  expected: '${expected_control}'"
+    echo "  actual:   '${actual}'"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  echo "PASS: ${test_name}"
+}
+
+# Control labels should be recognized
+run_control_label_test "ready-for-merge-is-control" \
+  "ready-for-merge" "true"
+
+run_control_label_test "requires-manual-review-is-control" \
+  "requires-manual-review" "true"
+
+run_control_label_test "rejected-is-control" \
+  "rejected" "true"
+
+run_control_label_test "ready-for-review-is-control" \
+  "ready-for-review" "true"
+
+run_control_label_test "fullsend-no-fix-is-control" \
+  "fullsend-no-fix" "true"
+
+run_control_label_test "fullsend-fix-is-control" \
+  "fullsend-fix" "true"
+
+# Non-control labels should NOT be recognized
+run_control_label_test "area-api-not-control" \
+  "area/api" "false"
+
+run_control_label_test "priority-high-not-control" \
+  "priority/high" "false"
+
+run_control_label_test "bug-not-control" \
+  "bug" "false"
+
+run_control_label_test "empty-not-control" \
+  "" "false"
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `bash internal/scaffold/fullsend-repo/scripts/post-review-test.sh`
+Expected: All tests passed (these are unit tests for the extracted logic — they should pass immediately since we're defining the function inline in the test file).
+
+- [ ] **Step 3: Add label_actions processing to post-review.sh**
+
+Edit `internal/scaffold/fullsend-repo/scripts/post-review.sh`. Add two blocks:
+
+**Block A: Before `fullsend post-review` (insert after line 131, before line 133).**
+
+This block validates label_actions and appends the reason to the body, rewriting the result JSON file (same pattern as the protected-path downgrade).
+
+```bash
+# ---------------------------------------------------------------------------
+# Label actions: validate agent-recommended labels and append reason to body.
+# Actual label mutations happen after the review is posted (see below).
+# ---------------------------------------------------------------------------
+REVIEW_CONTROL_LABELS=(
+  "ready-for-merge" "requires-manual-review" "rejected"
+  "ready-for-review" "fullsend-no-fix" "fullsend-fix"
+)
+
+is_control_label() {
+  local label="$1"
+  for cl in "${REVIEW_CONTROL_LABELS[@]}"; do
+    if [[ "${cl}" == "${label}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+VALIDATED_LABEL_ADDS=()
+VALIDATED_LABEL_REMOVES=()
+LABEL_REASON=""
+
+HAS_LABEL_ACTIONS=$(jq 'has("label_actions")' "${RESULT_FILE}")
+if [[ "${HAS_LABEL_ACTIONS}" == "true" ]]; then
+  LABEL_REASON=$(jq -r '.label_actions.reason' "${RESULT_FILE}")
+  LABEL_COUNT=$(jq '.label_actions.actions | length' "${RESULT_FILE}")
+
+  echo "Validating ${LABEL_COUNT} label action(s)..."
+
+  # Fetch existing repo labels once.
+  EXISTING_LABELS=$(gh api "repos/${REPO_FULL_NAME}/labels" --paginate --jq '.[].name' 2>/dev/null || true)
+
+  label_exists() {
+    local label="$1"
+    echo "${EXISTING_LABELS}" | grep -qFx "${label}"
+  }
+
+  for i in $(seq 0 $((LABEL_COUNT - 1))); do
+    LA_ACTION=$(jq -r ".label_actions.actions[${i}].action" "${RESULT_FILE}")
+    LA_LABEL=$(jq -r ".label_actions.actions[${i}].label" "${RESULT_FILE}")
+
+    if [[ ! "${LA_LABEL}" =~ ^[a-zA-Z0-9._/:\ +\-]+$ ]]; then
+      echo "::warning::Refused label '${LA_LABEL}' -- contains invalid characters"
+      continue
+    fi
+
+    if is_control_label "${LA_LABEL}"; then
+      echo "::warning::Refused to ${LA_ACTION} control label '${LA_LABEL}' -- control labels are managed by the review pipeline"
+      continue
+    fi
+
+    case "${LA_ACTION}" in
+      add)
+        if ! label_exists "${LA_LABEL}"; then
+          echo "::warning::Skipping label '${LA_LABEL}' -- does not exist in repo (will not auto-create)"
+          continue
+        fi
+        VALIDATED_LABEL_ADDS+=("${LA_LABEL}")
+        ;;
+      remove)
+        VALIDATED_LABEL_REMOVES+=("${LA_LABEL}")
+        ;;
+      *)
+        echo "::warning::Unknown label action '${LA_ACTION}' for label '${LA_LABEL}'"
+        ;;
+    esac
+  done
+
+  # Append label reason to body if any labels validated.
+  VALIDATED_COUNT=$(( ${#VALIDATED_LABEL_ADDS[@]} + ${#VALIDATED_LABEL_REMOVES[@]} ))
+  if [[ "${VALIDATED_COUNT}" -gt 0 ]]; then
+    LABEL_NOTICE=$'\n\n---\n'"**Labels:** ${LABEL_REASON}"
+    LABEL_MODIFIED_RESULT=$(mktemp)
+    jq --arg notice "${LABEL_NOTICE}" \
+      '.body = (.body + $notice)' \
+      "${RESULT_FILE}" > "${LABEL_MODIFIED_RESULT}"
+    RESULT_FILE="${LABEL_MODIFIED_RESULT}"
+  fi
+fi
+```
+
+**Block B: After outcome labels (insert after line 218, before the final echo).**
+
+This block applies the validated labels using the GitHub labels API.
+
+```bash
+# ---------------------------------------------------------------------------
+# Contextual labels: apply validated label mutations from label_actions.
+# ---------------------------------------------------------------------------
+for label in "${VALIDATED_LABEL_ADDS[@]}"; do
+  echo "Adding contextual label '${label}'..."
+  gh api "repos/${REPO_FULL_NAME}/issues/${PR_NUMBER}/labels" \
+    -f "labels[]=${label}" --silent || \
+    echo "::warning::Failed to add label '${label}'"
+done
+
+for label in "${VALIDATED_LABEL_REMOVES[@]}"; do
+  echo "Removing contextual label '${label}'..."
+  encoded=$(printf '%s' "${label}" | jq -sRr @uri)
+  gh api "repos/${REPO_FULL_NAME}/issues/${PR_NUMBER}/labels/${encoded}" \
+    -X DELETE --silent 2>/dev/null || true
+done
+```
+
+- [ ] **Step 4: Run the test file**
+
+Run: `bash internal/scaffold/fullsend-repo/scripts/post-review-test.sh`
+Expected: All tests passed
+
+- [ ] **Step 5: Run make lint**
+
+Run: `make lint`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/scaffold/fullsend-repo/scripts/post-review.sh \
+       internal/scaffold/fullsend-repo/scripts/post-review-test.sh
+git commit -S -s -m "feat(post-review): process label_actions from review result (#1706)
+
+Validate agent-recommended labels against a control-label guard list,
+check label existence, append reason to review body, and apply
+mutations via the GitHub labels API after posting.
+
+Mirrors the label_actions processing in post-triage.sh.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Wire issue-labels skill into review agent harness and definition
+
+**Files:**
+- Modify: `internal/scaffold/fullsend-repo/harness/review.yaml`
+- Modify: `internal/scaffold/fullsend-repo/agents/review.md`
+
+- [ ] **Step 1: Add skill to harness**
+
+Edit `internal/scaffold/fullsend-repo/harness/review.yaml`. Add `- skills/issue-labels` to the `skills:` list (after line 14):
+
+```yaml
+skills:
+  - skills/pr-review
+  - skills/code-review
+  - skills/docs-review
+  - skills/issue-labels
+```
+
+- [ ] **Step 2: Add skill to agent definition frontmatter**
+
+Edit `internal/scaffold/fullsend-repo/agents/review.md`. Add `issue-labels` to the `skills:` list in the YAML frontmatter (after line 15):
+
+```yaml
+skills:
+  - code-review
+  - pr-review
+  - docs-review
+  - issue-labels
+```
+
+- [ ] **Step 3: Add labeling section to agent definition**
+
+Edit `internal/scaffold/fullsend-repo/agents/review.md`. Insert a new section after "Skill routing" (after line 109) and before "Zero-trust principle":
+
+```markdown
+## Contextual labels
+
+After producing the review verdict, invoke the `issue-labels` skill to
+recommend contextual labels for the PR based on the diff's area and domain.
+
+- Emit `label_actions` in the result JSON alongside the review verdict.
+- Labels target the PR itself -- issue labeling remains the triage agent's
+  domain.
+- If no labels clearly apply, omit `label_actions` entirely. Silence is
+  better than noise.
+```
+
+- [ ] **Step 4: Update the pipeline mode output docs in the agent definition**
+
+Edit `internal/scaffold/fullsend-repo/agents/review.md`. Add `label_actions` to the top-level object table (after line 230, the `reason` row):
+
+```markdown
+| `label_actions` | object | no | Contextual label recommendations (see `issue-labels` skill) |
+```
+
+Also add a jq example showing label_actions usage. After the `failure` jq example block (after line 311), add:
+
+```markdown
+For any action with contextual labels, add `label_actions`:
+
+```bash
+jq -n \
+  --arg action "approve" \
+  --argjson pr_number <number> \
+  --arg repo "<owner/repo>" \
+  --arg head_sha "<sha>" \
+  --arg body "<markdown review comment>" \
+  --argjson label_actions '{"reason":"PR modifies API surface","actions":[{"action":"add","label":"area/api"}]}' \
+  '{action: $action, pr_number: $pr_number, repo: $repo,
+    head_sha: $head_sha, body: $body, label_actions: $label_actions}' \
+  > "$FULLSEND_OUTPUT_DIR/agent-result.json"
+```
+```
+
+- [ ] **Step 5: Run make lint**
+
+Run: `make lint`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/scaffold/fullsend-repo/harness/review.yaml \
+       internal/scaffold/fullsend-repo/agents/review.md
+git commit -S -s -m "feat(review): wire issue-labels skill into review agent (#1706)
+
+Add issue-labels to the harness skills list and agent definition.
+Document when and how to invoke the skill during review, and add
+label_actions to the pipeline mode output docs.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Update user-facing documentation
+
+**Files:**
+- Modify: `docs/agents/review.md`
+- Modify: `docs/guides/user/customizing-with-skills.md`
+
+- [ ] **Step 1: Update review agent docs with contextual labels note**
+
+Edit `docs/agents/review.md`. After the "Control labels" table (after line 49, before "## Configuration and extension"), add:
+
+```markdown
+The `issue-labels` skill may also apply contextual labels (e.g., `area/api`,
+`priority/high`) but these are informational -- they do not control agent
+behavior.
+```
+
+- [ ] **Step 2: Add issue-labels skill section to review agent docs**
+
+Edit `docs/agents/review.md`. Replace the "Configuration and extension" section (lines 51-54) to add the skill subsection:
+
+```markdown
+## Configuration and extension
+
+### Skill: `issue-labels`
+
+The review agent includes the `issue-labels` skill to discover your repo's
+labels and apply them to PRs during review. This is the same skill used by the
+[triage agent](triage.md) -- overloading it affects both agents.
+
+To overload the built-in skill, create your own `issue-labels` skill in
+`.agents/skills/issue-labels/SKILL.md` and symlink `.claude/skills` to
+`.agents/skills` so it's discoverable by both fullsend and local agent tooling.
+You can also overload it at the org level in your `.fullsend` config repo at
+`customized/skills/issue-labels/SKILL.md`. At runtime, your version replaces
+the upstream default -- no other configuration needed.
+
+See [Customizing with AGENTS.md](../guides/user/customizing-with-agents-md.md) and
+[Customizing with Skills](../guides/user/customizing-with-skills.md).
+```
+
+- [ ] **Step 3: Update the skills table**
+
+Edit `docs/guides/user/customizing-with-skills.md`. Update line 111 (the Review row in the built-in skills table) to include `issue-labels`:
+
+```markdown
+| [Review](../../agents/review.md) | `code-review`, `pr-review`, `docs-review`, `issue-labels` | Review evaluation across dimensions |
+```
+
+- [ ] **Step 4: Update the triage docs example**
+
+Edit `docs/agents/triage.md`. The example overloaded skill at line 72 still says "Apply contextual labels to triaged issues using team labeling conventions." Update the description to match the generalized skill:
+
+```markdown
+description: >-
+  Apply contextual labels to issues and pull requests using team labeling conventions.
+```
+
+Also update line 77 from "Apply labels to the issue being triaged" to "Apply labels to the issue or pull request being processed."
+
+And update line 82 from "These are managed by the triage pipeline. Never include them in `label_actions`:" to "These are managed by agent pipelines. Never include them in `label_actions`:"
+
+Note: the example's control-label list can stay as-is since it's showing a user-authored skill — users can include whatever control labels they want to guard against.
+
+- [ ] **Step 5: Run make lint**
+
+Run: `make lint`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/agents/review.md \
+       docs/guides/user/customizing-with-skills.md \
+       docs/agents/triage.md
+git commit -S -s -m "docs: document review agent contextual labels (#1706)
+
+Add issue-labels skill section to review agent docs, update the
+built-in skills table, and align triage docs example with the
+generalized skill language.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Final validation
+
+- [ ] **Step 1: Run all tests**
+
+Run: `make lint && bash internal/scaffold/fullsend-repo/scripts/post-review-test.sh && bash internal/scaffold/fullsend-repo/schemas/review-result-label-actions-test.sh`
+Expected: All pass
+
+- [ ] **Step 2: Review the full diff**
+
+Run: `git log --oneline main..HEAD` and `git diff main..HEAD --stat`
+
+Verify 5 commits covering:
+1. Skill generalization
+2. Schema + schema tests
+3. Post-script + post-script tests
+4. Harness + agent definition
+5. Documentation (review docs, skills table, triage docs alignment)
+
+- [ ] **Step 3: Verify no untracked files**
+
+Run: `git status`
+Expected: clean working tree

--- a/docs/superpowers/specs/2026-06-11-review-agent-contextual-labels-design.md
+++ b/docs/superpowers/specs/2026-06-11-review-agent-contextual-labels-design.md
@@ -1,0 +1,186 @@
+# Review Agent: Contextual Labels via issue-labels Skill
+
+**Issue:** #1706
+**Date:** 2026-06-11
+
+## Problem
+
+The triage agent uses the `issue-labels` skill to discover repo label
+conventions and apply contextual labels (e.g., `area/api`, `priority/high`) to
+issues. The review agent has no equivalent — PRs it reviews receive no
+contextual labels, even when the diff clearly maps to a known area or priority.
+
+## Approach
+
+Generalize the existing `issue-labels` skill to work for both issues and PRs,
+then wire it into the review agent's harness, schema, agent definition, and
+post-script. No new skill is created; the same skill serves both agents.
+
+## Changes
+
+### 1. `internal/scaffold/fullsend-repo/skills/issue-labels/SKILL.md`
+
+Generalize to be agent-agnostic:
+
+- Change description from "triaged issues" to "issues and pull requests."
+- Remove the "Control labels (do NOT recommend these)" section entirely. The
+  post-scripts for both agents already validate and refuse control labels
+  server-side — duplicating the list in the skill is a maintenance burden and
+  already out of sync (`question` is missing from the skill but present in the
+  triage post-script).
+- Reword triage-specific language: "issue being triaged" becomes "issue or pull
+  request."
+- In Step 2 (issue types check), add: "Skip this step when labeling a pull
+  request — GitHub issue types do not apply to PRs."
+- Step 3 (research conventions) stays unchanged — querying recent issues is
+  sufficient since label taxonomies are repo-wide.
+
+### 2. `internal/scaffold/fullsend-repo/harness/review.yaml`
+
+Add `issue-labels` to the `skills:` list:
+
+```yaml
+skills:
+  - skills/pr-review
+  - skills/code-review
+  - skills/docs-review
+  - skills/issue-labels
+```
+
+### 3. `internal/scaffold/fullsend-repo/agents/review.md`
+
+Add `issue-labels` to the frontmatter `skills:` list. Add a short section after
+"Skill routing" explaining when to invoke it:
+
+- Invoke the `issue-labels` skill after producing the review verdict.
+- Based on the diff's area/domain, recommend labels to add or remove.
+- Emit `label_actions` in the result JSON alongside the review verdict.
+- Labels target the PR itself — issue labeling remains the triage agent's
+  domain.
+- If no labels clearly apply, omit `label_actions` entirely.
+
+### 4. `internal/scaffold/fullsend-repo/schemas/review-result.schema.json`
+
+Add an optional `label_actions` property. Reuse the same `$defs/label_actions`
+shape from `triage-result.schema.json`:
+
+```json
+"label_actions": {
+  "type": "object",
+  "required": ["reason", "actions"],
+  "properties": {
+    "reason": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Single sentence explaining why these labels are being applied or removed"
+    },
+    "actions": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 20,
+      "items": {
+        "type": "object",
+        "required": ["action", "label"],
+        "properties": {
+          "action": { "type": "string", "enum": ["add", "remove"] },
+          "label": { "type": "string", "minLength": 1, "pattern": "^[a-zA-Z0-9._/: +-]+$" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+The field is optional — not listed in any `required` array or conditional
+`then` clause. When omitted, the post-script skips label processing.
+
+### 5. `internal/scaffold/fullsend-repo/scripts/post-review.sh`
+
+Add a `label_actions` processing block after the outcome-labels section
+(after line 218). This mirrors the triage post-script's implementation:
+
+**Control-label guard:**
+
+```bash
+CONTROL_LABELS=(
+  "ready-for-merge" "requires-manual-review" "rejected"
+  "ready-for-review" "fullsend-no-fix" "fullsend-fix"
+)
+```
+
+With an `is_control_label()` function matching the triage pattern.
+
+**Label existence check:**
+
+```bash
+label_exists() {
+  local label="$1"
+  local encoded
+  encoded=$(printf '%s' "${label}" | jq -sRr @uri)
+  gh api "repos/${REPO_FULL_NAME}/labels/${encoded}" \
+    --silent 2>/dev/null
+}
+```
+
+**Processing loop:**
+
+1. Extract `label_actions` from the result JSON. If absent or null, skip.
+2. Read `label_actions.reason` (single sentence).
+3. Iterate `label_actions.actions[]`:
+   - Validate label name regex: `^[a-zA-Z0-9._/: +-]+$`
+   - Reject control labels with `::warning::`
+   - Check label exists in repo; skip with `::warning::` if not
+   - Apply `add` via `POST /repos/{}/issues/{}/labels`
+   - Apply `remove` via `DELETE /repos/{}/issues/{}/labels/{}`
+4. If at least one label was applied, append to the review body:
+   `**Labels:** {reason}`
+
+Labels are applied using the GitHub labels API (not `gh pr edit`) to match the
+triage post-script's pattern. While the review dispatch does not currently
+listen on `pull_request.labeled`, using the API keeps the approach consistent
+and future-proof.
+
+### 6. `docs/agents/review.md`
+
+After the "Control labels" table, add a note:
+
+> The `issue-labels` skill may also apply contextual labels (e.g., `area/api`,
+> `priority/high`) but these are informational — they do not control agent
+> behavior.
+
+Add a "Skill: `issue-labels`" subsection under "Configuration and extension"
+matching the triage docs pattern — explaining:
+
+- The review agent includes the `issue-labels` skill to discover repo labels
+  and apply them to PRs during review.
+- The skill is shared with the triage agent; overloading it affects both.
+- How to overload (same mechanism: `.agents/skills/issue-labels/SKILL.md` or
+  org-level `.fullsend` config repo).
+
+### 7. `docs/guides/user/customizing-with-skills.md`
+
+Update the built-in skills table to add `issue-labels` to the review agent row:
+
+```
+| [Review](../../agents/review.md) | `code-review`, `pr-review`, `docs-review`, `issue-labels` | Review evaluation across dimensions |
+```
+
+## What does NOT change
+
+- **Triage post-script** — no changes needed. It already validates control
+  labels server-side.
+- **Triage agent definition** — unchanged.
+- **Label conventions query** — stays issue-only per design decision (label
+  taxonomies are repo-wide).
+- **Dispatch workflow** — no event routing changes needed. Review dispatch does
+  not listen on `pull_request.labeled`.
+
+## Testing
+
+- Unit: validate the updated schema accepts results with and without
+  `label_actions`.
+- Integration: verify post-script processes `label_actions` correctly — applies
+  valid labels, refuses control labels, skips non-existent labels.
+- Mirror `post-review-test.sh` updates to cover the new label processing block.

--- a/internal/scaffold/fullsend-repo/agents/review.md
+++ b/internal/scaffold/fullsend-repo/agents/review.md
@@ -13,6 +13,7 @@ skills:
   - code-review
   - pr-review
   - docs-review
+  - issue-labels
 ---
 
 # Review Agent
@@ -122,6 +123,17 @@ If a finding about PR metadata cannot be verified against the API
 data, do not include it. False claims about verifiable metadata (e.g.,
 stating a PR "is not a Draft" when `draft: true`) erode trust in the
 review across all reviewed PRs.
+
+## Contextual labels
+
+After producing the review verdict, invoke the `issue-labels` skill to
+recommend contextual labels for the PR based on the diff's area and domain.
+
+- Emit `label_actions` in the result JSON alongside the review verdict.
+- Labels target the PR itself -- issue labeling remains the triage agent's
+  domain.
+- If no labels clearly apply, omit `label_actions` entirely. Silence is
+  better than noise.
 
 ## Zero-trust principle
 
@@ -243,6 +255,7 @@ fields such as `outcome`, `summary`, `prior_review_sha`, or
 | `body`      | string  | conditional     | Markdown review comment (min 1 char)             |
 | `findings`  | array   | conditional     | Array of finding objects (min 1 item when present)|
 | `reason`    | string  | conditional     | One of: `tool-failure`, `missing-context`, `ambiguous-findings`, `token-limit` |
+| `label_actions` | object | no | Contextual label recommendations (see `issue-labels` skill) |
 
 **Required fields per action:**
 
@@ -323,6 +336,21 @@ jq -n \
   --arg reason "<tool-failure|missing-context|ambiguous-findings|token-limit>" \
   '{action: $action, pr_number: $pr_number, repo: $repo,
     reason: $reason}' \
+  > "$FULLSEND_OUTPUT_DIR/agent-result.json"
+```
+
+For any action with contextual labels, add `label_actions`:
+
+```bash
+jq -n \
+  --arg action "approve" \
+  --argjson pr_number <number> \
+  --arg repo "<owner/repo>" \
+  --arg head_sha "<sha>" \
+  --arg body "<markdown review comment>" \
+  --argjson label_actions '{"reason":"PR modifies API surface","actions":[{"action":"add","label":"area/api"}]}' \
+  '{action: $action, pr_number: $pr_number, repo: $repo,
+    head_sha: $head_sha, body: $body, label_actions: $label_actions}' \
   > "$FULLSEND_OUTPUT_DIR/agent-result.json"
 ```
 

--- a/internal/scaffold/fullsend-repo/harness/review.yaml
+++ b/internal/scaffold/fullsend-repo/harness/review.yaml
@@ -12,6 +12,7 @@ skills:
   - skills/pr-review
   - skills/code-review
   - skills/docs-review
+  - skills/issue-labels
 
 host_files:
   - src: env/gcp-vertex.env

--- a/internal/scaffold/fullsend-repo/schemas/review-result-label-actions-test.sh
+++ b/internal/scaffold/fullsend-repo/schemas/review-result-label-actions-test.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Tests for label_actions support in review-result.schema.json
+set -euo pipefail
+
+SCHEMA="$(cd "$(dirname "$0")" && pwd)/review-result.schema.json"
+FAILURES=0
+
+fail() {
+  echo "FAIL: $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+validate() {
+  local desc="$1"
+  local json="$2"
+  local expect_pass="$3"
+
+  if echo "${json}" | python3 -c "
+import sys, json
+from jsonschema import validate, ValidationError, Draft202012Validator
+schema = json.load(open('${SCHEMA}'))
+instance = json.load(sys.stdin)
+Draft202012Validator(schema).validate(instance)
+sys.exit(0)
+" 2>/dev/null; then
+    if [ "${expect_pass}" = "true" ]; then
+      echo "PASS: ${desc}"
+    else
+      fail "${desc} (expected rejection but schema accepted it)"
+    fi
+  else
+    if [ "${expect_pass}" = "false" ]; then
+      echo "PASS: ${desc}"
+    else
+      fail "${desc} (expected acceptance but schema rejected it)"
+    fi
+  fi
+}
+
+# 1. approve without label_actions (baseline)
+validate "approve-without-label-actions" '{
+  "action": "approve",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "Looks good to me."
+}' true
+
+# 2. approve with valid label_actions
+validate "approve-with-label-actions" '{
+  "action": "approve",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "Looks good to me.",
+  "label_actions": {
+    "reason": "Approved PR, adding reviewed label",
+    "actions": [
+      { "action": "add", "label": "reviewed" }
+    ]
+  }
+}' true
+
+# 3. request-changes with label_actions
+validate "request-changes-with-label-actions" '{
+  "action": "request-changes",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "Please fix the issues.",
+  "findings": [
+    {
+      "severity": "high",
+      "category": "security",
+      "file": "main.go",
+      "description": "SQL injection vulnerability"
+    }
+  ],
+  "label_actions": {
+    "reason": "Security issue found, flagging for review",
+    "actions": [
+      { "action": "add", "label": "security" },
+      { "action": "remove", "label": "needs-review" }
+    ]
+  }
+}' true
+
+# 4. failure with label_actions
+validate "failure-with-label-actions" '{
+  "action": "failure",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "reason": "tool-failure",
+  "label_actions": {
+    "reason": "Tool failure, marking for manual review",
+    "actions": [
+      { "action": "add", "label": "needs-manual-review" }
+    ]
+  }
+}' true
+
+# 5. label_actions missing reason — should fail
+validate "label-actions-missing-reason" '{
+  "action": "approve",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "LGTM",
+  "label_actions": {
+    "actions": [
+      { "action": "add", "label": "reviewed" }
+    ]
+  }
+}' false
+
+# 6. label_actions with empty actions array — should fail
+validate "label-actions-empty-actions" '{
+  "action": "approve",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "LGTM",
+  "label_actions": {
+    "reason": "No labels to change",
+    "actions": []
+  }
+}' false
+
+# 7. label_actions with invalid action verb — should fail
+validate "label-actions-invalid-verb" '{
+  "action": "approve",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "LGTM",
+  "label_actions": {
+    "reason": "Replace a label",
+    "actions": [
+      { "action": "replace", "label": "old-label" }
+    ]
+  }
+}' false
+
+# 8. label_actions with extra property — should fail
+validate "label-actions-extra-property" '{
+  "action": "approve",
+  "pr_number": 42,
+  "repo": "org/repo",
+  "head_sha": "abc1234",
+  "body": "LGTM",
+  "label_actions": {
+    "reason": "Adding label",
+    "actions": [
+      { "action": "add", "label": "reviewed" }
+    ],
+    "priority": "high"
+  }
+}' false
+
+echo ""
+if [ "${FAILURES}" -gt 0 ]; then
+  echo "${FAILURES} test(s) failed."
+  exit 1
+else
+  echo "All tests passed."
+fi

--- a/internal/scaffold/fullsend-repo/schemas/review-result.schema.json
+++ b/internal/scaffold/fullsend-repo/schemas/review-result.schema.json
@@ -23,6 +23,9 @@
     "reason": {
       "type": "string",
       "enum": ["tool-failure", "missing-context", "ambiguous-findings", "token-limit"]
+    },
+    "label_actions": {
+      "$ref": "#/$defs/label_actions"
     }
   },
   "allOf": [
@@ -61,6 +64,32 @@
         "actionable": {
           "type": "boolean",
           "description": "True when this non-blocking finding should be tracked as a follow-up issue if the review approves."
+        }
+      },
+      "additionalProperties": false
+    },
+    "label_actions": {
+      "type": "object",
+      "required": ["reason", "actions"],
+      "properties": {
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Single sentence explaining why these labels are being applied or removed"
+        },
+        "actions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {
+            "type": "object",
+            "required": ["action", "label"],
+            "properties": {
+              "action": { "type": "string", "enum": ["add", "remove"] },
+              "label": { "type": "string", "minLength": 1, "pattern": "^[a-zA-Z0-9._/: +-]+$" }
+            },
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false

--- a/internal/scaffold/fullsend-repo/scripts/post-review-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-review-test.sh
@@ -224,6 +224,7 @@ run_label_test() {
   : > "${GH_LOG}"
 
   local exit_code=0
+  # shellcheck disable=SC2030
   (
     cd "${run_dir}"
     export PATH="${MOCK_BIN}:${PATH}"
@@ -262,6 +263,7 @@ run_label_test_stdout() {
   : > "${GH_LOG}"
 
   local exit_code=0
+  # shellcheck disable=SC2030,SC2031
   (
     cd "${run_dir}"
     export PATH="${MOCK_BIN}:${PATH}"
@@ -300,6 +302,7 @@ run_label_test_no_pattern() {
   : > "${GH_LOG}"
 
   local exit_code=0
+  # shellcheck disable=SC2030,SC2031
   (
     cd "${run_dir}"
     export PATH="${MOCK_BIN}:${PATH}"

--- a/internal/scaffold/fullsend-repo/scripts/post-review-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-review-test.sh
@@ -99,6 +99,62 @@ run_test "failure-action-no-label" \
 run_test "unknown-action-no-label" \
   "banana" "false" "none"
 
+# ---------------------------------------------------------------------------
+# Control-label guard tests
+# ---------------------------------------------------------------------------
+
+REVIEW_CONTROL_LABELS=(
+  "ready-for-merge" "requires-manual-review" "rejected"
+  "ready-for-review" "fullsend-no-fix" "fullsend-fix"
+)
+
+is_control_label() {
+  local label="$1"
+  for cl in "${REVIEW_CONTROL_LABELS[@]}"; do
+    if [[ "${cl}" == "${label}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_control_label_test() {
+  local test_name="$1"
+  local label="$2"
+  local expected_control="$3"
+
+  if is_control_label "${label}"; then
+    local actual="true"
+  else
+    local actual="false"
+  fi
+
+  if [ "${actual}" != "${expected_control}" ]; then
+    echo "FAIL: ${test_name}"
+    echo "  label:    '${label}'"
+    echo "  expected: '${expected_control}'"
+    echo "  actual:   '${actual}'"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  echo "PASS: ${test_name}"
+}
+
+# Control labels should be recognized
+run_control_label_test "ready-for-merge-is-control" "ready-for-merge" "true"
+run_control_label_test "requires-manual-review-is-control" "requires-manual-review" "true"
+run_control_label_test "rejected-is-control" "rejected" "true"
+run_control_label_test "ready-for-review-is-control" "ready-for-review" "true"
+run_control_label_test "fullsend-no-fix-is-control" "fullsend-no-fix" "true"
+run_control_label_test "fullsend-fix-is-control" "fullsend-fix" "true"
+
+# Non-control labels should NOT be recognized
+run_control_label_test "area-api-not-control" "area/api" "false"
+run_control_label_test "priority-high-not-control" "priority/high" "false"
+run_control_label_test "bug-not-control" "bug" "false"
+run_control_label_test "empty-not-control" "" "false"
+
 # --- Summary ---
 
 echo ""

--- a/internal/scaffold/fullsend-repo/scripts/post-review-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-review-test.sh
@@ -155,6 +155,229 @@ run_control_label_test "priority-high-not-control" "priority/high" "false"
 run_control_label_test "bug-not-control" "bug" "false"
 run_control_label_test "empty-not-control" "" "false"
 
+# ---------------------------------------------------------------------------
+# Integration tests for label_actions processing
+# ---------------------------------------------------------------------------
+# These tests run the full post-review.sh with mock gh/fullsend binaries
+# to verify label_actions validation, body modification, and API calls.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POST_SCRIPT="${SCRIPT_DIR}/post-review.sh"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+GH_LOG="${TMPDIR}/gh-calls.log"
+MOCK_BIN="${TMPDIR}/bin"
+mkdir -p "${MOCK_BIN}"
+
+cat > "${MOCK_BIN}/gh" <<MOCKEOF
+#!/usr/bin/env bash
+# Mock gh: handle specific subcommands, log everything else.
+
+# gh pr view ... --json state ... → OPEN
+if [[ "\$1" == "pr" ]] && [[ "\$2" == "view" ]] && [[ "\$*" == *"--json state"* ]]; then
+  echo "OPEN"
+  exit 0
+fi
+
+# gh pr view ... --json files ... → no protected files
+if [[ "\$1" == "pr" ]] && [[ "\$2" == "view" ]] && [[ "\$*" == *"--json files"* ]]; then
+  echo "src/main.go"
+  exit 0
+fi
+
+# gh api repos/.../labels --paginate (list repo labels)
+if [[ "\$1" == "api" ]] && [[ "\$2" == *"/labels" ]] && [[ "\$*" == *"--paginate"* ]] && [[ "\$*" != *"-f "* ]] && [[ "\$*" != *"-X "* ]]; then
+  printf '%s\n' "area/api" "area/cli" "priority/high" "component/parser"
+  exit 0
+fi
+
+# Log all other calls
+echo "gh \$*" >> "${GH_LOG}"
+MOCKEOF
+chmod +x "${MOCK_BIN}/gh"
+
+cat > "${MOCK_BIN}/fullsend" <<MOCKEOF
+#!/usr/bin/env bash
+# Mock fullsend: log the call, consume stdin if --result - is used.
+BODY=""
+PREV=""
+for arg in "\$@"; do
+  if [[ "\${arg}" == "-" ]] && [[ "\${PREV}" == "--result" ]]; then
+    BODY=\$(cat)
+  fi
+  PREV="\${arg}"
+done
+echo "fullsend \$*" >> "${GH_LOG}"
+MOCKEOF
+chmod +x "${MOCK_BIN}/fullsend"
+
+run_label_test() {
+  local test_name="$1"
+  local json_content="$2"
+  local expected_pattern="$3"
+
+  local run_dir="${TMPDIR}/run-${test_name}"
+  mkdir -p "${run_dir}/iteration-1/output"
+  echo "${json_content}" > "${run_dir}/iteration-1/output/agent-result.json"
+  : > "${GH_LOG}"
+
+  local exit_code=0
+  (
+    cd "${run_dir}"
+    export PATH="${MOCK_BIN}:${PATH}"
+    export REVIEW_TOKEN="fake-token"
+    export PR_NUMBER="99"
+    export REPO_FULL_NAME="test-org/test-repo"
+    bash "${POST_SCRIPT}"
+  ) > "${TMPDIR}/stdout-${test_name}.log" 2>&1 || exit_code=$?
+
+  if [[ ${exit_code} -ne 0 ]]; then
+    echo "FAIL: ${test_name} — exit code ${exit_code}"
+    cat "${TMPDIR}/stdout-${test_name}.log"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  if ! grep -qF "${expected_pattern}" "${GH_LOG}"; then
+    echo "FAIL: ${test_name} — expected pattern '${expected_pattern}' not found in gh calls"
+    echo "Actual calls:"
+    cat "${GH_LOG}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  echo "PASS: ${test_name}"
+}
+
+run_label_test_stdout() {
+  local test_name="$1"
+  local json_content="$2"
+  local expected_stdout="$3"
+
+  local run_dir="${TMPDIR}/run-${test_name}"
+  mkdir -p "${run_dir}/iteration-1/output"
+  echo "${json_content}" > "${run_dir}/iteration-1/output/agent-result.json"
+  : > "${GH_LOG}"
+
+  local exit_code=0
+  (
+    cd "${run_dir}"
+    export PATH="${MOCK_BIN}:${PATH}"
+    export REVIEW_TOKEN="fake-token"
+    export PR_NUMBER="99"
+    export REPO_FULL_NAME="test-org/test-repo"
+    bash "${POST_SCRIPT}"
+  ) > "${TMPDIR}/stdout-${test_name}.log" 2>&1 || exit_code=$?
+
+  if [[ ${exit_code} -ne 0 ]]; then
+    echo "FAIL: ${test_name} — exit code ${exit_code}"
+    cat "${TMPDIR}/stdout-${test_name}.log"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  if ! grep -qF "${expected_stdout}" "${TMPDIR}/stdout-${test_name}.log"; then
+    echo "FAIL: ${test_name} — expected stdout '${expected_stdout}' not found"
+    echo "Actual stdout:"
+    cat "${TMPDIR}/stdout-${test_name}.log"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  echo "PASS: ${test_name}"
+}
+
+run_label_test_no_pattern() {
+  local test_name="$1"
+  local json_content="$2"
+  local forbidden_pattern="$3"
+
+  local run_dir="${TMPDIR}/run-${test_name}"
+  mkdir -p "${run_dir}/iteration-1/output"
+  echo "${json_content}" > "${run_dir}/iteration-1/output/agent-result.json"
+  : > "${GH_LOG}"
+
+  local exit_code=0
+  (
+    cd "${run_dir}"
+    export PATH="${MOCK_BIN}:${PATH}"
+    export REVIEW_TOKEN="fake-token"
+    export PR_NUMBER="99"
+    export REPO_FULL_NAME="test-org/test-repo"
+    bash "${POST_SCRIPT}"
+  ) > "${TMPDIR}/stdout-${test_name}.log" 2>&1 || exit_code=$?
+
+  if [[ ${exit_code} -ne 0 ]]; then
+    echo "FAIL: ${test_name} — exit code ${exit_code}"
+    cat "${TMPDIR}/stdout-${test_name}.log"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  if grep -qF "${forbidden_pattern}" "${GH_LOG}"; then
+    echo "FAIL: ${test_name} — forbidden pattern '${forbidden_pattern}' was found in gh calls"
+    echo "Actual calls:"
+    cat "${GH_LOG}"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  echo "PASS: ${test_name}"
+}
+
+# --- Label actions integration tests ---
+
+# Approve with label_actions — label should be added via API
+run_label_test "label-actions-applied" \
+  '{"action":"approve","pr_number":99,"repo":"test-org/test-repo","head_sha":"abc123","body":"LGTM","label_actions":{"reason":"PR modifies API surface.","actions":[{"action":"add","label":"area/api"}]}}' \
+  "gh api repos/test-org/test-repo/issues/99/labels -f labels[]=area/api --silent"
+
+# Control label refused — should NOT call the labels API for it
+run_label_test_stdout "label-actions-control-label-refused" \
+  '{"action":"approve","pr_number":99,"repo":"test-org/test-repo","head_sha":"abc123","body":"LGTM","label_actions":{"reason":"Tried to set control label.","actions":[{"action":"add","label":"ready-for-merge"}]}}' \
+  "::warning::Refused to add control label 'ready-for-merge'"
+
+# Non-existent label skipped — label "bug" is not in mock label list
+run_label_test_stdout "label-actions-nonexistent-label-skipped" \
+  '{"action":"approve","pr_number":99,"repo":"test-org/test-repo","head_sha":"abc123","body":"LGTM","label_actions":{"reason":"Agent recommended a label that does not exist.","actions":[{"action":"add","label":"bug"}]}}' \
+  "::warning::Skipping label 'bug'"
+
+# Invalid characters refused
+run_label_test_stdout "label-actions-invalid-characters-refused" \
+  '{"action":"approve","pr_number":99,"repo":"test-org/test-repo","head_sha":"abc123","body":"LGTM","label_actions":{"reason":"Injection attempt.","actions":[{"action":"add","label":"label;injection"}]}}' \
+  "::warning::Refused label 'label;injection'"
+
+# Remove label — should call DELETE
+run_label_test "label-actions-remove" \
+  '{"action":"approve","pr_number":99,"repo":"test-org/test-repo","head_sha":"abc123","body":"LGTM","label_actions":{"reason":"Stale area label removed.","actions":[{"action":"remove","label":"area/cli"}]}}' \
+  "gh api repos/test-org/test-repo/issues/99/labels/area%2Fcli -X DELETE --silent"
+
+# Multiple adds — both should be applied
+run_label_test "label-actions-multiple-add" \
+  '{"action":"approve","pr_number":99,"repo":"test-org/test-repo","head_sha":"abc123","body":"LGTM","label_actions":{"reason":"Multiple labels apply.","actions":[{"action":"add","label":"area/api"},{"action":"add","label":"priority/high"}]}}' \
+  "gh api repos/test-org/test-repo/issues/99/labels -f labels[]=area/api --silent"
+
+run_label_test "label-actions-multiple-second-label" \
+  '{"action":"approve","pr_number":99,"repo":"test-org/test-repo","head_sha":"abc123","body":"LGTM","label_actions":{"reason":"Multiple labels apply.","actions":[{"action":"add","label":"area/api"},{"action":"add","label":"priority/high"}]}}' \
+  "gh api repos/test-org/test-repo/issues/99/labels -f labels[]=priority/high --silent"
+
+# When all label actions are refused, reason should NOT appear in the review body
+run_label_test_no_pattern "label-actions-all-refused-no-body-append" \
+  '{"action":"approve","pr_number":99,"repo":"test-org/test-repo","head_sha":"abc123","body":"LGTM","label_actions":{"reason":"Should not appear.","actions":[{"action":"add","label":"ready-for-merge"}]}}' \
+  "labels[]=ready-for-merge"
+
+# No label_actions field — should still post review without errors
+run_label_test "label-actions-absent-still-posts" \
+  '{"action":"approve","pr_number":99,"repo":"test-org/test-repo","head_sha":"abc123","body":"LGTM"}' \
+  "fullsend post-review"
+
+# request-changes with label_actions — labels should still be applied
+run_label_test "label-actions-with-request-changes" \
+  '{"action":"request-changes","pr_number":99,"repo":"test-org/test-repo","head_sha":"abc123","body":"Issues found","findings":[{"severity":"high","category":"bug","file":"main.go","description":"nil deref"}],"label_actions":{"reason":"Touches CI config.","actions":[{"action":"add","label":"area/api"}]}}' \
+  "gh api repos/test-org/test-repo/issues/99/labels -f labels[]=area/api --silent"
+
 # --- Summary ---
 
 echo ""

--- a/internal/scaffold/fullsend-repo/scripts/post-review-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-review-test.sh
@@ -381,6 +381,18 @@ run_label_test "label-actions-with-request-changes" \
   '{"action":"request-changes","pr_number":99,"repo":"test-org/test-repo","head_sha":"abc123","body":"Issues found","findings":[{"severity":"high","category":"bug","file":"main.go","description":"nil deref"}],"label_actions":{"reason":"Touches CI config.","actions":[{"action":"add","label":"area/api"}]}}' \
   "gh api repos/test-org/test-repo/issues/99/labels -f labels[]=area/api --silent"
 
+# Label with embedded newline (GHA command injection attempt) — should be refused
+run_label_test_stdout "label-actions-newline-injection-refused" \
+  '{"action":"approve","pr_number":99,"repo":"test-org/test-repo","head_sha":"abc123","body":"LGTM","label_actions":{"reason":"Injection.","actions":[{"action":"add","label":"ok\n::set-output name=x::pwned"}]}}' \
+  "::warning::Refused label"
+
+# Label with :: delimiter (GHA command injection attempt) — :: is sanitized to :,
+# so the label becomes ":warning:injected" which passes the character regex but
+# does not exist in the repo. The important thing is the :: is stripped.
+run_label_test_stdout "label-actions-gha-delimiter-sanitized" \
+  '{"action":"approve","pr_number":99,"repo":"test-org/test-repo","head_sha":"abc123","body":"LGTM","label_actions":{"reason":"Injection.","actions":[{"action":"add","label":"::warning::injected"}]}}' \
+  "::warning::Skipping label ':warning:injected'"
+
 # --- Summary ---
 
 echo ""

--- a/internal/scaffold/fullsend-repo/scripts/post-review.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-review.sh
@@ -139,6 +139,88 @@ if [ "${ACTION}" = "approve" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Label-actions validation: the review agent may recommend contextual labels
+# (e.g. area/api, priority/high). Validate them here so the label reason
+# appears in the review body. Actual label API calls happen after posting.
+# ---------------------------------------------------------------------------
+REVIEW_CONTROL_LABELS=(
+  "ready-for-merge" "requires-manual-review" "rejected"
+  "ready-for-review" "fullsend-no-fix" "fullsend-fix"
+)
+
+is_control_label() {
+  local label="$1"
+  for cl in "${REVIEW_CONTROL_LABELS[@]}"; do
+    if [[ "${cl}" == "${label}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+VALIDATED_LABEL_ADDS=()
+VALIDATED_LABEL_REMOVES=()
+LABEL_REASON=""
+
+HAS_LABEL_ACTIONS=$(jq 'has("label_actions")' "${RESULT_FILE}")
+if [[ "${HAS_LABEL_ACTIONS}" == "true" ]]; then
+  LABEL_REASON=$(jq -r '.label_actions.reason' "${RESULT_FILE}")
+  LABEL_COUNT=$(jq '.label_actions.actions | length' "${RESULT_FILE}")
+
+  echo "Validating ${LABEL_COUNT} label action(s)..."
+
+  # Fetch existing repo labels once.
+  EXISTING_LABELS=$(gh api "repos/${REPO_FULL_NAME}/labels" --paginate --jq '.[].name' 2>/dev/null || true)
+
+  label_exists() {
+    local label="$1"
+    echo "${EXISTING_LABELS}" | grep -qFx "${label}"
+  }
+
+  for i in $(seq 0 $((LABEL_COUNT - 1))); do
+    LA_ACTION=$(jq -r ".label_actions.actions[${i}].action" "${RESULT_FILE}")
+    LA_LABEL=$(jq -r ".label_actions.actions[${i}].label" "${RESULT_FILE}")
+
+    if [[ ! "${LA_LABEL}" =~ ^[a-zA-Z0-9._/:\ +\-]+$ ]]; then
+      echo "::warning::Refused label '${LA_LABEL}' -- contains invalid characters"
+      continue
+    fi
+
+    if is_control_label "${LA_LABEL}"; then
+      echo "::warning::Refused to ${LA_ACTION} control label '${LA_LABEL}' -- control labels are managed by the review pipeline"
+      continue
+    fi
+
+    case "${LA_ACTION}" in
+      add)
+        if ! label_exists "${LA_LABEL}"; then
+          echo "::warning::Skipping label '${LA_LABEL}' -- does not exist in repo (will not auto-create)"
+          continue
+        fi
+        VALIDATED_LABEL_ADDS+=("${LA_LABEL}")
+        ;;
+      remove)
+        VALIDATED_LABEL_REMOVES+=("${LA_LABEL}")
+        ;;
+      *)
+        echo "::warning::Unknown label action '${LA_ACTION}' for label '${LA_LABEL}'"
+        ;;
+    esac
+  done
+
+  # Append label reason to body if any labels validated.
+  VALIDATED_COUNT=$(( ${#VALIDATED_LABEL_ADDS[@]} + ${#VALIDATED_LABEL_REMOVES[@]} ))
+  if [[ "${VALIDATED_COUNT}" -gt 0 ]]; then
+    LABEL_NOTICE=$'\n\n---\n'"**Labels:** ${LABEL_REASON}"
+    LABEL_MODIFIED_RESULT=$(mktemp)
+    jq --arg notice "${LABEL_NOTICE}" \
+      '.body = (.body + $notice)' \
+      "${RESULT_FILE}" > "${LABEL_MODIFIED_RESULT}"
+    RESULT_FILE="${LABEL_MODIFIED_RESULT}"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
 # Post the review. Exit code 10 = stale-head: the PR HEAD moved after the
 # agent reviewed it. When this happens, post a /fs-review comment to
 # re-dispatch a fresh review for the current HEAD.
@@ -224,5 +306,22 @@ elif [ "${ACTION}" = "reject" ]; then
 elif [ "${ACTION}" = "request_changes" ]; then
   echo "Request-changes disposition — no outcome label (fix agent triggers on event)"
 fi
+
+# ---------------------------------------------------------------------------
+# Contextual labels: apply validated label mutations from label_actions.
+# ---------------------------------------------------------------------------
+for label in "${VALIDATED_LABEL_ADDS[@]}"; do
+  echo "Adding contextual label '${label}'..."
+  gh api "repos/${REPO_FULL_NAME}/issues/${PR_NUMBER}/labels" \
+    -f "labels[]=${label}" --silent || \
+    echo "::warning::Failed to add label '${label}'"
+done
+
+for label in "${VALIDATED_LABEL_REMOVES[@]}"; do
+  echo "Removing contextual label '${label}'..."
+  encoded=$(printf '%s' "${label}" | jq -sRr @uri)
+  gh api "repos/${REPO_FULL_NAME}/issues/${PR_NUMBER}/labels/${encoded}" \
+    -X DELETE --silent 2>/dev/null || true
+done
 
 echo "Review posted on ${REPO_FULL_NAME}#${PR_NUMBER}"

--- a/internal/scaffold/fullsend-repo/scripts/post-review.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-review.sh
@@ -29,6 +29,11 @@ fi
 echo "::add-mask::${REVIEW_TOKEN}"
 export GH_TOKEN="${REVIEW_TOKEN}"
 
+# Temp file cleanup: accumulate files to remove on exit so later traps
+# don't overwrite earlier ones.
+CLEANUP_FILES=()
+trap 'rm -f "${CLEANUP_FILES[@]}"' EXIT
+
 # Refuse to post reviews on merged or closed PRs
 PR_STATE=$(gh pr view "${PR_NUMBER}" --repo "${REPO_FULL_NAME}" --json state --jq '.state')
 if [ "${PR_STATE}" != "OPEN" ]; then
@@ -129,7 +134,7 @@ if [ "${ACTION}" = "approve" ]; then
 
     # Rewrite the result file with downgraded action and appended notice.
     MODIFIED_RESULT=$(mktemp)
-    trap 'rm -f "${MODIFIED_RESULT}"' EXIT
+    CLEANUP_FILES+=("${MODIFIED_RESULT}")
     jq --arg notice "${PROTECTED_NOTICE}" \
       '.action = "comment" | .body = (.body + $notice)' \
       "${RESULT_FILE}" > "${MODIFIED_RESULT}"
@@ -181,6 +186,16 @@ if [[ "${HAS_LABEL_ACTIONS}" == "true" ]]; then
     LA_ACTION=$(jq -r ".label_actions.actions[${i}].action" "${RESULT_FILE}")
     LA_LABEL=$(jq -r ".label_actions.actions[${i}].label" "${RESULT_FILE}")
 
+    # Sanitize jq -r output: strip newlines, carriage returns, and GHA
+    # workflow command delimiters to prevent command injection via crafted
+    # label names or action values.
+    LA_ACTION="${LA_ACTION//$'\n'/}"
+    LA_ACTION="${LA_ACTION//$'\r'/}"
+    LA_ACTION="${LA_ACTION//::/:}"
+    LA_LABEL="${LA_LABEL//$'\n'/}"
+    LA_LABEL="${LA_LABEL//$'\r'/}"
+    LA_LABEL="${LA_LABEL//::/:}"
+
     if [[ ! "${LA_LABEL}" =~ ^[a-zA-Z0-9._/:\ +\-]+$ ]]; then
       echo "::warning::Refused label '${LA_LABEL}' -- contains invalid characters"
       continue
@@ -213,7 +228,7 @@ if [[ "${HAS_LABEL_ACTIONS}" == "true" ]]; then
   if [[ "${VALIDATED_COUNT}" -gt 0 ]]; then
     LABEL_NOTICE=$'\n\n---\n'"**Labels:** ${LABEL_REASON}"
     LABEL_MODIFIED_RESULT=$(mktemp)
-    trap 'rm -f "${LABEL_MODIFIED_RESULT}"' EXIT
+    CLEANUP_FILES+=("${LABEL_MODIFIED_RESULT}")
     jq --arg notice "${LABEL_NOTICE}" \
       '.body = (.body + $notice)' \
       "${RESULT_FILE}" > "${LABEL_MODIFIED_RESULT}"

--- a/internal/scaffold/fullsend-repo/scripts/post-review.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-review.sh
@@ -213,6 +213,7 @@ if [[ "${HAS_LABEL_ACTIONS}" == "true" ]]; then
   if [[ "${VALIDATED_COUNT}" -gt 0 ]]; then
     LABEL_NOTICE=$'\n\n---\n'"**Labels:** ${LABEL_REASON}"
     LABEL_MODIFIED_RESULT=$(mktemp)
+    trap 'rm -f "${LABEL_MODIFIED_RESULT}"' EXIT
     jq --arg notice "${LABEL_NOTICE}" \
       '.body = (.body + $notice)' \
       "${RESULT_FILE}" > "${LABEL_MODIFIED_RESULT}"

--- a/internal/scaffold/fullsend-repo/skills/issue-labels/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/issue-labels/SKILL.md
@@ -2,26 +2,18 @@
 name: issue-labels
 description: >-
   Discover repository labels and recommend contextual labels to add or remove
-  on triaged issues. Produces label_actions in the agent result JSON.
+  on issues and pull requests. Produces label_actions in the agent result JSON.
 ---
 
 # Issue Labels
 
-Recommend contextual labels for the issue being triaged. These are labels that
-describe the issue's domain, area, priority, or other team-specific dimensions
--- NOT control labels used by the triage pipeline.
+Recommend contextual labels for the issue or pull request being processed.
+These are labels that describe the domain, area, priority, or other
+team-specific dimensions -- NOT control labels used by agent pipelines.
 
-## Control labels (do NOT recommend these)
-
-The following labels are managed by the triage pipeline. Never include them in
-your `label_actions` output -- the post script will refuse them:
-
-- `needs-info`
-- `ready-to-code`
-- `duplicate`
-- `feature`
-- `blocked`
-- `triaged`
+Control labels are managed by each agent's post-script and will be refused
+server-side if recommended. You do not need to track which labels are
+control labels -- just recommend what fits and the pipeline will filter.
 
 ## Step 1: Discover available labels
 
@@ -29,14 +21,17 @@ your `label_actions` output -- the post script will refuse them:
 gh label list --repo OWNER/REPO --json name,description --limit 100
 ```
 
-If the repo has no non-control labels, skip labeling entirely -- do not emit
-`label_actions`.
+If the repo has no labels beyond those used by agent pipelines, skip labeling
+entirely -- do not emit `label_actions`.
 
 ## Step 2: Check for GitHub issue types
 
 GitHub issue types (Bug, Feature, Task, etc.) classify issues at a higher level
-than labels. If the repo uses issue types, do **not** recommend labels that
-duplicate the issue type — e.g., do not add `bug` or `type/bug` when the issue
+than labels. **Skip this step when labeling a pull request** -- GitHub issue
+types do not apply to PRs.
+
+If the repo uses issue types, do **not** recommend labels that
+duplicate the issue type -- e.g., do not add `bug` or `type/bug` when the issue
 already has the Bug type.
 
 Query the current issue to check for an issue type:
@@ -68,11 +63,11 @@ summary to inform your recommendations.
 
 ## Step 4: Recommend labels
 
-Based on the issue content, the available labels, and the observed conventions:
+Based on the content, the available labels, and the observed conventions:
 
-- Recommend labels to **add** if they clearly apply to this issue.
-- Recommend labels to **remove** if the issue already has stale labels from a
-  prior triage that no longer apply.
+- Recommend labels to **add** if they clearly apply.
+- Recommend labels to **remove** if stale labels from a prior run no longer
+  apply.
 - If no labels clearly apply, do not emit `label_actions` at all. Silence is
   better than noise.
 - Only recommend labels that exist in `gh label list`. Do not invent labels.


### PR DESCRIPTION
## Summary

- Generalize the `issue-labels` skill to work for both issues and PRs (remove hardcoded control-label list, reword triage-specific language)
- Add optional `label_actions` field to the review result schema (same shape as triage)
- Add label_actions processing to `post-review.sh` — validates labels against a control-label guard, appends reason to review body, applies via GitHub labels API
- Wire `issue-labels` into the review agent harness and definition
- Update user-facing docs (review agent docs, skills table, triage docs alignment)

Closes #1706

## Test plan

- [x] Schema validation tests pass (8 cases: 4 valid, 4 invalid)
- [x] Post-review control-label guard tests pass (19 total: 9 existing + 10 new)
- [x] `make lint` passes
- [x] Manual: `fullsend run review` against `appdumpster/test-repo#33` — agent produces `label_actions` with valid repo labels, schema validates, post-script validates and appends label reason to review body (3 runs, consistent results — see [comment](https://github.com/fullsend-ai/fullsend/pull/2196#issuecomment-4686504190))

🤖 Generated with [Claude Code](https://claude.com/claude-code)