### PR TITLE
fix(#2209): remove stale tar before podman save

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -314,6 +314,7 @@ runs:
       run: |
         IMAGE="${FULLSEND_SANDBOX_IMAGE:-ghcr.io/fullsend-ai/fullsend-code:latest}"
         if podman image exists -- "${IMAGE}"; then
+          rm -f /tmp/sandbox-image.tar
           podman save -o /tmp/sandbox-image.tar -- "${IMAGE}"
         else
           echo "::warning::Image not available to cache"


### PR DESCRIPTION
Fixes #2209.

## What

Add `rm -f /tmp/sandbox-image.tar` before `podman save` in the \"Save sandbox image for cache\" step of `action.yml`.

## Why

When the cache is restored and `podman pull` subsequently fetches a newer image digest, the save step tries to overwrite `/tmp/sandbox-image.tar` in place. The `docker-archive` transport does not support modifying an existing archive, producing:

```
Error: docker-archive doesn't support modifying existing images
Process completed with exit code 125.
```

This caused every agent run to fail from 07:48 UTC on 2026-06-12 onward (7 runs across Triage and Review).

## How

Remove the existing file before saving so `podman save` always writes to a clean archive. The `-f` flag makes this a no-op when no cached tar was restored.