### PR TITLE
fix(#2060): set up Go on runner before post-code pre-commit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -331,6 +331,13 @@ runs:
       shell: bash
       run: pip install --quiet "jsonschema>=4.18.0"
 
+    - name: Set up Go for target repo pre-commit hooks
+      if: hashFiles('target-repo/go.mod') != ''
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: target-repo/go.mod
+        cache: false
+
     - name: Run fullsend
       if: inputs.agent != '__install_only__'
       shell: bash


### PR DESCRIPTION
## Summary

Fixes #2060.

When a target repo's `go.mod` declares a Go version newer than the golangci-lint binary installed by pre-commit's `language: golang` mechanism, golangci-lint exits with code 3 before analyzing any code — blocking PR creation with:

```
Error: can't load config: the Go language version (go1.25) used to build
golangci-lint is lower than the targeted Go version (1.26.0)
```

## Change

Add a conditional `actions/setup-go@v6` step in `action.yml` that runs before `fullsend run` (and therefore before `post-code.sh`'s authoritative pre-commit gate). The step reads the target repo's `go.mod` via `go-version-file` and installs the matching Go toolchain on the runner. pre-commit then uses that toolchain when building golangci-lint from source, satisfying the version requirement.

```yaml
- name: Set up Go for target repo pre-commit hooks
  if: hashFiles('target-repo/go.mod') != ''
  uses: actions/setup-go@v6
  with:
    go-version-file: target-repo/go.mod
    cache: false
```

**Non-Go repos:** the `hashFiles` guard skips the step entirely — no latency impact.

**`cache: false`:** avoids polluting the runner's module cache with the target repo's dependencies.

## Relation to prior fixes

- #1990 fixed the Go version mismatch in the **sandbox image**. This fixes the same class of problem on the **GHA runner** during `post-code.sh`, which runs after the sandbox is destroyed.
- No changes to dispatch files — this step lives in `action.yml`, which all code agent runs invoke.