### PR TITLE
fix(#2024): triage agent must not ask reporters implementation questions

### DIFF
--- a/internal/scaffold/fullsend-repo/agents/triage.md
+++ b/internal/scaffold/fullsend-repo/agents/triage.md
@@ -102,6 +102,27 @@ Use this phased approach to evaluate the issue:
 - Are reproduction steps present and specific (not vague)?
 - Is the environment described (OS, browser, version, configuration)?
 
+### Question classification
+
+Before forming any clarifying question, classify it:
+
+**User-facing questions** — the reporter can answer from their own experience:
+- What behavior did you observe vs. expect?
+- What OS, version, or configuration are you using?
+- Can you share the exact error message or log?
+- Does this happen every time or intermittently?
+
+**Implementation-facing questions** — require knowledge of how the project works internally:
+- Which document format should be used (ADR, problem doc, etc.)?
+- How should a given feature be architected?
+- Which internal component owns this behavior?
+- What is the project's convention for X?
+
+**Rule:** Implementation-facing questions must NOT be directed at the reporter. Instead:
+1. Attempt to self-resolve using the repository context gathered in Step 2 (README, CLAUDE.md, AGENTS.md, docs/, ADRs, CONTRIBUTING.md).
+2. If self-resolution succeeds, incorporate the answer into your analysis without asking anyone.
+3. If self-resolution fails (the answer is genuinely not in the repo), flag it in `reasoning` as an open architectural question for maintainers — but still attempt to proceed with the best available information. Only use `action: "insufficient"` if the gap materially prevents triage.
+
 ### Phase 3 — Hypothesis formation and dependency analysis
 - Can you form a plausible root cause hypothesis from the available information?
 - Could a developer start investigating without contacting the reporter?
@@ -162,7 +183,7 @@ Information is missing that would change the triage outcome. Ask ONE focused, sp
     "impact": 0.0,
     "overall": 0.0
   },
-  "comment": "Your clarifying question, written as a professional GitHub comment. Address the reporter as a person. Ask ONE question — the most diagnostic question that would move clarity scores the most. Be specific about what you need."
+  "comment": "Your clarifying question, written as a professional GitHub comment. Address the reporter as a person. Ask ONE question — the most diagnostic question that would move clarity scores the most. Be specific about what you need. The question must be user-facing (something the reporter can answer from their own experience). Never ask about internal project conventions, document formats, or architecture decisions — those are implementation-facing questions that must be self-resolved from repository context."
 }
 ```
 
@@ -244,6 +265,7 @@ Information is sufficient for a developer to investigate and fix.
 - Reference prior comments: "You mentioned X earlier — can you elaborate on [specific aspect]?"
 - Be empathetic but efficient. Acknowledge the reporter's experience, then ask your question.
 - Do NOT ask questions whose answers would not change your triage outcome.
+- **Only direct user-facing questions to the reporter.** Never ask the reporter about internal project conventions, document formats, architecture decisions, or implementation details. If you have an implementation-facing question, apply the self-resolve rule from the question classification section above.
 
 ## Output rules
 


### PR DESCRIPTION
## Problem

The triage agent was asking issue reporters about internal implementation details — e.g. whether to create a problem document or an ADR (#1907). End users have no knowledge of these project-internal concepts and should not be asked to make architectural decisions.

Fixes #2024.

## Solution

Add a **question classification** step to the triage prompt (Phase 2 of Step 3). Before directing any question to the reporter, the agent must classify it:

- **User-facing** — the reporter can answer from their own experience (symptoms, environment, expected behavior). Direct these to the reporter.
- **Implementation-facing** — requires internal project knowledge (document formats, architecture conventions, component ownership). Never direct these to the reporter.

For implementation-facing questions, the agent must:
1. Attempt to self-resolve from repo context already gathered in Step 2 (README, CLAUDE.md, AGENTS.md, docs/, ADRs).
2. If resolved, incorporate silently — no question asked.
3. If unresolvable, flag in `reasoning` for maintainers. Only use `action: insufficient` if the gap materially prevents triage.

The same constraint is reinforced in the `insufficient` action's `comment` field description and in the questioning guidelines bullet list.

## Changes

- `internal/scaffold/fullsend-repo/agents/triage.md` — prompt only, no schema or harness changes.