### PR TITLE
perf(#2222): skip sandbox image pull when cached digest matches remote

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -250,7 +250,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y podman
+        sudo apt-get install -y podman skopeo
         podman --version
 
     - name: Configure rootless Podman
@@ -301,10 +301,25 @@ runs:
       run: |
         IMAGE="${FULLSEND_SANDBOX_IMAGE:-ghcr.io/fullsend-ai/fullsend-code:latest}"
         echo "Pre-pulling sandbox image: ${IMAGE}"
-        DIGEST_BEFORE="$(podman image inspect --format '{{.Digest}}' -- "${IMAGE}" 2>/dev/null || true)"
+
+        LOCAL_DIGEST="$(podman image inspect --format '{{.Digest}}' -- "${IMAGE}" 2>/dev/null || true)"
+
+        if [[ -n "${LOCAL_DIGEST}" ]]; then
+          # Check remote digest without pulling (~1s HEAD request).
+          REMOTE_DIGEST="$(skopeo inspect --no-tags --format '{{.Digest}}' "docker://${IMAGE}" 2>/dev/null || true)"
+          if [[ -z "${REMOTE_DIGEST}" ]]; then
+            echo "Could not fetch remote digest; falling through to pull"
+          elif [[ "${LOCAL_DIGEST}" == "${REMOTE_DIGEST}" ]]; then
+            echo "Local image is current (digest ${LOCAL_DIGEST:0:19}…); skipping pull"
+            exit 0
+          else
+            echo "Digest mismatch (local=${LOCAL_DIGEST:0:19}… remote=${REMOTE_DIGEST:0:19}…); pulling"
+          fi
+        fi
+
         timeout 300 podman pull -- "${IMAGE}" || echo "::warning::Image pre-pull failed; sandbox create will pull on demand"
-        DIGEST_AFTER="$(podman image inspect --format '{{.Digest}}' -- "${IMAGE}" 2>/dev/null || true)"
-        if [ "${DIGEST_BEFORE}" != "${DIGEST_AFTER}" ]; then
+        PULLED_DIGEST="$(podman image inspect --format '{{.Digest}}' -- "${IMAGE}" 2>/dev/null || true)"
+        if [[ "${LOCAL_DIGEST}" != "${PULLED_DIGEST}" ]]; then
           echo "changed=true" >> "${GITHUB_OUTPUT}"
         fi
 


### PR DESCRIPTION
## Summary

- Use `skopeo inspect --no-tags` to check the remote image digest (~1s) before deciding whether to pull
- When the cached image already matches the remote, skip the pull/save/upload cycle entirely
- Install `skopeo` alongside `podman` (same ecosystem, tiny package)
- On cold cache or digest mismatch, behavior is unchanged

This should eliminate ~4.5 min of wasted cache overhead on most runs, since we rebuild the sandbox image rarely. If we don't see a meaningful improvement over the bare 30s pull, we'll follow up by removing the cache entirely.

Relates-to: #2222

## Test plan

- [ ] Observe a run with a warm cache: should see "Local image is current … skipping pull" and no save/upload steps
- [ ] Observe a run after an image rebuild: should see "Digest mismatch … pulling" and the normal save/upload cycle
- [ ] Observe a cold-cache run (no tar restored): should fall through to pull as before
- [ ] Compare total setup time against pre-change baseline (~4.5 min with cache overhead, ~30s bare pull)

🤖 Generated with [Claude Code](https://claude.com/claude-code)