### PR TITLE
fix(#2130): mint fresh tokens for status comments

### DIFF
--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -178,4 +178,4 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ inputs.source_repo }}
           status-number: ${{ fromJSON(inputs.event_payload).issue.number }}
-          status-token: ${{ steps.app-token.outputs.token }}
+          mint-url: ${{ inputs.mint_url }}

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -380,4 +380,4 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ inputs.source_repo }}
           status-number: ${{ steps.context.outputs.pr_number }}
-          status-token: ${{ steps.app-token.outputs.token }}
+          mint-url: ${{ inputs.mint_url }}

--- a/.github/workflows/reusable-retro.yml
+++ b/.github/workflows/reusable-retro.yml
@@ -153,4 +153,4 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ inputs.source_repo }}
           status-number: ${{ fromJSON(inputs.event_payload).pull_request.number || fromJSON(inputs.event_payload).issue.number }}
-          status-token: ${{ steps.app-token.outputs.token }}
+          mint-url: ${{ inputs.mint_url }}

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -169,4 +169,4 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ inputs.source_repo }}
           status-number: ${{ fromJSON(inputs.event_payload).pull_request.number || fromJSON(inputs.event_payload).issue.number }}
-          status-token: ${{ steps.app-token.outputs.token }}
+          mint-url: ${{ inputs.mint_url }}

--- a/.github/workflows/reusable-triage.yml
+++ b/.github/workflows/reusable-triage.yml
@@ -149,4 +149,4 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status-repo: ${{ inputs.source_repo }}
           status-number: ${{ fromJSON(inputs.event_payload).issue.number }}
-          status-token: ${{ steps.app-token.outputs.token }}
+          mint-url: ${{ inputs.mint_url }}

--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,16 @@ inputs:
   status-number:
     description: Issue/PR number for status comments (optional).
     default: ""
+  mint-url:
+    description: >-
+      Mint service URL for on-demand status comment tokens. When set, the
+      binary mints a fresh short-lived token before each status API call
+      instead of using a static status-token.
+    default: ""
   status-token:
-    description: Token for status comments (defaults to GH_TOKEN env var).
+    description: >-
+      DEPRECATED — use mint-url instead. Static GitHub token for status
+      comments. Ignored when mint-url is set.
     default: ""
 
 runs:
@@ -363,9 +371,13 @@ runs:
         STATUS_RUN_URL: ${{ inputs.run-url }}
         STATUS_REPO: ${{ inputs.status-repo }}
         STATUS_NUMBER: ${{ inputs.status-number }}
+        MINT_URL: ${{ inputs.mint-url }}
         STATUS_TOKEN: ${{ inputs.status-token }}
       run: |
         set -euo pipefail
+        if [[ -n "${STATUS_TOKEN}" ]]; then
+          echo "::add-mask::${STATUS_TOKEN}"
+        fi
         FULLSEND_DIR="${FULLSEND_DIR:-${GITHUB_WORKSPACE}}"
         TARGET_REPO="${TARGET_REPO:-${GITHUB_WORKSPACE}/target-repo}"
         mkdir -p "${GITHUB_WORKSPACE}/output"
@@ -373,16 +385,17 @@ runs:
         # Post-scripts enforce secret scanning, protected-path blocks,
         # and review-downgrade controls. Skipping them in CI bypasses
         # all post-push security gates.
-        if [[ -n "${STATUS_TOKEN}" ]]; then
-          echo "::add-mask::${STATUS_TOKEN}"
-        fi
         STATUS_FLAGS=()
         if [[ -n "${STATUS_REPO}" && -n "${STATUS_NUMBER}" ]]; then
           STATUS_FLAGS+=(--status-repo "${STATUS_REPO}" --status-number "${STATUS_NUMBER}")
           if [[ -n "${STATUS_RUN_URL}" ]]; then
             STATUS_FLAGS+=(--run-url "${STATUS_RUN_URL}")
           fi
+          if [[ -n "${MINT_URL}" ]]; then
+            STATUS_FLAGS+=(--mint-url "${MINT_URL}")
+          fi
           if [[ -n "${STATUS_TOKEN}" ]]; then
+            echo "::warning::status-token is deprecated; use mint-url instead"
             STATUS_FLAGS+=(--status-token "${STATUS_TOKEN}")
           fi
         fi
@@ -393,10 +406,12 @@ runs:
           "${STATUS_FLAGS[@]+"${STATUS_FLAGS[@]}"}"
 
     - name: Finalize orphaned status comment
-      if: always() && inputs.agent != '__install_only__' && inputs.status-repo != '' && inputs.status-number != ''
+      if: always() && inputs.agent != '__install_only__' && inputs.status-repo != '' && inputs.status-number != '' && (inputs.mint-url != '' || inputs.status-token != '')
       shell: bash
       env:
+        MINT_URL: ${{ inputs.mint-url }}
         STATUS_TOKEN: ${{ inputs.status-token }}
+        AGENT: ${{ inputs.agent }}
         STATUS_REPO: ${{ inputs.status-repo }}
         STATUS_NUMBER: ${{ inputs.status-number }}
         RUN_ID: ${{ github.run_id }}
@@ -405,17 +420,19 @@ runs:
         JOB_STATUS: ${{ job.status }}
       run: |
         set -euo pipefail
+        if [[ -n "${STATUS_TOKEN}" ]]; then
+          echo "::add-mask::${STATUS_TOKEN}"
+        fi
         # When the fullsend process is hard-killed (SIGKILL, OOM, segfault),
         # the deferred PostCompletion call never runs and the status comment
         # remains in "Started" state. This step runs unconditionally (if:
         # always()) to detect and finalize orphaned comments. See #2149.
-        TOKEN="${STATUS_TOKEN:-${GITHUB_TOKEN:-}}"
-        if [[ -z "${TOKEN}" ]]; then
-          echo "::warning::No token available for status comment reconciliation"
-          exit 0
+        RECONCILE_FLAGS=(--repo "${STATUS_REPO}" --number "${STATUS_NUMBER}" --run-id "${RUN_ID}")
+        if [[ -n "${MINT_URL}" ]]; then
+          RECONCILE_FLAGS+=(--mint-url "${MINT_URL}" --role "${AGENT}")
+        elif [[ -n "${STATUS_TOKEN}" ]]; then
+          RECONCILE_FLAGS+=(--token "${STATUS_TOKEN}")
         fi
-        echo "::add-mask::${TOKEN}"
-        RECONCILE_FLAGS=(--repo "${STATUS_REPO}" --number "${STATUS_NUMBER}" --run-id "${RUN_ID}" --token "${TOKEN}")
         if [[ -n "${RUN_URL}" ]]; then
           RECONCILE_FLAGS+=(--run-url "${RUN_URL}")
         fi

--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -58,7 +58,7 @@ fullsend
 │   ├── --run-url <url>                      #   CI/CD run URL for status comments
 │   ├── --status-repo <owner/repo>           #   Repository for status comments
 │   ├── --status-number <int>                #   Issue/PR number for status comments
-│   └── --status-token <token>               #   Token for status comments (default: GH_TOKEN)
+│   └── --mint-url <url>                     #   Mint service URL for on-demand status tokens
 ├── fetch-skill      <url>                    # Fetch a skill at runtime (in-sandbox)
 ├── scan                                     # Run security scanner on input/output
 │   ├── input                                # Scan event payload for prompt injection
@@ -74,7 +74,8 @@ fullsend
     ├── --run-url <url>                      #   Workflow run URL (optional)
     ├── --sha <string>                       #   Commit SHA (optional)
     ├── --reason <string>                    #   Termination reason: terminated or cancelled (default: terminated)
-    └── --token <token>                      #   GitHub token (default: $GITHUB_TOKEN)
+    ├── --mint-url <url>                     #   Mint service URL for on-demand token (default: $FULLSEND_MINT_URL)
+    └── --role <string>                      #   Agent role for minting (required with --mint-url)
 ```
 
 ### Command Decomposition

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -235,7 +235,7 @@ target issue/PR. These flags mirror what the CI workflows pass automatically:
 | `--run-url` | URL of the CI/CD run shown in the status comment |
 | `--status-repo` | Repository (`owner/repo`) to post status comments on |
 | `--status-number` | Issue or PR number for status comments |
-| `--status-token` | Token for posting comments (defaults to `GH_TOKEN`) |
+| `--mint-url` | Mint service URL for on-demand status comment tokens (default: `$FULLSEND_MINT_URL`) |
 
 Example:
 

--- a/docs/reference/installation.md
+++ b/docs/reference/installation.md
@@ -732,7 +732,8 @@ The composite action accepts four optional inputs for status notifications:
 | `run-url` | URL of the CI/CD run shown in the status comment |
 | `status-repo` | Repository (`owner/repo`) to post status comments on |
 | `status-number` | Issue or PR number for status comments |
-| `status-token` | Token for posting comments (defaults to `GH_TOKEN`) |
+| `mint-url` | URL of the token mint service used to obtain fresh tokens for posting comments |
+| `status-token` | **Deprecated.** Static token for posting comments; use `mint-url` instead |
 
 All reusable workflows pass these inputs automatically.
 

--- a/internal/cli/mint.go
+++ b/internal/cli/mint.go
@@ -40,9 +40,10 @@ func defaultMintRoles() []string {
 }
 
 // roleAlias maps role aliases to their canonical names.
-// The fix role reuses the coder app — same PEM, same app ID.
+// The code and fix roles both reuse the coder app — same PEM, same app ID.
 var roleAlias = map[string]string{
-	"fix": "coder",
+	"code": "coder",
+	"fix":  "coder",
 }
 
 // resolveRole returns the canonical role name, resolving aliases.

--- a/internal/cli/mint_test.go
+++ b/internal/cli/mint_test.go
@@ -588,6 +588,7 @@ func TestMintStatusCmd_TooManyArgs(t *testing.T) {
 // --- role aliasing tests ---
 
 func TestResolveRole(t *testing.T) {
+	assert.Equal(t, "coder", resolveRole("code"))
 	assert.Equal(t, "coder", resolveRole("fix"))
 	assert.Equal(t, "coder", resolveRole("coder"))
 	assert.Equal(t, "triage", resolveRole("triage"))

--- a/internal/cli/reconcilestatus.go
+++ b/internal/cli/reconcilestatus.go
@@ -7,19 +7,27 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/fullsend-ai/fullsend/internal/forge"
 	gh "github.com/fullsend-ai/fullsend/internal/forge/github"
+	"github.com/fullsend-ai/fullsend/internal/mintclient"
 	"github.com/fullsend-ai/fullsend/internal/statuscomment"
 )
 
+var newForgeClient = func(token string) forge.Client {
+	return gh.New(token)
+}
+
 func newReconcileStatusCmd() *cobra.Command {
 	var (
-		repo   string
-		number int
-		runID  string
-		runURL string
-		sha    string
-		token  string
-		reason string
+		repo    string
+		number  int
+		runID   string
+		runURL  string
+		sha     string
+		reason  string
+		mintURL string
+		role    string
+		token   string // deprecated: use mintURL
 	)
 
 	cmd := &cobra.Command{
@@ -35,13 +43,6 @@ terminal tag (<!-- fullsend:status:terminal -->). If found, updates it
 to an "Interrupted" state and adds the terminal tag. If already
 finalized, this is a no-op.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if token == "" {
-				token = os.Getenv("GITHUB_TOKEN")
-			}
-			if token == "" {
-				return fmt.Errorf("--token or GITHUB_TOKEN required")
-			}
-
 			if number <= 0 {
 				return fmt.Errorf("--number must be a positive integer, got %d", number)
 			}
@@ -52,6 +53,34 @@ finalized, this is a no-op.`,
 			}
 			owner, repoName := parts[0], parts[1]
 
+			if mintURL == "" {
+				mintURL = os.Getenv("FULLSEND_MINT_URL")
+			}
+
+			var client forge.Client
+			if mintURL != "" {
+				if role == "" {
+					return fmt.Errorf("--role is required when using --mint-url")
+				}
+				result, err := mintclient.MintToken(cmd.Context(), mintclient.MintRequest{
+					MintURL: mintURL,
+					Role:    resolveRole(role),
+					Repos:   []string{repoName},
+				})
+				if err != nil {
+					return fmt.Errorf("minting status token: %w", err)
+				}
+				if os.Getenv("GITHUB_ACTIONS") == "true" && mintTokenPattern.MatchString(result.Token) {
+					fmt.Fprintf(os.Stderr, "::add-mask::%s\n", result.Token)
+				}
+				client = newForgeClient(result.Token)
+			} else if token != "" {
+				fmt.Fprintf(os.Stderr, "WARNING: --token is deprecated; use --mint-url instead\n")
+				client = newForgeClient(token)
+			} else {
+				return fmt.Errorf("--mint-url or FULLSEND_MINT_URL required (--token is deprecated)")
+			}
+
 			var termReason statuscomment.TerminationReason
 			switch reason {
 			case "cancelled":
@@ -59,8 +88,6 @@ finalized, this is a no-op.`,
 			default:
 				termReason = statuscomment.ReasonTerminated
 			}
-
-			client := gh.New(token)
 			return statuscomment.ReconcileOrphaned(cmd.Context(), client, owner, repoName, number, runID, runURL, sha, termReason)
 		},
 	}
@@ -70,8 +97,12 @@ finalized, this is a no-op.`,
 	cmd.Flags().StringVar(&runID, "run-id", "", "workflow run ID used in the status comment marker (required)")
 	cmd.Flags().StringVar(&runURL, "run-url", "", "URL to the workflow run (optional)")
 	cmd.Flags().StringVar(&sha, "sha", "", "commit SHA (optional, shown as short hash)")
-	cmd.Flags().StringVar(&token, "token", "", "GitHub token (default: $GITHUB_TOKEN)")
 	cmd.Flags().StringVar(&reason, "reason", "terminated", "termination reason: terminated or cancelled")
+	cmd.Flags().StringVar(&mintURL, "mint-url", "", "mint service URL for on-demand token (default: $FULLSEND_MINT_URL)")
+	cmd.Flags().StringVar(&role, "role", "", "agent role for minting (required with --mint-url)")
+	cmd.Flags().StringVar(&token, "token", "", "DEPRECATED: use --mint-url instead")
+	_ = cmd.Flags().MarkDeprecated("token", "use --mint-url instead")
+	_ = cmd.Flags().MarkHidden("token")
 	_ = cmd.MarkFlagRequired("repo")
 	_ = cmd.MarkFlagRequired("number")
 	_ = cmd.MarkFlagRequired("run-id")

--- a/internal/cli/reconcilestatus_test.go
+++ b/internal/cli/reconcilestatus_test.go
@@ -1,10 +1,15 @@
 package cli
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
+	gh "github.com/fullsend-ai/fullsend/internal/forge/github"
 )
 
 func TestNewReconcileStatusCmd_RequiredFlags(t *testing.T) {
@@ -31,19 +36,24 @@ func TestNewReconcileStatusCmd_ValidationErrors(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "missing token",
+			name:    "missing mint-url",
 			args:    []string{"--repo", "org/repo", "--number", "7", "--run-id", "run-1"},
-			wantErr: "--token or GITHUB_TOKEN required",
+			wantErr: "--mint-url or FULLSEND_MINT_URL required",
 		},
 		{
 			name:    "invalid number",
-			args:    []string{"--repo", "org/repo", "--number", "0", "--run-id", "run-1", "--token", "tok"},
+			args:    []string{"--repo", "org/repo", "--number", "0", "--run-id", "run-1"},
 			wantErr: "--number must be a positive integer",
 		},
 		{
 			name:    "invalid repo format",
-			args:    []string{"--repo", "noslash", "--number", "7", "--run-id", "run-1", "--token", "tok"},
+			args:    []string{"--repo", "noslash", "--number", "7", "--run-id", "run-1"},
 			wantErr: "--repo must be in owner/repo format",
+		},
+		{
+			name:    "mint-url without role",
+			args:    []string{"--repo", "org/repo", "--number", "7", "--run-id", "run-1", "--mint-url", "https://mint.example.com"},
+			wantErr: "--role is required when using --mint-url",
 		},
 	}
 	for _, tt := range tests {
@@ -55,4 +65,93 @@ func TestNewReconcileStatusCmd_ValidationErrors(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
+}
+
+func TestNewReconcileStatusCmd_MintURLFlags(t *testing.T) {
+	cmd := newReconcileStatusCmd()
+
+	for _, name := range []string{"mint-url", "role"} {
+		f := cmd.Flags().Lookup(name)
+		require.NotNil(t, f, "flag %q should exist", name)
+	}
+
+	mintURL := cmd.Flags().Lookup("mint-url")
+	assert.Equal(t, "", mintURL.DefValue)
+
+	role := cmd.Flags().Lookup("role")
+	assert.Equal(t, "", role.DefValue)
+}
+
+func TestNewReconcileStatusCmd_MintURLFromEnv(t *testing.T) {
+	t.Setenv("FULLSEND_MINT_URL", "https://mint.example.com")
+
+	cmd := newReconcileStatusCmd()
+	cmd.SetArgs([]string{"--repo", "org/repo", "--number", "7", "--run-id", "run-1", "--role", "review"})
+	err := cmd.Execute()
+	// Will fail at the OIDC exchange (no ACTIONS_ID_TOKEN_REQUEST_URL), but
+	// proves the env var was picked up and --role validation passed.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "minting status token")
+}
+
+func TestNewReconcileStatusCmd_TokenFlagDeprecated(t *testing.T) {
+	cmd := newReconcileStatusCmd()
+	f := cmd.Flags().Lookup("token")
+	require.NotNil(t, f, "--token flag should exist for backwards compatibility")
+	assert.NotEmpty(t, f.Deprecated, "--token flag should be marked deprecated")
+}
+
+func TestNewReconcileStatusCmd_DeprecatedTokenExecution(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	origNew := newForgeClient
+	newForgeClient = func(token string) forge.Client {
+		return gh.New(token).WithBaseURL(srv.URL)
+	}
+	defer func() { newForgeClient = origNew }()
+
+	t.Setenv("FULLSEND_MINT_URL", "")
+
+	cmd := newReconcileStatusCmd()
+	cmd.SetArgs([]string{
+		"--repo", "org/repo",
+		"--number", "7",
+		"--run-id", "run-1",
+		"--token", "test-token",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestNewReconcileStatusCmd_DeprecatedTokenCancelledReason(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	origNew := newForgeClient
+	newForgeClient = func(token string) forge.Client {
+		return gh.New(token).WithBaseURL(srv.URL)
+	}
+	defer func() { newForgeClient = origNew }()
+
+	t.Setenv("FULLSEND_MINT_URL", "")
+
+	cmd := newReconcileStatusCmd()
+	cmd.SetArgs([]string{
+		"--repo", "org/repo",
+		"--number", "7",
+		"--run-id", "run-1",
+		"--reason", "cancelled",
+		"--token", "test-token",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -26,6 +26,7 @@ import (
 	gh "github.com/fullsend-ai/fullsend/internal/forge/github"
 	"github.com/fullsend-ai/fullsend/internal/harness"
 	"github.com/fullsend-ai/fullsend/internal/lock"
+	"github.com/fullsend-ai/fullsend/internal/mintclient"
 	"github.com/fullsend-ai/fullsend/internal/resolve"
 	agentruntime "github.com/fullsend-ai/fullsend/internal/runtime"
 	"github.com/fullsend-ai/fullsend/internal/sandbox"
@@ -63,7 +64,8 @@ type statusOpts struct {
 	runURL      string
 	statusRepo  string
 	statusNum   int
-	statusToken string
+	mintURL     string
+	statusToken string // deprecated: use mintURL
 }
 
 func newRunCmd() *cobra.Command {
@@ -107,7 +109,10 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&sOpts.runURL, "run-url", "", "URL of the CI/CD run for status comments")
 	cmd.Flags().StringVar(&sOpts.statusRepo, "status-repo", "", "repository (owner/repo) for status comments")
 	cmd.Flags().IntVar(&sOpts.statusNum, "status-number", 0, "issue/PR number for status comments")
-	cmd.Flags().StringVar(&sOpts.statusToken, "status-token", "", "token for status comments (defaults to GH_TOKEN)")
+	cmd.Flags().StringVar(&sOpts.mintURL, "mint-url", "", "mint service URL for on-demand status tokens (default: $FULLSEND_MINT_URL)")
+	cmd.Flags().StringVar(&sOpts.statusToken, "status-token", "", "DEPRECATED: use --mint-url instead")
+	_ = cmd.Flags().MarkDeprecated("status-token", "use --mint-url instead")
+	_ = cmd.Flags().MarkHidden("status-token")
 	_ = cmd.MarkFlagRequired("fullsend-dir")
 	_ = cmd.MarkFlagRequired("target-repo")
 
@@ -400,7 +405,7 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	// post-script — and can report cancellation/failure even when the
 	// sandbox never starts. See #1859.
 	if sOpts.statusRepo != "" && sOpts.statusNum > 0 {
-		notifier, notifyErr := setupStatusNotifier(absFullsendDir, sOpts, printer)
+		notifier, notifyErr := setupStatusNotifier(absFullsendDir, agentName, sOpts, printer)
 		if notifyErr != nil {
 			printer.StepWarn("Status notifications disabled: " + notifyErr.Error())
 		} else {
@@ -1840,19 +1845,22 @@ func titleCase(s string) string {
 	return strings.Join(words, " ")
 }
 
-func setupStatusNotifier(fullsendDir string, sOpts statusOpts, printer *ui.Printer) (*statuscomment.Notifier, error) {
+func setupStatusNotifier(fullsendDir string, agentName string, sOpts statusOpts, printer *ui.Printer) (*statuscomment.Notifier, error) {
 	parts := strings.SplitN(sOpts.statusRepo, "/", 2)
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("--status-repo must be in owner/repo format, got %q", sOpts.statusRepo)
 	}
 	owner, repo := parts[0], parts[1]
 
-	token := sOpts.statusToken
-	if token == "" {
-		token = os.Getenv("GH_TOKEN")
+	mintURL := sOpts.mintURL
+	if mintURL == "" {
+		mintURL = os.Getenv("FULLSEND_MINT_URL")
 	}
-	if token == "" {
-		return nil, fmt.Errorf("no status token available (set --status-token or GH_TOKEN)")
+
+	staticToken := sOpts.statusToken
+
+	if mintURL == "" && staticToken == "" {
+		return nil, fmt.Errorf("no mint URL available (set --mint-url or FULLSEND_MINT_URL)")
 	}
 
 	var notifyCfg config.StatusNotificationConfig
@@ -1868,8 +1876,6 @@ func setupStatusNotifier(fullsendDir string, sOpts statusOpts, printer *ui.Print
 		printer.StepWarn("Failed to read config.yaml for status notifications: " + err.Error())
 	}
 
-	client := gh.New(token)
-
 	sha := os.Getenv("GITHUB_SHA")
 	// In cross-repo workflow_dispatch mode, GITHUB_SHA is the dispatching
 	// repo's default branch HEAD — not the PR's head commit. Prefer the
@@ -1882,10 +1888,34 @@ func setupStatusNotifier(fullsendDir string, sOpts statusOpts, printer *ui.Print
 		runID = fmt.Sprintf("%d", time.Now().UnixNano())
 	}
 
-	n := statuscomment.New(client, notifyCfg, owner, repo, sOpts.statusNum, sOpts.runURL, sha, runID)
+	var initialClient forge.Client
+	if staticToken != "" {
+		initialClient = gh.New(staticToken)
+	}
+
+	n := statuscomment.New(initialClient, notifyCfg, owner, repo, sOpts.statusNum, sOpts.runURL, sha, runID)
 	n.SetWarnFunc(func(format string, args ...any) {
 		printer.StepWarn(fmt.Sprintf(format, args...))
 	})
+
+	if mintURL != "" {
+		role := resolveRole(agentName)
+		n.SetClientFactory(func(ctx context.Context) (forge.Client, error) {
+			result, err := mintclient.MintToken(ctx, mintclient.MintRequest{
+				MintURL: mintURL,
+				Role:    role,
+				Repos:   []string{repo},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("minting status token: %w", err)
+			}
+			if os.Getenv("GITHUB_ACTIONS") == "true" && mintTokenPattern.MatchString(result.Token) {
+				fmt.Fprintf(os.Stderr, "::add-mask::%s\n", result.Token)
+			}
+			return gh.New(result.Token), nil
+		})
+	}
+
 	return n, nil
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1311,7 +1311,6 @@ func TestSetupFetchService_ResolvesTokenWhenNoForgeClient(t *testing.T) {
 	h := &harness.Harness{
 		Agent:                  "agents/test.md",
 		AllowedRemoteResources: []string{"https://github.com/org/"},
-		AllowRuntimeFetch:      true,
 	}
 
 	tokenResolved := false
@@ -1356,6 +1355,33 @@ func TestSetupFetchService_NoForgeClientNoRemoteResources(t *testing.T) {
 	assert.NotEmpty(t, env.addr)
 }
 
+func TestSetupFetchService_TokenResolutionFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	h := &harness.Harness{
+		Agent:                  "agents/test.md",
+		AllowedRemoteResources: []string{"https://github.com/org/"},
+	}
+
+	var warned string
+	env, shutdown, err := setupFetchService(
+		context.Background(),
+		nil,
+		h,
+		func() (string, error) { return "", fmt.Errorf("no token available") },
+		fetchsvc.ServiceConfig{
+			Harness:       h,
+			WorkspaceRoot: tmpDir,
+			MaxFetches:    10,
+		},
+		func(msg string) { warned = msg },
+	)
+	require.NoError(t, err)
+	defer shutdown()
+
+	assert.NotEmpty(t, env.addr)
+	assert.Contains(t, warned, "no token available")
+}
+
 func TestSetupFetchService_CustomMaxFetches(t *testing.T) {
 	tmpDir := t.TempDir()
 	maxFetches := 50
@@ -1387,34 +1413,6 @@ func TestSetupFetchService_CustomMaxFetches(t *testing.T) {
 	assert.NotEmpty(t, env.addr)
 }
 
-func TestSetupFetchService_TokenResolutionFails(t *testing.T) {
-	tmpDir := t.TempDir()
-	h := &harness.Harness{
-		Agent:                  "agents/test.md",
-		AllowedRemoteResources: []string{"https://github.com/org/"},
-		AllowRuntimeFetch:      true,
-	}
-
-	var warned string
-	env, shutdown, err := setupFetchService(
-		context.Background(),
-		nil,
-		h,
-		func() (string, error) { return "", fmt.Errorf("no token available") },
-		fetchsvc.ServiceConfig{
-			Harness:       h,
-			WorkspaceRoot: tmpDir,
-			MaxFetches:    10,
-		},
-		func(msg string) { warned = msg },
-	)
-	require.NoError(t, err)
-	defer shutdown()
-
-	assert.NotEmpty(t, env.addr)
-	assert.Contains(t, warned, "no token available")
-}
-
 func TestEffectiveMaxRuntimeFetches_MatchesFetchsvcDefault(t *testing.T) {
 	h := &harness.Harness{}
 	if h.EffectiveMaxRuntimeFetches() != fetchsvc.DefaultMaxFetches {
@@ -1425,4 +1423,187 @@ func TestEffectiveMaxRuntimeFetches_MatchesFetchsvcDefault(t *testing.T) {
 
 type mockForgeClient struct {
 	forge.Client
+}
+
+func TestSetupStatusNotifier_MintURL(t *testing.T) {
+	tmpDir := t.TempDir()
+	printer := ui.New(io.Discard)
+
+	sOpts := statusOpts{
+		statusRepo: "org/repo",
+		statusNum:  7,
+		mintURL:    "https://mint.example.com",
+	}
+
+	t.Setenv("GITHUB_RUN_ID", "run-42")
+
+	n, err := setupStatusNotifier(tmpDir, "review", sOpts, printer)
+	require.NoError(t, err)
+	assert.NotNil(t, n)
+	assert.True(t, n.HasClientFactory(), "client factory should be set when mint URL provided")
+}
+
+func TestSetupStatusNotifier_MintURLFromEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	printer := ui.New(io.Discard)
+
+	sOpts := statusOpts{
+		statusRepo: "org/repo",
+		statusNum:  7,
+	}
+
+	t.Setenv("FULLSEND_MINT_URL", "https://mint.example.com")
+	t.Setenv("GITHUB_RUN_ID", "run-42")
+
+	n, err := setupStatusNotifier(tmpDir, "code", sOpts, printer)
+	require.NoError(t, err)
+	assert.NotNil(t, n)
+	assert.True(t, n.HasClientFactory(), "client factory should be set from FULLSEND_MINT_URL env var")
+}
+
+func TestSetupStatusNotifier_NoMintURL(t *testing.T) {
+	tmpDir := t.TempDir()
+	printer := ui.New(io.Discard)
+
+	sOpts := statusOpts{
+		statusRepo: "org/repo",
+		statusNum:  7,
+	}
+
+	t.Setenv("GITHUB_RUN_ID", "run-42")
+	t.Setenv("FULLSEND_MINT_URL", "")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	_, err := setupStatusNotifier(tmpDir, "review", sOpts, printer)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no mint URL available")
+}
+
+func TestSetupStatusNotifier_DeprecatedToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	printer := ui.New(io.Discard)
+
+	sOpts := statusOpts{
+		statusRepo:  "org/repo",
+		statusNum:   7,
+		statusToken: "test-static-token",
+	}
+
+	t.Setenv("GITHUB_RUN_ID", "run-42")
+	t.Setenv("FULLSEND_MINT_URL", "")
+
+	n, err := setupStatusNotifier(tmpDir, "code", sOpts, printer)
+	require.NoError(t, err)
+	assert.NotNil(t, n)
+	assert.False(t, n.HasClientFactory(), "client factory should not be set when using deprecated static token")
+}
+
+func TestSetupStatusNotifier_InvalidRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	printer := ui.New(io.Discard)
+
+	sOpts := statusOpts{
+		statusRepo: "noslash",
+		statusNum:  7,
+	}
+
+	_, err := setupStatusNotifier(tmpDir, "review", sOpts, printer)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--status-repo must be in owner/repo format")
+}
+
+func TestRunCommand_HasMintURLFlag(t *testing.T) {
+	cmd := newRunCmd()
+
+	f := cmd.Flags().Lookup("mint-url")
+	require.NotNil(t, f, "run command should have --mint-url flag")
+	assert.Equal(t, "", f.DefValue)
+}
+
+func TestRunCommand_StatusTokenFlagDeprecated(t *testing.T) {
+	cmd := newRunCmd()
+
+	f := cmd.Flags().Lookup("status-token")
+	require.NotNil(t, f, "run command should have --status-token flag for backwards compatibility")
+	assert.NotEmpty(t, f.Deprecated, "--status-token flag should be marked deprecated")
+}
+
+func TestTitleCase(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"hello world", "Hello World"},
+		{"code", "Code"},
+		{"", ""},
+		{"already Title", "Already Title"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, titleCase(tt.in))
+	}
+}
+
+func TestSetupStatusNotifier_ConfigYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	printer := ui.New(io.Discard)
+
+	configData := `defaults:
+  status_notifications:
+    comment:
+      start: enabled
+      completion: disabled
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(configData), 0o644))
+
+	sOpts := statusOpts{
+		statusRepo: "org/repo",
+		statusNum:  7,
+		mintURL:    "https://mint.example.com",
+	}
+
+	t.Setenv("GITHUB_RUN_ID", "run-42")
+
+	n, err := setupStatusNotifier(tmpDir, "review", sOpts, printer)
+	require.NoError(t, err)
+	assert.NotNil(t, n)
+}
+
+func TestSetupStatusNotifier_RunIDFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	printer := ui.New(io.Discard)
+
+	sOpts := statusOpts{
+		statusRepo:  "org/repo",
+		statusNum:   7,
+		statusToken: "test-static-token",
+	}
+
+	t.Setenv("GITHUB_RUN_ID", "")
+	t.Setenv("FULLSEND_MINT_URL", "")
+
+	n, err := setupStatusNotifier(tmpDir, "code", sOpts, printer)
+	require.NoError(t, err)
+	assert.NotNil(t, n)
+}
+
+func TestSetupStatusNotifier_PRHeadSHA(t *testing.T) {
+	tmpDir := t.TempDir()
+	printer := ui.New(io.Discard)
+
+	eventPayload := `{"inputs":{"event_payload":"{\"pull_request\":{\"head\":{\"sha\":\"abc123def456\"}}}"}}`
+	eventFile := filepath.Join(tmpDir, "event.json")
+	require.NoError(t, os.WriteFile(eventFile, []byte(eventPayload), 0o644))
+
+	sOpts := statusOpts{
+		statusRepo:  "org/repo",
+		statusNum:   7,
+		statusToken: "test-static-token",
+	}
+
+	t.Setenv("GITHUB_EVENT_PATH", eventFile)
+	t.Setenv("GITHUB_RUN_ID", "run-42")
+	t.Setenv("FULLSEND_MINT_URL", "")
+
+	n, err := setupStatusNotifier(tmpDir, "code", sOpts, printer)
+	require.NoError(t, err)
+	assert.NotNil(t, n)
 }

--- a/internal/statuscomment/statuscomment.go
+++ b/internal/statuscomment/statuscomment.go
@@ -38,15 +38,20 @@ const (
 // now is overridable in tests to fix the current time for ReconcileOrphaned.
 var now = time.Now
 
+// ClientFactory returns a fresh forge.Client. It is called before each
+// API operation so the underlying token is never stale.
+type ClientFactory func(ctx context.Context) (forge.Client, error)
+
 // Notifier manages status comment lifecycle for a single agent run.
 type Notifier struct {
-	client      forge.Client
-	cfg         config.StatusNotificationConfig
-	owner, repo string
-	number      int
-	runURL      string
-	sha         string
-	marker      string
+	client        forge.Client
+	clientFactory ClientFactory
+	cfg           config.StatusNotificationConfig
+	owner, repo   string
+	number        int
+	runURL        string
+	sha           string
+	marker        string
 
 	startCommentID int
 	startTime      time.Time
@@ -79,6 +84,32 @@ func (n *Notifier) SetWarnFunc(f func(string, ...any)) {
 	n.warnf = f
 }
 
+// SetClientFactory sets a factory that mints a fresh forge.Client before
+// each API operation. When set, the static client passed to New is only
+// used if the factory is nil.
+func (n *Notifier) SetClientFactory(f ClientFactory) {
+	n.clientFactory = f
+}
+
+// HasClientFactory reports whether a client factory has been configured.
+func (n *Notifier) HasClientFactory() bool {
+	return n.clientFactory != nil
+}
+
+// refreshClient replaces n.client with a freshly minted client when a
+// factory is configured. Returns an error only if the factory itself fails.
+func (n *Notifier) refreshClient(ctx context.Context) error {
+	if n.clientFactory == nil {
+		return nil
+	}
+	c, err := n.clientFactory(ctx)
+	if err != nil {
+		return fmt.Errorf("minting fresh client: %w", err)
+	}
+	n.client = c
+	return nil
+}
+
 func commentEnabled(val string) bool {
 	return val == "" || val == "enabled"
 }
@@ -88,6 +119,9 @@ func (n *Notifier) PostStart(ctx context.Context, description string) error {
 	n.startTime = n.now().UTC()
 
 	if commentEnabled(n.cfg.Comment.Start) {
+		if err := n.refreshClient(ctx); err != nil {
+			return err
+		}
 		body := n.buildStartBody(description)
 		comment, err := n.client.CreateIssueComment(ctx, n.owner, n.repo, n.number, body)
 		if err != nil {
@@ -119,11 +153,17 @@ func (n *Notifier) PostCompletion(ctx context.Context, description, status strin
 		// Completion comments disabled — clean up the start comment so it
 		// doesn't remain orphaned in its "Started" state.
 		if n.startCommentID != 0 {
-			if err := n.client.DeleteIssueComment(ctx, n.owner, n.repo, n.startCommentID); err != nil {
+			if err := n.refreshClient(ctx); err != nil {
+				n.warnf("failed to mint token for start comment cleanup: %v", err)
+			} else if err := n.client.DeleteIssueComment(ctx, n.owner, n.repo, n.startCommentID); err != nil {
 				n.warnf("failed to delete start comment when completion disabled: %v", err)
 			}
 		}
 		return nil
+	}
+
+	if err := n.refreshClient(ctx); err != nil {
+		return err
 	}
 
 	body := n.buildCompletionBody(description, status, completionTime)

--- a/internal/statuscomment/statuscomment_test.go
+++ b/internal/statuscomment/statuscomment_test.go
@@ -869,3 +869,215 @@ func TestReconcileOrphaned_UnknownReasonDefaultsToTerminated(t *testing.T) {
 	assert.Contains(t, body, "Started 6:43 AM UTC")
 	assert.Contains(t, body, "Ended 2:47 PM UTC")
 }
+
+func TestClientFactory_CalledBeforePostStart(t *testing.T) {
+	fc1 := forge.NewFakeClient()
+	fc2 := forge.NewFakeClient()
+	fc2.AuthenticatedUser = "mint-bot[bot]"
+	cfg := config.StatusNotificationConfig{}
+
+	n := New(fc1, cfg, "org", "repo", 7, "https://ci/run/42", "a1b2c3d", "run-42")
+	n.now = fixedTime
+
+	factoryCalled := false
+	n.SetClientFactory(func(ctx context.Context) (forge.Client, error) {
+		factoryCalled = true
+		return fc2, nil
+	})
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+	assert.True(t, factoryCalled, "factory should be called before PostStart API calls")
+	assert.Len(t, fc2.IssueComments["org/repo/7"], 1, "comment should be on factory-returned client")
+	assert.Empty(t, fc1.IssueComments, "original client should not be used")
+}
+
+func TestClientFactory_CalledBeforePostCompletion(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.AuthenticatedUser = "bot[bot]"
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+
+	n := newTestNotifier(fc, cfg)
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+
+	fc2 := forge.NewFakeClient()
+	fc2.AuthenticatedUser = "bot[bot]"
+	// Pre-populate fc2 with the same comments so analyzeTimeline works.
+	fc2.IssueComments = map[string][]forge.IssueComment{
+		"org/repo/7": {fc.IssueComments["org/repo/7"][0]},
+	}
+
+	completionFactoryCalled := false
+	n.SetClientFactory(func(ctx context.Context) (forge.Client, error) {
+		completionFactoryCalled = true
+		return fc2, nil
+	})
+
+	n.now = func() time.Time { return fixedTime().Add(5 * time.Minute) }
+	err = n.PostCompletion(context.Background(), "Working", "success")
+	require.NoError(t, err)
+	assert.True(t, completionFactoryCalled, "factory should be called before PostCompletion API calls")
+}
+
+func TestClientFactory_ErrorPropagated(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{}
+	n := New(fc, cfg, "org", "repo", 7, "", "", "run-42")
+	n.now = fixedTime
+
+	n.SetClientFactory(func(ctx context.Context) (forge.Client, error) {
+		return nil, fmt.Errorf("mint service unavailable")
+	})
+
+	err := n.PostStart(context.Background(), "Working")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mint service unavailable")
+}
+
+func TestClientFactory_NilUsesStaticClient(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+	assert.Len(t, fc.IssueComments["org/repo/7"], 1, "static client should be used when no factory set")
+}
+
+func TestClientFactory_ErrorOnPostCompletion(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "enabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+
+	n.SetClientFactory(func(ctx context.Context) (forge.Client, error) {
+		return nil, fmt.Errorf("token expired")
+	})
+
+	n.now = func() time.Time { return fixedTime().Add(5 * time.Minute) }
+	err = n.PostCompletion(context.Background(), "Working", "success")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token expired")
+}
+
+func TestClientFactory_CompletionDisabled_DeletePath(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "disabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+	require.Equal(t, 1, n.startCommentID)
+
+	fc2 := forge.NewFakeClient()
+	fc2.AuthenticatedUser = "fullsend-bot[bot]"
+	fc2.IssueComments = map[string][]forge.IssueComment{
+		"org/repo/7": {fc.IssueComments["org/repo/7"][0]},
+	}
+
+	factoryCalled := false
+	n.SetClientFactory(func(ctx context.Context) (forge.Client, error) {
+		factoryCalled = true
+		return fc2, nil
+	})
+
+	n.now = func() time.Time { return fixedTime().Add(time.Minute) }
+	err = n.PostCompletion(context.Background(), "Working", "success")
+	require.NoError(t, err)
+	assert.True(t, factoryCalled, "factory should be called even when completion disabled (for delete)")
+	require.Len(t, fc2.DeletedComments, 1)
+	assert.Equal(t, 1, fc2.DeletedComments[0])
+}
+
+func TestClientFactory_BothDisabled_NoMint(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "disabled", Completion: "disabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	factoryCalled := false
+	n.SetClientFactory(func(ctx context.Context) (forge.Client, error) {
+		factoryCalled = true
+		return nil, fmt.Errorf("should not be called")
+	})
+
+	err := n.PostCompletion(context.Background(), "Working", "success")
+	require.NoError(t, err, "should not error when no API call is needed")
+	assert.False(t, factoryCalled, "factory should not be called when both disabled and no start comment")
+}
+
+func TestHasClientFactory(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{}
+	n := newTestNotifier(fc, cfg)
+
+	assert.False(t, n.HasClientFactory(), "should be false when no factory set")
+
+	n.SetClientFactory(func(ctx context.Context) (forge.Client, error) {
+		return fc, nil
+	})
+	assert.True(t, n.HasClientFactory(), "should be true after SetClientFactory")
+}
+
+func TestClientFactory_CompletionDisabled_MintError(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "disabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+	require.NotZero(t, n.startCommentID)
+
+	var warnings []string
+	n.SetWarnFunc(func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	})
+	n.SetClientFactory(func(ctx context.Context) (forge.Client, error) {
+		return nil, fmt.Errorf("mint service down")
+	})
+
+	err = n.PostCompletion(context.Background(), "Working", "success")
+	require.NoError(t, err, "should not return error — fail-open on cleanup")
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "mint service down")
+}
+
+func TestClientFactory_CompletionDisabled_DeleteError(t *testing.T) {
+	fc := forge.NewFakeClient()
+	cfg := config.StatusNotificationConfig{
+		Comment: config.CommentNotificationConfig{Start: "enabled", Completion: "disabled"},
+	}
+	n := newTestNotifier(fc, cfg)
+
+	err := n.PostStart(context.Background(), "Working")
+	require.NoError(t, err)
+	require.NotZero(t, n.startCommentID)
+
+	fc2 := forge.NewFakeClient()
+	fc2.Errors["DeleteIssueComment"] = fmt.Errorf("forbidden")
+
+	var warnings []string
+	n.SetWarnFunc(func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	})
+	n.SetClientFactory(func(ctx context.Context) (forge.Client, error) {
+		return fc2, nil
+	})
+
+	err = n.PostCompletion(context.Background(), "Working", "success")
+	require.NoError(t, err, "should not return error — fail-open on cleanup")
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "forbidden")
+}


### PR DESCRIPTION
## Summary

- Status comments get stuck in "Started" when the pre-minted agent token expires before `PostCompletion` runs (#2130)
- The binary now mints its own fresh short-lived token via `mintclient` before each status comment API call, using OIDC credentials that live for the full job
- Adds `--mint-url` flag to `fullsend run` and `reconcile-status`, and `mint-url` input to `action.yml`
- Deprecates `--status-token` (run), `--token` (reconcile-status), and `status-token` (action.yml input) with runtime warnings — static tokens still work as fallback
- Validates token format before `::add-mask::` to prevent workflow command injection
- Moves `refreshClient` below `commentEnabled` guard in `PostCompletion` and makes cleanup-path mint failures fail-open (warning)
- Adds `"code" → "coder"` role alias so the agent name resolves to the correct mint role

## Test plan

- [x] `go test ./internal/statuscomment/...` — client factory tests pass
- [x] `go test ./internal/cli/...` — resolveRole alias, deprecated flag, reconcile-status tests pass
- [x] `go vet`, `gofmt`, pre-commit hooks all pass
- [ ] Deploy to a per-org install, trigger an agent run, confirm status comment updates even after the original agent token would have expired
- [ ] Verify `reconcile-status` with `--mint-url` correctly finalizes orphaned comments

Closes #2130

🤖 Generated with [Claude Code](https://claude.com/claude-code)