### PR TITLE
fix: widen CSMA post-reset jitter to prevent thundering herd

### DIFF
--- a/internal/scaffold/fullsend-repo/scripts/lib/github-api-csma.sh
+++ b/internal/scaffold/fullsend-repo/scripts/lib/github-api-csma.sh
@@ -14,6 +14,7 @@
 #   GITHUB_CSMA_MIN_REMAINING_GRAPHQL — default 100
 #   GITHUB_CSMA_SLOT_MIN_MS           — default 250
 #   GITHUB_CSMA_SLOT_MAX_MS           — default 750 (0 disables jitter)
+#   GITHUB_CSMA_SPREAD_MAX_SEC        — default 60 (post-reset desync spread)
 #   GITHUB_CSMA_BACKOFF_CAP_SEC       — default 120
 
 # shellcheck shell=bash
@@ -39,6 +40,10 @@ _github_csma_slot_min_ms() {
 
 _github_csma_slot_max_ms() {
   echo "${GITHUB_CSMA_SLOT_MAX_MS:-750}"
+}
+
+_github_csma_spread_max_sec() {
+  echo "${GITHUB_CSMA_SPREAD_MAX_SEC:-60}"
 }
 
 _github_csma_backoff_cap_sec() {
@@ -85,6 +90,16 @@ github_csma_sense() {
 
   echo "Rate limit sense: ${resource} remaining=${remaining} (min=${min_remaining}); waiting ${wait_secs}s until reset..." >&2
   sleep "${wait_secs}"
+
+  # After a rate-limit sleep, all runners wake at the same reset timestamp.
+  # Spread them over a wide window to avoid a thundering herd.
+  local spread_max
+  spread_max=$(_github_csma_spread_max_sec)
+  if (( spread_max > 0 )); then
+    local spread_secs=$(( RANDOM % spread_max ))
+    echo "Rate limit reset — spreading ${spread_secs}s to desync from other runners..." >&2
+    sleep "${spread_secs}"
+  fi
 }
 
 # Random inter-call delay (slot time) to reduce synchronized collisions.


### PR DESCRIPTION
## Summary

- After a rate-limit sleep, all parallel runners wake at the same reset timestamp and collide within a 750ms jitter window
- This caused `unknown owner type` errors from `gh project view` — its internal owner-resolution GraphQL call got trampled by sibling runners
- Adds a post-reset spread of up to 60s (`GITHUB_CSMA_SPREAD_MAX_SEC`) so runners fan out over a wide window after waking

## Context

Observed in https://github.com/fullsend-ai/.fullsend/actions/runs/27572357937/job/81511878257 — the prioritize agent succeeded but `post-prioritize.sh` failed because the CSMA sense function woke all runners simultaneously after a graphql rate limit reset.

## Test plan

- [x] Existing `post-prioritize-test.sh` passes
- [ ] Run a batch of 5+ prioritize jobs and observe post-scripts no longer collide after rate limit resets