### PR TITLE
chore(ci): bump OpenShell to 0.0.63, extract install scripts, add Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/scripts/install-openshell.sh
+++ b/.github/scripts/install-openshell.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Install the pinned OpenShell version via upstream install.sh.
+#
+# Sources openshell-version.sh for the version and commit SHA, then
+# runs the upstream installer. Requires sudo for RPM installation.
+#
+# Usage:
+#   .github/scripts/install-openshell.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/openshell-version.sh"
+
+echo "Installing OpenShell ${OPENSHELL_VERSION} (${OPENSHELL_SHA})"
+curl -LsSf "https://raw.githubusercontent.com/NVIDIA/OpenShell/${OPENSHELL_SHA}/install.sh" \
+  | OPENSHELL_VERSION="v${OPENSHELL_VERSION}" sh
+
+openshell --version

--- a/.github/scripts/openshell-version.sh
+++ b/.github/scripts/openshell-version.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Single source of truth for the pinned OpenShell version.
+#
+# Source this script to set OPENSHELL_VERSION and OPENSHELL_SHA in the
+# current shell. In GitHub Actions it also exports them to GITHUB_ENV
+# for downstream steps.
+#
+# Usage:
+#   source .github/scripts/openshell-version.sh
+
+# renovate: datasource=github-tags depName=NVIDIA/OpenShell
+OPENSHELL_VERSION=0.0.63
+OPENSHELL_SHA=ec197a43ef349e36c3fff04e9aaea9599fb83b31
+
+export OPENSHELL_VERSION OPENSHELL_SHA
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "OPENSHELL_VERSION=${OPENSHELL_VERSION}" >> "${GITHUB_ENV}"
+  echo "OPENSHELL_SHA=${OPENSHELL_SHA}" >> "${GITHUB_ENV}"
+fi

--- a/action.yml
+++ b/action.yml
@@ -265,14 +265,7 @@ runs:
         podman info
         systemctl --user start podman.socket
 
-    - name: Set OpenShell version
-      shell: bash
-      run: |
-        echo "OPENSHELL_VERSION=0.0.54" >> "${GITHUB_ENV}"
-        # SHA corresponding to 0.0.54
-        echo "OPENSHELL_SHA=79aa355dd008e496a7d8f97b361a7b2866066fbc" >> "${GITHUB_ENV}"
-
-    - name: Install OpenShell CLI
+    - name: Configure OpenShell gateway
       shell: bash
       run: |
         mkdir -p $HOME/.config/openshell/
@@ -280,8 +273,9 @@ runs:
         OPENSHELL_BIND_ADDRESS=0.0.0.0
         EOF
 
-        curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/${OPENSHELL_SHA}/install.sh | OPENSHELL_VERSION=v${OPENSHELL_VERSION} sh
-        openshell --version
+    - name: Install OpenShell CLI
+      shell: bash
+      run: "$GITHUB_ACTION_PATH/.github/scripts/install-openshell.sh"
 
     - name: Restore cached sandbox image
       id: sandbox-cache

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -11,7 +11,7 @@ Linux are supported with Podman as the container runtime.
 | Requirement | macOS | Linux |
 |-------------|-------|-------|
 | Container runtime | Podman Desktop with a running machine | Podman |
-| [OpenShell](https://github.com/NVIDIA/OpenShell) | 0.0.54 | 0.0.54 |
+| [OpenShell](https://github.com/NVIDIA/OpenShell) | 0.0.63 | 0.0.63 |
 | GCP project | [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled with [Claude models](https://console.cloud.google.com/vertex-ai/model-garden) enabled | Same |
 | GCP credentials | Service account key (see section below) | Same |
 | GitHub PAT | Classic PAT with `repo` scope (see section below) | Same |
@@ -51,7 +51,7 @@ to install it, here we use one similar to how we download it on Fullsend. Use th
 printed on your Fullsend workflow for better reproducibility.
 
 ```bash
-export OPENSHELL_VERSION=0.0.54
+export OPENSHELL_VERSION=0.0.63
 curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/v${OPENSHELL_VERSION}/install.sh | OPENSHELL_VERSION=v${OPENSHELL_VERSION} sh
 openshell --version
 ```
@@ -322,8 +322,6 @@ to the server (gateway). It is likely that you need to bind the gateway to `0.0.
 **arm64 sandbox image pull fails**
 - The default `:latest` tag is amd64-only. Add `FULLSEND_SANDBOX_IMAGE=ghcr.io/fullsend-ai/fullsend-sandbox:dev` to your env file
 
-**`L7 policy validation failed: unknown protocol 'tcp'`**
-- OpenShell 0.0.54 uses `protocol: rest` (not `tcp`) and `access: read-write`/`read-only` (not `allow`). Update your policy YAML files to use the new schema. See the built-in policies in `policies/` for examples.
 
 **`unable to replace "host-gateway"` on macOS**
 - Set `host_containers_internal_ip = "192.168.127.254"` under `[containers]` in `~/.config/containers/containers.conf` and restart the Podman machine

--- a/internal/scaffold/vendormanifest.go
+++ b/internal/scaffold/vendormanifest.go
@@ -150,6 +150,8 @@ var vendoredDefaultsInfraPaths = []string{
 	".github/actions/mint-token/action.yml",
 	".github/actions/setup-gcp/action.yml",
 	".github/actions/validate-enrollment/action.yml",
+	".github/scripts/install-openshell.sh",
+	".github/scripts/openshell-version.sh",
 }
 
 // enumerateVendoredPaths returns embed-derived paths for a current --vendor install layout.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "git-submodules": {
+    "enabled": true
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track OpenShell version pin in openshell-version.sh",
+      "fileMatch": [
+        "^\\.github/scripts/openshell-version\\.sh$"
+      ],
+      "matchStrings": [
+        "OPENSHELL_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)\\nOPENSHELL_SHA=(?<currentDigest>[0-9a-f]{40})"
+      ],
+      "depNameTemplate": "NVIDIA/OpenShell",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Combines changes from #882 (Renovate automation) and the version bump and install script extraction already in progress on this branch.

### OpenShell install script extraction

The inline version pin and install logic in `action.yml` are split into dedicated scripts:

| File | Purpose |
|------|---------|
| `.github/scripts/openshell-version.sh` | Single source of truth for `OPENSHELL_VERSION` and `OPENSHELL_SHA`; exports to `GITHUB_ENV`; carries Renovate inline comment |
| `.github/scripts/install-openshell.sh` | Sources version script and runs upstream installer |
| `action.yml` | Replaces monolithic step with 'Configure OpenShell gateway' + 'Install OpenShell CLI' (delegates to script) |

### Version bump

Pinned version updated 0.0.54 → **0.0.63** (SHA `ec197a43ef349e36c3fff04e9aaea9599fb83b31`).

### Docs update

`docs/guides/user/running-agents-locally.md`:
- Requirements table and install snippet updated to 0.0.63
- Stale troubleshooting note for the 0.0.54 tcp protocol schema removed

### Renovate automation (from #882)

- `renovate.json`: regex custom manager targets `.github/scripts/openshell-version.sh`; matches both `OPENSHELL_VERSION` and `OPENSHELL_SHA` in a single regex so Renovate updates them atomically; `git-submodules` manager replaces Dependabot
- `.github/dependabot.yml` removed (consolidated onto Renovate)

## Test plan

- [ ] Verify Renovate picks up `OPENSHELL_VERSION=0.0.63` and `OPENSHELL_SHA` from `.github/scripts/openshell-version.sh` and opens a bump PR (updating both fields) when a newer tag is published
- [ ] Confirm `action.yml` installs OpenShell successfully in a workflow run
- [ ] Confirm `make functional-tests` (once environment secrets are configured) installs the correct version via `.github/scripts/install-openshell.sh`

Refs #882