### PR TITLE
docs: document fix agent context model, URL behavior, and limitations

### DIFF
--- a/docs/agents/fix.md
+++ b/docs/agents/fix.md
@@ -13,6 +13,84 @@ The fix agent is triggered when the [review agent](review.md) requests changes o
 3. **Validation loop** — the output is checked against a schema, with up to 2 retry iterations if the output is malformed.
 4. **Post-script** pushes the commit and posts a summary comment on the PR.
 
+### What the agent reads
+
+The fix agent has two operating modes with different primary inputs:
+
+**Bot-triggered** (review agent requests changes):
+
+| Input | Source | How it gets there |
+|-------|--------|-------------------|
+| Review body | Latest `CHANGES_REQUESTED` review from the review bot | Pre-fetched on the runner before the sandbox starts, injected as `review-body.txt` |
+| PR diff | `gh pr diff` inside the sandbox | Agent calls this to understand what code changed |
+| Repository checkout | Full repo at PR HEAD | Checked out on the runner, mounted into the sandbox |
+| Repo conventions | `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md` | Read from the checkout inside the sandbox |
+
+**Human-triggered** (`/fs-fix [instruction]`):
+
+| Input | Source | How it gets there |
+|-------|--------|-------------------|
+| Human instruction | Free text after `/fs-fix` in the comment | Extracted by the workflow, passed as `HUMAN_INSTRUCTION` env var (up to 10,000 bytes) |
+| PR diff | `gh pr diff` inside the sandbox | Same as bot-triggered |
+| Repository checkout | Full repo at PR HEAD | Same as bot-triggered |
+| Repo conventions | `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md` | Same as bot-triggered |
+| Review body (if any) | Prior review bot `CHANGES_REQUESTED` review | Still injected as `review-body.txt`, but human instruction takes precedence |
+
+When a human instruction is present, it supersedes the review body as the
+primary directive.
+
+### What the agent does not read
+
+This is worth being explicit about, because the fix agent's scope is narrower
+than you might expect:
+
+- **Inline PR review comments.** The agent reads the consolidated review body,
+  not individual line-level comments. If you need the agent to act on a
+  specific inline comment, copy the relevant text into a `/fs-fix` instruction.
+- **Other PR comments.** General discussion comments on the PR are not part of
+  the agent's context. Only the review body and the `/fs-fix` instruction are
+  read.
+- **CI logs and check status.** The fix agent does not read GitHub Actions logs,
+  check run output, or merge readiness indicators. It addresses review
+  feedback, not CI failures. (The [code agent](code.md) handles CI failures
+  during implementation.)
+- **Issue body.** The fix agent does not read the linked issue. It operates
+  purely on the PR and review context.
+
+### Links and URLs in instructions
+
+The `/fs-fix` instruction text can contain URLs. Whether the agent can use them
+depends on where the URL points:
+
+| URL type | Works? | Why |
+|----------|--------|-----|
+| Same-repo issue or PR (`#123` or full GitHub URL) | Yes | Agent resolves via `gh` CLI through the GitHub API |
+| Same-repo file or commit | Yes | Same mechanism — GitHub API via minted token |
+| Cross-repo GitHub URL | No | Minted token is scoped to the target repo only |
+| GitHub Gist | No | `gist.github.com` is not routable through the sandbox proxy |
+| External URL (docs, pastebins, etc.) | No | Sandbox proxy blocks all non-API HTTP egress (403 Forbidden) |
+
+GitHub may auto-shorten same-repo URLs in rendered comments (e.g.,
+`https://github.com/org/repo/issues/2` becomes `#2`), but the dispatch
+pipeline reads the raw comment body, so the full URL is preserved in the
+instruction text either way.
+
+**If you need the agent to act on external context**, paste the relevant
+content directly into the `/fs-fix` comment rather than linking to it. The
+instruction supports multi-line text (up to 10,000 bytes).
+
+### Iteration limits
+
+The fix agent enforces iteration caps to prevent infinite review-fix loops:
+
+- **Bot-triggered:** up to 5 iterations per PR (configurable).
+- **Human-triggered:** up to 10 total iterations per PR (configurable), shared
+  across bot and human triggers.
+- When a bot-triggered run is approaching the bot cap, the agent applies the
+  `needs-human` label.
+- Each `/fs-fix` comment cancels any in-flight fix run for the same PR and
+  starts a new one.
+
 ## How it helps
 
 - Review feedback is addressed quickly — often before the reviewer checks back.
@@ -33,6 +111,8 @@ direct control over what to fix:
 - `/fs-fix` — fix whatever the [review agent](review.md) flagged
 - `/fs-fix you forgot to update the docs here`
 - `/fs-fix the error handling in processItem needs to distinguish between retryable and fatal errors`
+- `/fs-fix address the concern raised in #42` — same-repo references work
+  ([details](#links-and-urls-in-instructions))
 
 The fix agent also triggers automatically when the [review agent](review.md) submits a
 "changes requested" review on a same-repo PR (fork PRs are blocked).
@@ -46,7 +126,7 @@ Remove the label or use `/fs-fix` to re-engage.
 | Label | Meaning |
 |-------|---------|
 | `fullsend-no-fix` | Prevents bot-triggered fix runs on this PR. Applied by `/fs-fix-stop`. Human `/fs-fix` commands are unaffected. |
-| `needs-human` | The fix agent is approaching its iteration cap and needs human direction. Applied automatically when the fix iteration reaches the warning threshold. |
+| `needs-human` | The fix agent is approaching its iteration cap and needs human direction. Applied automatically when a bot-triggered fix iteration reaches the warning threshold. |
 
 ## Configuration and extension
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -279,7 +279,7 @@ ADR 0002: [Building block 11](ADRs/0002-initial-fullsend-design.md#11-review-age
 Aggregates review verdicts and applies labels:
 
 - unanimous approve-merge → `ready-for-merge` (for the **current** PR head at the end of that round only)
-- unanimous rework → `ready-to-code`
+- unanimous rework → triggers [fix agent](agents/fix.md)
 - split/conflicting (including conflicting security severities) → `requires-manual-review`
 - each **review run start** (including push-triggered re-review) clears **`ready-for-merge`** together with **`ready-for-review`** so merge approval is never stale after new commits
 ADR 0002: [Building block 12](ADRs/0002-initial-fullsend-design.md#12-coordinator-merge-algorithm).

--- a/docs/guides/user/bugfix-workflow.md
+++ b/docs/guides/user/bugfix-workflow.md
@@ -4,24 +4,24 @@ How fullsend handles a bug report from issue creation to merged fix, end to end.
 
 ## Overview
 
-When someone files a bug, fullsend's agent pipeline processes it through three stages:
+When someone files a bug, fullsend's agent pipeline processes it through four stages:
 
 1. **Triage** — validates the issue, checks for duplicates, attempts reproduction
 2. **Code** — implements a fix, writes tests, opens a PR, passes CI
 3. **Review** — multiple review agents evaluate the PR independently, a coordinator decides the outcome
+4. **Fix** — addresses review feedback automatically or on human command, then loops back to review
 
 Each stage is triggered by labels and can be restarted with slash commands. The pipeline uses GitHub's native primitives (issues, PRs, labels, branch protection) as its coordination layer — there is no central orchestrator. See [ADR 0002](../../ADRs/0002-initial-fullsend-design.md) for the full design.
 
 ```
 Issue filed → Triage → ready-to-code → Code Agent → PR opened → Review → ready-for-merge → Merge
-                │                          ↑                                │
-                │                          └── changes requested (planned) ─┘
+                │                                                  │ ↑
+                │                                                  │ │
+                │                                           Fix ───┘ └─── Re-review
                 ├── blocked → waiting for dependency
                 ├── duplicate → closed
                 └── needs-info → waiting for info
 ```
-
-> **Note:** The automated rework loop (Review → Code Agent on "changes requested") is not yet implemented. Today, a "changes requested" outcome requires human intervention. The planned [fix agent (#197)](https://github.com/fullsend-ai/fullsend/issues/197) will automate this loop.
 
 ## What you need to know as a developer
 
@@ -61,6 +61,8 @@ You can control the pipeline from issue or PR comments:
 | `/fs-triage` | Issue comment | Re-runs triage from scratch (clears all labels, reopens if closed) |
 | `/fs-code` | Issue comment | Hands off to the code agent (expects `ready-to-code` or forces with human ack) |
 | `/fs-review` | PR comment | Enqueues a new review round for the current PR head |
+| `/fs-fix` | PR comment | Triggers the [fix agent](../../agents/fix.md) on the PR; accepts optional free-text instruction |
+| `/fs-fix-stop` | PR comment | Disables bot-triggered fix runs for this PR (human `/fs-fix` still works) |
 | `/fs-retro` | Issue or PR comment | Triggers a retrospective analysis of the workflow |
 
 ### What to expect from agent PRs
@@ -86,12 +88,10 @@ Agent PRs go through the same review process as human PRs:
 The review stage runs N independent review agents in parallel. One is randomly selected as coordinator. The coordinator collects verdicts and applies one of three outcomes:
 
 - **Unanimous approve:** All reviewers agree the PR is good. Label `ready-for-merge` is applied. The PR can be merged per your org's governance policy.
-- **Unanimous rework:** All reviewers agree changes are needed. Label `ready-to-code` is re-applied. Today, a human must address the review feedback manually. When the [fix agent (#197)](https://github.com/fullsend-ai/fullsend/issues/197) is implemented, this rework loop will be automated.
+- **Unanimous rework:** All reviewers agree changes are needed. The [fix agent](../../agents/fix.md) triggers automatically, reads the consolidated review body, and pushes fixes to the existing PR. After the fix, a new review round begins.
 - **Split or conflicting:** Reviewers disagree, or there are conflicting security assessments. Label `requires-manual-review` is applied. A human must decide.
 
 Every push to a PR in the review stage triggers a new review round. This means `ready-for-merge` is never stale — it always reflects the current PR head.
-
-> **Planned:** The **fix agent** ([#197](https://github.com/fullsend-ai/fullsend/issues/197)) will handle the rework loop automatically. When a review agent requests changes or a human posts `/fs-fix [instruction]`, the fix agent reads the review feedback and pushes fixes to the existing PR — no manual coding required. The fix agent is a separate workflow from the code agent, with its own prompt scoped to "read review feedback, fix existing PR."
 
 ## The stages in detail
 
@@ -130,9 +130,24 @@ The review swarm:
 
 1. **N independent reviewers** evaluate the PR in parallel (configurable count).
 2. **One coordinator** (randomly selected) collects verdicts and posts a consolidated comment.
-3. **Outcome** is applied as a label: `ready-for-merge`, `ready-to-code` (rework), or `requires-manual-review`.
+3. **Outcome** is applied as a label (`ready-for-merge` or `requires-manual-review`) or triggers the [fix agent](../../agents/fix.md) (rework).
 
 Re-review happens automatically on every push to the PR. The `ready-for-merge` label is scoped to the PR head SHA at the time of review — it is cleared and re-evaluated on each new round.
+
+### Stage 4: Fix
+
+**Triggered by:** review agent submitting a "changes requested" review, or human `/fs-fix` command.
+
+The [fix agent](../../agents/fix.md):
+
+1. **Reads the review feedback.** For bot-triggered runs, the consolidated review body is the primary input. For human-triggered runs, the `/fs-fix` instruction text takes precedence.
+2. **Implements targeted fixes.** Addresses each actionable finding from the review, following repo conventions from `AGENTS.md`.
+3. **Verifies.** Runs the test suite and linters before committing.
+4. **Pushes a fix commit.** Posts a summary comment on the PR detailing what was fixed, what was disagreed with, and test results.
+
+After the fix commit, the review agents automatically re-review. This loop repeats until the reviewers approve, the iteration cap is reached, or a human intervenes with `/fs-fix-stop`.
+
+For details on what the fix agent reads, what it ignores, and how URLs in instructions behave, see the [fix agent reference](../../agents/fix.md).
 
 ### After merge
 
@@ -152,6 +167,7 @@ The **retro agent** ([#131](https://github.com/fullsend-ai/fullsend/issues/131))
 - `/fs-triage` — wipes all labels, reopens the issue, runs triage fresh.
 - `/fs-code` — restarts the code agent from the current issue state.
 - `/fs-review` — enqueues a new review round.
+- `/fs-fix [instruction]` — triggers the fix agent with an optional human directive.
 
 ### Taking over manually
 


### PR DESCRIPTION
## Summary

- Adds context model documentation to `docs/agents/fix.md` — what the fix agent reads (review body, human instruction, repo checkout, conventions files), what it does **not** read (inline PR comments, CI logs, other discussion comments, issue body), how URLs in `/fs-fix` instructions behave, and iteration limits
- Updates `docs/guides/user/bugfix-workflow.md` to reflect that the fix agent is shipped — adds Fix as Stage 4, updates the pipeline diagram, adds `/fs-fix` and `/fs-fix-stop` to the slash commands table, and removes stale "planned" callouts referencing issue #197

## Motivation

Team discussion surfaced an expectation gap: contributors expected the fix agent to behave like a full PR babysitter (reading all comments, CI logs, merge readiness indicators) when in reality it only reads the review agent's consolidated review body and the `/fs-fix` instruction text. The existing docs didn't make this explicit.

Additionally, live testing of URL handling in `/fs-fix` instructions revealed that:
- Same-repo references (`#123` or full GitHub URLs) work because the agent resolves them via `gh` CLI through the GitHub API
- External URLs (gists, pastebins, docs sites) are blocked by the sandbox proxy with 403 Forbidden
- The workaround is to paste external context directly into the `/fs-fix` comment

None of this was documented.

## Test plan

- [x] `hack/lint-agent-docs` passes (agent doc structure validated)
- [x] All relative markdown links in changed files resolve to existing files
- [x] No secrets, internal hostnames, or sensitive data in doc changes
- [x] Review for accuracy against `reusable-fix.yml`, `agents/fix.md` prompt, and `skills/fix-review/SKILL.md`


Made with [Cursor](https://cursor.com)