### PR TITLE
refactor(harness): migrate loadKnownSlugs to harness-first discovery

### DIFF
--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -24,6 +24,7 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/dispatch/gcf"
 	"github.com/fullsend-ai/fullsend/internal/forge"
 	gh "github.com/fullsend-ai/fullsend/internal/forge/github"
+	"github.com/fullsend-ai/fullsend/internal/harness"
 	"github.com/fullsend-ai/fullsend/internal/inference"
 	"github.com/fullsend-ai/fullsend/internal/inference/vertex"
 	"github.com/fullsend-ai/fullsend/internal/layers"
@@ -1331,7 +1332,7 @@ func runAppSetup(ctx context.Context, client forge.Client, printer *ui.Printer, 
 	// of app-set B. Without this, nonflux-triage (app-set "nonflux") would
 	// prevent fullsend-ai-triage (app-set "fullsend-ai") from being detected
 	// and installed.
-	knownSlugs := filterSlugsByAppSet(loadKnownSlugs(ctx, client, org), appSet)
+	knownSlugs := filterSlugsByAppSet(loadKnownSlugs(ctx, client, org, forge.ConfigRepoName, "HEAD", printer), appSet)
 	for role, slug := range filterSlugsByAppSet(sharedSlugs, appSet) {
 		knownSlugs[role] = slug
 	}
@@ -2017,8 +2018,45 @@ func filterSlugsByAppSet(slugs map[string]string, appSet string) map[string]stri
 	return out
 }
 
-// loadKnownSlugs tries to read agent slugs from an existing config.
-func loadKnownSlugs(ctx context.Context, client forge.Client, org string) map[string]string {
+// loadKnownSlugs discovers agent slugs from harness wrapper files in the
+// config repo, falling back to the config.yaml agents: block.
+func loadKnownSlugs(ctx context.Context, client forge.Client, org, configRepo, ref string, printer *ui.Printer) map[string]string {
+	agents, err := harness.DiscoverRemoteAgents(ctx, client, org, configRepo, ref)
+	if err != nil {
+		printer.StepWarn(fmt.Sprintf("harness discovery: %v", err))
+	}
+	if len(agents) > 0 {
+		slugs := make(map[string]string, len(agents))
+		seen := make(map[string]bool, len(agents))
+		for _, a := range agents {
+			if a.Role == "" && a.Slug == "" {
+				continue
+			}
+			if a.Role == "" || a.Slug == "" {
+				printer.StepWarn(fmt.Sprintf("harness %s has role=%q slug=%q; both must be set", a.Filename, a.Role, a.Slug))
+				continue
+			}
+			if seen[a.Role] {
+				printer.StepInfo(fmt.Sprintf("duplicate role %q in harness file %s, using first occurrence", a.Role, a.Filename))
+				continue
+			}
+			seen[a.Role] = true
+			slugs[a.Role] = a.Slug
+		}
+		if len(slugs) > 0 {
+			return slugs
+		}
+	}
+
+	slugs := loadKnownSlugsLegacy(ctx, client, org)
+	if len(slugs) > 0 {
+		printer.StepWarn("config.yaml agents: block is deprecated; agent identity should be in harness files with role/slug fields")
+	}
+	return slugs
+}
+
+// loadKnownSlugsLegacy reads agent slugs from the config.yaml agents: block.
+func loadKnownSlugsLegacy(ctx context.Context, client forge.Client, org string) map[string]string {
 	data, err := client.GetFileContent(ctx, org, forge.ConfigRepoName, "config.yaml")
 	if err != nil {
 		return nil

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -2547,6 +2547,194 @@ func TestApplyPerRepoScaffold_ProtectedBranch_DuplicatePR(t *testing.T) {
 	assert.Contains(t, output, "Merge the PR")
 }
 
+func TestLoadKnownSlugs_HarnessFilesPreferred(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.DirContents["myorg/.fullsend/harness@HEAD"] = []forge.DirectoryEntry{
+		{Path: "harness/triage.yaml", Type: "file"},
+		{Path: "harness/coder.yaml", Type: "file"},
+	}
+	client.FileContentsRef["myorg/.fullsend/harness/triage.yaml@HEAD"] = []byte("role: triage\nslug: fullsend-ai-triage\n")
+	client.FileContentsRef["myorg/.fullsend/harness/coder.yaml@HEAD"] = []byte("role: coder\nslug: fullsend-ai-coder\n")
+
+	// Also set up config.yaml agents: block — should NOT be used.
+	client.FileContents["myorg/.fullsend/config.yaml"] = []byte(`version: "1"
+agents:
+  - role: triage
+    slug: old-triage-slug
+    name: old-triage
+`)
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	slugs := loadKnownSlugs(context.Background(), client, "myorg", forge.ConfigRepoName, "HEAD", printer)
+
+	assert.Equal(t, map[string]string{
+		"triage": "fullsend-ai-triage",
+		"coder":  "fullsend-ai-coder",
+	}, slugs)
+	assert.NotContains(t, buf.String(), "agents: block")
+}
+
+func TestLoadKnownSlugs_FallbackToAgentsBlock(t *testing.T) {
+	client := forge.NewFakeClient()
+	// No harness/ directory → ErrNotFound from DirContents.
+
+	client.FileContents["myorg/.fullsend/config.yaml"] = []byte(`version: "1"
+agents:
+  - role: triage
+    slug: fullsend-ai-triage
+    name: fullsend-ai-triage
+  - role: coder
+    slug: fullsend-ai-coder
+    name: fullsend-ai-coder
+`)
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	slugs := loadKnownSlugs(context.Background(), client, "myorg", forge.ConfigRepoName, "HEAD", printer)
+
+	assert.Equal(t, map[string]string{
+		"triage": "fullsend-ai-triage",
+		"coder":  "fullsend-ai-coder",
+	}, slugs)
+	assert.Contains(t, buf.String(), "agents: block")
+}
+
+func TestLoadKnownSlugs_HarnessFilesWithoutRoleSlug_FallsBack(t *testing.T) {
+	client := forge.NewFakeClient()
+	// Harness files exist but lack role/slug (legacy format).
+	client.DirContents["myorg/.fullsend/harness@HEAD"] = []forge.DirectoryEntry{
+		{Path: "harness/triage.yaml", Type: "file"},
+	}
+	client.FileContentsRef["myorg/.fullsend/harness/triage.yaml@HEAD"] = []byte("agent: agents/triage.md\nmodel: opus\n")
+
+	client.FileContents["myorg/.fullsend/config.yaml"] = []byte(`version: "1"
+agents:
+  - role: triage
+    slug: fullsend-ai-triage
+    name: fullsend-ai-triage
+`)
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	slugs := loadKnownSlugs(context.Background(), client, "myorg", forge.ConfigRepoName, "HEAD", printer)
+
+	assert.Equal(t, map[string]string{
+		"triage": "fullsend-ai-triage",
+	}, slugs)
+	assert.Contains(t, buf.String(), "agents: block")
+}
+
+func TestLoadKnownSlugs_NeitherSource_ReturnsNil(t *testing.T) {
+	client := forge.NewFakeClient()
+	// No harness/ dir, no config.yaml.
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	slugs := loadKnownSlugs(context.Background(), client, "myorg", forge.ConfigRepoName, "HEAD", printer)
+
+	assert.Nil(t, slugs)
+	assert.NotContains(t, buf.String(), "agents: block")
+}
+
+func TestLoadKnownSlugs_DuplicateRoles_FirstWins(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.DirContents["myorg/.fullsend/harness@HEAD"] = []forge.DirectoryEntry{
+		{Path: "harness/code.yaml", Type: "file"},
+		{Path: "harness/fix.yaml", Type: "file"},
+	}
+	// Both files declare role: coder. DiscoverRemoteAgents sorts by Role then
+	// Filename, so code.yaml comes first.
+	client.FileContentsRef["myorg/.fullsend/harness/code.yaml@HEAD"] = []byte("role: coder\nslug: fullsend-ai-coder\n")
+	client.FileContentsRef["myorg/.fullsend/harness/fix.yaml@HEAD"] = []byte("role: coder\nslug: fullsend-ai-fix\n")
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	slugs := loadKnownSlugs(context.Background(), client, "myorg", forge.ConfigRepoName, "HEAD", printer)
+
+	assert.Equal(t, map[string]string{
+		"coder": "fullsend-ai-coder",
+	}, slugs)
+	assert.Contains(t, buf.String(), "duplicate role")
+}
+
+func TestLoadKnownSlugs_PartialError_LogsWarning(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.DirContents["myorg/.fullsend/harness@HEAD"] = []forge.DirectoryEntry{
+		{Path: "harness/triage.yaml", Type: "file"},
+		{Path: "harness/bad.yaml", Type: "file"},
+	}
+	client.FileContentsRef["myorg/.fullsend/harness/triage.yaml@HEAD"] = []byte("role: triage\nslug: fullsend-ai-triage\n")
+	// bad.yaml is not in FileContentsRef → GetFileContentAtRef returns ErrNotFound.
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	slugs := loadKnownSlugs(context.Background(), client, "myorg", forge.ConfigRepoName, "HEAD", printer)
+
+	assert.Equal(t, map[string]string{
+		"triage": "fullsend-ai-triage",
+	}, slugs)
+	assert.Contains(t, buf.String(), "harness discovery")
+}
+
+func TestLoadKnownSlugs_RoleWithoutSlug_WarnsAndSkips(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.DirContents["myorg/.fullsend/harness@HEAD"] = []forge.DirectoryEntry{
+		{Path: "harness/triage.yaml", Type: "file"},
+	}
+	client.FileContentsRef["myorg/.fullsend/harness/triage.yaml@HEAD"] = []byte("role: triage\n")
+
+	client.FileContents["myorg/.fullsend/config.yaml"] = []byte(`version: "1"
+agents:
+  - role: triage
+    slug: fullsend-ai-triage
+    name: fullsend-ai-triage
+`)
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	slugs := loadKnownSlugs(context.Background(), client, "myorg", forge.ConfigRepoName, "HEAD", printer)
+
+	assert.Equal(t, map[string]string{
+		"triage": "fullsend-ai-triage",
+	}, slugs)
+	assert.Contains(t, buf.String(), "both must be set")
+}
+
+func TestLoadKnownSlugs_HardError_ZeroAgents_FallsBack(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.Errors["ListDirectoryContents"] = fmt.Errorf("network timeout")
+
+	client.FileContents["myorg/.fullsend/config.yaml"] = []byte(`version: "1"
+agents:
+  - role: triage
+    slug: fullsend-ai-triage
+    name: fullsend-ai-triage
+`)
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	slugs := loadKnownSlugs(context.Background(), client, "myorg", forge.ConfigRepoName, "HEAD", printer)
+
+	assert.Equal(t, map[string]string{
+		"triage": "fullsend-ai-triage",
+	}, slugs)
+	assert.Contains(t, buf.String(), "harness discovery")
+	assert.Contains(t, buf.String(), "deprecated")
+}
+
+func TestLoadKnownSlugs_MalformedConfig_ReturnsNil(t *testing.T) {
+	client := forge.NewFakeClient()
+	// No harness/ dir, malformed config.yaml.
+	client.FileContents["myorg/.fullsend/config.yaml"] = []byte("not: valid: yaml: [")
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	slugs := loadKnownSlugs(context.Background(), client, "myorg", forge.ConfigRepoName, "HEAD", printer)
+
+	assert.Nil(t, slugs)
+}
+
 func TestApplyPerRepoScaffold_ProtectedBranch_BranchUpToDate(t *testing.T) {
 	client := forge.NewFakeClient()
 	client.Repos = []forge.Repository{{FullName: "acme/widget", DefaultBranch: "main"}}


### PR DESCRIPTION
## Summary

- ADR-0045 Phase 3, PR 4: Migrates `loadKnownSlugs()` in `internal/cli/admin.go` to prefer harness wrapper files over the `config.yaml` `agents:` block for agent identity discovery.
- Renames the existing function to `loadKnownSlugsLegacy` and introduces a new `loadKnownSlugs` that calls `harness.DiscoverRemoteAgents` first, falling back to the legacy path with a deprecation warning.
- Duplicate roles in harness files are handled deterministically (first in sort order wins).

## Test plan

- [x] `TestLoadKnownSlugs_HarnessFilesPreferred` — harness files present → uses harness slugs, no deprecation warning
- [x] `TestLoadKnownSlugs_FallbackToAgentsBlock` — no harness dir → falls back to `config.yaml`, emits deprecation warning
- [x] `TestLoadKnownSlugs_HarnessFilesWithoutRoleSlug_FallsBack` — harness files without role/slug → falls back to `config.yaml`
- [x] `TestLoadKnownSlugs_NeitherSource_ReturnsNil` — no harness files, no config.yaml → returns nil
- [x] `TestLoadKnownSlugs_DuplicateRoles_FirstWins` — duplicate roles in harness files → first entry (sorted order) wins
- [x] `make lint` passes
- [x] `go vet ./internal/cli/` clean
- [x] `go test ./internal/cli/` all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)