### PR TITLE
feat(harness): wire Lint() diagnostics into fullsend run and lock

### DIFF
--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -188,6 +188,7 @@ func lockOneAgent(ctx context.Context, agentName, absFullsendDir, forgeFlag stri
 
 	var allDeps []resolve.Dependency
 	seen := make(map[string]bool)
+	linted := make(map[string]bool) // track reported lint diagnostics to avoid duplicates across forge variants
 
 	for _, platform := range forgePlatforms {
 		h, baseDeps, loadErr := harness.LoadWithBase(ctx, harnessPath, harness.ComposeOpts{
@@ -200,6 +201,15 @@ func lockOneAgent(ctx context.Context, agentName, absFullsendDir, forgeFlag stri
 		if loadErr != nil {
 			printer.StepFail(fmt.Sprintf("Failed to load harness (forge: %s)", platform))
 			return nil, fmt.Errorf("loading harness for forge %q: %w", platform, loadErr)
+		}
+
+		// Run lint diagnostics (non-fatal), deduplicating across forge variants
+		for _, diag := range h.Lint() {
+			key := diag.String()
+			if !linted[key] {
+				linted[key] = true
+				emitDiagnosticWithContext(printer, agentName, diag)
+			}
 		}
 
 		if err := h.ResolveRelativeTo(absFullsendDir); err != nil {

--- a/internal/cli/lock_test.go
+++ b/internal/cli/lock_test.go
@@ -1197,3 +1197,61 @@ func TestRunLock_URLBaseAndURLRefsNoOrgConfig(t *testing.T) {
 	// Should fail with a clear error about missing org config.
 	assert.Contains(t, err.Error(), "config.yaml")
 }
+
+func TestRunLock_LintWarningOnMissingRole(t *testing.T) {
+	// Verifies that runLock emits a lint warning when harness has no role.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "harness"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "agents"), 0o755))
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "agents", "code.md"),
+		[]byte("You are a coding agent."),
+		0o644,
+	))
+	// Harness without role field, no URL references (no lock needed)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "harness", "code.yaml"),
+		[]byte("agent: agents/code.md\n"),
+		0o644,
+	))
+
+	var buf strings.Builder
+	printer := ui.New(&buf)
+	err := runLock(context.Background(), "code", dir, "", false, resolveFlags{}, printer)
+	require.NoError(t, err)
+
+	// Verify lint warning was printed with agent name context
+	output := buf.String()
+	assert.Contains(t, output, "code")
+	assert.Contains(t, output, "role")
+	assert.Contains(t, output, "warning")
+}
+
+func TestRunLock_NoLintWarningWithRole(t *testing.T) {
+	// Verifies that runLock does NOT emit a lint warning when harness has role set.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "harness"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "agents"), 0o755))
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "agents", "code.md"),
+		[]byte("You are a coding agent."),
+		0o644,
+	))
+	// Harness with role field
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "harness", "code.yaml"),
+		[]byte("agent: agents/code.md\nrole: coder\n"),
+		0o644,
+	))
+
+	var buf strings.Builder
+	printer := ui.New(&buf)
+	err := runLock(context.Background(), "code", dir, "", false, resolveFlags{}, printer)
+	require.NoError(t, err)
+
+	// Verify no lint warning about role
+	output := buf.String()
+	assert.NotContains(t, output, "role is not set")
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -341,6 +341,11 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	}
 	printer.StepDone(fmt.Sprintf("Harness loaded (%.1fs)", time.Since(harnessStart).Seconds()))
 
+	// Run lint checks and report any diagnostics (non-fatal).
+	for _, diag := range h.Lint() {
+		emitDiagnostic(printer, diag)
+	}
+
 	// Print plan.
 	printer.KeyValue("Agent", h.Agent)
 	if h.Role != "" {
@@ -1951,4 +1956,28 @@ func prHeadSHAFromEventPath(path string) string {
 		return ""
 	}
 	return payload.PullRequest.Head.SHA
+}
+
+// emitDiagnostic prints a harness lint diagnostic with severity-appropriate formatting.
+// Warnings use StepWarn, errors use StepFail. This ensures future SeverityError
+// diagnostics are visually distinct from warnings.
+func emitDiagnostic(printer *ui.Printer, diag harness.Diagnostic) {
+	switch diag.Severity {
+	case harness.SeverityError:
+		printer.StepFail(diag.String())
+	default:
+		printer.StepWarn(diag.String())
+	}
+}
+
+// emitDiagnosticWithContext prints a diagnostic with additional context (e.g., agent name).
+// Used by lock --all where multiple harnesses are processed and context helps identify which.
+func emitDiagnosticWithContext(printer *ui.Printer, context string, diag harness.Diagnostic) {
+	msg := fmt.Sprintf("%s: %s", context, diag.String())
+	switch diag.Severity {
+	case harness.SeverityError:
+		printer.StepFail(msg)
+	default:
+		printer.StepWarn(msg)
+	}
 }

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1607,3 +1607,120 @@ func TestSetupStatusNotifier_PRHeadSHA(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, n)
 }
+
+func TestEmitDiagnostic_Warning(t *testing.T) {
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+
+	diag := harness.Diagnostic{
+		Severity: harness.SeverityWarning,
+		Field:    "role",
+		Message:  "test warning message",
+	}
+	emitDiagnostic(printer, diag)
+
+	output := buf.String()
+	assert.Contains(t, output, "warning")
+	assert.Contains(t, output, "role")
+	assert.Contains(t, output, "test warning message")
+}
+
+func TestEmitDiagnostic_Error(t *testing.T) {
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+
+	diag := harness.Diagnostic{
+		Severity: harness.SeverityError,
+		Field:    "agent",
+		Message:  "test error message",
+	}
+	emitDiagnostic(printer, diag)
+
+	output := buf.String()
+	assert.Contains(t, output, "error")
+	assert.Contains(t, output, "agent")
+	assert.Contains(t, output, "test error message")
+}
+
+func TestEmitDiagnosticWithContext(t *testing.T) {
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+
+	diag := harness.Diagnostic{
+		Severity: harness.SeverityWarning,
+		Field:    "role",
+		Message:  "role is not set",
+	}
+	emitDiagnosticWithContext(printer, "triage", diag)
+
+	output := buf.String()
+	assert.Contains(t, output, "triage")
+	assert.Contains(t, output, "warning")
+	assert.Contains(t, output, "role")
+}
+
+func TestRunAgent_LintWarningOnMissingRole(t *testing.T) {
+	// Verifies that runAgent emits a lint warning when harness has no role,
+	// but the command still proceeds (fails later at sandbox availability).
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "harness"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "agents"), 0o755))
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "agents", "code.md"),
+		[]byte("You are a coding agent."),
+		0o644,
+	))
+	// Harness without role field
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "harness", "code.yaml"),
+		[]byte("agent: agents/code.md\n"),
+		0o644,
+	))
+
+	var buf bytes.Buffer
+	rFlags := resolveFlags{maxDepth: 10, maxResources: 50}
+	printer := ui.New(&buf)
+	err := runAgent(context.Background(), "code", dir, "", "/tmp/repo", "", nil, false, "", "", rFlags, statusOpts{}, printer, false)
+
+	// Command fails later (no openshell), but lint warning should be emitted
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "openshell")
+
+	// Verify lint warning was printed
+	output := buf.String()
+	assert.Contains(t, output, "role")
+	assert.Contains(t, output, "warning")
+}
+
+func TestRunAgent_NoLintWarningWithRole(t *testing.T) {
+	// Verifies that runAgent does NOT emit a lint warning when harness has role set.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "harness"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "agents"), 0o755))
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "agents", "code.md"),
+		[]byte("You are a coding agent."),
+		0o644,
+	))
+	// Harness with role field
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "harness", "code.yaml"),
+		[]byte("agent: agents/code.md\nrole: coder\n"),
+		0o644,
+	))
+
+	var buf bytes.Buffer
+	rFlags := resolveFlags{maxDepth: 10, maxResources: 50}
+	printer := ui.New(&buf)
+	err := runAgent(context.Background(), "code", dir, "", "/tmp/repo", "", nil, false, "", "", rFlags, statusOpts{}, printer, false)
+
+	// Command fails later (no openshell)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "openshell")
+
+	// Verify no lint warning about role
+	output := buf.String()
+	assert.NotContains(t, output, "role is not set")
+}


### PR DESCRIPTION
## Summary

- Wire `h.Lint()` into `fullsend run` after harness loading to surface non-fatal warnings
- Wire `h.Lint()` into `fullsend lock` with deduplication across forge variants
- Currently warns when `role` field is missing from harness files

This is **Phase 3 PR 3** of ADR-0045 (Forge-Portable Harness Schema).

## Context

ADR-0045 Phase 3 is the "Deprecate" milestone. This PR implements the first step: surfacing lint diagnostics in CLI commands. The `Lint()` method and `Diagnostic` type already exist in `internal/harness/lint.go` (shipped in Phase 1).

Lint diagnostics are informational only — commands still succeed regardless of warnings. This prepares users for Phase 4 where `role` will become required.

## Test plan

- [x] `go build ./cmd/fullsend/` compiles
- [x] `go test ./internal/cli/... -run "TestRun|TestLock"` passes
- [x] `make lint` passes
- [ ] Manual: `fullsend run` on harness without `role` → warning printed, command succeeds
- [ ] Manual: `fullsend lock --all` on harnesses without `role` → warnings printed (deduplicated), command succeeds

## Related

- ADR: `docs/ADRs/0045-forge-portable-harness-schema.md`
- Phase 3 plan: `docs/plans/adr-0045-forge-portable-harness-phase3.md`

🤖 Generated with [Claude Code](https://claude.ai/code)