### PR TITLE
feat(mint): add add-role and remove-role CLI commands

### DIFF
--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -16,6 +16,8 @@ fullsend
 │       └── repos    <org> [repo...]         # Disable agent on repos
 ├── mint                                     # Token mint management
 │   ├── deploy                               # Deploy/update mint Cloud Function
+│   ├── add-role       <role>                # Register role PEM + ROLE_APP_IDS entry
+│   ├── remove-role    <role>                # Remove role from mint
 │   ├── enroll       <org|owner/repo>        # Register org/repo in mint
 │   ├── unenroll     <org|owner/repo>        # Remove org/repo from mint
 │   ├── status       [org]                   # Inspect mint state and PEM health

--- a/docs/guides/infrastructure/infrastructure-reference.md
+++ b/docs/guides/infrastructure/infrastructure-reference.md
@@ -4,7 +4,7 @@ This guide provides implementation details for fullsend's infrastructure compone
 
 ## Token Mint (OIDC) — GCF Cloud Function
 
-> Managed by: `fullsend mint deploy`, `fullsend mint enroll`, `fullsend mint unenroll`, `fullsend mint status`, `fullsend mint token`
+> Managed by: `fullsend mint deploy`, `fullsend mint enroll`, `fullsend mint unenroll`, `fullsend mint status`, `fullsend mint add-role`, `fullsend mint remove-role`, `fullsend mint token`
 
 The mint is a GCP Cloud Function that exchanges GitHub OIDC tokens for scoped GitHub App installation tokens. This eliminates long-lived PATs from the system.
 

--- a/docs/guides/infrastructure/mint-administration.md
+++ b/docs/guides/infrastructure/mint-administration.md
@@ -54,15 +54,17 @@ Pass this URL as `--mint-url` when running `fullsend admin install`, or set the 
   | `roles/cloudfunctions.developer` | x | | | | | |
   | `roles/cloudfunctions.viewer` | | x | x | x | x | x |
   | `roles/run.admin` | x | x | x | x | x | |
-  | `roles/secretmanager.viewer` | | | | | | x |
+  | `roles/secretmanager.viewer` | | § | | | | x |
 
   \* `roles/resourcemanager.projectIamAdmin` and `roles/secretmanager.admin` are required for `mint deploy` only when using `--pem-dir` (first-time bootstrap). Standard deploys without `--pem-dir` do not need these roles.
 
   \*\* `roles/resourcemanager.projectIamAdmin` is required for `mint enroll` only in per-repo mode (`mint enroll owner/repo`). Org-scoped enrollment does not grant IAM bindings — use `inference provision` separately.
 
-  \*\*\* `roles/secretmanager.admin` is required for `mint add-role` when uploading a new PEM (`--pem` or browser mode). It is not required when using `--use-existing-pem-secret`.
+  \*\*\* `roles/secretmanager.admin` is required for `mint add-role` when uploading a new PEM (`--pem` or browser mode). When using `--use-existing-pem-secret`, only `roles/secretmanager.viewer` is required (see §).
 
   \*\*\*\* `roles/secretmanager.admin` is required for `mint remove-role` unless `--keep-pem` is passed (default deletes the PEM secret).
+
+  § `roles/secretmanager.viewer` is required for `mint add-role` when using `--use-existing-pem-secret` (checks that the PEM secret exists).
 
   `roles/owner` covers all of the above for users with broad access.
 

--- a/docs/guides/infrastructure/mint-administration.md
+++ b/docs/guides/infrastructure/mint-administration.md
@@ -2,6 +2,16 @@
 
 This guide covers deploying and managing the fullsend token mint Cloud Function. The mint is the OIDC token exchange service that lets GitHub Actions workflows authenticate as GitHub Apps — it is infrastructure that serves all enrolled organizations and repositories.
 
+| Command | Description |
+|---------|-------------|
+| `mint deploy` | Deploy or update the mint Cloud Function and GCP infrastructure |
+| `mint add-role` | Add an agent role (PEM secret + `ROLE_APP_IDS` entry) |
+| `mint remove-role` | Remove an agent role from the mint (deletes PEM secret by default) |
+| `mint enroll` | Register an org or repo in `ALLOWED_ORGS` and configure WIF |
+| `mint unenroll` | Remove an org or repo from the mint |
+| `mint status` | Inspect mint health, enrolled orgs, and PEM secrets |
+| `mint token` | Exchange a GitHub Actions OIDC token for an installation token |
+
 > **This guide is for platform operators** who deploy, manage, or troubleshoot the token mint Cloud Function. If you are an end user setting up fullsend for your organization, see [Installing fullsend](../../reference/installation.md) instead — the mint is typically deployed once by a platform operator, and organizations are enrolled as needed.
 
 ## Hosted mint
@@ -35,20 +45,24 @@ Pass this URL as `--mint-url` when running `fullsend admin install`, or set the 
 
 - **GCP IAM roles** — the user running mint commands authenticates via ADC (`gcloud auth application-default login`). The required roles depend on the command:
 
-  | IAM Role | `mint deploy` | `mint enroll` | `mint unenroll` | `mint status` |
-  |----------|:---:|:---:|:---:|:---:|
-  | `roles/iam.serviceAccountAdmin` | x | | | |
-  | `roles/iam.workloadIdentityPoolAdmin` | x | x | x | |
-  | `roles/resourcemanager.projectIamAdmin` | \* | \*\* | | |
-  | `roles/secretmanager.admin` | \* | | | |
-  | `roles/cloudfunctions.developer` | x | | | |
-  | `roles/cloudfunctions.viewer` | | x | x | x |
-  | `roles/run.admin` | x | x | x | |
-  | `roles/secretmanager.viewer` | | | | x |
+  | IAM Role | `mint deploy` | `mint add-role` | `mint remove-role` | `mint enroll` | `mint unenroll` | `mint status` |
+  |----------|:---:|:---:|:---:|:---:|:---:|:---:|
+  | `roles/iam.serviceAccountAdmin` | x | | | | | |
+  | `roles/iam.workloadIdentityPoolAdmin` | x | | | x | x | |
+  | `roles/resourcemanager.projectIamAdmin` | \* | | | \*\* | | |
+  | `roles/secretmanager.admin` | \* | \*\*\* | \*\*\*\* | | | |
+  | `roles/cloudfunctions.developer` | x | | | | | |
+  | `roles/cloudfunctions.viewer` | | x | x | x | x | x |
+  | `roles/run.admin` | x | x | x | x | x | |
+  | `roles/secretmanager.viewer` | | | | | | x |
 
   \* `roles/resourcemanager.projectIamAdmin` and `roles/secretmanager.admin` are required for `mint deploy` only when using `--pem-dir` (first-time bootstrap). Standard deploys without `--pem-dir` do not need these roles.
 
   \*\* `roles/resourcemanager.projectIamAdmin` is required for `mint enroll` only in per-repo mode (`mint enroll owner/repo`). Org-scoped enrollment does not grant IAM bindings — use `inference provision` separately.
+
+  \*\*\* `roles/secretmanager.admin` is required for `mint add-role` when uploading a new PEM (`--pem` or browser mode). It is not required when using `--use-existing-pem-secret`.
+
+  \*\*\*\* `roles/secretmanager.admin` is required for `mint remove-role` unless `--keep-pem` is passed (default deletes the PEM secret).
 
   `roles/owner` covers all of the above for users with broad access.
 
@@ -111,9 +125,101 @@ The `--pem-dir` directory must contain one `{role}.pem` file per agent role (e.g
 
 ### Mint URL stability
 
-The mint URL is stable across redeploys within the same project and region — updating the Cloud Function does not change its URL. Adding a new org to an existing mint only updates `ALLOWED_ORGS` (and WIF configuration) without redeploying the function. Shared `ROLE_APP_IDS` are set at deploy time and are not modified per enrollment. Existing enrolled repos continue working with no changes.
+The mint URL is stable across redeploys within the same project and region — updating the Cloud Function does not change its URL. Adding a new org to an existing mint only updates `ALLOWED_ORGS` (and WIF configuration) without redeploying the function. Shared `ROLE_APP_IDS` are managed at deploy/bootstrap time (`mint deploy --pem-dir`) or per-role via `mint add-role` / `remove-role` — not during enrollment. Existing enrolled repos continue working with no changes when orgs are added.
 
 Deploying to a **different region** (e.g., changing `--region` from `us-central1` to `us-east5`) creates a new Cloud Run service with a different URL. All enrolled repos store the mint URL in a repo or org variable (`FULLSEND_MINT_URL`), so changing the region requires updating every enrolled repo's variable. Avoid changing `--region` after initial deployment unless you plan to update all consumers.
+
+## Managing roles
+
+Agent roles on the mint are **global** — each role maps to a GitHub App PEM secret (`fullsend-{role}-app-pem`) and an entry in the shared `ROLE_APP_IDS` environment variable. Use `fullsend mint add-role` and `fullsend mint remove-role` to manage individual roles after the mint is deployed.
+
+| Command | When to use |
+|---------|-------------|
+| `mint deploy --pem-dir` | First-time bootstrap of the default app set (`fullsend-ai`) — seeds all default roles at once |
+| `mint add-role` | Add a single role later, or register a custom app set one role at a time |
+| `mint remove-role` | Remove a role from the mint (updates env vars; deletes PEM secret by default) |
+
+`mint enroll` does **not** create or modify roles — it only authorizes orgs/repos to use roles that already exist on the mint.
+
+### Adding a role
+
+`fullsend mint add-role` requires the mint to already be deployed. Choose one of three mutually exclusive input modes:
+
+**1. Existing app + PEM file** (`--slug` and `--pem`):
+
+```bash
+fullsend mint add-role coder \
+  --project="$GCP_PROJECT" \
+  --slug=fullsend-ai-coder \
+  --pem=/path/to/coder.pem
+```
+
+The CLI looks up the app's numeric ID from the GitHub API, verifies the PEM matches the app, stores the PEM in Secret Manager, and updates `ROLE_APP_IDS` / `ALLOWED_ROLES`.
+
+**2. Existing PEM secret** (`--slug` and `--use-existing-pem-secret`):
+
+```bash
+fullsend mint add-role review \
+  --project="$GCP_PROJECT" \
+  --slug=fullsend-ai-review \
+  --use-existing-pem-secret
+```
+
+Use this when the PEM secret `fullsend-{role}-app-pem` already exists in Secret Manager (for example, copied from another project) and you only need to register the app ID on the mint. `--pem` and `--use-existing-pem-secret` cannot be combined.
+
+**3. Create GitHub App via browser** (`--org`):
+
+```bash
+fullsend mint add-role prioritize \
+  --project="$GCP_PROJECT" \
+  --org=acme-corp \
+  --app-set=acme
+```
+
+Opens the GitHub App manifest flow in your browser, stores the PEM in Secret Manager, and updates the mint. Requires a GitHub token (`GH_TOKEN`, `GITHUB_TOKEN`, or `gh auth login`).
+
+#### add-role flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--project` | | GCP project ID (required) |
+| `--region` | `us-central1` | Cloud region for the mint service |
+| `--slug` | | GitHub App slug (with `--pem` or `--use-existing-pem-secret`) |
+| `--pem` | | Path to PEM file (with `--slug`; mutually exclusive with `--use-existing-pem-secret`) |
+| `--use-existing-pem-secret` | `false` | Skip PEM upload; require existing Secret Manager secret (with `--slug`) |
+| `--org` | | GitHub org for browser-based app creation |
+| `--app-set` | `fullsend-ai` | App set prefix for browser mode (`{app-set}-{role}`) |
+| `--public` | `false` | Install existing public app without confirm prompt (browser mode) |
+| `--force` | `false` | Overwrite existing `ROLE_APP_IDS` entry for this role |
+| `--dry-run` | `false` | Preview changes without making them |
+
+The `fix` and `code` roles reuse the `coder` app — add role `coder` instead.
+
+### Removing a role
+
+`fullsend mint remove-role` removes a role from `ROLE_APP_IDS` and `ALLOWED_ROLES`. By default it also deletes the PEM secret from Secret Manager. Use `--keep-pem` to retain the secret for later re-registration.
+
+```bash
+# Remove role and delete PEM secret (default)
+fullsend mint remove-role retro --project="$GCP_PROJECT"
+
+# Remove role but keep PEM secret
+fullsend mint remove-role retro --project="$GCP_PROJECT" --keep-pem
+```
+
+Requires typing the role name to confirm (unless `--dry-run` or `--yolo`). Removing `coder` also prevents `fix`/`code` token minting.
+
+#### remove-role flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--project` | | GCP project ID (required) |
+| `--region` | `us-central1` | Cloud region for the mint service |
+| `--keep-pem` | `false` | Retain PEM secret in Secret Manager (default: delete) |
+| `--dry-run` | `false` | Preview changes without making them |
+| `--yolo` | `false` | Skip interactive confirmation |
+
+This command does not uninstall GitHub Apps from organizations or update org `.fullsend` configuration — use `fullsend github setup` or edit config repos separately.
 
 ## Enrolling organizations and repositories
 
@@ -139,7 +245,7 @@ Enrollment does **not** grant Agent Platform (inference) access — use `fullsen
 
 ### Migration from per-org app ID flags
 
-Prior versions of `mint enroll` accepted `--app-set`, `--role-app-ids`, `--roles`, and `--source-org` to copy per-org app ID mappings into `ROLE_APP_IDS`. App IDs are now **shared per role** on the mint (like PEM secrets) and are set at deploy time via `mint deploy --pem-dir` or `fullsend admin install`. Enrollment only adds the org to `ALLOWED_ORGS` and updates WIF — remove those flags from scripts and ensure the mint already has role-keyed `ROLE_APP_IDS` before enrolling.
+Prior versions of `mint enroll` accepted `--app-set`, `--role-app-ids`, `--roles`, and `--source-org` to copy per-org app ID mappings into `ROLE_APP_IDS`. App IDs are now **shared per role** on the mint (like PEM secrets) and are set at deploy time via `mint deploy --pem-dir`, `fullsend admin install`, or per-role via `mint add-role`. Enrollment only adds the org to `ALLOWED_ORGS` and updates WIF — remove those flags from scripts and ensure the mint already has role-keyed `ROLE_APP_IDS` before enrolling.
 
 ### What enrollment does
 
@@ -148,7 +254,7 @@ Prior versions of `mint enroll` accepted `--app-set`, `--role-app-ids`, `--roles
 3. Runs post-enrollment verification (see below)
 4. Configures the mint-side WIF provider to accept OIDC tokens from the organization's repositories
 
-Role PEM secrets and `ROLE_APP_IDS` must already exist on the mint, created during `mint deploy --pem-dir` or `fullsend admin install`. Enrollment does not create, copy, or modify PEM secrets or app ID mappings.
+Role PEM secrets and `ROLE_APP_IDS` must already exist on the mint, created during `mint deploy --pem-dir`, `fullsend admin install`, or `mint add-role`. Enrollment does not create, copy, or modify PEM secrets or app ID mappings.
 
 ### Post-enrollment verification
 

--- a/docs/reference/installation.md
+++ b/docs/reference/installation.md
@@ -633,15 +633,17 @@ When using the split-responsibility workflow, each standalone command requires a
 | `roles/cloudfunctions.viewer` | | | | | x | x | x | x | x |
 | `roles/run.admin` | | | | x | x | x | x | x | |
 | `roles/iam.workloadIdentityPoolViewer` | | | x† | | | | | | |
-| `roles/secretmanager.viewer` | | | | | | | | | x |
+| `roles/secretmanager.viewer` | | | | | § | | | | x |
 
 \* `roles/resourcemanager.projectIamAdmin` and `roles/secretmanager.admin` are required for `mint deploy` only when using `--pem-dir` (first-time bootstrap). Standard deploys without `--pem-dir` do not need these roles.
 
 \*\* `roles/resourcemanager.projectIamAdmin` is required for `mint enroll` only in per-repo mode (`mint enroll owner/repo`). Org-scoped enrollment does not grant IAM bindings — use `inference provision` separately.
 
-\*\*\* `roles/secretmanager.admin` is required for `mint add-role` when uploading a new PEM (`--pem` or browser mode). It is not required when using `--use-existing-pem-secret`.
+\*\*\* `roles/secretmanager.admin` is required for `mint add-role` when uploading a new PEM (`--pem` or browser mode). When using `--use-existing-pem-secret`, only `roles/secretmanager.viewer` is required (see §).
 
 \*\*\*\* `roles/secretmanager.admin` is required for `mint remove-role` unless `--keep-pem` is passed (default deletes the PEM secret).
+
+§ `roles/secretmanager.viewer` is required for `mint add-role` when using `--use-existing-pem-secret` (checks that the PEM secret exists).
 
 † All commands that call GCP APIs also require `resourcemanager.projects.get` (typically available via `roles/browser` or any project-level viewer role). This is only notable for `inference status` where it is not covered by the other listed roles.
 

--- a/docs/reference/installation.md
+++ b/docs/reference/installation.md
@@ -611,6 +611,8 @@ The `admin install` command performs all setup in a single invocation. For organ
 | GitHub Maintainer | `fullsend github sync-scaffold <org>` | Update workflow templates to current CLI version |
 | GitHub Maintainer | `fullsend github uninstall <org>` | Remove GitHub configuration (org-level only) |
 | GCP Admin (Mint) | `fullsend mint deploy` | Deploy the token mint Cloud Function |
+| GCP Admin (Mint) | `fullsend mint add-role <role>` | Register a role PEM and app ID on the mint |
+| GCP Admin (Mint) | `fullsend mint remove-role <role>` | Remove a role from the mint (deletes PEM secret by default) |
 | GCP Admin (Mint) | `fullsend mint enroll <org\|owner/repo>` | Register an org or repo in the mint (does not grant Agent Platform access — use `inference provision`) |
 | GCP Admin (Mint) | `fullsend mint unenroll <org\|owner/repo>` | Remove an org or repo from the mint |
 | GCP Admin (Mint) | `fullsend mint status` | Inspect mint state and PEM health |
@@ -621,23 +623,27 @@ See [Setting up with pre-provisioned infrastructure](github-setup.md) for the co
 
 When using the split-responsibility workflow, each standalone command requires a subset of IAM roles. Use this table to request only what you need.
 
-| IAM Role | `inference provision` | `inference deprovision` | `inference status` | `mint deploy` | `mint enroll` | `mint unenroll` | `mint status` |
-|----------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| `roles/iam.workloadIdentityPoolAdmin` | x | x | | x | x | x | |
-| `roles/resourcemanager.projectIamAdmin` | x | | | \* | \*\* | | |
-| `roles/iam.serviceAccountAdmin` | | | | x | | | |
-| `roles/secretmanager.admin` | | | | \* | | | |
-| `roles/cloudfunctions.developer` | | | | x | | | |
-| `roles/cloudfunctions.viewer` | | | | | x | x | x |
-| `roles/run.admin` | | | | x | x | x | |
-| `roles/iam.workloadIdentityPoolViewer` | | | x\*\*\* | | | | |
-| `roles/secretmanager.viewer` | | | | | | | x |
+| IAM Role | `inference provision` | `inference deprovision` | `inference status` | `mint deploy` | `mint add-role` | `mint remove-role` | `mint enroll` | `mint unenroll` | `mint status` |
+|----------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| `roles/iam.workloadIdentityPoolAdmin` | x | x | | x | | | x | x | |
+| `roles/resourcemanager.projectIamAdmin` | x | | | \* | | | \*\* | | |
+| `roles/iam.serviceAccountAdmin` | | | | x | | | | | |
+| `roles/secretmanager.admin` | | | | \* | \*\*\* | \*\*\*\* | | | |
+| `roles/cloudfunctions.developer` | | | | x | | | | | |
+| `roles/cloudfunctions.viewer` | | | | | x | x | x | x | x |
+| `roles/run.admin` | | | | x | x | x | x | x | |
+| `roles/iam.workloadIdentityPoolViewer` | | | x† | | | | | | |
+| `roles/secretmanager.viewer` | | | | | | | | | x |
 
 \* `roles/resourcemanager.projectIamAdmin` and `roles/secretmanager.admin` are required for `mint deploy` only when using `--pem-dir` (first-time bootstrap). Standard deploys without `--pem-dir` do not need these roles.
 
 \*\* `roles/resourcemanager.projectIamAdmin` is required for `mint enroll` only in per-repo mode (`mint enroll owner/repo`). Org-scoped enrollment does not grant IAM bindings — use `inference provision` separately.
 
-\*\*\* All commands that call GCP APIs also require `resourcemanager.projects.get` (typically available via `roles/browser` or any project-level viewer role). This is only notable for `inference status` where it is not covered by the other listed roles.
+\*\*\* `roles/secretmanager.admin` is required for `mint add-role` when uploading a new PEM (`--pem` or browser mode). It is not required when using `--use-existing-pem-secret`.
+
+\*\*\*\* `roles/secretmanager.admin` is required for `mint remove-role` unless `--keep-pem` is passed (default deletes the PEM secret).
+
+† All commands that call GCP APIs also require `resourcemanager.projects.get` (typically available via `roles/browser` or any project-level viewer role). This is only notable for `inference status` where it is not covered by the other listed roles.
 
 Required GCP APIs also differ by command group:
 

--- a/internal/cli/mint.go
+++ b/internal/cli/mint.go
@@ -316,13 +316,15 @@ func newMintCmd() *cobra.Command {
 		Long: `Manage the GCP Cloud Function that mints GitHub App installation tokens,
 and mint short-lived tokens via OIDC.
 
-Infrastructure subcommands (deploy, enroll, unenroll, status) require GCP
+Infrastructure subcommands (deploy, enroll, unenroll, status, add-role, remove-role) require GCP
 project access. The 'token' subcommand requires only GitHub Actions OIDC.`,
 	}
 	cmd.AddCommand(newMintDeployCmd())
 	cmd.AddCommand(newMintEnrollCmd())
 	cmd.AddCommand(newMintUnenrollCmd())
 	cmd.AddCommand(newMintStatusCmd())
+	cmd.AddCommand(newMintAddRoleCmd())
+	cmd.AddCommand(newMintRemoveRoleCmd())
 	cmd.AddCommand(newMintTokenCmd())
 	return cmd
 }

--- a/internal/cli/mint.go
+++ b/internal/cli/mint.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -108,7 +109,7 @@ var githubHTTPClient = &http.Client{Timeout: 30 * time.Second}
 // lookupAppID fetches the numeric app ID for a public GitHub App by slug.
 // It makes an unauthenticated GET request to the GitHub API.
 func lookupAppID(ctx context.Context, slug string) (int, error) {
-	url := githubAPIBaseURL + "/apps/" + slug
+	url := githubAPIBaseURL + "/apps/" + url.PathEscape(slug)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return 0, fmt.Errorf("creating request for app %s: %w", slug, err)
@@ -835,10 +836,16 @@ Required IAM roles on the mint project:
 }
 
 // confirmUnenroll prompts the user to type the target name to confirm.
+// abortLabel names the operation in mismatch errors (default: "unenroll").
 // reader is the input source (os.Stdin in production, a buffer in tests).
-func confirmUnenroll(printer *ui.Printer, target string, reader *bufio.Reader, isTerminal bool) error {
+func confirmUnenroll(printer *ui.Printer, target string, reader *bufio.Reader, isTerminal bool, abortLabel ...string) error {
 	if !isTerminal {
 		return fmt.Errorf("stdin is not a terminal; use --yolo to skip confirmation")
+	}
+
+	label := "unenroll"
+	if len(abortLabel) > 0 && abortLabel[0] != "" {
+		label = abortLabel[0]
 	}
 
 	printer.StepWarn(fmt.Sprintf("This will remove %s from the mint.", target))
@@ -849,7 +856,7 @@ func confirmUnenroll(printer *ui.Printer, target string, reader *bufio.Reader, i
 		return fmt.Errorf("reading confirmation: %w", err)
 	}
 	if strings.TrimSpace(line) != target {
-		return fmt.Errorf("confirmation did not match; aborting unenroll")
+		return fmt.Errorf("confirmation did not match; aborting %s", label)
 	}
 	return nil
 }

--- a/internal/cli/mint_setup.go
+++ b/internal/cli/mint_setup.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -199,13 +200,25 @@ type mintSetupAddRoleConfig struct {
 
 func validateMintSetupRole(role string) (string, error) {
 	if role == "fix" || role == "code" {
-		return "", fmt.Errorf("role %q uses the coder app — add role \"coder\" instead", role)
+		return "", fmt.Errorf("role %q uses the coder app — use \"coder\" instead", role)
 	}
 	canonical := resolveRole(role)
 	if !mintcore.HasRole(canonical) {
 		return "", fmt.Errorf("unsupported role %q: must be one of %s", canonical, strings.Join(config.ValidRoles(), ", "))
 	}
 	return canonical, nil
+}
+
+var appSlugRE = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`)
+
+func validateAppSlug(slug string) error {
+	if slug == "" {
+		return fmt.Errorf("app slug cannot be empty")
+	}
+	if !appSlugRE.MatchString(slug) {
+		return fmt.Errorf("invalid app slug %q: must be lowercase letters, numbers, and hyphens", slug)
+	}
+	return nil
 }
 
 func parseMintAddRoleMode(slug, pemPath, org string, useExistingPEMSecret bool) (mintAddRoleMode, error) {
@@ -300,6 +313,11 @@ func runMintSetupAddRole(ctx context.Context, printer *ui.Printer, cfg mintSetup
 	printer.StepStart("Updating mint role configuration")
 	if err := provisioner.AddRoleToMint(ctx, cfg.role, strconv.Itoa(appID)); err != nil {
 		printer.StepFail("Failed to update mint env vars")
+		if cfg.mode != addRoleModeExistingSecret {
+			secretRole := mintcore.PemSecretRole(cfg.role)
+			return fmt.Errorf("registering role on mint: %w (PEM was already stored in secret fullsend-%s-app-pem; re-run with --use-existing-pem-secret to retry, or delete manually: gcloud secrets delete fullsend-%s-app-pem --project=%s)",
+				err, secretRole, secretRole, cfg.project)
+		}
 		return fmt.Errorf("registering role on mint: %w", err)
 	}
 	printer.StepDone("Role registered on mint")
@@ -314,6 +332,9 @@ func runMintSetupAddRole(ctx context.Context, printer *ui.Printer, cfg mintSetup
 }
 
 func resolveAddRoleFromSlugPEM(ctx context.Context, printer *ui.Printer, provisioner *gcf.Provisioner, cfg mintSetupAddRoleConfig) (int, error) {
+	if err := validateAppSlug(cfg.slug); err != nil {
+		return 0, err
+	}
 	printer.StepStart(fmt.Sprintf("Loading PEM and verifying app %q", cfg.slug))
 	pemData, err := os.ReadFile(cfg.pemPath)
 	if err != nil {
@@ -354,6 +375,9 @@ func resolveAddRoleFromSlugPEM(ctx context.Context, printer *ui.Printer, provisi
 }
 
 func resolveAddRoleFromExistingSecret(ctx context.Context, printer *ui.Printer, provisioner *gcf.Provisioner, cfg mintSetupAddRoleConfig) (int, error) {
+	if err := validateAppSlug(cfg.slug); err != nil {
+		return 0, err
+	}
 	printer.StepStart(fmt.Sprintf("Looking up app ID for %q", cfg.slug))
 	appID, err := lookupAppID(ctx, cfg.slug)
 	if err != nil {
@@ -374,6 +398,7 @@ func resolveAddRoleFromExistingSecret(ctx context.Context, printer *ui.Printer, 
 			mintcore.PemSecretRole(cfg.role))
 	}
 	printer.StepDone("PEM secret present")
+	printer.StepWarn(fmt.Sprintf("Skipping PEM verification — ensure fullsend-%s-app-pem matches app %q", mintcore.PemSecretRole(cfg.role), cfg.slug))
 	return appID, nil
 }
 

--- a/internal/cli/mint_setup.go
+++ b/internal/cli/mint_setup.go
@@ -1,0 +1,458 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/fullsend-ai/fullsend/internal/appsetup"
+	"github.com/fullsend-ai/fullsend/internal/config"
+	"github.com/fullsend-ai/fullsend/internal/dispatch/gcf"
+	gh "github.com/fullsend-ai/fullsend/internal/forge/github"
+	"github.com/fullsend-ai/fullsend/internal/mintcore"
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+type mintAddRoleMode int
+
+const (
+	addRoleModeUnspecified mintAddRoleMode = iota
+	addRoleModeSlugPEM
+	addRoleModeExistingSecret
+	addRoleModeBrowser
+)
+
+func newMintAddRoleCmd() *cobra.Command {
+	var project string
+	var region string
+	var slug string
+	var pemPath string
+	var org string
+	var appSet string
+	var publicApps bool
+	var useExistingPEMSecret bool
+	var force bool
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "add-role <role>",
+		Short: "Add an agent role to the token mint",
+		Long: `Registers a role on the mint by storing its PEM (when needed) and updating
+ROLE_APP_IDS / ALLOWED_ROLES on the deployed Cloud Function.
+
+Use one of three mutually exclusive input modes:
+
+  1. Existing app + PEM file:  --slug and --pem
+  2. Existing PEM secret:      --slug and --use-existing-pem-secret
+  3. Create GitHub App:        --org (opens browser for manifest flow)
+
+Requires the mint to already be deployed (fullsend mint deploy).
+
+When using --org, a GitHub token is required (GH_TOKEN, GITHUB_TOKEN, or gh auth login).
+
+Required IAM roles on the mint project:
+  - roles/run.admin                            (update Cloud Run env vars)
+  - roles/cloudfunctions.viewer                (read mint function metadata)
+  - roles/secretmanager.admin                  (create/update PEM secrets; not needed for --use-existing-pem-secret)`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if project == "" {
+				return fmt.Errorf("--project is required")
+			}
+			if !gcf.ValidateProjectID(project) {
+				return fmt.Errorf("invalid GCP project ID: %q", project)
+			}
+			if !gcf.ValidateRegion(region) {
+				return fmt.Errorf("invalid GCP region: %q", region)
+			}
+			if err := appsetup.ValidateAppSet(appSet); err != nil {
+				return fmt.Errorf("invalid --app-set: %w", err)
+			}
+
+			role, err := validateMintSetupRole(args[0])
+			if err != nil {
+				return err
+			}
+
+			mode, err := parseMintAddRoleMode(slug, pemPath, org, useExistingPEMSecret)
+			if err != nil {
+				return err
+			}
+
+			printer := ui.New(os.Stdout)
+			ctx := cmd.Context()
+			return runMintSetupAddRole(ctx, printer, mintSetupAddRoleConfig{
+				role:                 role,
+				project:              project,
+				region:               region,
+				slug:                 slug,
+				pemPath:              pemPath,
+				org:                  org,
+				appSet:               appSet,
+				publicApps:           publicApps,
+				useExistingPEMSecret: useExistingPEMSecret,
+				force:                force,
+				dryRun:               dryRun,
+				mode:                 mode,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "GCP project ID (required)")
+	cmd.Flags().StringVar(&region, "region", "us-central1", "GCP region")
+	cmd.Flags().StringVar(&slug, "slug", "", "GitHub App slug (with --pem or --use-existing-pem-secret)")
+	cmd.Flags().StringVar(&pemPath, "pem", "", "path to PEM file for the role (with --slug)")
+	cmd.Flags().StringVar(&org, "org", "", "GitHub org for browser-based app creation")
+	cmd.Flags().StringVar(&appSet, "app-set", appsetup.DefaultAppSet, "app set name prefix for browser-based app creation")
+	cmd.Flags().BoolVar(&publicApps, "public", false, "install existing public app without confirm prompt (browser mode)")
+	cmd.Flags().BoolVar(&useExistingPEMSecret, "use-existing-pem-secret", false, "skip PEM upload; require fullsend-{role}-app-pem in Secret Manager (with --slug)")
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite existing ROLE_APP_IDS entry for this role")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview changes without making them")
+
+	return cmd
+}
+
+func newMintRemoveRoleCmd() *cobra.Command {
+	var project string
+	var region string
+	var keepPEM bool
+	var dryRun bool
+	var yolo bool
+
+	cmd := &cobra.Command{
+		Use:   "remove-role <role>",
+		Short: "Remove an agent role from the token mint",
+		Long: `Removes a role from ROLE_APP_IDS and ALLOWED_ROLES on the mint Cloud Function.
+By default, also deletes the role's PEM secret from Secret Manager.
+
+Use --keep-pem to retain the PEM secret for later re-registration.
+
+Requires typing the role name to confirm (unless --dry-run or --yolo).
+
+Required IAM roles on the mint project:
+  - roles/run.admin                            (update Cloud Run env vars)
+  - roles/cloudfunctions.viewer                (read mint function metadata)
+  - roles/secretmanager.admin                  (delete PEM secrets; not needed with --keep-pem)`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if project == "" {
+				return fmt.Errorf("--project is required")
+			}
+			if !gcf.ValidateProjectID(project) {
+				return fmt.Errorf("invalid GCP project ID: %q", project)
+			}
+			if !gcf.ValidateRegion(region) {
+				return fmt.Errorf("invalid GCP region: %q", region)
+			}
+
+			role, err := validateMintSetupRole(args[0])
+			if err != nil {
+				return err
+			}
+
+			printer := ui.New(os.Stdout)
+			ctx := cmd.Context()
+			return runMintSetupRemoveRole(ctx, printer, role, project, region, keepPEM, dryRun, yolo, os.Stdin)
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "GCP project ID (required)")
+	cmd.Flags().StringVar(&region, "region", "us-central1", "GCP region")
+	cmd.Flags().BoolVar(&keepPEM, "keep-pem", false, "retain PEM secret in Secret Manager (default: delete)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview changes without making them")
+	cmd.Flags().BoolVar(&yolo, "yolo", false, "skip confirmation prompt")
+
+	return cmd
+}
+
+type mintSetupAddRoleConfig struct {
+	role                 string
+	project              string
+	region               string
+	slug                 string
+	pemPath              string
+	org                  string
+	appSet               string
+	publicApps           bool
+	useExistingPEMSecret bool
+	force                bool
+	dryRun               bool
+	mode                 mintAddRoleMode
+}
+
+func validateMintSetupRole(role string) (string, error) {
+	if role == "fix" || role == "code" {
+		return "", fmt.Errorf("role %q uses the coder app — add role \"coder\" instead", role)
+	}
+	canonical := resolveRole(role)
+	if !mintcore.HasRole(canonical) {
+		return "", fmt.Errorf("unsupported role %q: must be one of %s", canonical, strings.Join(config.ValidRoles(), ", "))
+	}
+	return canonical, nil
+}
+
+func parseMintAddRoleMode(slug, pemPath, org string, useExistingPEMSecret bool) (mintAddRoleMode, error) {
+	hasSlug := slug != ""
+	hasPEM := pemPath != ""
+	hasOrg := org != ""
+	hasExisting := useExistingPEMSecret
+
+	if hasPEM && hasExisting {
+		return addRoleModeUnspecified, fmt.Errorf("--pem and --use-existing-pem-secret are mutually exclusive")
+	}
+	if hasOrg && (hasSlug || hasPEM || hasExisting) {
+		return addRoleModeUnspecified, fmt.Errorf("--org cannot be combined with --slug, --pem, or --use-existing-pem-secret")
+	}
+
+	switch {
+	case hasSlug && hasPEM:
+		return addRoleModeSlugPEM, nil
+	case hasSlug && hasExisting:
+		return addRoleModeExistingSecret, nil
+	case hasOrg:
+		return addRoleModeBrowser, nil
+	default:
+		return addRoleModeUnspecified, fmt.Errorf("specify one input mode: (--slug and --pem), (--slug and --use-existing-pem-secret), or --org")
+	}
+}
+
+func runMintSetupAddRole(ctx context.Context, printer *ui.Printer, cfg mintSetupAddRoleConfig) error {
+	printer.Banner(Version())
+	printer.Blank()
+	printer.Header(fmt.Sprintf("Adding role %q to mint", cfg.role))
+	printer.Blank()
+
+	gcpClient := mintGCFClientFactory(cfg.project)
+	provisioner := gcf.NewProvisioner(gcf.Config{
+		ProjectID: cfg.project,
+		Region:    cfg.region,
+	}, gcpClient)
+
+	printer.StepStart("Discovering mint infrastructure")
+	discovery, err := provisioner.DiscoverMint(ctx)
+	if err != nil {
+		printer.StepFail("Mint discovery failed")
+		return fmt.Errorf("mint not found in project %s region %s: %w", cfg.project, cfg.region, err)
+	}
+	printer.StepDone(fmt.Sprintf("Found mint at %s", discovery.URL))
+
+	existing := mintcore.RoleOnlyAppIDs(discovery.RoleAppIDs)
+	if existingID, ok := existing[cfg.role]; ok && !cfg.force {
+		return fmt.Errorf("role %q is already registered (app ID %s); use --force to overwrite", cfg.role, existingID)
+	}
+
+	var appID int
+
+	switch cfg.mode {
+	case addRoleModeSlugPEM:
+		appID, err = resolveAddRoleFromSlugPEM(ctx, printer, provisioner, cfg)
+	case addRoleModeExistingSecret:
+		appID, err = resolveAddRoleFromExistingSecret(ctx, printer, provisioner, cfg)
+	case addRoleModeBrowser:
+		appID, err = resolveAddRoleFromBrowser(ctx, printer, provisioner, cfg)
+	default:
+		return fmt.Errorf("internal error: unspecified add-role mode")
+	}
+	if err != nil {
+		return err
+	}
+
+	if cfg.dryRun {
+		printer.Blank()
+		printer.StepInfo("Dry run — no changes will be made")
+		printer.StepInfo(fmt.Sprintf("Would register role %q with app ID %d", cfg.role, appID))
+		if cfg.mode != addRoleModeExistingSecret {
+			printer.StepInfo(fmt.Sprintf("Would store PEM in secret %s", fmt.Sprintf("fullsend-%s-app-pem", mintcore.PemSecretRole(cfg.role))))
+		}
+		printer.StepInfo("Would update ROLE_APP_IDS and ALLOWED_ROLES on mint")
+		return nil
+	}
+
+	printer.StepStart("Updating mint role configuration")
+	if err := provisioner.AddRoleToMint(ctx, cfg.role, strconv.Itoa(appID)); err != nil {
+		printer.StepFail("Failed to update mint env vars")
+		return fmt.Errorf("registering role on mint: %w", err)
+	}
+	printer.StepDone("Role registered on mint")
+
+	printer.Blank()
+	printer.Summary("Role added", []string{
+		fmt.Sprintf("Role: %s", cfg.role),
+		fmt.Sprintf("App ID: %d", appID),
+		fmt.Sprintf("Mint URL: %s", discovery.URL),
+	})
+	return nil
+}
+
+func resolveAddRoleFromSlugPEM(ctx context.Context, printer *ui.Printer, provisioner *gcf.Provisioner, cfg mintSetupAddRoleConfig) (int, error) {
+	printer.StepStart(fmt.Sprintf("Loading PEM and verifying app %q", cfg.slug))
+	pemData, err := os.ReadFile(cfg.pemPath)
+	if err != nil {
+		printer.StepFail("Failed to read PEM file")
+		return 0, fmt.Errorf("reading PEM file %q: %w", cfg.pemPath, err)
+	}
+	if err := appsetup.ValidateRSAPEM(pemData); err != nil {
+		printer.StepFail("Invalid PEM file")
+		return 0, fmt.Errorf("invalid PEM in %q: %w", cfg.pemPath, err)
+	}
+
+	appID, err := lookupAppID(ctx, cfg.slug)
+	if err != nil {
+		printer.StepFail("Failed to look up app ID")
+		return 0, err
+	}
+	if err := verifyPEMMatchesApp(ctx, pemData, appID, cfg.slug); err != nil {
+		printer.StepFail("PEM verification failed")
+		return 0, fmt.Errorf("verifying PEM for role %q: %w", cfg.role, err)
+	}
+	printer.StepDone(fmt.Sprintf("Verified PEM for app %s (ID %d)", cfg.slug, appID))
+
+	if cfg.dryRun {
+		return appID, nil
+	}
+
+	printer.StepStart("Storing PEM in Secret Manager")
+	if err := provisioner.EnsureMintServiceAccount(ctx); err != nil {
+		printer.StepFail("Failed to ensure mint service account")
+		return 0, fmt.Errorf("ensuring mint service account: %w", err)
+	}
+	if err := provisioner.StoreAgentPEM(ctx, cfg.role, pemData); err != nil {
+		printer.StepFail("Failed to store PEM")
+		return 0, fmt.Errorf("storing PEM for role %q: %w", cfg.role, err)
+	}
+	printer.StepDone("PEM stored")
+	return appID, nil
+}
+
+func resolveAddRoleFromExistingSecret(ctx context.Context, printer *ui.Printer, provisioner *gcf.Provisioner, cfg mintSetupAddRoleConfig) (int, error) {
+	printer.StepStart(fmt.Sprintf("Looking up app ID for %q", cfg.slug))
+	appID, err := lookupAppID(ctx, cfg.slug)
+	if err != nil {
+		printer.StepFail("Failed to look up app ID")
+		return 0, err
+	}
+	printer.StepDone(fmt.Sprintf("Found app %s (ID %d)", cfg.slug, appID))
+
+	printer.StepStart("Checking PEM secret in Secret Manager")
+	exists, err := provisioner.SecretExists(ctx, cfg.role)
+	if err != nil {
+		printer.StepFail("Failed to check PEM secret")
+		return 0, fmt.Errorf("checking PEM secret for role %q: %w", cfg.role, err)
+	}
+	if !exists {
+		printer.StepFail("PEM secret not found")
+		return 0, fmt.Errorf("PEM secret fullsend-%s-app-pem does not exist — omit --use-existing-pem-secret and pass --pem to upload one",
+			mintcore.PemSecretRole(cfg.role))
+	}
+	printer.StepDone("PEM secret present")
+	return appID, nil
+}
+
+func resolveAddRoleFromBrowser(ctx context.Context, printer *ui.Printer, provisioner *gcf.Provisioner, cfg mintSetupAddRoleConfig) (int, error) {
+	org := strings.ToLower(cfg.org)
+	if err := validateOrgName(org); err != nil {
+		return 0, err
+	}
+
+	token, err := resolveToken()
+	if err != nil {
+		return 0, err
+	}
+	client := gh.New(token)
+
+	printer.StepStart(fmt.Sprintf("Setting up GitHub App for role %q in org %s", cfg.role, org))
+	creds, err := runAppSetup(ctx, client, printer, org, []string{cfg.role}, cfg.project, "", cfg.publicApps, nil, cfg.appSet, nil)
+	if err != nil {
+		printer.StepFail("GitHub App setup failed")
+		return 0, err
+	}
+	if len(creds) != 1 {
+		return 0, fmt.Errorf("expected one app credential, got %d", len(creds))
+	}
+	printer.StepDone(fmt.Sprintf("GitHub App ready: %s (ID %d)", creds[0].Slug, creds[0].AppID))
+	return creds[0].AppID, nil
+}
+
+func runMintSetupRemoveRole(ctx context.Context, printer *ui.Printer, role, project, region string, keepPEM, dryRun, yolo bool, stdin *os.File) error {
+	printer.Banner(Version())
+	printer.Blank()
+	printer.Header(fmt.Sprintf("Removing role %q from mint", role))
+	printer.Blank()
+
+	if role == "coder" {
+		printer.StepWarn("Removing coder also prevents fix/code token minting")
+	}
+
+	gcpClient := mintGCFClientFactory(project)
+	provisioner := gcf.NewProvisioner(gcf.Config{
+		ProjectID: project,
+		Region:    region,
+	}, gcpClient)
+
+	printer.StepStart("Discovering mint infrastructure")
+	discovery, err := provisioner.DiscoverMint(ctx)
+	if err != nil {
+		printer.StepFail("Mint discovery failed")
+		return fmt.Errorf("mint not found in project %s region %s: %w", project, region, err)
+	}
+	printer.StepDone(fmt.Sprintf("Found mint at %s", discovery.URL))
+
+	existing := mintcore.RoleOnlyAppIDs(discovery.RoleAppIDs)
+	if _, ok := existing[role]; !ok {
+		return fmt.Errorf("role %q is not registered on the mint", role)
+	}
+
+	if dryRun {
+		printer.Blank()
+		printer.StepInfo("Dry run — no changes will be made")
+		printer.StepInfo(fmt.Sprintf("Would remove role %q from ROLE_APP_IDS and ALLOWED_ROLES", role))
+		if keepPEM {
+			printer.StepInfo("Would retain PEM secret")
+		} else {
+			printer.StepInfo(fmt.Sprintf("Would delete PEM secret fullsend-%s-app-pem", mintcore.PemSecretRole(role)))
+		}
+		return nil
+	}
+
+	if !yolo {
+		isTerminal := term.IsTerminal(int(stdin.Fd()))
+		if err := confirmUnenroll(printer, role, bufio.NewReader(stdin), isTerminal); err != nil {
+			return err
+		}
+	}
+
+	printer.StepStart("Removing role from mint configuration")
+	if err := provisioner.RemoveRoleFromMint(ctx, role); err != nil {
+		printer.StepFail("Failed to update mint env vars")
+		return fmt.Errorf("removing role from mint: %w", err)
+	}
+	printer.StepDone("Role removed from mint env vars")
+
+	if !keepPEM {
+		printer.StepStart("Deleting PEM secret")
+		if err := provisioner.DeleteAgentPEM(ctx, role); err != nil {
+			printer.StepFail("Failed to delete PEM secret")
+			return fmt.Errorf("deleting PEM secret for role %q: %w", role, err)
+		}
+		printer.StepDone("PEM secret deleted")
+	}
+
+	printer.Blank()
+	summary := []string{
+		fmt.Sprintf("Role: %s", role),
+		fmt.Sprintf("Mint URL: %s", discovery.URL),
+	}
+	if keepPEM {
+		summary = append(summary, "PEM secret: retained")
+	} else {
+		summary = append(summary, "PEM secret: deleted")
+	}
+	printer.Summary("Role removed", summary)
+	return nil
+}

--- a/internal/cli/mint_setup.go
+++ b/internal/cli/mint_setup.go
@@ -15,9 +15,19 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/appsetup"
 	"github.com/fullsend-ai/fullsend/internal/config"
 	"github.com/fullsend-ai/fullsend/internal/dispatch/gcf"
+	"github.com/fullsend-ai/fullsend/internal/forge"
 	gh "github.com/fullsend-ai/fullsend/internal/forge/github"
+	"github.com/fullsend-ai/fullsend/internal/layers"
 	"github.com/fullsend-ai/fullsend/internal/mintcore"
 	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+// Test hooks for browser-based add-role flow.
+var (
+	mintAddRoleResolveToken = resolveToken
+	mintAddRoleAppSetup     = func(ctx context.Context, client forge.Client, printer *ui.Printer, org string, roles []string, mintProject string, mintURL string, publicApps bool, sharedSlugs map[string]string, appSet string, storedAppIDs map[string]string) ([]layers.AgentCredentials, error) {
+		return runAppSetup(ctx, client, printer, org, roles, mintProject, mintURL, publicApps, sharedSlugs, appSet, storedAppIDs)
+	}
 )
 
 type mintAddRoleMode int
@@ -373,14 +383,14 @@ func resolveAddRoleFromBrowser(ctx context.Context, printer *ui.Printer, provisi
 		return 0, err
 	}
 
-	token, err := resolveToken()
+	token, err := mintAddRoleResolveToken()
 	if err != nil {
 		return 0, err
 	}
 	client := gh.New(token)
 
 	printer.StepStart(fmt.Sprintf("Setting up GitHub App for role %q in org %s", cfg.role, org))
-	creds, err := runAppSetup(ctx, client, printer, org, []string{cfg.role}, cfg.project, "", cfg.publicApps, nil, cfg.appSet, nil)
+	creds, err := mintAddRoleAppSetup(ctx, client, printer, org, []string{cfg.role}, cfg.project, "", cfg.publicApps, nil, cfg.appSet, nil)
 	if err != nil {
 		printer.StepFail("GitHub App setup failed")
 		return 0, err

--- a/internal/cli/mint_setup.go
+++ b/internal/cli/mint_setup.go
@@ -253,7 +253,7 @@ func runMintSetupAddRole(ctx context.Context, printer *ui.Printer, cfg mintSetup
 	}
 	printer.StepDone(fmt.Sprintf("Found mint at %s", discovery.URL))
 
-	existing, err := mintTrafficRoleAppIDs(ctx, provisioner, discovery)
+	existing, err := mintTrafficRoleAppIDs(ctx, printer, provisioner, discovery)
 	if err != nil {
 		return fmt.Errorf("reading traffic-serving ROLE_APP_IDS: %w", err)
 	}
@@ -426,7 +426,7 @@ func runMintSetupRemoveRole(ctx context.Context, printer *ui.Printer, role, proj
 	}
 	printer.StepDone(fmt.Sprintf("Found mint at %s", discovery.URL))
 
-	existing, err := mintTrafficRoleAppIDs(ctx, provisioner, discovery)
+	existing, err := mintTrafficRoleAppIDs(ctx, printer, provisioner, discovery)
 	if err != nil {
 		return fmt.Errorf("reading traffic-serving ROLE_APP_IDS: %w", err)
 	}
@@ -453,21 +453,23 @@ func runMintSetupRemoveRole(ctx context.Context, printer *ui.Printer, role, proj
 		}
 	}
 
-	if !keepPEM {
-		printer.StepStart("Deleting PEM secret")
-		if err := provisioner.DeleteAgentPEM(ctx, role); err != nil {
-			printer.StepFail("Failed to delete PEM secret")
-			return fmt.Errorf("deleting PEM secret for role %q: %w", role, err)
-		}
-		printer.StepDone("PEM secret deleted")
-	}
-
 	printer.StepStart("Removing role from mint configuration")
 	if err := provisioner.RemoveRoleFromMint(ctx, role); err != nil {
 		printer.StepFail("Failed to update mint env vars")
 		return fmt.Errorf("removing role from mint: %w", err)
 	}
 	printer.StepDone("Role removed from mint env vars")
+
+	if !keepPEM {
+		printer.StepStart("Deleting PEM secret")
+		if err := provisioner.DeleteAgentPEM(ctx, role); err != nil {
+			printer.StepFail("Failed to delete PEM secret")
+			secretID := fmt.Sprintf("fullsend-%s-app-pem", mintcore.PemSecretRole(role))
+			return fmt.Errorf("deleting PEM secret for role %q: %w (role was removed from mint; delete the orphaned secret manually: gcloud secrets delete %s --project=%s)",
+				role, err, secretID, project)
+		}
+		printer.StepDone("PEM secret deleted")
+	}
 
 	printer.Blank()
 	summary := []string{
@@ -485,9 +487,12 @@ func runMintSetupRemoveRole(ctx context.Context, printer *ui.Printer, role, proj
 
 // mintTrafficRoleAppIDs returns role-only ROLE_APP_IDS from the traffic-serving
 // Cloud Run revision, falling back to discovery template env vars when needed.
-func mintTrafficRoleAppIDs(ctx context.Context, provisioner *gcf.Provisioner, discovery *gcf.MintDiscovery) (map[string]string, error) {
+func mintTrafficRoleAppIDs(ctx context.Context, printer *ui.Printer, provisioner *gcf.Provisioner, discovery *gcf.MintDiscovery) (map[string]string, error) {
 	trafficEnv, err := provisioner.GetServiceTrafficEnvVars(ctx)
 	if err != nil {
+		if printer != nil {
+			printer.StepWarn(fmt.Sprintf("Could not read traffic-serving env vars; using template ROLE_APP_IDS: %v", err))
+		}
 		return mintcore.RoleOnlyAppIDs(discovery.RoleAppIDs), nil
 	}
 	if raw := trafficEnv["ROLE_APP_IDS"]; raw != "" {

--- a/internal/cli/mint_setup.go
+++ b/internal/cli/mint_setup.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -242,9 +243,21 @@ func runMintSetupAddRole(ctx context.Context, printer *ui.Printer, cfg mintSetup
 	}
 	printer.StepDone(fmt.Sprintf("Found mint at %s", discovery.URL))
 
-	existing := mintcore.RoleOnlyAppIDs(discovery.RoleAppIDs)
+	existing, err := mintTrafficRoleAppIDs(ctx, provisioner, discovery)
+	if err != nil {
+		return fmt.Errorf("reading traffic-serving ROLE_APP_IDS: %w", err)
+	}
 	if existingID, ok := existing[cfg.role]; ok && !cfg.force {
 		return fmt.Errorf("role %q is already registered (app ID %s); use --force to overwrite", cfg.role, existingID)
+	}
+
+	if cfg.dryRun && cfg.mode == addRoleModeBrowser {
+		printer.Blank()
+		printer.StepInfo("Dry run — no changes will be made")
+		printer.StepInfo(fmt.Sprintf("Would create GitHub App for role %q in org %s", cfg.role, cfg.org))
+		printer.StepInfo(fmt.Sprintf("Would store PEM in secret fullsend-%s-app-pem", mintcore.PemSecretRole(cfg.role)))
+		printer.StepInfo("Would update ROLE_APP_IDS and ALLOWED_ROLES on mint")
+		return nil
 	}
 
 	var appID int
@@ -403,7 +416,10 @@ func runMintSetupRemoveRole(ctx context.Context, printer *ui.Printer, role, proj
 	}
 	printer.StepDone(fmt.Sprintf("Found mint at %s", discovery.URL))
 
-	existing := mintcore.RoleOnlyAppIDs(discovery.RoleAppIDs)
+	existing, err := mintTrafficRoleAppIDs(ctx, provisioner, discovery)
+	if err != nil {
+		return fmt.Errorf("reading traffic-serving ROLE_APP_IDS: %w", err)
+	}
 	if _, ok := existing[role]; !ok {
 		return fmt.Errorf("role %q is not registered on the mint", role)
 	}
@@ -422,7 +438,7 @@ func runMintSetupRemoveRole(ctx context.Context, printer *ui.Printer, role, proj
 
 	if !yolo {
 		isTerminal := term.IsTerminal(int(stdin.Fd()))
-		if err := confirmUnenroll(printer, role, bufio.NewReader(stdin), isTerminal); err != nil {
+		if err := confirmUnenroll(printer, role, bufio.NewReader(stdin), isTerminal, "remove-role"); err != nil {
 			return err
 		}
 	}
@@ -455,4 +471,21 @@ func runMintSetupRemoveRole(ctx context.Context, printer *ui.Printer, role, proj
 	}
 	printer.Summary("Role removed", summary)
 	return nil
+}
+
+// mintTrafficRoleAppIDs returns role-only ROLE_APP_IDS from the traffic-serving
+// Cloud Run revision, falling back to discovery template env vars when needed.
+func mintTrafficRoleAppIDs(ctx context.Context, provisioner *gcf.Provisioner, discovery *gcf.MintDiscovery) (map[string]string, error) {
+	trafficEnv, err := provisioner.GetServiceTrafficEnvVars(ctx)
+	if err != nil {
+		return mintcore.RoleOnlyAppIDs(discovery.RoleAppIDs), nil
+	}
+	if raw := trafficEnv["ROLE_APP_IDS"]; raw != "" {
+		var m map[string]string
+		if err := json.Unmarshal([]byte(raw), &m); err != nil {
+			return nil, fmt.Errorf("parsing traffic ROLE_APP_IDS: %w", err)
+		}
+		return mintcore.RoleOnlyAppIDs(m), nil
+	}
+	return mintcore.RoleOnlyAppIDs(discovery.RoleAppIDs), nil
 }

--- a/internal/cli/mint_setup.go
+++ b/internal/cli/mint_setup.go
@@ -453,13 +453,6 @@ func runMintSetupRemoveRole(ctx context.Context, printer *ui.Printer, role, proj
 		}
 	}
 
-	printer.StepStart("Removing role from mint configuration")
-	if err := provisioner.RemoveRoleFromMint(ctx, role); err != nil {
-		printer.StepFail("Failed to update mint env vars")
-		return fmt.Errorf("removing role from mint: %w", err)
-	}
-	printer.StepDone("Role removed from mint env vars")
-
 	if !keepPEM {
 		printer.StepStart("Deleting PEM secret")
 		if err := provisioner.DeleteAgentPEM(ctx, role); err != nil {
@@ -468,6 +461,13 @@ func runMintSetupRemoveRole(ctx context.Context, printer *ui.Printer, role, proj
 		}
 		printer.StepDone("PEM secret deleted")
 	}
+
+	printer.StepStart("Removing role from mint configuration")
+	if err := provisioner.RemoveRoleFromMint(ctx, role); err != nil {
+		printer.StepFail("Failed to update mint env vars")
+		return fmt.Errorf("removing role from mint: %w", err)
+	}
+	printer.StepDone("Role removed from mint env vars")
 
 	printer.Blank()
 	summary := []string{

--- a/internal/cli/mint_test.go
+++ b/internal/cli/mint_test.go
@@ -986,10 +986,20 @@ func TestValidateMintSetupRole(t *testing.T) {
 	_, err = validateMintSetupRole("fix")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "coder")
+	assert.NotContains(t, err.Error(), "add role")
 
 	_, err = validateMintSetupRole("unknown")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported role")
+}
+
+func TestValidateAppSlug(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, validateAppSlug("fullsend-ai-review"))
+	require.NoError(t, validateAppSlug("my-app"))
+	err := validateAppSlug("Bad_Slug")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid app slug")
 }
 
 func TestParseMintAddRoleMode(t *testing.T) {
@@ -1623,6 +1633,60 @@ func TestRunMintSetupAddRole_AddRoleFails(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "registering role on mint")
+	assert.NotContains(t, err.Error(), "use-existing-pem-secret")
+}
+
+func TestRunMintSetupAddRole_AddRoleFailsAfterPEMStored(t *testing.T) {
+	testPEM := generateTestPEM(t)
+	pemPath := filepath.Join(t.TempDir(), "review.pem")
+	require.NoError(t, os.WriteFile(pemPath, testPEM, 0o600))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/apps/fullsend-ai-review":
+			fmt.Fprintln(w, `{"id": 88888}`)
+		case "/app":
+			fmt.Fprintln(w, `{"id": 88888}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeFunctionInfo(&gcf.FunctionInfo{
+			URI:     "https://mint.example.com",
+			EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100"}`},
+		}),
+		gcf.WithFakeTrafficEnvVars(map[string]string{
+			"ROLE_APP_IDS": `{"coder":"100"}`,
+		}),
+		gcf.WithFakeSecrets(map[string]bool{
+			"fullsend-review-app-pem": false,
+		}),
+		gcf.WithFakeErrors(map[string]error{
+			"UpdateServiceEnvVars": fmt.Errorf("permission denied"),
+		}),
+	))
+
+	printer := ui.New(&strings.Builder{})
+	err := runMintSetupAddRole(context.Background(), printer, mintSetupAddRoleConfig{
+		role:    "review",
+		project: "my-project-id",
+		region:  "us-central1",
+		slug:    "fullsend-ai-review",
+		pemPath: pemPath,
+		mode:    addRoleModeSlugPEM,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registering role on mint")
+	assert.Contains(t, err.Error(), "use-existing-pem-secret")
+	assert.Contains(t, err.Error(), "gcloud secrets delete")
 }
 
 func TestRunMintSetupRemoveRole_RemoveFails(t *testing.T) {

--- a/internal/cli/mint_test.go
+++ b/internal/cli/mint_test.go
@@ -1231,7 +1231,7 @@ func TestMintTrafficRoleAppIDs_PrefersTrafficRevision(t *testing.T) {
 		URL:        "https://mint.example.com",
 		RoleAppIDs: map[string]string{"coder": "100"},
 	}
-	roles, err := mintTrafficRoleAppIDs(context.Background(), provisioner, discovery)
+	roles, err := mintTrafficRoleAppIDs(context.Background(), nil, provisioner, discovery)
 	require.NoError(t, err)
 	assert.Equal(t, "200", roles["review"])
 }
@@ -1343,7 +1343,7 @@ func TestMintTrafficRoleAppIDs_InvalidJSON(t *testing.T) {
 		}),
 	))
 	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "my-project-id", Region: "us-central1"}, mintGCFClientFactory("my-project-id"))
-	_, err := mintTrafficRoleAppIDs(context.Background(), provisioner, &gcf.MintDiscovery{})
+	_, err := mintTrafficRoleAppIDs(context.Background(), nil, provisioner, &gcf.MintDiscovery{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parsing traffic ROLE_APP_IDS")
 }
@@ -1354,7 +1354,7 @@ func TestMintTrafficRoleAppIDs_FallbackWhenTrafficEmpty(t *testing.T) {
 	))
 	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "my-project-id", Region: "us-central1"}, mintGCFClientFactory("my-project-id"))
 	discovery := &gcf.MintDiscovery{RoleAppIDs: map[string]string{"coder": "100"}}
-	roles, err := mintTrafficRoleAppIDs(context.Background(), provisioner, discovery)
+	roles, err := mintTrafficRoleAppIDs(context.Background(), nil, provisioner, discovery)
 	require.NoError(t, err)
 	assert.Equal(t, "100", roles["coder"])
 }
@@ -1453,9 +1453,12 @@ func TestMintTrafficRoleAppIDs_FallbackOnTrafficError(t *testing.T) {
 	))
 	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "my-project-id", Region: "us-central1"}, mintGCFClientFactory("my-project-id"))
 	discovery := &gcf.MintDiscovery{RoleAppIDs: map[string]string{"coder": "100"}}
-	roles, err := mintTrafficRoleAppIDs(context.Background(), provisioner, discovery)
+	out := &strings.Builder{}
+	printer := ui.New(out)
+	roles, err := mintTrafficRoleAppIDs(context.Background(), printer, provisioner, discovery)
 	require.NoError(t, err)
 	assert.Equal(t, "100", roles["coder"])
+	assert.Contains(t, out.String(), "traffic-serving env vars")
 }
 
 func withMintAddRoleHooks(t *testing.T, resolveToken func() (string, error), appSetup func(context.Context, forge.Client, *ui.Printer, string, []string, string, string, bool, map[string]string, string, map[string]string) ([]layers.AgentCredentials, error)) {
@@ -1658,6 +1661,7 @@ func TestRunMintSetupRemoveRole_DeletePEMFails(t *testing.T) {
 	err := runMintSetupRemoveRole(context.Background(), printer, "triage", "my-project-id", "us-central1", false, false, true, os.Stdin)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "deleting PEM secret")
+	assert.Contains(t, err.Error(), "gcloud secrets delete")
 }
 
 func TestResolveAddRoleFromSlugPEM_LookupFails(t *testing.T) {

--- a/internal/cli/mint_test.go
+++ b/internal/cli/mint_test.go
@@ -48,6 +48,22 @@ func TestMintCommand_HasSubcommands(t *testing.T) {
 	assert.True(t, names["unenroll <org|owner/repo>"], "expected unenroll subcommand")
 	assert.True(t, names["status [org]"], "expected status subcommand")
 	assert.True(t, names["token"], "expected token subcommand")
+	assert.True(t, names["add-role <role>"], "expected add-role subcommand")
+	assert.True(t, names["remove-role <role>"], "expected remove-role subcommand")
+}
+
+func TestMintAddRoleCmd_Flags(t *testing.T) {
+	cmd := newMintAddRoleCmd()
+	assert.NotNil(t, cmd.Flags().Lookup("project"))
+	assert.NotNil(t, cmd.Flags().Lookup("slug"))
+	assert.NotNil(t, cmd.Flags().Lookup("pem"))
+	assert.NotNil(t, cmd.Flags().Lookup("use-existing-pem-secret"))
+}
+
+func TestMintRemoveRoleCmd_Flags(t *testing.T) {
+	cmd := newMintRemoveRoleCmd()
+	assert.NotNil(t, cmd.Flags().Lookup("project"))
+	assert.NotNil(t, cmd.Flags().Lookup("keep-pem"))
 }
 
 func TestMintCommand_RegisteredInRoot(t *testing.T) {
@@ -938,4 +954,153 @@ func TestConfirmUnenroll_NonTerminal(t *testing.T) {
 	err := confirmUnenroll(printer, "acme-org", reader, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "stdin is not a terminal")
+}
+
+// --- mint add-role / remove-role tests ---
+
+func TestValidateMintSetupRole(t *testing.T) {
+	t.Parallel()
+	role, err := validateMintSetupRole("coder")
+	require.NoError(t, err)
+	assert.Equal(t, "coder", role)
+
+	_, err = validateMintSetupRole("fix")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "coder")
+
+	_, err = validateMintSetupRole("unknown")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported role")
+}
+
+func TestParseMintAddRoleMode(t *testing.T) {
+	t.Parallel()
+	mode, err := parseMintAddRoleMode("my-app", "/tmp/pem", "", false)
+	require.NoError(t, err)
+	assert.Equal(t, addRoleModeSlugPEM, mode)
+
+	mode, err = parseMintAddRoleMode("my-app", "", "", true)
+	require.NoError(t, err)
+	assert.Equal(t, addRoleModeExistingSecret, mode)
+
+	mode, err = parseMintAddRoleMode("", "", "acme", false)
+	require.NoError(t, err)
+	assert.Equal(t, addRoleModeBrowser, mode)
+
+	_, err = parseMintAddRoleMode("my-app", "/tmp/pem", "", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+
+	_, err = parseMintAddRoleMode("my-app", "", "acme", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be combined")
+
+	_, err = parseMintAddRoleMode("", "", "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "specify one input mode")
+}
+
+func TestMintSetupAddRoleCmd_RequiresProject(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"mint", "add-role", "coder", "--slug=app", "--pem=/tmp/x.pem"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project is required")
+}
+
+func TestMintSetupAddRoleCmd_PemAndUseExistingMutuallyExclusive(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "add-role", "coder",
+		"--project=my-project-id",
+		"--slug=fullsend-ai-coder",
+		"--pem=/tmp/coder.pem",
+		"--use-existing-pem-secret",
+	})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestMintSetupAddRoleCmd_NoInputMode(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"mint", "add-role", "coder", "--project=my-project-id"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "specify one input mode")
+}
+
+func TestMintSetupAddRoleCmd_ExistingSecretDryRun(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"id": 99999}`)
+	}))
+	defer srv.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeFunctionInfo(&gcf.FunctionInfo{
+			URI:     "https://mint.example.com",
+			EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100"}`},
+		}),
+		gcf.WithFakeTrafficEnvVars(map[string]string{
+			"ROLE_APP_IDS": `{"coder":"100"}`,
+		}),
+		gcf.WithFakeSecrets(map[string]bool{
+			"fullsend-review-app-pem": true,
+		}),
+	))
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "add-role", "review",
+		"--project=my-project-id",
+		"--slug=fullsend-ai-review",
+		"--use-existing-pem-secret",
+		"--dry-run",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestMintSetupAddRoleCmd_AlreadyRegistered(t *testing.T) {
+	withMintGCFClient(t, mintDiscoveryClient())
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "add-role", "coder",
+		"--project=my-project-id",
+		"--slug=fullsend-ai-coder",
+		"--use-existing-pem-secret",
+	})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already registered")
+}
+
+func TestMintSetupRemoveRoleCmd_DryRun(t *testing.T) {
+	withMintGCFClient(t, mintDiscoveryClient())
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "remove-role", "coder",
+		"--project=my-project-id",
+		"--dry-run",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestMintSetupRemoveRoleCmd_NotRegistered(t *testing.T) {
+	withMintGCFClient(t, mintDiscoveryClient())
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "remove-role", "review",
+		"--project=my-project-id",
+		"--dry-run",
+	})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not registered")
 }

--- a/internal/cli/mint_test.go
+++ b/internal/cli/mint_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/fullsend-ai/fullsend/internal/config"
 	"github.com/fullsend-ai/fullsend/internal/dispatch/gcf"
+	"github.com/fullsend-ai/fullsend/internal/forge"
+	"github.com/fullsend-ai/fullsend/internal/layers"
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
@@ -208,6 +210,23 @@ func TestLookupAppID_Success(t *testing.T) {
 	appID, err := lookupAppID(context.Background(), "fullsend-ai-coder")
 	require.NoError(t, err)
 	assert.Equal(t, 12345, appID)
+}
+
+func TestLookupAppID_EscapesSlug(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/apps/my%2Fapp", r.URL.EscapedPath())
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"id": 42}`)
+	}))
+	defer srv.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	id, err := lookupAppID(context.Background(), "my/app")
+	require.NoError(t, err)
+	assert.Equal(t, 42, id)
 }
 
 func TestLookupAppID_NotFound(t *testing.T) {
@@ -1030,6 +1049,77 @@ func TestMintSetupAddRoleCmd_NoInputMode(t *testing.T) {
 	assert.Contains(t, err.Error(), "specify one input mode")
 }
 
+func TestMintSetupAddRoleCmd_InvalidProject(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "add-role", "coder",
+		"--project=BAD",
+		"--slug=app",
+		"--pem=/tmp/x.pem",
+	})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid GCP project ID")
+}
+
+func TestMintSetupAddRoleCmd_InvalidRegion(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "add-role", "coder",
+		"--project=my-project-id",
+		"--region=invalid",
+		"--slug=app",
+		"--pem=/tmp/x.pem",
+	})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid GCP region")
+}
+
+func TestMintSetupRemoveRoleCmd_InvalidProject(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"mint", "remove-role", "coder", "--project=BAD"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid GCP project ID")
+}
+
+func TestMintSetupAddRoleCmd_ForceOverwrite(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"id": 99999}`)
+	}))
+	defer srv.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeFunctionInfo(&gcf.FunctionInfo{
+			URI:     "https://mint.example.com",
+			EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100"}`},
+		}),
+		gcf.WithFakeTrafficEnvVars(map[string]string{
+			"ROLE_APP_IDS": `{"coder":"100"}`,
+		}),
+		gcf.WithFakeSecrets(map[string]bool{
+			"fullsend-coder-app-pem": true,
+		}),
+	))
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "add-role", "coder",
+		"--project=my-project-id",
+		"--slug=fullsend-ai-coder",
+		"--use-existing-pem-secret",
+		"--force",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
 func TestMintSetupAddRoleCmd_ExistingSecretDryRun(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -1316,4 +1406,347 @@ func TestMintRemoveRoleCmd_KeepPEMDryRun(t *testing.T) {
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)
+}
+
+func TestResolveAddRoleFromSlugPEM_InvalidPEM(t *testing.T) {
+	printer := ui.New(&strings.Builder{})
+	pemPath := filepath.Join(t.TempDir(), "bad.pem")
+	require.NoError(t, os.WriteFile(pemPath, []byte("not-a-pem"), 0o600))
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "p"}, gcf.NewFakeGCFClient())
+	_, err := resolveAddRoleFromSlugPEM(context.Background(), printer, provisioner, mintSetupAddRoleConfig{
+		role:    "review",
+		slug:    "fullsend-ai-review",
+		pemPath: pemPath,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid PEM")
+}
+
+func TestResolveAddRoleFromBrowser_InvalidOrg(t *testing.T) {
+	printer := ui.New(&strings.Builder{})
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "p"}, gcf.NewFakeGCFClient())
+	_, err := resolveAddRoleFromBrowser(context.Background(), printer, provisioner, mintSetupAddRoleConfig{
+		role: "review",
+		org:  "-invalid-",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "organization name")
+}
+
+func TestResolveAddRoleFromSlugPEM_MissingFile(t *testing.T) {
+	printer := ui.New(&strings.Builder{})
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "p"}, gcf.NewFakeGCFClient())
+	_, err := resolveAddRoleFromSlugPEM(context.Background(), printer, provisioner, mintSetupAddRoleConfig{
+		role:    "review",
+		slug:    "fullsend-ai-review",
+		pemPath: filepath.Join(t.TempDir(), "missing.pem"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading PEM file")
+}
+
+func TestMintTrafficRoleAppIDs_FallbackOnTrafficError(t *testing.T) {
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeErrors(map[string]error{
+			"GetServiceTrafficEnvVars": fmt.Errorf("unavailable"),
+		}),
+	))
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "my-project-id", Region: "us-central1"}, mintGCFClientFactory("my-project-id"))
+	discovery := &gcf.MintDiscovery{RoleAppIDs: map[string]string{"coder": "100"}}
+	roles, err := mintTrafficRoleAppIDs(context.Background(), provisioner, discovery)
+	require.NoError(t, err)
+	assert.Equal(t, "100", roles["coder"])
+}
+
+func withMintAddRoleHooks(t *testing.T, resolveToken func() (string, error), appSetup func(context.Context, forge.Client, *ui.Printer, string, []string, string, string, bool, map[string]string, string, map[string]string) ([]layers.AgentCredentials, error)) {
+	t.Helper()
+	oldToken := mintAddRoleResolveToken
+	oldSetup := mintAddRoleAppSetup
+	if resolveToken != nil {
+		mintAddRoleResolveToken = resolveToken
+	}
+	if appSetup != nil {
+		mintAddRoleAppSetup = appSetup
+	}
+	t.Cleanup(func() {
+		mintAddRoleResolveToken = oldToken
+		mintAddRoleAppSetup = oldSetup
+	})
+}
+
+func TestResolveAddRoleFromBrowser_NoToken(t *testing.T) {
+	withMintAddRoleHooks(t, func() (string, error) {
+		return "", fmt.Errorf("no GitHub token found")
+	}, nil)
+	printer := ui.New(&strings.Builder{})
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "p"}, gcf.NewFakeGCFClient())
+	_, err := resolveAddRoleFromBrowser(context.Background(), printer, provisioner, mintSetupAddRoleConfig{
+		role: "review",
+		org:  "acme-corp",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no GitHub token")
+}
+
+func TestResolveAddRoleFromBrowser_Success(t *testing.T) {
+	withMintAddRoleHooks(t,
+		func() (string, error) { return "test-token", nil },
+		func(_ context.Context, _ forge.Client, _ *ui.Printer, org string, roles []string, _ string, _ string, _ bool, _ map[string]string, _ string, _ map[string]string) ([]layers.AgentCredentials, error) {
+			assert.Equal(t, "acme-corp", org)
+			assert.Equal(t, []string{"review"}, roles)
+			return []layers.AgentCredentials{{AgentEntry: config.AgentEntry{Slug: "fullsend-ai-review"}, AppID: 424242}}, nil
+		},
+	)
+	printer := ui.New(&strings.Builder{})
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "p"}, gcf.NewFakeGCFClient())
+	appID, err := resolveAddRoleFromBrowser(context.Background(), printer, provisioner, mintSetupAddRoleConfig{
+		role: "review",
+		org:  "Acme-Corp",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 424242, appID)
+}
+
+func TestResolveAddRoleFromBrowser_AppSetupFails(t *testing.T) {
+	withMintAddRoleHooks(t,
+		func() (string, error) { return "test-token", nil },
+		func(context.Context, forge.Client, *ui.Printer, string, []string, string, string, bool, map[string]string, string, map[string]string) ([]layers.AgentCredentials, error) {
+			return nil, fmt.Errorf("manifest flow failed")
+		},
+	)
+	printer := ui.New(&strings.Builder{})
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "p"}, gcf.NewFakeGCFClient())
+	_, err := resolveAddRoleFromBrowser(context.Background(), printer, provisioner, mintSetupAddRoleConfig{
+		role: "review",
+		org:  "acme-corp",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "manifest flow failed")
+}
+
+func TestResolveAddRoleFromBrowser_WrongCredCount(t *testing.T) {
+	withMintAddRoleHooks(t,
+		func() (string, error) { return "test-token", nil },
+		func(context.Context, forge.Client, *ui.Printer, string, []string, string, string, bool, map[string]string, string, map[string]string) ([]layers.AgentCredentials, error) {
+			return []layers.AgentCredentials{{AppID: 1}, {AppID: 2}}, nil
+		},
+	)
+	printer := ui.New(&strings.Builder{})
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "p"}, gcf.NewFakeGCFClient())
+	_, err := resolveAddRoleFromBrowser(context.Background(), printer, provisioner, mintSetupAddRoleConfig{
+		role: "review",
+		org:  "acme-corp",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected one app credential")
+}
+
+func TestMintAddRoleCmd_BrowserRegisters(t *testing.T) {
+	withMintAddRoleHooks(t,
+		func() (string, error) { return "test-token", nil },
+		func(context.Context, forge.Client, *ui.Printer, string, []string, string, string, bool, map[string]string, string, map[string]string) ([]layers.AgentCredentials, error) {
+			return []layers.AgentCredentials{{AgentEntry: config.AgentEntry{Slug: "fullsend-ai-review"}, AppID: 55555}}, nil
+		},
+	)
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeFunctionInfo(&gcf.FunctionInfo{
+			URI:     "https://mint.example.com",
+			EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100"}`},
+		}),
+		gcf.WithFakeTrafficEnvVars(map[string]string{
+			"ROLE_APP_IDS": `{"coder":"100"}`,
+		}),
+	))
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "add-role", "review",
+		"--project=my-project-id",
+		"--org=acme-corp",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestRunMintSetupAddRole_DiscoveryFails(t *testing.T) {
+	withMintGCFClient(t, gcf.NewFakeGCFClient())
+	printer := ui.New(&strings.Builder{})
+	err := runMintSetupAddRole(context.Background(), printer, mintSetupAddRoleConfig{
+		role:    "review",
+		project: "my-project-id",
+		region:  "us-central1",
+		slug:    "fullsend-ai-review",
+		pemPath: "/tmp/missing.pem",
+		mode:    addRoleModeSlugPEM,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mint not found")
+}
+
+func TestRunMintSetupAddRole_AddRoleFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"id": 99999}`)
+	}))
+	defer srv.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeFunctionInfo(&gcf.FunctionInfo{
+			URI:     "https://mint.example.com",
+			EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100"}`},
+		}),
+		gcf.WithFakeTrafficEnvVars(map[string]string{
+			"ROLE_APP_IDS": `{"coder":"100"}`,
+		}),
+		gcf.WithFakeSecrets(map[string]bool{
+			"fullsend-review-app-pem": true,
+		}),
+		gcf.WithFakeErrors(map[string]error{
+			"UpdateServiceEnvVars": fmt.Errorf("permission denied"),
+		}),
+	))
+
+	printer := ui.New(&strings.Builder{})
+	err := runMintSetupAddRole(context.Background(), printer, mintSetupAddRoleConfig{
+		role:                 "review",
+		project:              "my-project-id",
+		region:               "us-central1",
+		slug:                 "fullsend-ai-review",
+		mode:                 addRoleModeExistingSecret,
+		useExistingPEMSecret: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registering role on mint")
+}
+
+func TestRunMintSetupRemoveRole_RemoveFails(t *testing.T) {
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeFunctionInfo(&gcf.FunctionInfo{
+			URI:     "https://mint.example.com",
+			EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100","triage":"200"}`},
+		}),
+		gcf.WithFakeTrafficEnvVars(map[string]string{
+			"ROLE_APP_IDS": `{"coder":"100","triage":"200"}`,
+		}),
+		gcf.WithFakeErrors(map[string]error{
+			"UpdateServiceEnvVars": fmt.Errorf("permission denied"),
+		}),
+	))
+	printer := ui.New(&strings.Builder{})
+	err := runMintSetupRemoveRole(context.Background(), printer, "triage", "my-project-id", "us-central1", false, false, true, os.Stdin)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "removing role from mint")
+}
+
+func TestRunMintSetupRemoveRole_DeletePEMFails(t *testing.T) {
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeFunctionInfo(&gcf.FunctionInfo{
+			URI:     "https://mint.example.com",
+			EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100","triage":"200"}`},
+		}),
+		gcf.WithFakeTrafficEnvVars(map[string]string{
+			"ROLE_APP_IDS": `{"coder":"100","triage":"200"}`,
+		}),
+		gcf.WithFakeErrors(map[string]error{
+			"DeleteSecret": fmt.Errorf("permission denied"),
+		}),
+	))
+	printer := ui.New(&strings.Builder{})
+	err := runMintSetupRemoveRole(context.Background(), printer, "triage", "my-project-id", "us-central1", false, false, true, os.Stdin)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deleting PEM secret")
+}
+
+func TestResolveAddRoleFromSlugPEM_LookupFails(t *testing.T) {
+	testPEM := generateTestPEM(t)
+	pemPath := filepath.Join(t.TempDir(), "review.pem")
+	require.NoError(t, os.WriteFile(pemPath, testPEM, 0o600))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	printer := ui.New(&strings.Builder{})
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "p"}, gcf.NewFakeGCFClient())
+	_, err := resolveAddRoleFromSlugPEM(context.Background(), printer, provisioner, mintSetupAddRoleConfig{
+		role:    "review",
+		slug:    "missing-app",
+		pemPath: pemPath,
+	})
+	require.Error(t, err)
+}
+
+func TestResolveAddRoleFromSlugPEM_StoreFails(t *testing.T) {
+	testPEM := generateTestPEM(t)
+	pemPath := filepath.Join(t.TempDir(), "review.pem")
+	require.NoError(t, os.WriteFile(pemPath, testPEM, 0o600))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/apps/fullsend-ai-review":
+			fmt.Fprintln(w, `{"id": 88888}`)
+		case "/app":
+			fmt.Fprintln(w, `{"id": 88888}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeSecrets(map[string]bool{
+			"fullsend-review-app-pem": false,
+		}),
+		gcf.WithFakeErrors(map[string]error{
+			"CreateSecret": fmt.Errorf("permission denied"),
+		}),
+	))
+	printer := ui.New(&strings.Builder{})
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "p"}, mintGCFClientFactory("p"))
+	_, err := resolveAddRoleFromSlugPEM(context.Background(), printer, provisioner, mintSetupAddRoleConfig{
+		role:    "review",
+		slug:    "fullsend-ai-review",
+		pemPath: pemPath,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storing PEM")
+}
+
+func TestResolveAddRoleFromExistingSecret_CheckFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"id": 99999}`)
+	}))
+	defer srv.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeErrors(map[string]error{
+			"GetSecret": fmt.Errorf("api unavailable"),
+		}),
+	))
+	printer := ui.New(&strings.Builder{})
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "p"}, mintGCFClientFactory("p"))
+	_, err := resolveAddRoleFromExistingSecret(context.Background(), printer, provisioner, mintSetupAddRoleConfig{
+		role: "review",
+		slug: "fullsend-ai-review",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checking PEM secret")
 }

--- a/internal/cli/mint_test.go
+++ b/internal/cli/mint_test.go
@@ -1268,3 +1268,52 @@ func TestMintTrafficRoleAppIDs_FallbackWhenTrafficEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "100", roles["coder"])
 }
+
+func TestMintAddRoleCmd_ExistingSecretMissingPEM(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"id": 99999}`)
+	}))
+	defer srv.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeFunctionInfo(&gcf.FunctionInfo{
+			URI:     "https://mint.example.com",
+			EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100"}`},
+		}),
+		gcf.WithFakeTrafficEnvVars(map[string]string{
+			"ROLE_APP_IDS": `{"coder":"100"}`,
+		}),
+		gcf.WithFakeSecrets(map[string]bool{
+			"fullsend-review-app-pem": false,
+		}),
+	))
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "add-role", "review",
+		"--project=my-project-id",
+		"--slug=fullsend-ai-review",
+		"--use-existing-pem-secret",
+	})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestMintRemoveRoleCmd_KeepPEMDryRun(t *testing.T) {
+	withMintGCFClient(t, mintDiscoveryClient())
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "remove-role", "coder",
+		"--project=my-project-id",
+		"--keep-pem",
+		"--dry-run",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}

--- a/internal/cli/mint_test.go
+++ b/internal/cli/mint_test.go
@@ -1153,3 +1153,118 @@ func TestConfirmUnenroll_CustomAbortLabel(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "aborting remove-role")
 }
+
+func TestMintAddRoleCmd_ExistingSecretRegisters(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/apps/fullsend-ai-review", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"id": 99999}`)
+	}))
+	defer srv.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeFunctionInfo(&gcf.FunctionInfo{
+			URI:     "https://mint.example.com",
+			EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100"}`},
+		}),
+		gcf.WithFakeTrafficEnvVars(map[string]string{
+			"ROLE_APP_IDS": `{"coder":"100"}`,
+		}),
+		gcf.WithFakeSecrets(map[string]bool{
+			"fullsend-review-app-pem": true,
+		}),
+	))
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "add-role", "review",
+		"--project=my-project-id",
+		"--slug=fullsend-ai-review",
+		"--use-existing-pem-secret",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestMintAddRoleCmd_SlugPEMRegisters(t *testing.T) {
+	testPEM := generateTestPEM(t)
+	pemPath := filepath.Join(t.TempDir(), "review.pem")
+	require.NoError(t, os.WriteFile(pemPath, testPEM, 0o600))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/apps/fullsend-ai-review":
+			fmt.Fprintln(w, `{"id": 88888}`)
+		case "/app":
+			fmt.Fprintln(w, `{"id": 88888}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	orig := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = orig }()
+
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeFunctionInfo(&gcf.FunctionInfo{
+			URI:     "https://mint.example.com",
+			EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100"}`},
+		}),
+		gcf.WithFakeTrafficEnvVars(map[string]string{
+			"ROLE_APP_IDS": `{"coder":"100"}`,
+		}),
+		gcf.WithFakeErrors(map[string]error{"GetSecret": gcf.ErrSecretNotFound}),
+	))
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "add-role", "review",
+		"--project=my-project-id",
+		"--slug=fullsend-ai-review",
+		"--pem=" + pemPath,
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestMintRemoveRoleCmd_YoloSuccess(t *testing.T) {
+	withMintGCFClient(t, mintDiscoveryClient())
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "remove-role", "triage",
+		"--project=my-project-id",
+		"--yolo",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestMintTrafficRoleAppIDs_InvalidJSON(t *testing.T) {
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeTrafficEnvVars(map[string]string{
+			"ROLE_APP_IDS": `not-json`,
+		}),
+	))
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "my-project-id", Region: "us-central1"}, mintGCFClientFactory("my-project-id"))
+	_, err := mintTrafficRoleAppIDs(context.Background(), provisioner, &gcf.MintDiscovery{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing traffic ROLE_APP_IDS")
+}
+
+func TestMintTrafficRoleAppIDs_FallbackWhenTrafficEmpty(t *testing.T) {
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeTrafficEnvVars(map[string]string{}),
+	))
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "my-project-id", Region: "us-central1"}, mintGCFClientFactory("my-project-id"))
+	discovery := &gcf.MintDiscovery{RoleAppIDs: map[string]string{"coder": "100"}}
+	roles, err := mintTrafficRoleAppIDs(context.Background(), provisioner, discovery)
+	require.NoError(t, err)
+	assert.Equal(t, "100", roles["coder"])
+}

--- a/internal/cli/mint_test.go
+++ b/internal/cli/mint_test.go
@@ -1104,3 +1104,52 @@ func TestMintSetupRemoveRoleCmd_NotRegistered(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not registered")
 }
+
+func TestMintAddRoleCmd_BrowserDryRun(t *testing.T) {
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeFunctionInfo(&gcf.FunctionInfo{
+			URI:     "https://mint.example.com",
+			EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100"}`},
+		}),
+		gcf.WithFakeTrafficEnvVars(map[string]string{
+			"ROLE_APP_IDS": `{"coder":"100"}`,
+		}),
+	))
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{
+		"mint", "add-role", "review",
+		"--project=my-project-id",
+		"--org=acme-corp",
+		"--dry-run",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestMintTrafficRoleAppIDs_PrefersTrafficRevision(t *testing.T) {
+	withMintGCFClient(t, gcf.NewFakeGCFClient(
+		gcf.WithFakeFunctionInfo(&gcf.FunctionInfo{
+			URI:     "https://mint.example.com",
+			EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100"}`},
+		}),
+		gcf.WithFakeTrafficEnvVars(map[string]string{
+			"ROLE_APP_IDS": `{"coder":"100","review":"200"}`,
+		}),
+	))
+	provisioner := gcf.NewProvisioner(gcf.Config{ProjectID: "my-project-id", Region: "us-central1"}, mintGCFClientFactory("my-project-id"))
+	discovery := &gcf.MintDiscovery{
+		URL:        "https://mint.example.com",
+		RoleAppIDs: map[string]string{"coder": "100"},
+	}
+	roles, err := mintTrafficRoleAppIDs(context.Background(), provisioner, discovery)
+	require.NoError(t, err)
+	assert.Equal(t, "200", roles["review"])
+}
+
+func TestConfirmUnenroll_CustomAbortLabel(t *testing.T) {
+	printer := ui.New(&strings.Builder{})
+	reader := bufio.NewReader(strings.NewReader("wrong\n"))
+	err := confirmUnenroll(printer, "retro", reader, true, "remove-role")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aborting remove-role")
+}

--- a/internal/dispatch/gcf/fakeclient.go
+++ b/internal/dispatch/gcf/fakeclient.go
@@ -31,6 +31,7 @@ type fakeGCFClient struct {
 
 	// Track secret names written via AddSecretVersion.
 	secretVersionNames []string
+	deletedSecretIDs   []string
 
 	// Per-secret state for CopyAgentPEM tests.
 	secretData map[string][]byte // secretID → payload
@@ -146,6 +147,7 @@ func (f *fakeGCFClient) EnableSecretVersion(_ context.Context, _ string, sid str
 }
 func (f *fakeGCFClient) DeleteSecret(_ context.Context, _ string, sid string) error {
 	f.calls = append(f.calls, "DeleteSecret")
+	f.deletedSecretIDs = append(f.deletedSecretIDs, sid)
 	if f.secrets != nil {
 		delete(f.secrets, sid)
 	}

--- a/internal/dispatch/gcf/provisioner.go
+++ b/internal/dispatch/gcf/provisioner.go
@@ -223,6 +223,98 @@ func (p *Provisioner) StoreAgentPEM(ctx context.Context, role string, pemData []
 	return nil
 }
 
+// DeleteAgentPEM permanently deletes the Secret Manager secret for the given role.
+func (p *Provisioner) DeleteAgentPEM(ctx context.Context, role string) error {
+	if p.cfg.ProjectID == "" {
+		return fmt.Errorf("GCP project ID is required")
+	}
+	if err := mintcore.ValidateRoleName(role); err != nil {
+		return fmt.Errorf("invalid role name %q: %w", role, err)
+	}
+	sid := secretID(role)
+	if err := p.gcpAPI.DeleteSecret(ctx, p.cfg.ProjectID, sid); err != nil {
+		return fmt.Errorf("deleting secret %s: %w", sid, err)
+	}
+	return nil
+}
+
+// AddRoleToMint registers a role's app ID in ROLE_APP_IDS and updates ALLOWED_ROLES
+// on the traffic-serving Cloud Run revision.
+func (p *Provisioner) AddRoleToMint(ctx context.Context, role, appID string) error {
+	if p.cfg.ProjectID == "" {
+		return fmt.Errorf("GCP project ID is required")
+	}
+	if err := mintcore.ValidateRoleName(role); err != nil {
+		return fmt.Errorf("invalid role name %q: %w", role, err)
+	}
+	if appID == "" {
+		return fmt.Errorf("app ID is required for role %q", role)
+	}
+
+	trafficEnvVars, err := p.gcpAPI.GetServiceTrafficEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
+	if err != nil {
+		return fmt.Errorf("reading traffic-serving env vars: %w", err)
+	}
+
+	updated := make(map[string]string, len(trafficEnvVars))
+	for k, v := range trafficEnvVars {
+		updated[k] = v
+	}
+
+	merged, err := mergeRoleAppIDsJSON(updated["ROLE_APP_IDS"], map[string]string{role: appID})
+	if err != nil {
+		return fmt.Errorf("merging ROLE_APP_IDS: %w", err)
+	}
+	updated["ROLE_APP_IDS"] = merged
+	updated["ALLOWED_ROLES"] = deriveAllowedRoles(updated["ROLE_APP_IDS"])
+
+	rev, err := p.gcpAPI.UpdateServiceEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated)
+	if err != nil {
+		if rev != "" {
+			return fmt.Errorf("updating mint env vars (revision %s created but traffic routing may have failed): %w", rev, err)
+		}
+		return fmt.Errorf("updating mint env vars: %w", err)
+	}
+	return nil
+}
+
+// RemoveRoleFromMint removes a role-only entry from ROLE_APP_IDS and updates
+// ALLOWED_ROLES on the traffic-serving Cloud Run revision.
+func (p *Provisioner) RemoveRoleFromMint(ctx context.Context, role string) error {
+	if p.cfg.ProjectID == "" {
+		return fmt.Errorf("GCP project ID is required")
+	}
+	if err := mintcore.ValidateRoleName(role); err != nil {
+		return fmt.Errorf("invalid role name %q: %w", role, err)
+	}
+
+	trafficEnvVars, err := p.gcpAPI.GetServiceTrafficEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName)
+	if err != nil {
+		return fmt.Errorf("reading traffic-serving env vars: %w", err)
+	}
+
+	updated := make(map[string]string, len(trafficEnvVars))
+	for k, v := range trafficEnvVars {
+		updated[k] = v
+	}
+
+	pruned, err := removeRoleFromAppIDsJSON(updated["ROLE_APP_IDS"], role)
+	if err != nil {
+		return fmt.Errorf("pruning ROLE_APP_IDS: %w", err)
+	}
+	updated["ROLE_APP_IDS"] = pruned
+	updated["ALLOWED_ROLES"] = deriveAllowedRoles(updated["ROLE_APP_IDS"])
+
+	rev, err := p.gcpAPI.UpdateServiceEnvVars(ctx, p.cfg.ProjectID, p.cfg.Region, functionName, updated)
+	if err != nil {
+		if rev != "" {
+			return fmt.Errorf("updating mint env vars (revision %s created but traffic routing may have failed): %w", rev, err)
+		}
+		return fmt.Errorf("updating mint env vars: %w", err)
+	}
+	return nil
+}
+
 // MintDiscovery holds the results of a single GetFunction call, providing
 // the URL, existing role-to-app-ID mappings, and per-repo WIF repos.
 type MintDiscovery struct {
@@ -838,6 +930,23 @@ func mergeAllowedOrgs(existing, desired map[string]string) {
 	}
 	sort.Strings(merged)
 	desired["ALLOWED_ORGS"] = strings.Join(merged, ",")
+}
+
+// removeRoleFromAppIDsJSON removes a role-only key from ROLE_APP_IDS JSON.
+// Legacy org/role keys are preserved.
+func removeRoleFromAppIDsJSON(existingJSON, role string) (string, error) {
+	prevMap := make(map[string]string)
+	if existingJSON != "" {
+		if err := json.Unmarshal([]byte(existingJSON), &prevMap); err != nil {
+			return "", err
+		}
+	}
+	delete(prevMap, role)
+	merged, err := json.Marshal(prevMap)
+	if err != nil {
+		return "", err
+	}
+	return string(merged), nil
 }
 
 // mergeRoleAppIDsJSON merges role-only app IDs into existing ROLE_APP_IDS JSON.

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -3227,3 +3227,43 @@ func TestDeleteAgentPEM_InvalidRole(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid role name")
 }
+
+func TestDeleteAgentPEM_DeleteFails(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.errs["DeleteSecret"] = fmt.Errorf("permission denied")
+	p := NewProvisioner(Config{ProjectID: "proj1"}, fake)
+	err := p.DeleteAgentPEM(context.Background(), "coder")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deleting secret")
+}
+
+func TestAddRoleToMint_RevisionRoutingFails(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		URI:     "https://mint.example.com",
+		EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100"}`},
+	}
+	fake.updateServiceRevision = "fullsend-mint-00099"
+	fake.errs["UpdateServiceEnvVars"] = fmt.Errorf("routing failed")
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.AddRoleToMint(context.Background(), "review", "200")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "traffic routing may have failed")
+	assert.Contains(t, err.Error(), "fullsend-mint-00099")
+}
+
+func TestRemoveRoleFromMint_UpdateEnvVarsError(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		URI: "https://mint.example.com",
+		EnvVars: map[string]string{
+			"ROLE_APP_IDS":  `{"coder":"100","review":"200"}`,
+			"ALLOWED_ROLES": "coder,review",
+		},
+	}
+	fake.errs["UpdateServiceEnvVars"] = fmt.Errorf("permission denied")
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.RemoveRoleFromMint(context.Background(), "review")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "updating mint env vars")
+}

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -3076,3 +3076,81 @@ func TestRemoveOrgFromWIFCondition_NoOpWhenOrgAbsent(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, fake.(*fakeGCFClient).calls, "UpdateWIFProvider")
 }
+
+// --- Role management tests ---
+
+func TestRemoveRoleFromAppIDsJSON(t *testing.T) {
+	t.Parallel()
+	out, err := removeRoleFromAppIDsJSON(`{"coder":"1","review":"2","acme/coder":"9"}`, "coder")
+	require.NoError(t, err)
+	var m map[string]string
+	require.NoError(t, json.Unmarshal([]byte(out), &m))
+	assert.Equal(t, map[string]string{"review": "2", "acme/coder": "9"}, m)
+}
+
+func TestAddRoleToMint_MergesRoleAppIDs(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		URI: "https://mint.example.com",
+		EnvVars: map[string]string{
+			"ALLOWED_ORGS":  "acme-corp",
+			"ROLE_APP_IDS":  `{"coder":"100"}`,
+			"ALLOWED_ROLES": "coder",
+		},
+	}
+
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.AddRoleToMint(context.Background(), "review", "200")
+	require.NoError(t, err)
+
+	require.NotNil(t, fake.lastUpdateServiceEnvVars)
+	var roleAppIDs map[string]string
+	require.NoError(t, json.Unmarshal([]byte(fake.lastUpdateServiceEnvVars["ROLE_APP_IDS"]), &roleAppIDs))
+	assert.Equal(t, "100", roleAppIDs["coder"])
+	assert.Equal(t, "200", roleAppIDs["review"])
+	assert.Equal(t, "coder,review", fake.lastUpdateServiceEnvVars["ALLOWED_ROLES"])
+}
+
+func TestAddRoleToMint_MissingProjectID(t *testing.T) {
+	p := NewProvisioner(Config{}, newFakeGCFClient())
+	err := p.AddRoleToMint(context.Background(), "coder", "123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GCP project ID is required")
+}
+
+func TestRemoveRoleFromMint_PrunesRoleAppIDs(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		URI: "https://mint.example.com",
+		EnvVars: map[string]string{
+			"ROLE_APP_IDS":  `{"coder":"100","review":"200"}`,
+			"ALLOWED_ROLES": "coder,review",
+		},
+	}
+
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.RemoveRoleFromMint(context.Background(), "review")
+	require.NoError(t, err)
+
+	require.NotNil(t, fake.lastUpdateServiceEnvVars)
+	var roleAppIDs map[string]string
+	require.NoError(t, json.Unmarshal([]byte(fake.lastUpdateServiceEnvVars["ROLE_APP_IDS"]), &roleAppIDs))
+	assert.Equal(t, map[string]string{"coder": "100"}, roleAppIDs)
+	assert.Equal(t, "coder", fake.lastUpdateServiceEnvVars["ALLOWED_ROLES"])
+}
+
+func TestDeleteAgentPEM(t *testing.T) {
+	fake := newFakeGCFClient()
+	p := NewProvisioner(Config{ProjectID: "proj1"}, fake)
+	err := p.DeleteAgentPEM(context.Background(), "coder")
+	require.NoError(t, err)
+	assert.Contains(t, fake.calls, "DeleteSecret")
+}
+
+func TestDeleteAgentPEM_FixRoleUsesCoderSecret(t *testing.T) {
+	fake := newFakeGCFClient()
+	p := NewProvisioner(Config{ProjectID: "proj1"}, fake)
+	err := p.DeleteAgentPEM(context.Background(), "fix")
+	require.NoError(t, err)
+	assert.Contains(t, fake.calls, "DeleteSecret")
+}

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -3152,5 +3152,5 @@ func TestDeleteAgentPEM_FixRoleUsesCoderSecret(t *testing.T) {
 	p := NewProvisioner(Config{ProjectID: "proj1"}, fake)
 	err := p.DeleteAgentPEM(context.Background(), "fix")
 	require.NoError(t, err)
-	assert.Contains(t, fake.calls, "DeleteSecret")
+	assert.Equal(t, []string{"fullsend-coder-app-pem"}, fake.deletedSecretIDs)
 }

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -3168,3 +3168,62 @@ func TestRemoveRoleFromMint_MissingProjectID(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "GCP project ID is required")
 }
+
+func TestAddRoleToMint_InvalidRole(t *testing.T) {
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, newFakeGCFClient())
+	err := p.AddRoleToMint(context.Background(), "BAD", "123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid role name")
+}
+
+func TestAddRoleToMint_EmptyAppID(t *testing.T) {
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, newFakeGCFClient())
+	err := p.AddRoleToMint(context.Background(), "coder", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "app ID is required")
+}
+
+func TestAddRoleToMint_MalformedExistingJSON(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.trafficEnvVars = map[string]string{"ROLE_APP_IDS": "not-json"}
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.AddRoleToMint(context.Background(), "coder", "123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "merging ROLE_APP_IDS")
+}
+
+func TestAddRoleToMint_UpdateEnvVarsError(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.functionInfo = &FunctionInfo{
+		URI:     "https://mint.example.com",
+		EnvVars: map[string]string{"ROLE_APP_IDS": `{"coder":"100"}`},
+	}
+	fake.errs["UpdateServiceEnvVars"] = fmt.Errorf("permission denied")
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.AddRoleToMint(context.Background(), "review", "200")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "updating mint env vars")
+}
+
+func TestRemoveRoleFromMint_InvalidRole(t *testing.T) {
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, newFakeGCFClient())
+	err := p.RemoveRoleFromMint(context.Background(), "BAD")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid role name")
+}
+
+func TestRemoveRoleFromMint_MalformedExistingJSON(t *testing.T) {
+	fake := newFakeGCFClient()
+	fake.trafficEnvVars = map[string]string{"ROLE_APP_IDS": "not-json"}
+	p := NewProvisioner(Config{ProjectID: "proj1", Region: "us-central1"}, fake)
+	err := p.RemoveRoleFromMint(context.Background(), "coder")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pruning ROLE_APP_IDS")
+}
+
+func TestDeleteAgentPEM_InvalidRole(t *testing.T) {
+	p := NewProvisioner(Config{ProjectID: "proj1"}, newFakeGCFClient())
+	err := p.DeleteAgentPEM(context.Background(), "BAD")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid role name")
+}

--- a/internal/dispatch/gcf/provisioner_test.go
+++ b/internal/dispatch/gcf/provisioner_test.go
@@ -3154,3 +3154,17 @@ func TestDeleteAgentPEM_FixRoleUsesCoderSecret(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"fullsend-coder-app-pem"}, fake.deletedSecretIDs)
 }
+
+func TestDeleteAgentPEM_MissingProjectID(t *testing.T) {
+	p := NewProvisioner(Config{}, newFakeGCFClient())
+	err := p.DeleteAgentPEM(context.Background(), "coder")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GCP project ID is required")
+}
+
+func TestRemoveRoleFromMint_MissingProjectID(t *testing.T) {
+	p := NewProvisioner(Config{}, newFakeGCFClient())
+	err := p.RemoveRoleFromMint(context.Background(), "coder")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GCP project ID is required")
+}

--- a/skills/mint-enroll/SKILL.md
+++ b/skills/mint-enroll/SKILL.md
@@ -82,7 +82,7 @@ PEM keys and app IDs are tied to the role, not the org. Secrets use role-only na
 (`fullsend-{role}-app-pem`) — one secret per role, shared across orgs on the
 mint. `ROLE_APP_IDS` uses the same model: one GitHub App ID per role (e.g.,
 `coder` → `123456`), shared by all enrolled orgs. PEMs and app IDs must already
-exist (from `mint deploy --pem-dir` or `fullsend admin install`); enrollment
+exist (from `mint deploy --pem-dir`, `mint add-role`, or `fullsend admin install`); enrollment
 does not create, copy, or modify PEM secrets or app ID mappings.
 
 Apps must be installed on the target org before the mint can produce tokens.

--- a/skills/mint-enroll/SKILL.md
+++ b/skills/mint-enroll/SKILL.md
@@ -82,7 +82,7 @@ PEM keys and app IDs are tied to the role, not the org. Secrets use role-only na
 (`fullsend-{role}-app-pem`) — one secret per role, shared across orgs on the
 mint. `ROLE_APP_IDS` uses the same model: one GitHub App ID per role (e.g.,
 `coder` → `123456`), shared by all enrolled orgs. PEMs and app IDs must already
-exist (from `mint deploy --pem-dir`, `mint add-role`, or `fullsend admin install`); enrollment
+exist (from `mint deploy --pem-dir` or `fullsend admin install`); enrollment
 does not create, copy, or modify PEM secrets or app ID mappings.
 
 Apps must be installed on the target org before the mint can produce tokens.


### PR DESCRIPTION
## Summary
- Add `fullsend mint add-role` with three input modes: `--slug` + `--pem`, `--slug` + `--use-existing-pem-secret`, or `--org` (browser manifest flow)
- Add `fullsend mint remove-role` to prune `ROLE_APP_IDS` / `ALLOWED_ROLES` and delete PEM secrets by default (`--keep-pem` to retain)
- Extend the GCP provisioner with `AddRoleToMint`, `RemoveRoleFromMint`, and `DeleteAgentPEM`
- Document commands and IAM requirements in `docs/guides/infrastructure/mint-administration.md`

## Test plan
- [x] `go test ./internal/dispatch/gcf/... ./internal/cli/...`
- [ ] `fullsend mint add-role coder --project=... --slug=... --pem=... --dry-run`
- [ ] `fullsend mint remove-role <role> --project=... --dry-run`


Made with [Cursor](https://cursor.com)