### PR TITLE
docs: document Codecov coverage thresholds for contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,9 @@ The `internal/mintcore/` module is shared between the mint and devmint. Its file
 When making changes to Go code under `cmd/` or `internal/`:
 
 1. **Unit tests:** Run `make go-test` (or `go test ./...`) and fix any failures before committing.
-2. **Vet:** Run `make go-vet` to catch common issues.
-3. **E2E tests:** Run `make e2e-test` if your changes touch `internal/appsetup/`, `internal/forge/`, `internal/cli/`, or `internal/layers/`. These tests exercise the full admin install/uninstall flow against a live GitHub org using Playwright browser automation.
+2. **Coverage:** CI enforces thresholds via [Codecov](https://about.codecov.io/) (see [`.codecov.yml`](.codecov.yml)). **Patch coverage** on changed lines must meet **80%** (with a 5% tolerance). **Project coverage** must not drop more than **1%** below the base branch. `make go-test` runs tests with `-cover` locally but does not enforce these thresholds — a PR can still fail the Codecov status check if new or changed code lacks tests. Add or extend `_test.go` files for logic you introduce or modify.
+3. **Vet:** Run `make go-vet` to catch common issues.
+4. **E2E tests:** Run `make e2e-test` if your changes touch `internal/appsetup/`, `internal/forge/`, `internal/cli/`, or `internal/layers/`. These tests exercise the full admin install/uninstall flow against a live GitHub org using Playwright browser automation.
 
 ### Running e2e tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ This project uses the [Probot DCO app](https://github.com/apps/dco) to enforce s
 ### Opening a PR
 
 - Run `make lint` before pushing and fix any failures.
+- For Go changes, run `make go-test` and add tests for new or modified logic. CI uploads coverage to Codecov and enforces the thresholds in [`.codecov.yml`](.codecov.yml): **80% patch coverage** on changed lines (5% tolerance) and **no more than 1% drop** in overall project coverage relative to the base branch.
 - Keep PRs focused. One problem area or decision per PR is easier to review than a grab-bag.
 - If your change touches a problem doc, make sure the "Open questions" section still makes sense after your edit.
 


### PR DESCRIPTION
## Summary
- Document Codecov patch (80%) and project (1% drop) coverage thresholds in `AGENTS.md` and `CONTRIBUTING.md`.
- Point contributors to `.codecov.yml` as the source of truth and note that `make go-test` does not enforce thresholds locally.

## Test plan
- [x] Docs-only change; no code or CI behavior changes.
- [ ] Verify wording matches `.codecov.yml` thresholds.


Made with [Cursor](https://cursor.com)