### PR TITLE
fix(sandbox): put /sandbox/go/bin last in code image PATH

### DIFF
--- a/.github/workflows/sandbox-images.yml
+++ b/.github/workflows/sandbox-images.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Validate PATH security
         run: |
-          docker run --rm fullsend-code:ci-smoke sh -c '
+          docker run --rm --entrypoint '' fullsend-code:ci-smoke sh -c '
             LAST=$(echo "$PATH" | tr ":" "\n" | tail -1)
             [ "$LAST" = "/sandbox/go/bin" ] || { echo "FAIL: /sandbox/go/bin not last (got $LAST)"; exit 1; }
             [ "$(which git)" = "/usr/bin/git" ] || { echo "FAIL: git shadowed ($(which git))"; exit 1; }

--- a/.github/workflows/sandbox-images.yml
+++ b/.github/workflows/sandbox-images.yml
@@ -136,3 +136,26 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=code
           cache-to: type=gha,mode=max,scope=code
+
+      # Load a single-platform image locally so we can smoke-test PATH ordering.
+      # Multi-arch builds cannot --load, so this reuses the GHA cache from above.
+      - name: Build code image for smoke test
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: images/code
+          file: images/code/Containerfile
+          platforms: linux/amd64
+          load: true
+          tags: fullsend-code:ci-smoke
+          build-args: |
+            BASE_IMAGE=${{ needs.build-base.outputs.image-ref }}
+          cache-from: type=gha,scope=code
+
+      - name: Validate PATH security
+        run: |
+          docker run --rm fullsend-code:ci-smoke sh -c '
+            LAST=$(echo "$PATH" | tr ":" "\n" | tail -1)
+            [ "$LAST" = "/sandbox/go/bin" ] || { echo "FAIL: /sandbox/go/bin not last (got $LAST)"; exit 1; }
+            [ "$(which git)" = "/usr/bin/git" ] || { echo "FAIL: git shadowed ($(which git))"; exit 1; }
+            [ "$(which scan-secrets)" = "/usr/local/bin/scan-secrets" ] || { echo "FAIL: scan-secrets shadowed ($(which scan-secrets))"; exit 1; }
+          '

--- a/.github/workflows/sandbox-images.yml
+++ b/.github/workflows/sandbox-images.yml
@@ -156,6 +156,6 @@ jobs:
           docker run --rm --entrypoint '' fullsend-code:ci-smoke sh -c '
             LAST=$(echo "$PATH" | tr ":" "\n" | tail -1)
             [ "$LAST" = "/sandbox/go/bin" ] || { echo "FAIL: /sandbox/go/bin not last (got $LAST)"; exit 1; }
-            [ "$(which git)" = "/usr/bin/git" ] || { echo "FAIL: git shadowed ($(which git))"; exit 1; }
-            [ "$(which scan-secrets)" = "/usr/local/bin/scan-secrets" ] || { echo "FAIL: scan-secrets shadowed ($(which scan-secrets))"; exit 1; }
+            [ "$(command -v git)" = "/usr/bin/git" ] || { echo "FAIL: git shadowed ($(command -v git))"; exit 1; }
+            [ "$(command -v scan-secrets)" = "/usr/local/bin/scan-secrets" ] || { echo "FAIL: scan-secrets shadowed ($(command -v scan-secrets))"; exit 1; }
           '

--- a/images/code/Containerfile
+++ b/images/code/Containerfile
@@ -119,7 +119,7 @@ USER sandbox
 # /sandbox/go/bin is placed AFTER system paths so sandbox-user binaries
 # cannot shadow trusted system tools (go, git, scan-secrets, etc.).
 ENV GOPATH="/sandbox/go" \
-    PATH="/usr/local/go/bin:/sandbox/go/bin:${PATH}"
+    PATH="/usr/local/go/bin:${PATH}:/sandbox/go/bin"
 
 # ---------------------------------------------------------------------------
 # gopls — Go language server for Claude Code LSP code intelligence.


### PR DESCRIPTION
## Summary
- Fix PATH ordering in `images/code/Containerfile` so `/sandbox/go/bin` comes after system paths
- Prevents sandbox-writable binaries from shadowing trusted tools (`git`, `scan-secrets`, `gitleaks`, `lychee`)
- Closes #2169

## Test plan
- [ ] After CI rebuilds the code image, `docker run <image> sh -c 'echo $PATH'` shows `/sandbox/go/bin` as the last component
- [ ] `docker run <image> which git` resolves to `/usr/bin/git`
- [ ] `docker run <image> which scan-secrets` resolves to `/usr/local/bin/scan-secrets`
- [ ] `docker run <image> gopls version` still works
- [ ] Shadowing edge case: fake `/sandbox/go/bin/git` does not override `which git`


Made with [Cursor](https://cursor.com)