### PR TITLE
docs(adr): multi-repo management for per-repo installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ This is not a product spec. It's an evolving exploration of a hard problem space
 - **[docs/problems/](docs/problems/)** — Deep dives into each major problem domain, each evolving independently:
   - [Intent Representation](docs/problems/intent-representation.md) — How do we capture, verify, and enforce what changes are wanted?
   - [Security Threat Model](docs/problems/security-threat-model.md) — Prompt injection, insider threats, agent drift, supply chain attacks
-  - [MCP Configuration Drift](docs/problems/mcp-config-drift.md) — Detecting unauthorized changes in MCP server configurations that define the agent tool surface
   - [Agent Architecture](docs/problems/agent-architecture.md) — What agents exist, what authority do they have, how do they interact?
   - [Agent Infrastructure](docs/problems/agent-infrastructure.md) — Where agents run, what resources they get, 3rd party vs internal vs build our own
   - [Autonomy Spectrum](docs/problems/autonomy-spectrum.md) — When to auto-merge vs. escalate to humans
@@ -49,11 +48,12 @@ This is not a product spec. It's an evolving exploration of a hard problem space
   - [Universal Harness Access — Phase 4 Implementation](docs/plans/universal-harness-access-phase4.md) — Phased PR breakdown for ADR-0038 Phase 4 (runtime dependency loading)
   - [Agent Execution Environment](docs/plans/agent-execution-environment.md) — Sandbox and runtime environment for agent execution
   - [Vertex AI Inference Provisioning](docs/plans/vertex-inference-provisioning.md) — Provisioning and configuration for Vertex AI inference endpoints
-  - [ADR-0044 Deprecate Per-Org Installation Mode](docs/plans/deprecate-per-org-install.md) — Phased removal of per-org installation mode in favor of per-repo
   - [ADR-0045 Forge-Portable Harness Schema — Phase 1](docs/plans/adr-0045-forge-portable-harness-phase1.md) — Implementation plan for ADR-0045 forge-portable harness schema (Phase 1)
   - [ADR-0045 Forge-Portable Harness Schema — Phase 2](docs/plans/adr-0045-forge-portable-harness-phase2.md) — Implementation plan for ADR-0045 Phase 2: adopt new schema fields across install, scaffold, and lock flows
   - [ADR-0045 Forge-Portable Harness Schema — Phase 3](docs/plans/adr-0045-forge-portable-harness-phase3.md) — Implementation plan for ADR-0045 Phase 3: deprecate config.yaml agents block, add Lint() diagnostics, migrate to harness-first discovery
   - [ADR-0046 Drift Scanner](docs/plans/2026-03-06-adr46-drift-scanner.md) — Implementation plan for ADR-0046 drift detection tool
+  - [Repos Management](docs/plans/repos-management.md) — Implementation plan for declarative multi-repo management
+  - [Repos Init](docs/plans/repos-init.md) — Implementation plan for `fullsend repos init` manifest bootstrapping
 - **[docs/guides/](docs/guides/)** — Practical how-to documentation for administrators and developers (see [ADR 0023](docs/ADRs/0023-user-documentation-structure.md))
 - **[docs/ADRs/](docs/ADRs/)** — Architecture Decision Records for crystallizing specific decisions (see [ADR 0001](docs/ADRs/0001-use-adrs-for-decision-making.md))
 - **[web/](web/)** — Browser-delivered assets for the public site (document graph today; future Vite app here). Cloudflare Worker config lives in [`cloudflare_site/`](cloudflare_site/) ([ADR 0019](docs/ADRs/0019-web-source-and-cloudflare-site-layout.md)).

--- a/docs/ADRs/0033-per-repo-installation-mode.md
+++ b/docs/ADRs/0033-per-repo-installation-mode.md
@@ -291,8 +291,6 @@ Per-repo install requires only `repo` and `workflow` OAuth scopes when reusing e
 
 ### 8. Coexistence
 
-> **Note:** [ADR 0044](0044-deprecate-per-org-installation-mode.md) deprecates the per-org side of this coexistence model, promoting per-repo as the sole supported installation mode.
-
 Per-repo and per-org coexist within the same org. Some repos use the org `.fullsend` config repo (per-org), others run independently (per-repo). They use different dispatch paths, credential stores, and shim templates.
 
 To prevent per-org enrollment from overriding a per-repo installation, per-repo install sets a repository Actions variable `FULLSEND_PER_REPO_INSTALL=true`. The per-org enrollment flow checks this guard at three points:
@@ -373,3 +371,4 @@ Ordered by the project's threat priority (external injection > insider > drift >
 - [ADR 0031: Reusable workflows](0031-reusable-workflows-for-action-installed-distribution.md) — publishes stage reusable workflows and composite actions
 - [ADR 0034: Centralized event routing](0034-centralized-shim-routing-via-dispatch.md) — routing logic in `dispatch.yml`, replicated as `reusable-dispatch.yml` for per-repo
 - ADR 0035: Layered content resolution — upstream defaults sparse-checked at runtime, overrides via `customized/` (per-org) or `.fullsend/` (per-repo)
+- [ADR 0057: Repos management](0057-repos-management.md) — addresses bulk operations, enrollment inventory, and drift detection gaps for per-repo at scale

--- a/docs/ADRs/0057-repos-management.md
+++ b/docs/ADRs/0057-repos-management.md
@@ -1,0 +1,125 @@
+---
+title: "57. Repos management for per-repo installations"
+status: Accepted
+relates_to:
+  - agent-infrastructure
+  - agent-architecture
+topics:
+  - installation
+  - per-repo
+  - repos
+  - multi-org
+  - management
+---
+
+# 57. Repos management for per-repo installations
+
+Date: 2026-06-17
+
+## Status
+
+Accepted
+
+<!-- ADRs are point-in-time records, but not fully frozen after acceptance.
+     Minor annotations are welcome: cross-references to related ADRs, short
+     notes linking to newer decisions, or clarifying remarks. However, do not
+     substantially rewrite the Context, Decision, or Consequences sections. If
+     the decision itself needs to change, write a new ADR that supersedes this
+     one. For evolving design narrative, use docs/architecture.md. -->
+
+Builds on [ADR 0033](0033-per-repo-installation-mode.md) (per-repo
+installation mode) and [ADR 0048](0048-automatic-updates.md) (automatic
+updates). Core commands work independently of ADR 0048;
+version-management commands require its `--upstream-ref` mechanism.
+
+## Context
+
+Per-repo installation ([ADR 0033](0033-per-repo-installation-mode.md))
+is fullsend's target model — each repo is self-contained with its own
+`.fullsend/` directory, shim workflow, WIF provider, variables, and
+secrets. However, the per-repo install path (`runPerRepoInstall()` in
+`admin.go`) handles one repo at a time. Organizations managing tens or
+hundreds of repos across multiple GitHub orgs face three gaps:
+
+1. **No bulk operations.** Installing on 50 repos means 50 manual runs.
+2. **No enrollment inventory.** Discovering which repos have fullsend
+   requires scanning for guard variables across all repos — an O(n) API
+   operation with no centralized record.
+3. **No drift detection.** No reference state to compare against:
+   "which repos have a stale mint URL?" or "which repos are still on
+   v2.1.0?"
+
+Per-org's enrollment system provides these operationally but at the cost
+of a dedicated config repo, org-level variables, enrollment PRs,
+reconciliation scripts, and three-level workflow nesting. A thin
+orchestration layer over existing per-repo machinery can provide the same
+value without that infrastructure.
+
+## Decision
+
+Add a `fullsend repos` subcommand group that manages per-repo
+installations at scale via a declarative `repos.yaml` manifest.
+
+**Target persona:** platform administrators (SRE/DevOps) managing
+fullsend across an organization. Individual repo owners continue using
+`fullsend github` for single-repo setup. The relationship is analogous
+to Terraform vs cloud provider CLIs.
+
+**Subcommands:**
+
+| Command | Purpose |
+|---------|---------|
+| `repos init` | Discover existing installations, generate manifest |
+| `repos status` | Read-only comparison of manifest vs actual state |
+| `repos install` | Provision fullsend on uninstalled manifest repos |
+| `repos sync` / `repos diff` | Reconcile configuration drift |
+| `repos upgrade` | Upgrade scaffold shim ref across repos |
+| `repos upgrade-mint` | Upgrade token mint Cloud Function |
+| `repos remove` | Remove fullsend from specific repos |
+
+**Manifest:** a YAML file declaring desired state — mint config, default
+field values, and a list of repos (strings for defaults, objects for
+overrides). Supports glob patterns (`acme-corp/*`) and multi-org repos
+in a single file. Lives wherever the operator chooses (not in a
+`.fullsend` config repo). All read commands accept `--manifest` as a
+local path or URL per [ADR 0038](0038-universal-harness-access.md).
+
+**Key design constraints:**
+
+- WIF provisioning and mint registration are serialized
+  (read-modify-write on Cloud Run env vars). Install uses three phases:
+  parallel discovery → sequential WIF → parallel scaffold.
+- Version changes (`repos upgrade`) are separated from config
+  reconciliation (`repos sync`) to prevent accidental upgrades.
+- Works alongside per-org installations during a migration period;
+  serves as the migration path for ADR 0044 (pending) deprecation.
+
+Manifest schema, field resolution semantics, subcommand specifications,
+and implementation details are in the
+[repos management plan](../plans/repos-management.md) and
+[repos init plan](../plans/repos-init.md).
+
+## Consequences
+
+- **Operational parity with per-org** — bulk install, inventory, and
+  drift detection without per-org's infrastructure complexity (config
+  repo, org-level variables, enrollment workflows).
+- **Cross-org management** — a single manifest manages repos across
+  multiple GitHub orgs, unlike per-org's single-org model.
+- **Operator discipline required** — the manifest must be maintained
+  manually; adding repos to the org doesn't auto-add them (unless
+  matched by a glob pattern).
+- **API rate scaling** — discovery is O(n) API calls per repo; large
+  deployments may require rate limiting and `--repo` filtering.
+- **Migration path** — if per-org is deprecated, the repos tool provides
+  the migration mechanism before the old model is removed.
+
+## References
+
+- [ADR 0033](0033-per-repo-installation-mode.md) — per-repo installation model
+- [ADR 0038](0038-universal-harness-access.md) — URL-based resource references
+- ADR 0044 (pending) — per-org deprecation; repos tool replaces its deferred Option C
+- [ADR 0045](0045-forge-portable-harness-schema.md) — harness composition via `base` URLs
+- [ADR 0048](0048-automatic-updates.md) — `--upstream-ref` version pinning
+- [Implementation plan: repos management](../plans/repos-management.md)
+- [Implementation plan: repos init](../plans/repos-init.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,7 @@ Infrastructure platform choice and configuration are specified in the adopting o
 - Installer scaffold: the `WorkflowsLayer` deploys content from an embedded scaffold (`internal/scaffold/`), keeping deployable files as real files under version control rather than Go string constants.
 - Reusable workflows: agent workflows in `.fullsend` are thin callers (~40-70 lines) that delegate infrastructure logic to upstream reusable workflows (`fullsend-ai/fullsend/.github/workflows/reusable-*.yml`) via `workflow_call`. Infrastructure patches ship once upstream and propagate to all orgs without re-install ([ADR 0031](ADRs/0031-reusable-workflows-for-action-installed-distribution.md)). **`--vendor`** ([ADR 0047](ADRs/0047-vendored-installs-with-vendor-flag.md)) commits workflows and agent content at install time; layered installs (default) fetch upstream at runtime.
 - Event-driven stage dispatch: eliminate `workflow_dispatch` + `gh workflow run` fan-out from `dispatch.yml` in favor of synchronous `workflow_call` so the dispatched run stays linked to the caller ([ADR 0041](ADRs/0041-synchronous-workflow-call-event-dispatch.md)).
+- Multi-repo management: a `fullsend repos` subcommand group with a declarative `repos.yaml` manifest for managing per-repo installations at scale — bulk install, status, sync, upgrade, and removal across repos and orgs ([ADR 0057](ADRs/0057-repos-management.md)).
 
 **Open questions:**
 
@@ -237,7 +238,7 @@ ADR 0002: [Building block 1](ADRs/0002-initial-fullsend-design.md#1-webhook--dis
 
 ### 2. Slash-command parser + ACL
 
-Parses `/fs-triage`, `/fs-code`, `/fs-review`, and related commands and enforces who is allowed to invoke each. All slash commands and event-triggered dispatch paths require write-level repository permission (admin, maintain, or write), verified via the collaborator permission API ([ADR 0054](ADRs/0054-require-authorization-on-all-agent-dispatch-paths.md)).
+Parses `/fs-triage`, `/fs-code`, `/fs-review`, and related commands and enforces who is allowed to invoke each.
 ADR 0002: [Building block 2](ADRs/0002-initial-fullsend-design.md#2-slash-command-parser--acl).
 
 ### 3. Label state machine guard
@@ -362,10 +363,7 @@ See [ADR 0003](ADRs/0003-org-config-repo-convention.md) for the config repo conv
   [ADR 0047](ADRs/0047-vendored-installs-with-vendor-flag.md)). The
   scaffold installs only org-specific files and a `customized/` directory for org
   overrides. Org files in `customized/` overwrite upstream defaults at runtime
-  ([ADR 0035](ADRs/0035-layered-content-resolution.md)). Per-repo
-  `.pre-commit-tools.yaml` files extend the tools registry additively (L2
-  merge) without replacing it
-  ([ADR 0056](ADRs/0056-per-repo-precommit-tools-registry.md)).
+  ([ADR 0035](ADRs/0035-layered-content-resolution.md)).
 
 ## Multi-org deployment model
 
@@ -613,8 +611,7 @@ GitHub event ──► SHIM WORKFLOW (fullsend.yml in enrolled repo)
                  ║ │                                                           │ ║
                  ║ │ Post-agent secret scan (redact from extracted output).    │ ║
                  ║ │                                                           │ ║
-                 ║ │ Post-script (scripts/post-code.sh, with PUSH_TOKEN,       │ ║
-                 ║ │   minted by the binary via --mint-url):                   │ ║
+                 ║ │ Post-script (scripts/post-code.sh, with PUSH_TOKEN):      │ ║
                  ║ │   1. Verify feature branch (not main/master)              │ ║
                  ║ │   2. Protected-path check                                 │ ║
                  ║ │   3. gitleaks secret scan                                 │ ║

--- a/docs/plans/repos-init.md
+++ b/docs/plans/repos-init.md
@@ -1,0 +1,313 @@
+# Implementation Plan: `fullsend repos init`
+
+## Context
+
+[ADR 0057](../ADRs/0057-repos-management.md) defines a declarative
+`repos.yaml` manifest as the single source of truth for multi-repo
+management. Without `repos init`, operators must author this manifest
+from scratch.
+
+The `repos init` command generates a manifest for both scenarios:
+
+- **Greenfield onboarding:** The org has no fullsend installations.
+  The operator selects which repos to include (interactively or via
+  flags) and the command generates a manifest with default config.
+  Running `repos install` afterward provisions everything.
+- **Migration from existing installations:** The org has per-repo
+  and/or per-org installations. The command discovers their state
+  (variables, workflow refs, enrollment lists) and generates a manifest
+  that reflects current reality. Existing installations are
+  pre-selected in interactive mode. Per-org enrolled repos are included
+  so they can be converted to per-repo via `repos install`.
+
+In both cases the output is the same artifact — a `repos.yaml`
+manifest. The per-repo and per-org discovery logic is needed only
+during the transition period. Once all installations are managed via
+`repos.yaml` and the per-org mode is removed (ADR 0044), the
+discovery checks become dead code and can be removed, leaving
+`repos init` as a simple repo-selection and manifest-generation tool.
+
+This plan can be implemented in parallel with PRs 4–8 of the
+[repos management plan](repos-management.md). It shares two
+dependencies with that plan:
+
+- **PR 2** (manifest parser): provides `Manifest` types for output.
+- **PR 3** (forge methods): provides `ListRepoVariables` for efficient
+  per-repo discovery.
+
+### Dependency graph
+
+```
+PR 2 (manifest parser) ──┬──> repos init
+                          │
+PR 3 (forge methods) ─────┘
+```
+
+---
+
+## PR: `fullsend repos init` (manifest bootstrapping)
+
+**Scope:** New CLI command. Read-only discovery + manifest generation.
+
+### `internal/cli/repos.go` (modify)
+
+Add `newReposInitCmd()` to the repos subcommand group.
+
+Flags:
+
+- `--output` / `-o` (string, default `repos.yaml`): output path.
+  Use `-` for stdout.
+- `--repos` (string, comma-separated): explicit list of repo names to
+  include. Skips interactive selection.
+- `--all` (bool): include all eligible repos without prompting.
+- `--mint-project` (string): GCP project for the `mint.project` field.
+- `--mint-region` (string, default `us-central1`): GCP region for
+  the `mint.region` field.
+- `--inference-project` (string): default GCP project for inference.
+- `--concurrency` (int, default 8): max parallel API calls.
+
+Positional argument: `<target>` (org name or `owner/repo`). Detection
+uses the same `strings.Contains(arg, "/")` pattern as
+`fullsend github setup` (`internal/cli/admin.go:284`).
+
+### `internal/repos/init.go` (new)
+
+```go
+type InitConfig struct {
+    Target           string   // org name or owner/repo
+    Repos            []string // explicit repo names (nil = interactive/all)
+    All              bool     // include all repos without prompting
+    MintProject      string
+    MintRegion       string
+    InferenceProject string
+    MaxConcurrency   int
+}
+
+type DiscoveredRepo struct {
+    Owner           string
+    Repo            string
+    Source          string // "per-repo", "per-org", or "new"
+    MintURL         string
+    InferenceRegion string
+    FullsendRef     string
+}
+
+type InitResult struct {
+    Manifest     *Manifest
+    PerRepoCount int
+    PerOrgCount  int
+    NewCount     int
+    TODOs        []string // fields requiring manual attention
+}
+
+func Init(ctx context.Context, cfg InitConfig,
+    client forge.Client,
+    selectRepos RepoSelectFunc,
+    progress ProgressFunc) (*InitResult, error)
+```
+
+#### Repo selection
+
+`RepoSelectFunc` is a callback the CLI layer provides to handle
+interactive selection. The init logic calls it with the full repo
+list and each repo's discovered status (per-repo / per-org / new).
+The callback returns the subset the operator selected.
+
+```go
+type RepoCandidate struct {
+    Owner     string
+    Repo      string
+    Status    string // "per-repo", "per-org", "new"
+    Ref       string // discovered ref, empty for new
+}
+
+type RepoSelectFunc func(candidates []RepoCandidate) ([]string, error)
+```
+
+Selection modes:
+
+- **Explicit** (`cfg.Repos` non-nil): skip selection, use provided
+  list. Validate that all names exist in the org.
+- **All** (`cfg.All`): skip selection, include everything returned
+  by `ListOrgRepos`.
+- **Interactive** (default): call `selectRepos` with candidates.
+  Repos with existing installations are pre-selected. The CLI layer
+  renders this as a new multi-select checklist (arrow keys, space to
+  toggle, enter to confirm). This is a new UX pattern — the existing
+  `promptEnrollment` in `fullsend github setup`
+  (`internal/cli/admin.go:2070`) is a binary all-or-none prompt, not
+  a per-repo selector.
+
+For single-repo targets (`owner/repo`), selection is skipped — the
+manifest contains one entry.
+
+#### Discovery algorithm
+
+**Org-level** (target has no `/`):
+
+1. Call `ListOrgRepos(ctx, org)` to enumerate eligible repos.
+2. Check for per-org config repo (`{org}/.fullsend`):
+   - Read `config.yaml` via `GetFileContent`
+     (`internal/forge/forge.go:199`).
+   - Parse with `config.ParseOrgConfig()`
+     (`internal/config/config.go:147`).
+   - Extract: enrollment map (`Repos` field,
+     `internal/config/config.go:79`), mint URL
+     (`Dispatch.MintURL`, `internal/config/config.go:23`),
+     `AllowedRemoteResources`.
+3. For each repo (parallel, bounded by `MaxConcurrency`):
+   - Call `ListRepoVariables(ctx, owner, repo)` to read guard
+     variable, mint URL, and region in one API call.
+   - If `FULLSEND_PER_REPO_INSTALL == "true"`
+     (`forge.PerRepoGuardVar`, `internal/forge/forge.go:17`):
+     - Read workflow file (`.github/workflows/fullsend.yml`, fall
+       back to `.yaml`) via `GetFileContent`.
+     - Extract `@ref` from `uses:` line.
+     - Mark `source: per-repo`.
+   - Else if repo appears in per-org enrollment with
+     `enabled: true`:
+     - Use mint URL and config from per-org `config.yaml`.
+     - Read the per-org shim workflow file and extract `@ref` from
+       the `uses:` line (same as per-repo discovery). Do not use
+       `config.DefaultUpstreamRef` — it is `v0`, a major-version
+       floating tag for workflow-call resolution, not a concrete
+       release version. If no workflow file exists, omit the ref
+       and let it inherit from `defaults.fullsend_ref`.
+     - Mark `source: per-org`.
+   - Otherwise:
+     - Mark `source: new` (not yet installed).
+4. Present candidates to repo selection (explicit / all /
+   interactive).
+5. Run manifest generation on the selected subset.
+
+**Single-repo** (target has `/`):
+
+1. Check guard variable on the repo.
+2. If per-repo: read variables and workflow file.
+3. If not: check org config repo (`{owner}/.fullsend`,
+   `forge.ConfigRepoName`, `internal/forge/forge.go:13`) for
+   enrollment.
+4. If neither: mark as `source: new`.
+5. Generate single-entry manifest.
+
+#### Manifest generation
+
+```go
+func buildManifest(repos []DiscoveredRepo,
+    cfg InitConfig) (*Manifest, []string)
+```
+
+1. **Compute `mint:` block:**
+   - `url`: from discovered `FULLSEND_MINT_URL` (should be uniform
+     across repos sharing a mint). If repos report different mint
+     URLs, use the most common and add a TODO. For greenfield (no
+     discovered URLs), leave as TODO (Cloud Run URLs contain a random
+     hash and cannot be derived from the project name alone).
+   - `project`: from `--mint-project` flag. If not provided, add to
+     TODO list.
+   - `region`: from `--mint-region` flag (default `us-central1`).
+
+2. **Compute `defaults:` block** by finding the mode (most common
+   value) for each field across discovered repos. For greenfield
+   repos (`source: new`) with no discovered values, use the CLI
+   version as `fullsend_ref` and `--inference-project` /
+   `--mint-region` from flags:
+   - `fullsend_ref`: mode of all discovered refs, or CLI version.
+   - `inference_region`: mode of all discovered
+     `FULLSEND_GCP_REGION` values, or `--mint-region`.
+   - `inference_project`: from `--inference-project` flag, or TODO.
+   - `allowed_remote_resources`: from per-org config if present.
+
+3. **Build repo entries:**
+   - Repos matching all defaults → simple string entries
+     (`acme-corp/api-server`).
+   - Repos with overrides (different ref, different region) → object
+     entries with only the differing fields.
+   - Per-org enrolled repos are included as normal entries. A YAML
+     comment group header notes they are currently per-org and will
+     be converted to per-repo on `repos install`.
+   - New repos (not yet installed) are included as normal entries.
+
+4. **Return TODO list** for fields that could not be discovered (e.g.,
+   `inference_project` when no flag provided, `mint.project` when
+   omitted).
+
+**Secret limitation:** `FULLSEND_GCP_PROJECT_ID` and
+`FULLSEND_GCP_WIF_PROVIDER` are GitHub secrets — values are not
+readable via the API. The `inference_project` field must come from
+`--inference-project` flag, from the per-org config, or be left as a
+TODO. The WIF provider is not stored in the manifest (it is
+provisioned by `repos install`).
+
+#### Ref extraction
+
+```go
+var workflowRefPattern = regexp.MustCompile(
+    `uses:\s+fullsend-ai/fullsend/.*@(\S+)`,
+)
+
+func extractWorkflowRef(content []byte) string
+```
+
+Reuses the same regex pattern as `internal/repos/status.go` (PR 4 of
+the repos management plan). If this PR lands before PR 4, define the
+function in `init.go` and move it to a shared file (e.g.,
+`internal/repos/workflow.go`) when PR 4 lands.
+
+#### Manifest serialization
+
+```go
+func (m *Manifest) Marshal() ([]byte, error)
+```
+
+Add `Marshal()` to the `Manifest` type defined in PR 2. Uses
+`yaml.Marshal` with a descriptive header comment:
+
+```
+# Generated by fullsend repos init on <date>.
+# Review and adjust before running fullsend repos install.
+```
+
+### `internal/repos/init_test.go` (new)
+
+- **Greenfield:** Org with no installations, `--repos` flag → manifest
+  with all repos as new entries, defaults from flags/CLI version.
+- **Greenfield:** Org with no installations, `--all` flag → all repos
+  included.
+- **Migration:** Org with mixed per-repo and per-org → correct
+  manifest with both types, existing repos pre-selected.
+- **Migration:** Org with only per-repo installations → no per-org
+  config read.
+- **Migration:** Org with only per-org enrollments → uses config.yaml
+  enrollment list and dispatch mint URL.
+- Single repo (per-repo installed) → minimal manifest.
+- Single repo (per-org enrolled) → reads org config for enrollment.
+- Single repo (not installed) → manifest with one new entry.
+- Defaults computation: most common ref becomes default, repos with
+  minority values get object entries.
+- Per-repo overrides: repos with different ref/region generate object
+  entries with only the differing fields.
+- Interactive selection callback: verify candidates include status
+  labels, pre-selected repos match existing installations.
+- Secret limitation: `inference_project` left as TODO when no flag
+  provided.
+- Multiple mint URLs discovered → most common used, TODO generated.
+
+### Test strategy
+
+Unit tests with `forge.FakeClient`. Pre-populate `FileContents` for
+per-org `config.yaml` and workflow files. Pre-populate variable values
+for guard variables and config. `RepoSelectFunc` implemented as a
+test double that records candidates and returns a predetermined
+selection.
+
+---
+
+## File Summary
+
+| File | Action |
+|------|--------|
+| `internal/repos/init.go` | Create |
+| `internal/repos/init_test.go` | Create |
+| `internal/cli/repos.go` | Modify |
+| `internal/repos/manifest.go` | Modify (add `Marshal()`) |

--- a/docs/plans/repos-management.md
+++ b/docs/plans/repos-management.md
@@ -1,0 +1,1311 @@
+# Implementation Plan: Repos Management for Per-Repo Installations
+
+## Context
+
+[ADR 0057](../ADRs/0057-repos-management.md) adds a `fullsend repos`
+subcommand group with a declarative `repos.yaml` manifest for managing
+per-repo installations across multiple orgs.
+
+The work is structured as 8 PRs across two phases. Phase 1 (PRs 1–4)
+builds the foundation: extracting reusable install logic, the manifest
+parser, a new forge method, and read-only status. Phase 2 (PRs 5–8)
+adds write operations: bulk install, sync/diff, upgrade, and remove.
+
+---
+
+## Design
+
+This section captures the manifest schema, behavioral specifications,
+and design constraints that the ADR defers to this plan. The PR
+sections below implement these specifications.
+
+### Manifest schema (`repos.yaml`)
+
+The manifest declares desired state for all managed repos:
+
+```yaml
+version: 1
+
+# Shared mint infrastructure — one mint serves all repos.
+# url: Cloud Run endpoint (contains a random hash, not derivable from project/region).
+# project + region: needed for WIF provisioning (IAM bindings), not for addressing the mint.
+mint:
+  url: https://fullsend-mint-abc123-uc.a.run.app
+  project: acme-fullsend-prod
+  region: us-central1
+
+# Default configuration applied to all repos unless overridden.
+defaults:
+  inference_project: acme-inference-prod
+  inference_region: us-central1
+  fullsend_ref: v2.3.0
+  base_harness: https://github.com/acme-corp/harness-library/blob/v1/base.yaml#sha256=a1b2c3...
+  allowed_remote_resources:
+    - https://raw.githubusercontent.com/fullsend-ai/fullsend/
+    - https://github.com/acme-corp/harness-library/
+
+# Repos to manage. Simple strings inherit all defaults;
+# objects override specific fields.
+repos:
+  # Simple form — inherits all defaults
+  - acme-corp/api-server
+  - acme-corp/web-frontend
+
+  # Object form — per-repo overrides
+  - repo: acme-corp/ml-pipeline
+    inference_project: acme-ml-prod
+    inference_region: us-east1
+
+  # Pinned to an older version
+  - repo: acme-corp/legacy-service
+    fullsend_ref: v2.1.0
+
+  # Cross-org: different org, different GCP project
+  - repo: acme-platform/infra-tools
+    inference_project: acme-platform-prod
+
+  # Glob pattern — all non-archived, non-fork repos in the org
+  - acme-oss/*
+```
+
+#### Field-to-resource mapping
+
+Manifest fields map to repo-level resources as follows:
+
+| Manifest field | Repo resource | Type |
+|---|---|---|
+| `inference_project` | `FULLSEND_GCP_PROJECT_ID` | Secret |
+| `inference_region` | `FULLSEND_GCP_REGION` | Variable |
+| `fullsend_ref` | `@ref` in scaffold shim `uses:` line | Workflow file |
+| `mint.url` | `FULLSEND_MINT_URL` | Variable |
+| `base_harness` | `.fullsend/harness.yaml` `base:` field | Config file |
+| `allowed_remote_resources` | `allowed_remote_resources` in org `config.yaml` | Config file ¹ |
+
+¹ `allowed_remote_resources` is an org-level field from `config.yaml`,
+not a per-repo resource. It is not managed by `repos sync`.
+
+#### Field resolution
+
+Per-repo overrides take precedence over `defaults`, which take
+precedence over built-in defaults:
+
+```
+resolved.field = resolveField(repo.field, defaults.field, builtinDefault)
+
+// resolveField precedence:
+//   1. If repo.field is explicit null → return "" (stop chain)
+//   2. If repo.field is set and non-empty → return repo.field
+//   3. If defaults.field is non-empty → return defaults.field
+//   4. Return builtinDefault
+```
+
+Empty-string and zero-value overrides are treated as unset and fall
+through to defaults. To explicitly clear a field that has a default,
+set it to YAML null (`~` or `null`). A null override stops the fallback
+chain rather than inheriting the default.
+
+#### Glob expansion
+
+Entries containing `*` are expanded by calling `ListOrgRepos` on the
+org portion and filtering by the glob pattern. Expansion happens at
+command execution time. Glob-expanded repos inherit defaults (no
+per-repo overrides). Explicit entries take precedence over globs.
+
+> **Limitation: glob patterns exclude private, archived, and forked
+> repos.** The current `ListOrgRepos` excludes all three categories
+> (designed for per-org mode). In per-repo mode, private repos are
+> valid targets. The implementation must extend `ListOrgRepos` with a
+> new method signature to include private repos without regressing
+> per-org callers. Until then, private repos must be listed explicitly.
+> Archived and forked repos remain excluded by default.
+
+#### Multi-org support
+
+Each repo entry is an `owner/repo` pair. Repos from different GitHub
+organizations coexist in the same manifest. The mint's `ALLOWED_ORGS`
+supports multiple orgs, and `ROLE_APP_IDS` maps role names to app
+IDs — the mint infrastructure is inherently multi-org.
+
+Cross-org sharing works because:
+
+- **Apps**: shared public apps can be installed on repos in any org.
+- **WIF**: per-repo providers are scoped by `assertion.repository`
+  (not by org), so repos in different orgs get independent providers.
+- **Mint registration**: `EnsureOrgInMint` adds each repo's org to
+  `ALLOWED_ORGS` (comma-separated list).
+
+### Subcommand specifications
+
+#### `fullsend repos init`
+
+Generates a `repos.yaml` manifest. Discovers existing per-repo and
+per-org installations. Covered by the
+[repos init plan](repos-init.md).
+
+#### `fullsend repos status`
+
+Read-only discovery. Compares manifest against actual forge state.
+
+For each repo: reads variables (`FULLSEND_MINT_URL`,
+`FULLSEND_GCP_REGION`, `FULLSEND_PER_REPO_INSTALL`) in a single API
+call, reads the workflow file and extracts `@ref`, compares against
+manifest-resolved config, reports drift.
+
+```
+$ fullsend repos status
+
+REPO                          REF       STATUS         DRIFT
+acme-corp/api-server          v2.3.0    installed      none
+acme-corp/web-frontend        v2.1.0    installed      MINT_URL differs
+acme-corp/ml-pipeline         v2.3.0    installed      none
+acme-corp/mobile-app          —         not installed  —
+
+2 installed, 1 drifted, 1 not installed
+```
+
+Supports `--json` for machine-readable output. Exit code 0 if all repos
+match; 1 if drift or missing repos.
+
+#### `fullsend repos install`
+
+Installs fullsend on repos not yet installed. Three-phase execution:
+
+1. **Phase 1 (parallel):** Discover current state, check guard
+   variables, partition into `toInstall` and `alreadyInstalled`.
+2. **Phase 2 (sequential):** `EnsureOrgInMint` once per unique org,
+   then `RegisterPerRepoWIF` per repo. Re-checks the guard variable
+   before provisioning to narrow the TOCTOU window. Both operations
+   are not concurrent-safe (read-modify-write on Cloud Run env vars).
+3. **Phase 3 (parallel):** Scaffold commits, variable/secret writes.
+
+Concurrent `repos install` and `fullsend github setup` targeting the
+same repo are unsafe — no distributed lock is held.
+
+Supports `--dry-run`, `--repo` (filter), `--concurrency`.
+
+#### `fullsend repos diff`
+
+Previews what `repos sync` would change.
+
+```
+$ fullsend repos diff
+
+REPO                     FIELD               CURRENT              DESIRED
+acme-corp/web-frontend   FULLSEND_MINT_URL   https://old-mint...  https://fullsend-mint-abc123...
+acme-corp/web-frontend   FULLSEND_GCP_REGION us-west1             us-central1
+```
+
+#### `fullsend repos sync`
+
+Reconciles configuration drift for installed repos.
+
+| Resource | Action |
+|----------|--------|
+| `FULLSEND_MINT_URL` variable | Upsert to match manifest `mint.url` |
+| `FULLSEND_GCP_REGION` variable | Upsert to match resolved `inference_region` |
+| `FULLSEND_PER_REPO_INSTALL` variable | Ensure set to `"true"` |
+| `FULLSEND_GCP_PROJECT_ID` secret | Upsert to match resolved `inference_project` |
+
+Sync does **not** touch scaffold shim version (managed by `upgrade`)
+or harness files (managed via ADR 0045's `base` composition). Warns
+about repos with `FULLSEND_PER_REPO_INSTALL=true` not in the manifest.
+
+#### `fullsend repos upgrade`
+
+Upgrades scaffold shim ref. Uses
+[ADR 0048](../ADRs/0048-automatic-updates.md)'s `--upstream-ref` —
+regenerates the shim with the new `__FULLSEND_REF__` value.
+
+```
+$ fullsend repos upgrade
+
+Checking mint compatibility...
+  Mint at https://fullsend-mint-abc123-uc.a.run.app: v2.3.0 ✓
+
+Upgrading repos:
+  acme-corp/api-server       v2.1.0 → v2.3.0  ✓
+  acme-corp/web-frontend     v2.1.0 → v2.3.0  ✓
+  acme-corp/legacy-service   v2.1.0            (pinned, already current)
+  acme-corp/bleeding-edge    latest            (non-semver, skipped)
+
+2 upgraded, 1 current, 1 skipped
+```
+
+Version safety: checks mint compatibility before upgrading, blocks
+downgrades by default (`--force` to override), respects per-repo
+pinned versions. The `--ref` flag overrides the manifest for one-off
+upgrades.
+
+#### `fullsend repos upgrade-mint`
+
+Upgrades the token mint Cloud Function. Uses existing provisioner
+deploy logic. Must run before `repos upgrade` if the mint version
+is behind the target fullsend ref. The `/health` endpoint must be
+extended to include a `version` field (currently only returns
+`{"status":"ok"}`).
+
+#### `fullsend repos remove`
+
+Removes fullsend from specific repos. Requires explicit repo names —
+no glob expansion, to prevent accidental bulk deletion.
+
+For each repo: deletes workflow file, variables, secrets, deregisters
+from mint's `PER_REPO_WIF_REPOS` (sequential), deletes WIF provider.
+
+Does **not** remove repos from the manifest (operator edits manually).
+Does **not** remove `.fullsend/` — it contains user-authored config
+that may be version-controlled independently.
+
+Supports `--dry-run`, `--skip-wif-cleanup`, `--concurrency`.
+
+### Version management
+
+The repos tool's version management builds on
+[ADR 0048](../ADRs/0048-automatic-updates.md)'s `--upstream-ref`.
+
+The manifest's `fullsend_ref` maps to `--upstream-ref`:
+- `defaults.fullsend_ref` — default for all repos
+- Per-repo `fullsend_ref` — override for that repo
+
+Mixed-version repos are a normal operating state. `repos status`
+reports version health. `repos upgrade` changes versions explicitly.
+`repos sync` never touches versions — this separation prevents
+accidental upgrades during routine config reconciliation.
+
+### Relationship to per-org deprecation (ADR 0044, pending)
+
+The repos tool can be built and shipped **independently** of ADR 0044
+(pending) — and ideally **before** it:
+
+- `repos status` detects per-org enrolled repos and reports them
+  distinctly.
+- `repos install` respects the guard variable — it won't install
+  per-repo on a repo that is already per-repo installed.
+- When ADR 0044 is implemented, the repos tool serves as the migration
+  path: operators write a `repos.yaml` and run `repos install` to
+  convert per-org repos to per-repo.
+
+Building the repos tool first de-risks deprecation by giving users the
+replacement tooling before removing what it replaces.
+
+### Future enhancements
+
+**Unified install command:** `fullsend repos install` could subsume
+`fullsend github setup` for installation — accepting a positional
+`owner/repo` with no manifest for single-repo mode, or `--manifest`
+for batch mode. This unification would be a significant UX shift and
+should be proposed in its own ADR when pursued.
+
+---
+
+### Subsystems touched
+
+| Subsystem | Key files | What changes |
+|-----------|-----------|-------------|
+| CLI | `internal/cli/repos.go`, `internal/cli/root.go` | New `repos` subcommand group |
+| Repos logic | `internal/repos/` (new package) | Manifest parser, install, status, sync, upgrade, remove |
+| CLI admin | `internal/cli/admin.go` | Delegates to extracted install logic |
+| Forge interface | `internal/forge/forge.go`, `github/github.go`, `fake.go` | `ListRepoVariables`, `DeleteRepoVariable`, `DeleteRepoSecret` |
+| Provisioner | `internal/dispatch/gcf/provisioner.go` | `DeletePerRepoWIF` wraps existing `RemoveRepoFromMint` + `DeleteWIFProvider` |
+
+## PR Dependency Graph
+
+```
+PRs 1, 2, 3 ─────────> PR 5 (repos install)
+PRs 2, 3 ────> PR 4 (repos status) ──┬──> PR 6 (sync/diff)
+                                      └──> PR 7 (upgrade)
+PRs 1, 3 ─────────> PR 8 (remove)
+```
+
+PRs 1, 2, 3 are independent and can be developed in parallel.
+PR 4 depends on PRs 2 and 3 (manifest resolution + variable listing).
+PR 5 depends on PRs 1, 2, and 3 (extracted install + manifest +
+`ListRepoVariables` for guard variable checks in Phase 1).
+PR 6 depends on PR 4 (status logic is shared with diff).
+PR 7 depends on PR 4 (reuses `extractWorkflowRef()` for reading
+current refs from workflow files).
+PR 8 depends on PRs 1 and 3 (reuses install types +
+`DeleteRepoVariable`/`DeleteRepoSecret`) and can be developed in
+parallel with PRs 4–7.
+
+The `repos init` command is covered by a
+[separate implementation plan](repos-init.md) and can be developed
+in parallel with PRs 4–8.
+
+---
+
+## Phase 1: Foundation
+
+### PR 1: Extract per-repo install logic into reusable package
+
+**Scope:** Refactor only. Zero behavioral change.
+
+The existing `runPerRepoInstall()` in `internal/cli/admin.go` is ~450
+lines mixing install logic with CLI concerns (interactive prompts,
+progress spinners, flag parsing). Extract the core logic into a
+reusable package so both `fullsend github setup` and `repos install`
+can call it.
+
+#### `internal/repos/install.go` (new)
+
+Define the install interface as a pure function taking a config struct:
+
+```go
+type InstallConfig struct {
+    Owner            string
+    Repo             string
+    MintURL          string
+    MintProject      string
+    MintRegion       string
+    InferenceProject string
+    InferenceRegion  string
+    UpstreamRef      string
+    SkipAppSetup     bool
+    SkipMintCheck    bool
+    SkipMintDeploy   bool
+    SkipWIF          bool   // skip WIF provisioning (already done externally)
+    WIFProvider      string // pre-provisioned WIF provider name
+    VendorBinary     bool
+}
+
+type InstallResult struct {
+    Owner           string
+    Repo            string
+    Success         bool
+    Error           error
+    AlreadyInstalled bool
+    WIFProvider     string
+    ScaffoldPR      string
+}
+
+func Install(ctx context.Context, cfg InstallConfig,
+    client forge.Client, provisioner WIFProvisioner,
+    progress ProgressFunc) (*InstallResult, error)
+```
+
+Extract from `runPerRepoInstall()`:
+
+- Infrastructure discovery (mint check, app discovery)
+- App creation (delegate to `appsetup.Run()`)
+- Mint provisioning (delegate to provisioner)
+- WIF provisioning (delegate to provisioner)
+- Scaffold generation and commit
+- Variable/secret writes
+
+Keep in `admin.go`:
+
+- Flag parsing and validation
+- Interactive prompts (app name confirmation, etc.)
+- Progress spinner rendering
+- Error message formatting
+
+Define the `WIFProvisioner` interface to decouple from the concrete
+GCF provisioner:
+
+```go
+type WIFProvisioner interface {
+    DiscoverMint(ctx context.Context) (*MintDiscovery, error)
+    ProvisionWIF(ctx context.Context) (string, error)
+    RegisterPerRepoWIF(ctx context.Context, repo string) error
+    EnsureOrgInMint(ctx context.Context, expectedURL string, org string) error
+    DeletePerRepoWIF(ctx context.Context, repo string) error
+}
+```
+
+Define `ProgressFunc` for progress reporting:
+
+```go
+type ProgressFunc func(repo, phase, message string)
+```
+
+#### `internal/cli/admin.go` (modify)
+
+Replace the body of `runPerRepoInstall()` with a call to
+`repos.Install()`, mapping CLI flags to `InstallConfig` fields and
+wrapping the progress callback for spinner output.
+
+#### `internal/repos/install_test.go` (new)
+
+Test `Install()` with a fake forge client and fake WIF provisioner:
+
+- Fresh install: verify scaffold committed, variables set, secrets set.
+- Already installed (guard variable present): returns
+  `AlreadyInstalled: true`, no writes.
+- Skip app setup: verify `appsetup.Run()` not called.
+- Skip mint check: verify `DiscoverMint()` not called.
+- WIF provisioning failure: returns error, no scaffold committed.
+- Scaffold commit failure: returns error with WIF provider set
+  (partial state).
+
+#### Test strategy
+
+Unit tests with fakes. Run `make go-test` to verify no regressions in
+`admin_test.go`.
+
+---
+
+### PR 2: Repos manifest parser and validation
+
+**Scope:** New package code. No CLI wiring yet.
+
+#### `internal/repos/manifest.go` (new)
+
+```go
+type Manifest struct {
+    Version  int            `yaml:"version"`
+    Mint     MintConfig     `yaml:"mint"`
+    Defaults DefaultsConfig `yaml:"defaults"`
+    Repos    []RepoEntry    `yaml:"repos"`
+}
+
+type MintConfig struct {
+    URL     string `yaml:"url"`
+    Project string `yaml:"project"`
+    Region  string `yaml:"region"`
+}
+
+type DefaultsConfig struct {
+    InferenceProject       string   `yaml:"inference_project"`
+    InferenceRegion        string   `yaml:"inference_region"`
+    FullsendRef            string   `yaml:"fullsend_ref"`
+    BaseHarness            string   `yaml:"base_harness"`
+    AllowedRemoteResources []string `yaml:"allowed_remote_resources"`
+}
+
+type RepoEntry struct {
+    Repo             string         `yaml:"repo"`
+    InferenceProject NullableString `yaml:"inference_project,omitempty"`
+    InferenceRegion  NullableString `yaml:"inference_region,omitempty"`
+    FullsendRef      NullableString `yaml:"fullsend_ref,omitempty"`
+    BaseHarness      NullableString `yaml:"base_harness,omitempty"`
+}
+
+// NullableString distinguishes three YAML states:
+// - omitted:       Set=false, Null=false, Value=""
+// - explicit null:  Set=true,  Null=true,  Value=""
+// - explicit value: Set=true,  Null=false,  Value="v2.3.0"
+// Plain *string cannot distinguish omitted from null in yaml.v3
+// (both unmarshal to nil). This wrapper inspects the yaml.Node tag.
+type NullableString struct {
+    Value string
+    Set   bool
+    Null  bool
+}
+
+func (n *NullableString) UnmarshalYAML(node *yaml.Node) error {
+    if node.Tag == "!!null" {
+        n.Set = true
+        n.Null = true
+        return nil
+    }
+    n.Set = true
+    return node.Decode(&n.Value)
+}
+
+func (n NullableString) MarshalYAML() (interface{}, error) {
+    if n.Null {
+        return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!null"}, nil
+    }
+    if !n.Set {
+        return nil, nil
+    }
+    return n.Value, nil
+}
+
+func (n NullableString) IsZero() bool {
+    return !n.Set
+}
+```
+
+Key functions:
+
+```go
+func LoadManifest(pathOrURL string) (*Manifest, error)
+
+func (m *Manifest) Validate() error
+
+func (m *Manifest) ExpandGlobs(ctx context.Context,
+    client forge.Client) ([]ResolvedRepo, error)
+
+func (m *Manifest) ResolveConfig(owner, repo string) ResolvedConfig
+```
+
+Custom YAML unmarshaling for `RepoEntry` — handle both string form
+(`"acme-corp/api"`) and object form (`repo: acme-corp/api`). Uses the
+yaml.v3 `*yaml.Node` signature (the project uses `gopkg.in/yaml.v3`):
+
+```go
+func (r *RepoEntry) UnmarshalYAML(node *yaml.Node) error {
+    if node.Kind == yaml.ScalarNode {
+        r.Repo = node.Value
+        return nil
+    }
+    type raw RepoEntry
+    return node.Decode((*raw)(r))
+}
+```
+
+`LoadManifest()` accepts a local file path or an HTTPS URL. If the
+argument starts with `https://`, fetch the content via HTTP GET before
+parsing. This follows the ADR 0038 resource reference model and reuses
+the URL fetching logic from the harness resource loader.
+
+`Validate()` checks:
+
+- `version` is 1 (only supported version).
+- `mint.url` is a valid HTTPS URL.
+- `mint.project` and `mint.region` are non-empty.
+- Each repo entry has a valid `owner/repo` format.
+- No duplicate repos (after glob expansion).
+- Glob patterns are valid `filepath.Match` patterns with an `org/`
+  prefix (e.g., `acme-corp/*`, `acme-corp/api-*`).
+
+`ExpandGlobs()`:
+
+- For entries containing `*`, extract the org prefix.
+- Call `ListOrgRepos(ctx, org)` to list eligible repos. Note: the
+  current `ListOrgRepos` implementation excludes private, archived,
+  and forked repos (`internal/forge/github/github.go:343`) — it was
+  designed for per-org mode where agents run on a public `.fullsend`
+  config repo. For per-repo mode, private repos are valid targets
+  since agents run on the target repo itself. The implementation must
+  extend `ListOrgRepos` (or add a variant) to include private repos
+  when called from glob expansion. Archived and forked repos remain
+  excluded by default.
+- Filter by glob pattern using `filepath.Match`.
+- Merge with explicit entries (explicit wins over glob).
+- Return `[]ResolvedRepo` with resolved configuration per repo.
+
+`ResolveConfig()`:
+
+- Look up the repo in the manifest (explicit or glob-matched).
+- Merge: per-repo override > `defaults` > built-in defaults.
+- `RepoEntry` uses `NullableString` fields so that `ResolveConfig`
+  can distinguish three states: omitted (`Set=false`, inherit
+  default), explicitly null (`Null=true`, stops fallback chain), or
+  set to a non-empty value (`Set=true, Value != ""`, overrides
+  default). A fourth state — explicitly set to empty string
+  (`Set=true, Value=""`) — is treated as unset and falls through to
+  defaults, matching the ADR prose. Plain `*string` cannot make these
+  distinctions because `yaml.v3` unmarshals both omitted and `null`
+  as nil. `NullableString` uses a custom `UnmarshalYAML` that
+  inspects the `yaml.Node` tag to detect explicit null.
+- Resolution helper for a single field:
+
+  ```go
+  func resolveField(override NullableString, fallback string, builtinDefault string) string {
+      if override.Null {
+          return "" // explicit null stops fallback chain
+      }
+      if override.Set && override.Value != "" {
+          return override.Value
+      }
+      if fallback != "" {
+          return fallback
+      }
+      return builtinDefault
+  }
+  ```
+
+  The `override` parameter is `NullableString` (from `RepoEntry`)
+  because per-repo fields need three-state semantics. The `fallback`
+  parameter is plain `string` (from `DefaultsConfig`) because
+  defaults are either set or empty — no null distinction needed.
+
+- Return `ResolvedConfig` with all fields resolved.
+
+```go
+type ResolvedConfig struct {
+    Owner                  string
+    Repo                   string
+    MintURL                string
+    MintProject            string
+    MintRegion             string
+    InferenceProject       string
+    InferenceRegion        string
+    FullsendRef            string
+    BaseHarness            string
+    AllowedRemoteResources []string
+}
+```
+
+#### `internal/repos/manifest_test.go` (new)
+
+- Parse simple manifest (all string repos).
+- Parse manifest with mixed string and object repos.
+- Parse manifest with glob patterns.
+- Custom YAML unmarshaling: string form and object form.
+- Validation: missing mint URL, invalid repo format, duplicate repos.
+- Glob expansion with fake forge client.
+- Config resolution: defaults only, per-repo override, multi-org.
+- Version validation: reject version != 1.
+- URL loading: `httptest` server serving manifest YAML, verify parsed
+  correctly.
+- URL loading: non-200 response → error.
+
+#### Test strategy
+
+Unit tests. Glob expansion tested with `forge.FakeClient` pre-populated
+with repo lists. URL loading tested with `httptest`.
+
+---
+
+### PR 3: Add `ListRepoVariables`, `DeleteRepoVariable`, `DeleteRepoSecret` to forge
+
+**Scope:** Interface addition. No CLI changes.
+
+#### `internal/forge/forge.go` (modify)
+
+Add three methods to the `forge.Client` interface:
+
+```go
+ListRepoVariables(ctx context.Context, owner, repo string) (map[string]string, error)
+DeleteRepoVariable(ctx context.Context, owner, repo, name string) error
+DeleteRepoSecret(ctx context.Context, owner, repo, name string) error
+```
+
+`ListRepoVariables` returns all Actions variables as a name→value map.
+`DeleteRepoVariable` and `DeleteRepoSecret` are needed by `repos remove`
+(PR 8) and are cheaper to add here alongside `ListRepoVariables`.
+
+Also add a `ListOrgReposIncludePrivate(ctx, org)` method (or an
+`includePrivate bool` parameter on `ListOrgRepos`) so that glob
+expansion in per-repo mode includes private repos. The current
+`ListOrgRepos` excludes them because per-org mode runs agents on a
+public `.fullsend` config repo, but per-repo mode runs agents on the
+target repo itself, making private repos valid targets. The new
+signature avoids regressing existing per-org callers.
+
+#### `internal/forge/github/github.go` (modify)
+
+Implement `ListRepoVariables`:
+
+- Call `GET /repos/{owner}/{repo}/actions/variables` (paginated).
+- Parse response: `{ variables: [{ name, value }], total_count }`.
+- Return `map[string]string`.
+
+Implement `DeleteRepoVariable`:
+
+- Call `DELETE /repos/{owner}/{repo}/actions/variables/{name}`.
+- Return nil on 204 or 404 (idempotent).
+
+Implement `DeleteRepoSecret`:
+
+- Call `DELETE /repos/{owner}/{repo}/actions/secrets/{name}`.
+- Return nil on 204 or 404 (idempotent).
+
+#### `internal/forge/fake.go` (modify)
+
+Add implementations to `FakeClient`:
+
+- `ListRepoVariables`: return from `VariableValues` map (existing
+  field, keyed by `owner/repo/name`).
+- `DeleteRepoVariable`: remove from `VariableValues`.
+- `DeleteRepoSecret`: remove from `Secrets`.
+
+Track deletions in new slices for test assertions:
+
+```go
+DeletedVariables []VariableRecord
+DeletedSecrets   []SecretRecord
+```
+
+#### `internal/forge/github/github_test.go` (modify)
+
+Add `httptest`-based tests:
+
+- `ListRepoVariables`: paginated response (2 pages), empty repo,
+  API error.
+- `DeleteRepoVariable`: successful delete (204), already missing
+  (404), API error.
+- `DeleteRepoSecret`: successful delete (204), already missing (404),
+  API error.
+
+#### Test strategy
+
+Unit tests with `httptest` for GitHub implementation. Fake client
+tested via consumers in later PRs.
+
+---
+
+### PR 4: `fullsend repos status` (read-only discovery)
+
+**Scope:** New CLI command. Read-only.
+
+**Depends on:** PR 2 (manifest parser), PR 3 (`ListRepoVariables`).
+
+#### `internal/cli/repos.go` (new)
+
+Add the `repos` subcommand group under the root command:
+
+```go
+func newReposCmd() *cobra.Command {
+    cmd := &cobra.Command{
+        Use:   "repos",
+        Short: "Manage per-repo installations across multiple orgs",
+    }
+    cmd.AddCommand(newReposStatusCmd())
+    return cmd
+}
+```
+
+Flags for `repos status`:
+
+- `--manifest` / `-f` (string, default `repos.yaml`): path or URL to
+  manifest file. URLs are fetched following the ADR 0038 resource
+  reference model.
+- `--json` (bool): emit JSON output instead of table.
+- `--repo` (string, repeatable): filter to specific repos.
+- `--concurrency` (int, default 8): max parallel API calls.
+
+#### `internal/cli/root.go` (modify)
+
+Wire `newReposCmd()` into the root command.
+
+#### `internal/repos/status.go` (new)
+
+```go
+type RepoStatus struct {
+    Owner           string
+    Repo            string
+    Installed       bool
+    CurrentRef      string
+    ExpectedRef     string
+    MintURL         string
+    ExpectedMintURL string
+    Region          string
+    ExpectedRegion  string
+    Drifts          []Drift
+}
+
+type Drift struct {
+    Field    string
+    Expected string
+    Actual   string
+}
+
+func Status(ctx context.Context, manifest *Manifest,
+    client forge.Client, maxConcurrency int) ([]RepoStatus, error)
+```
+
+Per-repo discovery (parallelizable, read-only):
+
+1. Call `ListRepoVariables(ctx, owner, repo)` to read guard variable,
+   mint URL, region.
+2. Call `GetFileContent(ctx, owner, repo, ".github/workflows/fullsend.yml")`
+   (fall back to `.yaml`) to extract the current `@ref`.
+3. Compare against manifest-resolved config.
+4. Build `RepoStatus` with drift entries.
+
+Ref extraction from workflow file:
+
+```go
+var workflowRefPattern = regexp.MustCompile(
+    `uses:\s+fullsend-ai/fullsend/.*@(\S+)`,
+)
+
+func extractWorkflowRef(content []byte) string
+```
+
+Exit code: 0 if all repos match; 1 if any drift or missing.
+
+#### `internal/repos/status_test.go` (new)
+
+- All repos installed, no drift → exit 0.
+- One repo not installed → exit 1.
+- Drift in mint URL → correct drift entry.
+- Drift in ref → correct drift entry.
+- Multiple drifts on one repo.
+- Workflow file missing → not installed.
+- API error → partial results with error.
+- Glob-expanded repos.
+
+#### Test strategy
+
+Unit tests with `forge.FakeClient`. Pre-populate `FileContents` and
+variable values to simulate installed/non-installed repos.
+
+---
+
+## Phase 2: Write Operations
+
+### PR 5: `fullsend repos install` (bulk install with WIF serialization)
+
+**Scope:** New CLI command. Creates infrastructure.
+
+**Depends on:** PR 1 (extracted install logic), PR 2 (manifest parser).
+
+#### `internal/cli/repos.go` (modify)
+
+Add `newReposInstallCmd()` to the repos subcommand group.
+
+Flags:
+
+- `--manifest` / `-f` (string, default `repos.yaml`): path or URL.
+- `--dry-run` (bool).
+- `--repo` (string, repeatable): install specific repos only.
+- `--skip-app-setup` (bool).
+- `--skip-mint-check` (bool).
+- `--concurrency` (int, default 4): max parallel scaffold writes.
+
+#### `internal/repos/batch_install.go` (new)
+
+```go
+type BatchInstallConfig struct {
+    Manifest       *Manifest
+    DryRun         bool
+    RepoFilter     []string
+    MaxConcurrency int
+    SkipAppSetup   bool
+    SkipMintCheck  bool
+}
+
+type BatchInstallResult struct {
+    Installed []InstallResult
+    Skipped   []InstallResult
+    Failed    []InstallResult
+}
+
+func BatchInstall(ctx context.Context, cfg BatchInstallConfig,
+    client forge.Client, provisionerFactory ProvisionerFactory,
+    progress ProgressFunc) (*BatchInstallResult, error)
+```
+
+Three-phase execution:
+
+**Phase 1 (parallel):** For each repo (or filtered subset), call
+`ListRepoVariables` to check guard variable. Partition into
+`toInstall` and `alreadyInstalled`.
+
+**Phase 2 (sequential):**
+
+First, call `EnsureOrgInMint(ctx, mintURL, org)` once per unique org
+in `toInstall` — validates the mint exists at the expected URL and
+ensures each org is in `ALLOWED_ORGS`. This is an org-level operation;
+calling it per repo would be redundant and add unnecessary latency
+from repeated read-modify-write cycles on Cloud Run env vars. If
+`EnsureOrgInMint` fails for an org, all repos in `toInstall`
+belonging to that org are moved to `BatchInstallResult.Failed` with
+the error and excluded from per-repo WIF provisioning and Phase 3.
+
+Then, for each remaining repo in `toInstall`:
+
+- Re-check `FULLSEND_PER_REPO_INSTALL` guard variable. If it is now
+  `"true"` (another process installed between Phase 1 and Phase 2),
+  move the repo to `alreadyInstalled` and skip provisioning. This
+  narrows the TOCTOU window documented in the ADR.
+- Call `ProvisionWIF(ctx)` — creates WIF provider for this repo.
+  Store the returned provider name in a `map[string]string` keyed by
+  `owner/repo` (e.g., `wifProviders["acme-corp/api"] = providerName`).
+- Call `RegisterPerRepoWIF(ctx, repo)` — adds repo to mint's
+  `PER_REPO_WIF_REPOS`.
+
+These operations modify shared GCP state and must be sequential.
+If `ProvisionWIF` or `RegisterPerRepoWIF` fails for a repo, that
+repo is moved to `BatchInstallResult.Failed` and excluded from
+Phase 3. Only repos with a populated `wifProviders[repo]` entry
+proceed.
+
+**Phase 3 (parallel, bounded by `MaxConcurrency`):** For each repo
+where Phase 2 succeeded (i.e., `wifProviders[repo]` is non-empty):
+
+- Look up `wifProviders[repo]` to retrieve the provider name
+  provisioned in Phase 2.
+- Call `Install()` (from PR 1) with `SkipWIF: true` and `WIFProvider`
+  set to the looked-up provider name. This skips WIF provisioning
+  inside `Install()` and uses the pre-provisioned value for the
+  `FULLSEND_GCP_WIF_PROVIDER` secret.
+- Commits scaffold, writes variables/secrets.
+
+Errors on individual repos do not abort the batch. Failed repos are
+collected in `BatchInstallResult.Failed`.
+
+`ProvisionerFactory` creates a provisioner scoped to a specific repo:
+
+```go
+type ProvisionerFactory func(cfg InstallConfig) WIFProvisioner
+```
+
+#### `internal/repos/batch_install_test.go` (new)
+
+- Fresh repos: all repos uninstalled → all installed.
+- Partial repos: some already installed → only new repos installed.
+- WIF serialization: verify `RegisterPerRepoWIF` calls are sequential
+  (mutex-checking fake).
+- Repo filter: only filtered repos installed.
+- Error on one repo: others still installed, failed in `Failed` list.
+- Dry-run: no write operations.
+
+#### Test strategy
+
+Unit tests with `forge.FakeClient` and fake `WIFProvisioner`. Verify
+call ordering via recorded method calls.
+
+---
+
+### PR 6: `fullsend repos sync` + `fullsend repos diff`
+
+**Scope:** New CLI commands. Writes variables/secrets.
+
+**Depends on:** PR 4 (status logic shared with diff).
+
+#### `internal/cli/repos.go` (modify)
+
+Add `newReposDiffCmd()` and `newReposSyncCmd()`.
+
+Flags for both:
+
+- `--manifest` / `-f`.
+- `--repo` (repeatable).
+
+`sync` additionally:
+
+- `--dry-run` (equivalent to `diff`).
+- `--concurrency` (int, default 4).
+
+#### `internal/repos/sync.go` (new)
+
+```go
+type Change struct {
+    Owner    string
+    Repo     string
+    Field    string
+    Type     string // "variable" or "secret"
+    Action   string // "create", "update"
+    OldValue string // empty for secrets (not readable)
+    NewValue string // empty for secrets
+}
+
+func Diff(ctx context.Context, manifest *Manifest,
+    client forge.Client, maxConcurrency int) ([]Change, error)
+
+func Sync(ctx context.Context, manifest *Manifest,
+    client forge.Client, maxConcurrency int,
+    progress ProgressFunc) ([]Change, error)
+```
+
+What sync reconciles:
+
+| Resource | Action |
+|----------|--------|
+| `FULLSEND_MINT_URL` | Upsert to match `mint.url` |
+| `FULLSEND_GCP_REGION` | Upsert to match resolved `inference_region` |
+| `FULLSEND_PER_REPO_INSTALL` | Ensure `"true"` |
+| `FULLSEND_GCP_PROJECT_ID` | Upsert to match resolved `inference_project` |
+
+What sync does NOT touch:
+
+- Scaffold shim version (`@ref`).
+- Harness files.
+- Repos not in the manifest (warns about extras found).
+
+Secret handling: secrets cannot be read via the API (only existence
+checked via `RepoSecretExists`). For secrets, diff reports "exists"
+or "missing". Sync always writes the manifest value (idempotent via
+`CreateRepoSecret` overwrite).
+
+`Diff` reuses the discovery logic from `Status` (PR 4) to find
+current state, then computes the change set.
+
+#### `internal/repos/sync_test.go` (new)
+
+- No drift → empty change list.
+- Variable drift (mint URL, region) → correct change entries.
+- Missing guard variable → create action.
+- Secret missing → create action.
+- Secret exists but project changed in manifest → update action.
+- Extra installed repos not in manifest → warning.
+- Sync applies changes → verify forge writes called.
+- Dry-run → no writes.
+
+#### Test strategy
+
+Unit tests with `forge.FakeClient`.
+
+---
+
+### PR 7: `fullsend repos upgrade` + `fullsend repos upgrade-mint`
+
+**Scope:** New CLI commands. Writes workflow files, deploys Cloud
+Function.
+
+**Depends on:** PR 4 (reuses `extractWorkflowRef()` for reading
+current refs from workflow files).
+
+#### `internal/cli/repos.go` (modify)
+
+Add `newReposUpgradeCmd()` and `newReposUpgradeMintCmd()`.
+
+`upgrade` flags:
+
+- `--manifest` / `-f`.
+- `--ref` (string): override manifest `fullsend_ref`.
+- `--repo` (repeatable).
+- `--dry-run`.
+- `--force`: upgrade even if current ref is newer.
+- `--concurrency` (int, default 4).
+
+`upgrade-mint` flags:
+
+- `--manifest` / `-f`.
+
+#### `internal/repos/upgrade.go` (new)
+
+```go
+type UpgradeConfig struct {
+    Manifest       *Manifest
+    RefOverride    string
+    RepoFilter     []string
+    DryRun         bool
+    Force          bool
+    MaxConcurrency int
+}
+
+type UpgradeResult struct {
+    Owner      string
+    Repo       string
+    OldRef     string
+    NewRef     string
+    Upgraded   bool
+    Skipped    bool
+    SkipReason string
+    Error      error
+}
+
+func Upgrade(ctx context.Context, cfg UpgradeConfig,
+    client forge.Client,
+    progress ProgressFunc) ([]UpgradeResult, error)
+
+func UpgradeMint(ctx context.Context, manifest *Manifest,
+    provisioner WIFProvisioner,
+    progress ProgressFunc) error
+```
+
+Upgrade logic per repo:
+
+1. Read workflow file, extract current `@ref` via
+   `extractWorkflowRef()`.
+2. Determine target ref: `--ref` flag > per-repo `fullsend_ref` >
+   `defaults.fullsend_ref`.
+3. Skip if target is a non-semver ref (e.g., `latest`, branch names).
+   Floating tags are not upgraded — they already track the newest
+   release. Log as "floating tag, skipped".
+4. Skip if current == target.
+5. If both current and target are valid semver: skip if current >
+   target unless `--force` is set (prevents accidental downgrade).
+   If current is not valid semver (e.g., a branch name or SHA),
+   proceed with the upgrade — the current ref cannot be compared.
+6. Regenerate scaffold shim with new ref using
+   `scaffold.PerRepoShimTemplate()`.
+7. Commit via `CommitFiles` (or `CommitFilesToBranch` + PR if branch
+   protection).
+
+Ref replacement in scaffold:
+
+```go
+func replaceShimRef(content []byte, newRef string) ([]byte, error)
+```
+
+Replaces all `@<oldRef>` occurrences in `uses:` lines referencing
+`fullsend-ai/fullsend`, and updates `fullsend_actions_ref` and
+`fullsend_cli_ref` input values — matching the `__FULLSEND_REF__`
+template from ADR 0048.
+
+In-place replacement is chosen over full scaffold regeneration to
+preserve any user customizations in the shim workflow. The tradeoff
+is fragility if ADR 0048's final field names differ from the regex
+targets — the implementation must align with ADR 0048's shipped
+template. If that dependency proves unstable, fall back to full
+regeneration via `scaffold.PerRepoShimTemplate()`.
+
+Mint compatibility check:
+
+- Query mint `/health` endpoint for version.
+- Compare against target fullsend ref (semver).
+- Refuse if mint version < minimum required for target ref.
+- Direct operator to `repos upgrade-mint` first.
+
+`UpgradeMint`:
+
+- Create provisioner from manifest's mint config.
+- Call provisioner deploy with force mode to redeploy the function.
+- Wait for health check to pass.
+
+#### `internal/repos/upgrade_test.go` (new)
+
+- All repos at target → all skipped.
+- All repos behind target → all upgraded, verify workflow content.
+- Mixed: some current, some behind, some ahead.
+- `--force` overrides "ahead" skip.
+- `--ref` overrides manifest ref.
+- `--repo` filter.
+- Dry-run → no writes.
+- Semver comparison: table-driven tests.
+- Branch protection → PR creation fallback.
+- Mint too old → error with upgrade-mint message.
+
+#### Test strategy
+
+Unit tests with `forge.FakeClient`. Semver comparison as table-driven
+tests. Mint compatibility tested with a fake HTTP server.
+
+---
+
+### PR 8: `fullsend repos remove` (uninstall)
+
+**Scope:** New CLI command. Deletes infrastructure.
+
+**Depends on:** PR 1 (reuses types), PR 3 (`DeleteRepoVariable`,
+`DeleteRepoSecret`).
+
+Can be developed in parallel with PRs 4–7.
+
+#### `internal/cli/repos.go` (modify)
+
+Add `newReposRemoveCmd()`.
+
+Flags:
+
+- `--manifest` / `-f`: used to resolve mint config for WIF cleanup.
+- `--repo` (repeatable, **required**): repos to remove.
+- `--dry-run`.
+- `--skip-wif-cleanup`: skip GCP WIF provider deletion and mint
+  deregistration.
+- `--concurrency` (int, default 4): max parallel Phase 1 cleanup
+  operations.
+
+No glob expansion. `--repo` requires exact `owner/repo` values to
+prevent accidental bulk removal.
+
+#### `internal/repos/remove.go` (new)
+
+```go
+type RemoveConfig struct {
+    Manifest       *Manifest
+    Repos          []string
+    DryRun         bool
+    SkipWIFCleanup bool
+    MaxConcurrency int
+}
+
+type RemoveResult struct {
+    Owner           string
+    Repo            string
+    Success         bool
+    Error           error
+    WorkflowDeleted bool
+    VarsDeleted     int
+    SecretsDeleted  int
+    WIFDeregistered bool
+    WIFDeleted      bool
+}
+
+func Remove(ctx context.Context, cfg RemoveConfig,
+    client forge.Client, provisionerFactory ProvisionerFactory,
+    progress ProgressFunc) ([]RemoveResult, error)
+```
+
+Removal runs in two phases, mirroring install's parallel/sequential
+structure:
+
+**Phase 1 — per-repo cleanup (parallel across repos, bounded by
+`MaxConcurrency`):**
+
+For each repo:
+
+1. Delete workflow file (`.github/workflows/fullsend.yml`, fall back
+   to `.yaml`). Try `DeleteFile` first. A 404 means the file is
+   already absent — treat as success (`WorkflowDeleted = true`).
+   If it returns HTTP 403 or 422 (branch protection), fall back to
+   `CommitFilesToBranch` + PR creation (same pattern as `repos
+   upgrade` uses for scaffold commits). Other errors (network,
+   unexpected permissions) are not retried via the fallback.
+2. Only if step 1 succeeds: delete repo variables
+   (`FULLSEND_MINT_URL`, `FULLSEND_GCP_REGION`,
+   `FULLSEND_PER_REPO_INSTALL`) via `DeleteRepoVariable`.
+3. Only if step 1 succeeds: delete repo secrets
+   (`FULLSEND_GCP_PROJECT_ID`, `FULLSEND_GCP_WIF_PROVIDER`) via
+   `DeleteRepoSecret`.
+
+Steps 2 and 3 are independent and run concurrently within each repo.
+If workflow deletion fails, the repo is marked as failed and
+variables/secrets are left intact — this avoids leaving the repo in a
+broken state where the workflow exists but its required variables are
+gone.
+
+**Phase 2 — WIF cleanup (sequential, only for Phase 1 successes):**
+
+4. For each repo where Phase 1 succeeded (check
+   `RemoveResult.WorkflowDeleted`), unless `--skip-wif-cleanup`:
+   a. Deregister from mint's `PER_REPO_WIF_REPOS` (sequential — same
+      read-modify-write constraint as install Phase 2).
+   b. Delete WIF provider from GCP.
+
+Repos whose Phase 1 failed are skipped in Phase 2 — deleting the WIF
+provider while the workflow still exists would leave it referencing a
+non-existent provider.
+
+Does NOT remove repos from the manifest — operator edits `repos.yaml`
+manually.
+
+#### `internal/dispatch/gcf/provisioner.go` (existing)
+
+`DeletePerRepoWIF` on the `WIFProvisioner` interface wraps two
+existing provisioner operations:
+
+1. `RemoveRepoFromMint` — filters the repo out of
+   `PER_REPO_WIF_REPOS` via a read-modify-write on the Cloud Function
+   environment variable. Idempotent.
+2. `DeleteWIFProvider` — deletes the WIF provider from GCP IAM.
+
+#### `internal/repos/remove_test.go` (new)
+
+- Remove installed repo → all resources deleted.
+- Remove non-installed repo → no errors (delete calls return 404).
+- Skip WIF cleanup → no provisioner calls.
+- Dry-run → no writes.
+- Multiple repos → all removed, WIF deregistration sequential.
+- Partial failure → one repo errors, others still removed.
+
+#### `internal/dispatch/gcf/provisioner_test.go` (existing)
+
+`RemoveRepoFromMint` and `DeleteWIFProvider` are already tested.
+`DeletePerRepoWIF` is a thin wrapper — test via `remove_test.go`.
+
+#### Test strategy
+
+Unit tests with `forge.FakeClient` and fake GCF client.
+
+---
+
+## File Summary
+
+| File | PR | Action |
+|------|-----|--------|
+| `internal/repos/install.go` | 1 | Create |
+| `internal/repos/install_test.go` | 1 | Create |
+| `internal/cli/admin.go` | 1 | Modify |
+| `internal/repos/manifest.go` | 2 | Create |
+| `internal/repos/manifest_test.go` | 2 | Create |
+| `internal/forge/forge.go` | 3 | Modify |
+| `internal/forge/github/github.go` | 3 | Modify |
+| `internal/forge/fake.go` | 3 | Modify |
+| `internal/forge/github/github_test.go` | 3 | Modify |
+| `internal/cli/repos.go` | 4 | Create |
+| `internal/cli/root.go` | 4 | Modify |
+| `internal/repos/status.go` | 4 | Create |
+| `internal/repos/status_test.go` | 4 | Create |
+| `internal/repos/batch_install.go` | 5 | Create |
+| `internal/repos/batch_install_test.go` | 5 | Create |
+| `internal/cli/repos.go` | 5 | Modify |
+| `internal/repos/sync.go` | 6 | Create |
+| `internal/repos/sync_test.go` | 6 | Create |
+| `internal/cli/repos.go` | 6 | Modify |
+| `internal/repos/upgrade.go` | 7 | Create |
+| `internal/repos/upgrade_test.go` | 7 | Create |
+| `internal/cli/repos.go` | 7 | Modify |
+| `internal/repos/remove.go` | 8 | Create |
+| `internal/repos/remove_test.go` | 8 | Create |
+| `internal/dispatch/gcf/provisioner.go` | 8 | Modify |
+| `internal/dispatch/gcf/provisioner_test.go` | 8 | Modify |
+| `internal/cli/repos.go` | 8 | Modify |


### PR DESCRIPTION
## Summary

- Adds ADR XXXX proposing a `fullsend repos` subcommand group for managing per-repo installations at scale — bulk install, status/drift detection, sync, upgrade, and removal across multiple orgs via a declarative `repos.yaml` manifest.
- Adds `fullsend repos init` for bootstrapping the manifest from existing installations (per-repo and per-org) or greenfield onboarding with interactive repo selection.
- Includes two separate implementation plans: one for the core repos subcommands (8 PRs across 2 phases), one for `repos init` (independent, parallelizable).
- Manifest supports local paths and URLs (following ADR 0038 resource reference model).
- Cons and risks annotated with whether each is new or inherited from the current per-org/per-repo implementation.

## Test plan

- [x] `make lint` passes (ADR frontmatter, markdown links, broken symlinks)
- [ ] Review ADR for completeness and alignment with ADR 0044 (PR #2340)
- [ ] Review implementation plans for feasibility and dependency ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)