### PR TITLE
ci(e2e): always report status on PRs, short-circuit for irrelevant paths

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,19 +24,6 @@ on:
       - 'scripts/check-e2e-authorization.sh'
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
-    paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'e2e/**'
-      - 'internal/scaffold/fullsend-repo/**'
-      - 'internal/security/hooks/**'
-      - 'internal/dispatch/gcf/mintsrc/**'
-      - 'internal/sentencetoken/english.json'
-      - 'Makefile'
-      - '.github/workflows/e2e.yml'
-      - '.github/actions/check-e2e-authorization/**'
-      - 'scripts/check-e2e-authorization.sh'
   merge_group:
   workflow_dispatch:
 
@@ -93,19 +80,39 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Check for e2e-relevant changes
+        id: changes
+        if: github.event_name == 'pull_request_target'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          if echo "$FILES" | grep -qE '\.go$|^go\.(mod|sum)$|^e2e/|^internal/scaffold/fullsend-repo/|^internal/security/hooks/|^internal/dispatch/gcf/mintsrc/|^internal/sentencetoken/english\.json$|^Makefile$|\.github/workflows/e2e\.yml$|\.github/actions/check-e2e-authorization/|^scripts/check-e2e-authorization\.sh$'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No e2e-relevant files changed — skipping tests"
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.changes.outputs.relevant != 'false'
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-go@v5
+        if: steps.changes.outputs.relevant != 'false'
         with:
           go-version-file: go.mod
 
       - name: Install Playwright system dependencies
+        if: steps.changes.outputs.relevant != 'false'
         run: npx playwright install-deps chromium
 
       - name: Check for secrets
+        if: steps.changes.outputs.relevant != 'false'
         id: secrets-check
         run: |
           if [ -z "$E2E_GITHUB_SESSION_B64" ]; then
@@ -118,7 +125,7 @@ jobs:
           E2E_GITHUB_SESSION_B64: ${{ secrets.E2E_GITHUB_SESSION }}
 
       - name: Decode session
-        if: steps.secrets-check.outputs.available == 'true'
+        if: steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
         run: |
           SESSION_FILE="${RUNNER_TEMP}/github-session.json"
           printf '%s' "$E2E_GITHUB_SESSION_B64" | base64 -d > "$SESSION_FILE"
@@ -127,14 +134,14 @@ jobs:
           E2E_GITHUB_SESSION_B64: ${{ secrets.E2E_GITHUB_SESSION }}
 
       - name: Authenticate to GCP
-        if: steps.secrets-check.outputs.available == 'true'
+        if: steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.E2E_GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.E2E_GCP_SERVICE_ACCOUNT }}
 
       - name: Run e2e tests
-        if: steps.secrets-check.outputs.available == 'true'
+        if: steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
         run: make e2e-test
         env:
           E2E_SCREENSHOT_DIR: ${{ runner.temp }}/e2e-screenshots
@@ -144,7 +151,7 @@ jobs:
           E2E_GCP_PROJECT_ID: ${{ secrets.E2E_GCP_PROJECT_ID }}
 
       - name: Upload debug screenshots
-        if: always() && steps.secrets-check.outputs.available == 'true'
+        if: always() && steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-screenshots-${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,7 @@ permissions: {}
 on:
   push:
     branches: [main]
+    # SYNC-WITH: grep regex in "Check for e2e-relevant changes" step in the e2e job
     paths:
       - '**/*.go'
       - 'go.mod'
@@ -87,9 +88,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+        # SYNC-WITH: push.paths filter above
         run: |
-          FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
-          if echo "$FILES" | grep -qE '\.go$|^go\.(mod|sum)$|^e2e/|^internal/scaffold/fullsend-repo/|^internal/security/hooks/|^internal/dispatch/gcf/mintsrc/|^internal/sentencetoken/english\.json$|^Makefile$|\.github/workflows/e2e\.yml$|\.github/actions/check-e2e-authorization/|^scripts/check-e2e-authorization\.sh$'; then
+          FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename') || {
+            echo "::warning::Failed to fetch PR files — running e2e tests as a precaution"
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          if echo "$FILES" | grep -qE '\.go$|^go\.(mod|sum)$|^e2e/|^internal/scaffold/fullsend-repo/|^internal/security/hooks/|^internal/dispatch/gcf/mintsrc/|^internal/sentencetoken/english\.json$|^Makefile$|^\.github/workflows/e2e\.yml$|^\.github/actions/check-e2e-authorization/|^scripts/check-e2e-authorization\.sh$'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             echo "::notice::No e2e-relevant files changed — skipping tests"


### PR DESCRIPTION
## Summary

- Remove `paths:` filter from `pull_request_target` so the e2e workflow triggers on all PRs
- Add a path-relevance check that short-circuits when no e2e-relevant files changed
- Docs-only and config-only PRs now get a passing `e2e` status instead of no status at all

This restores the approach from #1988 which was lost when the e2e workflow was refactored to use `pull_request_target` with a gate/e2e job split. Without this fix, any PR that doesn't touch Go files is blocked from the merge queue because `e2e` is a required check that never starts.

Fixes #1989

## Test plan

- [ ] Open a docs-only PR and verify `e2e` reports a passing status with the "No e2e-relevant files changed" notice
- [ ] Open a Go-touching PR and verify `e2e` runs the full test suite as before
- [ ] Verify a docs-only PR can be enqueued in the merge queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)