### PR TITLE
feat(merge-queue): add await-and-enqueue script

### DIFF
--- a/skills/merge-queue/SKILL.md
+++ b/skills/merge-queue/SKILL.md
@@ -15,6 +15,9 @@ allowed-tools: Bash(bash skills/merge-queue/scripts/*:*)
 Run `bash skills/merge-queue/scripts/enqueue-pr.sh [PR_NUMBER_OR_URL]` to enqueue a PR.
 Omit the argument to enqueue the current branch's PR.
 
+If the PR is not yet eligible (checks pending, missing approvals), use
+`await-and-enqueue.sh` instead — see below.
+
 ### Accepted input formats
 
 - **PR number:** `652` (uses the current repo context from `gh`)
@@ -37,6 +40,18 @@ Run `bash skills/merge-queue/scripts/dequeue-reason.sh <PR_NUMBER_OR_URL>` to fi
 
 Shows each removal event's timestamp, reason (e.g. `failed_checks`, `merge_conflict`), and the commit SHA at the time of removal.
 
+## Await and enqueue
+
+Run `bash skills/merge-queue/scripts/await-and-enqueue.sh [PR_NUMBER_OR_URL]` to
+poll a PR until all required checks pass and the PR is approved, then
+automatically enqueue it. Exits early if any check fails.
+
+Use this when `enqueue-pr.sh` rejects a PR because checks are still pending.
+GitHub's `auto-merge` API (`gh pr merge --auto`) does not work with merge
+queues, so this script fills that gap.
+
+Set `POLL_INTERVAL` (default: 30 seconds) to control how often it checks.
+
 ## Prerequisites
 
 - `gh` CLI authenticated with write access to the target repository
@@ -48,3 +63,5 @@ Shows each removal event's timestamp, reason (e.g. `failed_checks`, `merge_confl
 - **"Pull request is already in the merge queue"** — the PR was previously enqueued; no action needed.
 - **"Pull request is not mergeable"** — the PR may need approvals, passing checks, or conflict resolution before it can be enqueued.
 - **"Resource not accessible by integration"** — the `gh` token lacks sufficient permissions.
+- **"status checks are expected"** — required checks haven't finished yet. Use `await-and-enqueue.sh` to poll and enqueue once they pass.
+- **`gh pr merge --auto` fails with merge queues** — GitHub's auto-merge API does not support merge queues. Use `await-and-enqueue.sh` instead.

--- a/skills/merge-queue/scripts/await-and-enqueue.sh
+++ b/skills/merge-queue/scripts/await-and-enqueue.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Waits for a PR's required checks and approvals, then enqueues it.
+# Exits early if any required check fails.
+#
+# Usage: await-and-enqueue.sh [PR_NUMBER_OR_URL]
+#
+# If no argument is given, uses the current branch's PR.
+# Polls every 30 seconds. Requires: gh CLI, jq.
+
+set -euo pipefail
+
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+pr="${1:-}"
+
+# Resolve PR URL and repo
+if [[ -z "$pr" ]]; then
+  pr_json_init="$(gh pr view --json url,baseRefName,headRepository -q '{url,baseRefName,headRepository}')"
+else
+  pr_json_init="$(gh pr view "$pr" --json url,baseRefName,headRepository -q '{url,baseRefName,headRepository}')"
+fi
+
+pr_url="$(echo "$pr_json_init" | jq -r .url)"
+base_branch="$(echo "$pr_json_init" | jq -r .baseRefName)"
+
+# Extract owner/repo from the PR URL
+repo_nwo="$(echo "$pr_url" | sed -E 's|https://github.com/([^/]+/[^/]+)/pull/.*|\1|')"
+
+# Fetch required status checks from branch rulesets
+required_checks="$(gh api "repos/$repo_nwo/rules/branches/$base_branch" \
+  --jq '[.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[].context] | unique | .[]' 2>/dev/null || true)"
+
+if [[ -n "$required_checks" ]]; then
+  echo "Required checks: $(echo "$required_checks" | tr '\n' ', ' | sed 's/,$//')"
+fi
+
+echo "Waiting for checks and approvals on: $pr_url"
+
+while true; do
+  # Get check rollup and review decision in one call
+  pr_json="$(gh pr view "$pr_url" --json statusCheckRollup,reviewDecision)"
+
+  review_decision="$(echo "$pr_json" | jq -r '.reviewDecision // "NONE"')"
+
+  # Build a map of check name -> conclusion
+  declare -A check_status=()
+  while IFS=$'\t' read -r state name; do
+    check_status["$name"]="$state"
+  done < <(echo "$pr_json" | jq -r '.statusCheckRollup[] | [(.conclusion // .status // "PENDING"), .name] | @tsv')
+
+  has_pending=false
+  has_failure=false
+
+  # Check reported statuses
+  for name in "${!check_status[@]}"; do
+    state="${check_status[$name]}"
+    case "$state" in
+      SUCCESS|NEUTRAL|SKIPPED|COMPLETED)
+        ;;
+      FAILURE|ERROR|CANCELLED|TIMED_OUT|STARTUP_FAILURE|ACTION_REQUIRED)
+        echo "FAILED: $name ($state)"
+        has_failure=true
+        ;;
+      *)
+        has_pending=true
+        ;;
+    esac
+  done
+
+  # Check for required checks that haven't appeared yet
+  if [[ -n "$required_checks" ]]; then
+    while IFS= read -r req; do
+      if [[ -z "${check_status[$req]+x}" ]]; then
+        echo "Required check not yet reported: $req"
+        has_pending=true
+      fi
+    done <<< "$required_checks"
+  fi
+
+  unset check_status
+
+  if [[ "$has_failure" == "true" ]]; then
+    echo "Aborting — one or more required checks failed."
+    exit 1
+  fi
+
+  if [[ "$has_pending" == "true" ]]; then
+    echo "Waiting ${POLL_INTERVAL}s..."
+    sleep "$POLL_INTERVAL"
+    continue
+  fi
+
+  if [[ "$review_decision" != "APPROVED" ]]; then
+    echo "Checks passed but review not yet approved (status: $review_decision)... waiting ${POLL_INTERVAL}s"
+    sleep "$POLL_INTERVAL"
+    continue
+  fi
+
+  echo "All checks passed and PR is approved. Enqueuing..."
+  break
+done
+
+# Delegate to the enqueue script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$SCRIPT_DIR/enqueue-pr.sh" "$pr_url"

--- a/skills/merge-queue/scripts/await-and-enqueue.sh
+++ b/skills/merge-queue/scripts/await-and-enqueue.sh
@@ -14,9 +14,9 @@ pr="${1:-}"
 
 # Resolve PR URL and repo
 if [[ -z "$pr" ]]; then
-  pr_json_init="$(gh pr view --json url,baseRefName,headRepository -q '{url,baseRefName,headRepository}')"
+  pr_json_init="$(gh pr view --json url,baseRefName -q '{url,baseRefName}')"
 else
-  pr_json_init="$(gh pr view "$pr" --json url,baseRefName,headRepository -q '{url,baseRefName,headRepository}')"
+  pr_json_init="$(gh pr view "$pr" --json url,baseRefName -q '{url,baseRefName}')"
 fi
 
 pr_url="$(echo "$pr_json_init" | jq -r .url)"
@@ -25,12 +25,12 @@ base_branch="$(echo "$pr_json_init" | jq -r .baseRefName)"
 # Extract owner/repo from the PR URL
 repo_nwo="$(echo "$pr_url" | sed -E 's|https://github.com/([^/]+/[^/]+)/pull/.*|\1|')"
 
-# Fetch required status checks from branch rulesets
-required_checks="$(gh api "repos/$repo_nwo/rules/branches/$base_branch" \
-  --jq '[.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[].context] | unique | .[]' 2>/dev/null || true)"
+# Fetch required status checks from branch rulesets as a JSON array
+required_json="$(gh api "repos/$repo_nwo/rules/branches/$base_branch" \
+  --jq '[.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[].context] | unique' 2>/dev/null || echo '[]')"
 
-if [[ -n "$required_checks" ]]; then
-  echo "Required checks: $(echo "$required_checks" | tr '\n' ', ' | sed 's/,$//')"
+if [[ "$(echo "$required_json" | jq 'length')" -gt 0 ]]; then
+  echo "Required checks: $(echo "$required_json" | jq -r 'join(", ")')"
 fi
 
 echo "Waiting for checks and approvals on: $pr_url"
@@ -41,46 +41,37 @@ while true; do
 
   review_decision="$(echo "$pr_json" | jq -r '.reviewDecision // "NONE"')"
 
-  # Build a map of check name -> conclusion
-  declare -A check_status=()
-  while IFS=$'\t' read -r state name; do
-    check_status["$name"]="$state"
-  done < <(echo "$pr_json" | jq -r '.statusCheckRollup[] | [(.conclusion // .status // "PENDING"), .name] | @tsv')
+  # Use jq to analyze all check statuses and required check coverage in one pass
+  result="$(echo "$pr_json" | jq -r --argjson required "$required_json" '
+    .statusCheckRollup as $checks |
+    # Build map of name -> conclusion
+    ($checks | map({(.name): (.conclusion // .status // "PENDING")}) | add // {}) as $map |
+    # Check for failures
+    [$map | to_entries[] | select(.value | test("FAILURE|ERROR|CANCELLED|TIMED_OUT|STARTUP_FAILURE|ACTION_REQUIRED")) | .key + " (" + .value + ")"] as $failures |
+    # Check for pending
+    [$map | to_entries[] | select(.value | test("SUCCESS|NEUTRAL|SKIPPED|COMPLETED|FAILURE|ERROR|CANCELLED|TIMED_OUT|STARTUP_FAILURE|ACTION_REQUIRED") | not) | .key] as $pending |
+    # Check for missing required checks
+    [$required[] | select(. as $r | $map | has($r) | not)] as $missing |
+    {failures: $failures, pending: $pending, missing: $missing}
+  ')"
 
-  has_pending=false
-  has_failure=false
+  failures="$(echo "$result" | jq -r '.failures[]' 2>/dev/null || true)"
+  pending="$(echo "$result" | jq -r '.pending[]' 2>/dev/null || true)"
+  missing="$(echo "$result" | jq -r '.missing[]' 2>/dev/null || true)"
 
-  # Check reported statuses
-  for name in "${!check_status[@]}"; do
-    state="${check_status[$name]}"
-    case "$state" in
-      SUCCESS|NEUTRAL|SKIPPED|COMPLETED)
-        ;;
-      FAILURE|ERROR|CANCELLED|TIMED_OUT|STARTUP_FAILURE|ACTION_REQUIRED)
-        echo "FAILED: $name ($state)"
-        has_failure=true
-        ;;
-      *)
-        has_pending=true
-        ;;
-    esac
-  done
-
-  # Check for required checks that haven't appeared yet
-  if [[ -n "$required_checks" ]]; then
-    while IFS= read -r req; do
-      if [[ -z "${check_status[$req]+x}" ]]; then
-        echo "Required check not yet reported: $req"
-        has_pending=true
-      fi
-    done <<< "$required_checks"
-  fi
-
-  unset check_status
-
-  if [[ "$has_failure" == "true" ]]; then
+  if [[ -n "$failures" ]]; then
+    echo "$failures" | while IFS= read -r f; do echo "FAILED: $f"; done
     echo "Aborting — one or more required checks failed."
     exit 1
+  fi
+
+  has_pending=false
+  if [[ -n "$pending" ]]; then
+    has_pending=true
+  fi
+  if [[ -n "$missing" ]]; then
+    echo "$missing" | while IFS= read -r m; do echo "Required check not yet reported: $m"; done
+    has_pending=true
   fi
 
   if [[ "$has_pending" == "true" ]]; then


### PR DESCRIPTION
## Summary

- Add `await-and-enqueue.sh` that polls a PR until required checks pass and approvals are present, then enqueues it
- Cross-references required checks from branch rulesets against actual check rollup — treats missing (not yet reported) checks as pending
- Exits early if any check fails
- Update SKILL.md with usage docs and note that `gh pr merge --auto` does not work with merge queues

GitHub's auto-merge API doesn't support merge queues, so this script fills that gap.

## Test plan

- [x] Tested against PR #2334 — correctly detected missing `e2e` check as pending
- [x] Verified it enqueues successfully when all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)