### PR TITLE
fix(#2405): fall back to --force-with-lease in post-fix.sh

### DIFF
--- a/internal/scaffold/fullsend-repo/scripts/post-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-code.sh
@@ -332,7 +332,10 @@ echo "${PUSH_OUTPUT}"
 if [ "${PUSH_RC}" -ne 0 ]; then
   if echo "${PUSH_OUTPUT}" | grep -qi "non-fast-forward\|rejected\|fetch first"; then
     echo "::warning::Plain push failed (non-fast-forward) — retrying with --force-with-lease"
-    git push --force-with-lease -u origin -- "${BRANCH}" 2>&1
+    if ! git push --force-with-lease -u origin -- "${BRANCH}" 2>&1; then
+      echo "::error::Force-with-lease push also failed"
+      exit 1
+    fi
   else
     echo "::error::Push failed with unexpected error"
     exit 1

--- a/internal/scaffold/fullsend-repo/scripts/post-fix-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-fix-test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# post-fix-test.sh — Test the push retry logic from post-fix.sh.
+#
+# Extracts and tests the push-retry decision logic in isolation using shell
+# functions. This avoids needing a full git repo or GitHub API access.
+#
+# Run from the repo root:
+#   bash internal/scaffold/fullsend-repo/scripts/post-fix-test.sh
+
+set -euo pipefail
+
+FAILURES=0
+
+# ---------------------------------------------------------------------------
+# Test helper — reimplements the push retry logic from post-fix.sh section 5.
+# Given a push exit code and output, returns the action.
+# ---------------------------------------------------------------------------
+decide_push_retry() {
+  local push_rc="$1"
+  local push_output="$2"
+
+  if [ "${push_rc}" -eq 0 ]; then
+    echo "success"
+    return 0
+  fi
+
+  if echo "${push_output}" | grep -qi "non-fast-forward\|rejected\|fetch first"; then
+    echo "retry:force-with-lease"
+    return 0
+  fi
+
+  echo "fail:unexpected-error"
+  return 0
+}
+
+run_push_retry_test() {
+  local test_name="$1"
+  local push_rc="$2"
+  local push_output="$3"
+  local expected_prefix="$4"
+
+  local actual
+  actual="$(decide_push_retry "${push_rc}" "${push_output}")"
+
+  if [[ "${actual}" != ${expected_prefix}* ]]; then
+    echo "FAIL: ${test_name}"
+    echo "  push_rc:         '${push_rc}'"
+    echo "  push_output:     '${push_output}'"
+    echo "  expected prefix: '${expected_prefix}'"
+    echo "  actual:          '${actual}'"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  echo "PASS: ${test_name}"
+}
+
+# --- Push retry test cases ---
+
+# Successful push → no retry needed
+run_push_retry_test "push-success" \
+  "0" "Everything up-to-date" "success"
+
+# Non-fast-forward error → retry with --force-with-lease
+run_push_retry_test "push-non-fast-forward" \
+  "1" "error: failed to push some refs: non-fast-forward" "retry:force-with-lease"
+
+# Rejected error → retry with --force-with-lease
+run_push_retry_test "push-rejected" \
+  "1" "! [rejected] agent/42 -> agent/42 (fetch first)" "retry:force-with-lease"
+
+# Unknown error → fail
+run_push_retry_test "push-unexpected-error" \
+  "1" "fatal: repository not found" "fail:unexpected-error"
+
+# --- Summary ---
+
+echo ""
+if [ ${FAILURES} -gt 0 ]; then
+  echo "${FAILURES} test(s) failed"
+  exit 1
+fi
+echo "All tests passed"

--- a/internal/scaffold/fullsend-repo/scripts/post-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-fix.sh
@@ -251,11 +251,26 @@ if [ "${NO_PUSH}" = "false" ]; then
   git remote set-url origin \
     "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO_FULL_NAME}.git"
 
-  # Plain push (no --force-with-lease). Agents always create new
-  # commits (amend is in disallowedTools), so force-push is unnecessary
-  # and plain push is safer (refuses diverged branches).
+  # Plain push first. Falls back to --force-with-lease when the push
+  # is rejected (non-fast-forward), which happens after a rebase — the
+  # agent rewrote history so the remote branch diverged. force-with-lease
+  # is safe: it still rejects if someone else pushed in the meantime.
   echo "Pushing branch ${BRANCH}..."
-  git push -u origin -- "${BRANCH}" 2>&1
+  PUSH_OUTPUT="$(git push -u origin -- "${BRANCH}" 2>&1)" && PUSH_RC=0 || PUSH_RC=$?
+  echo "${PUSH_OUTPUT}"
+
+  if [ "${PUSH_RC}" -ne 0 ]; then
+    if echo "${PUSH_OUTPUT}" | grep -qi "non-fast-forward\|rejected\|fetch first"; then
+      echo "::warning::Plain push failed (non-fast-forward) — retrying with --force-with-lease"
+      if ! git push --force-with-lease -u origin -- "${BRANCH}" 2>&1; then
+        echo "::error::Force-with-lease push also failed"
+        exit 1
+      fi
+    else
+      echo "::error::Push failed with unexpected error"
+      exit 1
+    fi
+  fi
   echo "Branch ${BRANCH} pushed successfully"
 fi
 


### PR DESCRIPTION
## Summary

- post-fix.sh used plain `git push`, which is rejected after a rebase (non-fast-forward)
- Now tries plain push first, falls back to `--force-with-lease` on non-fast-forward rejection
- Matches the existing pattern in post-code.sh (section 7b)

Closes #2405

## Test plan

- [ ] `/fs-fix rebase` on a PR whose branch is behind main should push successfully
- [ ] Normal (non-rebase) fix iterations still use plain push
- [ ] If someone else pushed to the branch concurrently, `--force-with-lease` still rejects (safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)