### PR TITLE
fix(#2420): automate v0 floating tag move in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Move v0 floating tag
+        if: "!contains(github.ref_name, '-')"
+        run: |
+          set -euo pipefail
+          CURRENT=""
+          if git rev-parse v0 >/dev/null 2>&1; then
+            CURRENT=$(git rev-parse v0)
+            if ! git merge-base --is-ancestor "${CURRENT}" "${GITHUB_SHA}"; then
+              echo "::warning::v0 already points at a newer commit, skipping"
+              exit 0
+            fi
+          fi
+          git tag -f v0 "${GITHUB_SHA}"
+          if [[ -n "${CURRENT}" ]]; then
+            git push --force-with-lease="v0:${CURRENT}" origin v0
+          else
+            git push origin v0
+          fi

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,13 @@
 version: 2
 
+git:
+  # Ignore major-version floating tags (v0, v1, ...) so they don't
+  # confuse GoReleaser's previous-tag detection for changelogs.
+  ignore_tags:
+    - v0
+    - v1
+    - v2
+
 builds:
   - main: ./cmd/fullsend/
     binary: fullsend

--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -109,29 +109,12 @@ GoReleaser takes over from here. Verify the workflow starts:
 gh run list --workflow=release.yml --limit=1
 ```
 
-### 8. Move the `v0` tag
-
-Downstream orgs reference reusable workflows via `@v0`. Use
-`AskUserQuestion` to confirm before force-pushing:
-
-> About to force-push `v0` to `<tag>`. This immediately changes what
-> all downstream `@v0` consumers resolve. Proceed?
-
-Once confirmed:
-
-```
-git tag -f v0 <tag>
-git push origin v0 --force
-```
-
-The Sandbox Images workflow (triggered by tag push) will also run.
-
-### 9. Run post-flight verification
+### 8. Run post-flight verification
 
 Read [post-flight.md](post-flight.md) in this skill's directory and
 follow the post-flight verification procedure.
 
-### 10. Install the binary locally
+### 9. Install the binary locally
 
 Use `AskUserQuestion` to ask where to install (default: `~/.local/bin/`),
 then run the install script using its repo-root-relative path:
@@ -150,4 +133,5 @@ installs the binary as `fullsend-<tag>` so multiple versions can coexist.
 - **Never delete a published tag.** If a release is bad, cut a new patch or RC.
 - **The changelog** is auto-generated from conventional commit prefixes.
 - **The `v0` tag** is a moving tag consumed by downstream orgs for reusable
-  workflows. Always move it as part of the release process (step 8).
+  workflows. It is automatically moved by the release workflow after
+  GoReleaser completes (skipped for pre-release tags).

--- a/skills/cutting-releases/post-flight.md
+++ b/skills/cutting-releases/post-flight.md
@@ -2,14 +2,15 @@
 
 Part of the [cutting-releases](SKILL.md) skill.
 
-Run after the version tag is pushed, the `v0` tag is moved, and the
-CI workflows complete. Focus on the areas identified during pre-flight
+Run after the version tag is pushed and the CI workflows complete.
+The release workflow automatically moves the `v0` floating tag after
+GoReleaser succeeds (skipped for pre-release tags). Focus on the areas identified during pre-flight
 step F.
 
 ## A. Wait for CI workflows
 
 Wait for the Release workflow (triggered by the `v*` tag) and the
-Sandbox Images workflow (triggered by the `v0` tag move) to complete:
+Sandbox Images workflow (triggered by release workflow) to complete:
 
 ```
 gh run list --workflow=release.yml --limit=1


### PR DESCRIPTION
## Summary

- Add post-GoReleaser step in `release.yml` to force-move `v0` tag, with ancestry check to prevent race conditions between concurrent releases
- Add `git.ignore_tags` in `.goreleaser.yml` so `v0` doesn't confuse previous-tag detection (root cause of `previous=<unknown>` / 1,216-entry changelogs)
- Remove manual step 8 from cutting-releases skill, update post-flight docs

Closes #2420

## Test plan

- [ ] Verify `release.yml` syntax is valid (actionlint / CI)
- [ ] Confirm `.goreleaser.yml` parses correctly (`goreleaser check`)
- [ ] On next release: changelog should show only commits since previous semver tag, not entire history
- [ ] On next release: `v0` tag should move automatically without manual intervention
- [ ] Pre-release tags (e.g. `v0.19.0-rc.1`) should skip the `v0` move step

🤖 Generated with [Claude Code](https://claude.com/claude-code)