### PR TITLE
fix(#2432): retry merge on 409 after updating PR branch

### DIFF
--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -2640,7 +2640,6 @@ func (c *LiveClient) DismissPullRequestReview(ctx context.Context, owner, repo s
 func (c *LiveClient) MergeChangeProposal(ctx context.Context, owner, repo string, number int) error {
 	const maxAttempts = 3
 	mergePath := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, number)
-	updatePath := fmt.Sprintf("/repos/%s/%s/pulls/%d/update-branch", owner, repo, number)
 
 	var lastMergeErr error
 	for attempt := range maxAttempts {
@@ -2657,15 +2656,9 @@ func (c *LiveClient) MergeChangeProposal(ctx context.Context, owner, repo string
 		lastMergeErr = err
 
 		if attempt < maxAttempts-1 {
-			// Update the PR branch to incorporate base branch changes.
-			updateResp, updateErr := c.do(ctx, http.MethodPut, updatePath, map[string]string{})
-			if updateErr != nil {
-				return fmt.Errorf("update pull request #%d branch: %w", number, updateErr)
+			if err := c.UpdatePullRequestBranch(ctx, owner, repo, number); err != nil {
+				return fmt.Errorf("merge pull request #%d: update branch failed: %w", number, err)
 			}
-			if err := checkStatus(updateResp, http.StatusAccepted, http.StatusOK); err != nil {
-				return fmt.Errorf("update pull request #%d branch: %w", number, err)
-			}
-			updateResp.Body.Close()
 
 			select {
 			case <-time.After(3 * time.Second):

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -2642,6 +2642,7 @@ func (c *LiveClient) MergeChangeProposal(ctx context.Context, owner, repo string
 	mergePath := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, number)
 	updatePath := fmt.Sprintf("/repos/%s/%s/pulls/%d/update-branch", owner, repo, number)
 
+	var lastMergeErr error
 	for attempt := range maxAttempts {
 		resp, err := c.put(ctx, mergePath, map[string]string{"merge_method": "squash"})
 		if err == nil {
@@ -2653,14 +2654,19 @@ func (c *LiveClient) MergeChangeProposal(ctx context.Context, owner, repo string
 		if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusConflict {
 			return fmt.Errorf("merge pull request #%d: %w", number, err)
 		}
-
-		// Update the PR branch to incorporate base branch changes.
-		updateResp, updateErr := c.do(ctx, http.MethodPut, updatePath, map[string]string{})
-		if updateErr == nil {
-			updateResp.Body.Close()
-		}
+		lastMergeErr = err
 
 		if attempt < maxAttempts-1 {
+			// Update the PR branch to incorporate base branch changes.
+			updateResp, updateErr := c.do(ctx, http.MethodPut, updatePath, map[string]string{})
+			if updateErr != nil {
+				return fmt.Errorf("update pull request #%d branch: %w", number, updateErr)
+			}
+			if err := checkStatus(updateResp, http.StatusAccepted, http.StatusOK); err != nil {
+				return fmt.Errorf("update pull request #%d branch: %w", number, err)
+			}
+			updateResp.Body.Close()
+
 			select {
 			case <-time.After(3 * time.Second):
 			case <-ctx.Done():
@@ -2669,7 +2675,7 @@ func (c *LiveClient) MergeChangeProposal(ctx context.Context, owner, repo string
 		}
 	}
 
-	return fmt.Errorf("merge pull request #%d: branch remained out of date after %d update-and-retry attempts", number, maxAttempts)
+	return fmt.Errorf("merge pull request #%d: branch remained out of date after %d update-and-retry attempts: %w", number, maxAttempts, lastMergeErr)
 }
 
 // UpdatePullRequestBranch updates a PR's head branch by merging the base

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -247,6 +247,14 @@ func isRetryable(resp *http.Response) (bool, []byte) {
 // typically require waiting at least 60 seconds.
 var secondaryRateLimitBackoff = 60 * time.Second
 
+// mergeRetryPollInterval is the interval for polling head SHA after an
+// update-branch call to confirm the branch actually advanced. Overridable in tests.
+var mergeRetryPollInterval = 200 * time.Millisecond
+
+// mergeRetryPollTimeout is the maximum time to wait for the head SHA to
+// change after an update-branch call. Overridable in tests.
+var mergeRetryPollTimeout = 10 * time.Second
+
 // retryDelay calculates how long to wait before retrying.
 // It uses the Retry-After header if present, otherwise exponential backoff
 // with jitter to prevent thundering-herd effects.
@@ -2656,14 +2664,19 @@ func (c *LiveClient) MergeChangeProposal(ctx context.Context, owner, repo string
 		lastMergeErr = err
 
 		if attempt < maxAttempts-1 {
+			headSHA, shaErr := c.GetPullRequestHeadSHA(ctx, owner, repo, number)
+			if shaErr != nil {
+				return fmt.Errorf("merge pull request #%d: get head SHA: %w", number, shaErr)
+			}
+
 			if err := c.UpdatePullRequestBranch(ctx, owner, repo, number); err != nil {
 				return fmt.Errorf("merge pull request #%d: update branch failed: %w", number, err)
 			}
 
-			select {
-			case <-time.After(3 * time.Second):
-			case <-ctx.Done():
-				return ctx.Err()
+			// Poll until the head SHA advances, confirming the async
+			// update-branch actually landed before we retry the merge.
+			if err := c.awaitBranchUpdate(ctx, owner, repo, number, headSHA); err != nil {
+				return fmt.Errorf("merge pull request #%d: %w", number, err)
 			}
 		}
 	}
@@ -2684,6 +2697,31 @@ func (c *LiveClient) UpdatePullRequestBranch(ctx context.Context, owner, repo st
 	}
 	resp.Body.Close()
 	return nil
+}
+
+// awaitBranchUpdate polls the PR's head SHA until it differs from oldSHA,
+// confirming that an async update-branch call has landed. It polls at
+// mergeRetryPollInterval and gives up after mergeRetryPollTimeout, falling
+// through so the caller can retry the merge (which will get another 409 if
+// the update still hasn't landed).
+func (c *LiveClient) awaitBranchUpdate(ctx context.Context, owner, repo string, number int, oldSHA string) error {
+	deadline := time.After(mergeRetryPollTimeout)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return nil // timed out; let the caller retry the merge
+		case <-time.After(mergeRetryPollInterval):
+			newSHA, err := c.GetPullRequestHeadSHA(ctx, owner, repo, number)
+			if err != nil {
+				continue // transient error; keep polling
+			}
+			if newSHA != oldSHA {
+				return nil
+			}
+		}
+	}
 }
 
 // ListWorkflowRuns returns recent workflow runs for a workflow file.

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -2635,13 +2635,41 @@ func (c *LiveClient) DismissPullRequestReview(ctx context.Context, owner, repo s
 }
 
 // MergeChangeProposal squash-merges a pull request by number.
+// If the merge fails with a 409 (head branch out of date), it updates the PR
+// branch and retries up to 3 times with a short delay between attempts.
 func (c *LiveClient) MergeChangeProposal(ctx context.Context, owner, repo string, number int) error {
-	resp, err := c.put(ctx, fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, number), map[string]string{"merge_method": "squash"})
-	if err != nil {
-		return fmt.Errorf("merge pull request #%d: %w", number, err)
+	const maxAttempts = 3
+	mergePath := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, number)
+	updatePath := fmt.Sprintf("/repos/%s/%s/pulls/%d/update-branch", owner, repo, number)
+
+	for attempt := range maxAttempts {
+		resp, err := c.put(ctx, mergePath, map[string]string{"merge_method": "squash"})
+		if err == nil {
+			resp.Body.Close()
+			return nil
+		}
+
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusConflict {
+			return fmt.Errorf("merge pull request #%d: %w", number, err)
+		}
+
+		// Update the PR branch to incorporate base branch changes.
+		updateResp, updateErr := c.do(ctx, http.MethodPut, updatePath, map[string]string{})
+		if updateErr == nil {
+			updateResp.Body.Close()
+		}
+
+		if attempt < maxAttempts-1 {
+			select {
+			case <-time.After(3 * time.Second):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
 	}
-	resp.Body.Close()
-	return nil
+
+	return fmt.Errorf("merge pull request #%d: branch remained out of date after %d update-and-retry attempts", number, maxAttempts)
 }
 
 // UpdatePullRequestBranch updates a PR's head branch by merging the base

--- a/internal/forge/github/github_merge_test.go
+++ b/internal/forge/github/github_merge_test.go
@@ -116,6 +116,6 @@ func TestMergeChangeProposal_409PersistsAfterRetries(t *testing.T) {
 	err := client.MergeChangeProposal(context.Background(), "org", "repo", 7)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "merge pull request #7")
-	// Should have tried multiple times before giving up.
-	assert.Greater(t, mergeAttempts.Load(), int32(1), "should have retried merge")
+	// Should have tried exactly maxAttempts times before giving up.
+	assert.Equal(t, int32(3), mergeAttempts.Load(), "should have retried merge exactly 3 times")
 }

--- a/internal/forge/github/github_merge_test.go
+++ b/internal/forge/github/github_merge_test.go
@@ -3,14 +3,30 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fastMergeRetryPoll overrides the merge retry poll vars to near-zero for tests.
+// It returns a cleanup function that restores the original values.
+func fastMergeRetryPoll(t *testing.T) {
+	t.Helper()
+	origInterval := mergeRetryPollInterval
+	origTimeout := mergeRetryPollTimeout
+	mergeRetryPollInterval = time.Millisecond
+	mergeRetryPollTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		mergeRetryPollInterval = origInterval
+		mergeRetryPollTimeout = origTimeout
+	})
+}
 
 func TestMergeChangeProposal_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -32,27 +48,36 @@ func TestMergeChangeProposal_Success(t *testing.T) {
 }
 
 func TestMergeChangeProposal_409UpdatesBranchAndRetries(t *testing.T) {
+	fastMergeRetryPoll(t)
+
 	var mergeAttempts atomic.Int32
 	var updateCalls atomic.Int32
+	var headSHA atomic.Value
+	headSHA.Store("old-sha")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPut && r.URL.Path == "/repos/org/repo/pulls/7/merge":
 			attempt := mergeAttempts.Add(1)
 			if attempt == 1 {
-				// First merge attempt: 409 conflict.
 				w.WriteHeader(http.StatusConflict)
 				json.NewEncoder(w).Encode(map[string]string{
 					"message": "Head branch is out of date",
 				})
 				return
 			}
-			// Second merge attempt: success.
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(map[string]string{"sha": "def456"})
 
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/repo/pulls/7":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"head": map[string]string{"sha": headSHA.Load().(string)},
+			})
+
 		case r.Method == http.MethodPut && r.URL.Path == "/repos/org/repo/pulls/7/update-branch":
 			updateCalls.Add(1)
+			headSHA.Store("new-sha")
 			w.WriteHeader(http.StatusAccepted)
 			json.NewEncoder(w).Encode(map[string]string{"message": "Updating pull request branch."})
 
@@ -90,7 +115,10 @@ func TestMergeChangeProposal_NonConflictErrorNotRetried(t *testing.T) {
 }
 
 func TestMergeChangeProposal_409PersistsAfterRetries(t *testing.T) {
+	fastMergeRetryPoll(t)
+
 	var mergeAttempts atomic.Int32
+	var headSHACounter atomic.Int32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -99,6 +127,14 @@ func TestMergeChangeProposal_409PersistsAfterRetries(t *testing.T) {
 			w.WriteHeader(http.StatusConflict)
 			json.NewEncoder(w).Encode(map[string]string{
 				"message": "Head branch is out of date",
+			})
+
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/repo/pulls/7":
+			// Return a new SHA each time so the poll completes.
+			n := headSHACounter.Add(1)
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"head": map[string]string{"sha": fmt.Sprintf("sha-%d", n)},
 			})
 
 		case r.Method == http.MethodPut && r.URL.Path == "/repos/org/repo/pulls/7/update-branch":
@@ -116,6 +152,85 @@ func TestMergeChangeProposal_409PersistsAfterRetries(t *testing.T) {
 	err := client.MergeChangeProposal(context.Background(), "org", "repo", 7)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "merge pull request #7")
-	// Should have tried exactly maxAttempts times before giving up.
 	assert.Equal(t, int32(3), mergeAttempts.Load(), "should have retried merge exactly 3 times")
+}
+
+func TestMergeChangeProposal_UpdateBranchFailsMidRetry(t *testing.T) {
+	fastMergeRetryPoll(t)
+
+	var mergeAttempts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/repos/org/repo/pulls/7/merge":
+			mergeAttempts.Add(1)
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]string{
+				"message": "Head branch is out of date",
+			})
+
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/repo/pulls/7":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"head": map[string]string{"sha": "old-sha"},
+			})
+
+		case r.Method == http.MethodPut && r.URL.Path == "/repos/org/repo/pulls/7/update-branch":
+			w.WriteHeader(http.StatusForbidden)
+			json.NewEncoder(w).Encode(map[string]string{"message": "Resource not accessible by integration"})
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.MergeChangeProposal(context.Background(), "org", "repo", 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "update branch failed")
+	assert.Equal(t, int32(1), mergeAttempts.Load(), "should not retry merge after update-branch failure")
+}
+
+func TestMergeChangeProposal_ContextCancelledDuringPoll(t *testing.T) {
+	fastMergeRetryPoll(t)
+	// Set a long poll timeout so cancellation fires first.
+	origTimeout := mergeRetryPollTimeout
+	mergeRetryPollTimeout = 10 * time.Second
+	t.Cleanup(func() { mergeRetryPollTimeout = origTimeout })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/repos/org/repo/pulls/7/merge":
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]string{
+				"message": "Head branch is out of date",
+			})
+
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/org/repo/pulls/7":
+			// Always return the same SHA so the poll never completes.
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"head": map[string]string{"sha": "stuck-sha"},
+			})
+
+		case r.Method == http.MethodPut && r.URL.Path == "/repos/org/repo/pulls/7/update-branch":
+			w.WriteHeader(http.StatusAccepted)
+			json.NewEncoder(w).Encode(map[string]string{"message": "Updating pull request branch."})
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	client := newTestClient(t, srv)
+	err := client.MergeChangeProposal(ctx, "org", "repo", 7)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }

--- a/internal/forge/github/github_merge_test.go
+++ b/internal/forge/github/github_merge_test.go
@@ -1,0 +1,121 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeChangeProposal_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/repos/org/repo/pulls/42/merge", r.URL.Path)
+
+		var body map[string]string
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "squash", body["merge_method"])
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"sha": "abc123"})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.MergeChangeProposal(context.Background(), "org", "repo", 42)
+	require.NoError(t, err)
+}
+
+func TestMergeChangeProposal_409UpdatesBranchAndRetries(t *testing.T) {
+	var mergeAttempts atomic.Int32
+	var updateCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/repos/org/repo/pulls/7/merge":
+			attempt := mergeAttempts.Add(1)
+			if attempt == 1 {
+				// First merge attempt: 409 conflict.
+				w.WriteHeader(http.StatusConflict)
+				json.NewEncoder(w).Encode(map[string]string{
+					"message": "Head branch is out of date",
+				})
+				return
+			}
+			// Second merge attempt: success.
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"sha": "def456"})
+
+		case r.Method == http.MethodPut && r.URL.Path == "/repos/org/repo/pulls/7/update-branch":
+			updateCalls.Add(1)
+			w.WriteHeader(http.StatusAccepted)
+			json.NewEncoder(w).Encode(map[string]string{"message": "Updating pull request branch."})
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.MergeChangeProposal(context.Background(), "org", "repo", 7)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), mergeAttempts.Load(), "should have attempted merge twice")
+	assert.Equal(t, int32(1), updateCalls.Load(), "should have called update-branch once")
+}
+
+func TestMergeChangeProposal_NonConflictErrorNotRetried(t *testing.T) {
+	var mergeAttempts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mergeAttempts.Add(1)
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Pull Request is not mergeable",
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.MergeChangeProposal(context.Background(), "org", "repo", 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not mergeable")
+	assert.Equal(t, int32(1), mergeAttempts.Load(), "should not retry non-409 errors")
+}
+
+func TestMergeChangeProposal_409PersistsAfterRetries(t *testing.T) {
+	var mergeAttempts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/repos/org/repo/pulls/7/merge":
+			mergeAttempts.Add(1)
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]string{
+				"message": "Head branch is out of date",
+			})
+
+		case r.Method == http.MethodPut && r.URL.Path == "/repos/org/repo/pulls/7/update-branch":
+			w.WriteHeader(http.StatusAccepted)
+			json.NewEncoder(w).Encode(map[string]string{"message": "Updating pull request branch."})
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	err := client.MergeChangeProposal(context.Background(), "org", "repo", 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "merge pull request #7")
+	// Should have tried multiple times before giving up.
+	assert.Greater(t, mergeAttempts.Load(), int32(1), "should have retried merge")
+}


### PR DESCRIPTION
## Summary

- When `MergeChangeProposal` gets a 409 "Head branch is out of date", it now calls GitHub's `PUT .../pulls/{n}/update-branch` to sync the PR with the base, waits 3s, then retries the merge (up to 3 attempts).
- Non-409 errors are returned immediately (no behavior change).
- Fixes the flaky `TestAdminInstallUninstall` failure at the enrollment PR merge step.

Closes #2432

## Test plan

- [x] `TestMergeChangeProposal_Success` — happy path unchanged
- [x] `TestMergeChangeProposal_409UpdatesBranchAndRetries` — 409 triggers update-branch then successful retry
- [x] `TestMergeChangeProposal_NonConflictErrorNotRetried` — 422 not retried
- [x] `TestMergeChangeProposal_409PersistsAfterRetries` — gives up after max attempts with clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)