### PR TITLE
chore: update obsolete GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -28,7 +28,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7
       - name: Delete stale branches
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,7 +53,7 @@ jobs:
     outputs:
       authorized: ${{ steps.auth.outputs.authorized }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}  # Base branch only — never checkout PR head in gate
 
@@ -102,13 +102,13 @@ jobs:
             echo "relevant=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: steps.changes.outputs.relevant != 'false'
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         if: steps.changes.outputs.relevant != 'false'
         with:
           go-version-file: go.mod
@@ -141,7 +141,7 @@ jobs:
 
       - name: Authenticate to GCP
         if: steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.E2E_GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.E2E_GCP_SERVICE_ACCOUNT }}
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload debug screenshots
         if: always() && steps.changes.outputs.relevant != 'false' && steps.secrets-check.outputs.available == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-screenshots-${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.run_id }}
           path: ${{ runner.temp }}/e2e-screenshots/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -47,7 +47,7 @@ jobs:
       - run: make script-test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: coverage.out
 
@@ -56,7 +56,7 @@ jobs:
     # subject on squash-merge). On push/merge_group: lint each commit.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -101,7 +101,7 @@ jobs:
   web:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pat-cleanup.yml
+++ b/.github/workflows/pat-cleanup.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -53,12 +53,12 @@ jobs:
 
     steps:
       - name: Checkout config repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checkout upstream defaults
         # Keep in sync with --vendor marker paths (see internal/scaffold/vendorcontent.go VendoredMarkerPath).
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: fullsend-ai/fullsend
           ref: ${{ inputs.fullsend_ai_ref }}
@@ -121,7 +121,7 @@ jobs:
           mint_url: ${{ inputs.mint_url }}
 
       - name: Checkout target repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.source_repo }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -69,7 +69,7 @@ jobs:
       event_payload: ${{ steps.payload.outputs.event_payload }}
     steps:
       - name: Checkout caller repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           sparse-checkout: .fullsend/config.yaml

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -65,11 +65,11 @@ jobs:
 
     steps:
       - name: Checkout config repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checkout upstream defaults
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: fullsend-ai/fullsend
           ref: ${{ inputs.fullsend_ai_ref }}
@@ -291,7 +291,7 @@ jobs:
           fi
 
       - name: Checkout target repository at PR HEAD
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.source_repo }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable-prioritize.yml
+++ b/.github/workflows/reusable-prioritize.yml
@@ -55,11 +55,11 @@ jobs:
 
     steps:
       - name: Checkout config repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checkout upstream defaults
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: fullsend-ai/fullsend
           ref: ${{ inputs.fullsend_ai_ref }}

--- a/.github/workflows/reusable-retro.yml
+++ b/.github/workflows/reusable-retro.yml
@@ -51,11 +51,11 @@ jobs:
 
     steps:
       - name: Checkout config repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checkout upstream defaults
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: fullsend-ai/fullsend
           ref: ${{ inputs.fullsend_ai_ref }}
@@ -118,7 +118,7 @@ jobs:
           mint_url: ${{ inputs.mint_url }}
 
       - name: Checkout target repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.source_repo }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -52,11 +52,11 @@ jobs:
 
     steps:
       - name: Checkout config repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checkout upstream defaults
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: fullsend-ai/fullsend
           ref: ${{ inputs.fullsend_ai_ref }}
@@ -118,7 +118,7 @@ jobs:
           mint_url: ${{ inputs.mint_url }}
 
       - name: Checkout target repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.source_repo }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable-triage.yml
+++ b/.github/workflows/reusable-triage.yml
@@ -51,11 +51,11 @@ jobs:
 
     steps:
       - name: Checkout config repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checkout upstream defaults
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: fullsend-ai/fullsend
           ref: ${{ inputs.fullsend_ai_ref }}
@@ -118,7 +118,7 @@ jobs:
           mint_url: ${{ inputs.mint_url }}
 
       - name: Checkout target repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.source_repo }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
@@ -47,7 +47,7 @@ jobs:
           mkdir -p _bundle/worker
           cp -a cloudflare_site/worker/. _bundle/worker/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: site
           path: _bundle/

--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # Trusted tree only: wrangler.toml must not come from PR checkout (no PR-controlled [build] on the deploy runner).
       # PR/fork Worker + static files ship in the Build Site artifact under _bundle/; we copy only public/ and worker/ (never extract TOML from the zip into cloudflare_site/).
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:
@@ -40,7 +40,7 @@ jobs:
         run: npm ci
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: site
           path: _bundle
@@ -81,7 +81,7 @@ jobs:
       - name: Resolve preview context (PR number + preview alias)
         id: preview-context
         if: success()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const run = context.payload.workflow_run;
@@ -220,7 +220,7 @@ jobs:
 
       - name: GitHub Deployment + preview comment
         if: steps.meta.outcome == 'success'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           DEPLOYMENT_URL: ${{ steps.meta.outputs.deployment_url }}
           PREVIEW_PR_NUMBER: ${{ steps.preview-context.outputs.pr_number }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-issue-label: stale
           stale-issue-message: >


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v4/v6/v6.0.2 to v7 (Node 24, safer `pull_request_target` defaults)
- Bump `actions/setup-go` from v5 to v6
- Bump `actions/upload-artifact` from v4 to v7
- Bump `actions/download-artifact` from v4 to v8
- Bump `actions/stale` from v9 to v10
- Bump `actions/github-script` from v8 to v9
- Bump `google-github-actions/auth` from v2 to v3 (e2e.yml only; setup-gcp already on v3)
- Bump `sigstore/cosign-installer` from v3 to v4
- Bump `codecov/codecov-action` from v5 to v7

SHA-pinned refs in `sandbox-images.yml` are intentionally left unchanged (supply-chain pinning for container builds).

### Motivation
Node 20 reached EOL in April 2026. `actions/checkout@v7` runs on Node 24 and adds safer `pull_request_target` defaults to prevent pwn request vulnerabilities. GitHub will backport enforcement to older major versions on July 16, 2026 — updating now avoids a forced migration.

The `actions/cache/restore@v4` Node 20 deprecation warning is also resolved by this PR, since it was triggered transitively by `actions/setup-go@v5` (now bumped to v6).

## Test plan
- [ ] CI passes with updated action versions
- [ ] `pull_request_target` workflows (e2e.yml) still check out correctly with v7's new defaults
- [ ] Reusable workflows called from `.fullsend` repos still function correctly
- [ ] Container builds in `sandbox-images.yml` are unaffected (SHA-pinned, not changed)

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)