### PR TITLE
docs: document GCP project for hosted mint

### DIFF
--- a/docs/guides/infrastructure/mint-administration.md
+++ b/docs/guides/infrastructure/mint-administration.md
@@ -16,7 +16,11 @@ This guide covers deploying and managing the fullsend token mint Cloud Function.
 
 ## Hosted mint
 
-The fullsend team operates a public hosted mint service. If your organization is enrolled, you can use it directly without deploying your own:
+The fullsend team operates a public hosted mint service. If your organization is enrolled, you can use it directly without deploying your own.
+
+**Platform GCP project:** The hosted mint currently runs in GCP project `it-gcp-konflux-dev-fullsend` (region `us-central1`).
+
+**Mint URL:**
 
 ```
 https://fullsend-mint-gljhbkcloq-uc.a.run.app


### PR DESCRIPTION
## Summary
- Document the GCP project (`it-gcp-konflux-dev-fullsend`) and region where the fullsend team hosts the default public mint Cloud Function
- Restructure the hosted mint section so the mint URL is labeled separately from the platform project details

## Test plan
- [x] Doc-only change; no code or CI impact
- [ ] Review hosted mint section for accuracy with platform operators


Made with [Cursor](https://cursor.com)