### PR TITLE
feat(#2479): enable Renovate via self-hosted GitHub App

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,47 @@
+# Renovate dependency update bot.
+#
+# Required setup:
+#   1. Create a GitHub App with permissions: contents:write,
+#      pull-requests:write, issues:read+write, checks:write.
+#   2. Install the App on the target org/repos.
+#   3. Set repository variable RENOVATE_APP_ID to the App ID.
+#   4. Set repository secret RENOVATE_PRIVATE_KEY to the App's PEM private key.
+#
+# See: https://docs.renovatebot.com/getting-started/running/#github-app
+name: Renovate
+
+on:
+  schedule:
+    - cron: "13 3,15 * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Run Renovate in dry-run mode"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - full
+
+permissions: {}
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+
+      - uses: renovatebot/github-action@v46
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          configurationFile: renovate.json
+        env:
+          LOG_LEVEL: info
+          RENOVATE_DRY_RUN: ${{ inputs.dry-run || 'false' }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "prHourlyLimit": 1,
+  "postUpdateOptions": ["gomodTidy"],
   "git-submodules": {
     "enabled": true
   },


### PR DESCRIPTION
## Summary

- Add `.github/workflows/renovate.yml` — runs self-hosted Renovate twice daily, authenticates via dedicated GitHub App using `actions/create-github-app-token`
- Update `renovate.json` — add `gomodTidy` post-update and `prHourlyLimit: 1`

Closes #2479

## Test plan

- [ ] Trigger workflow manually with dry-run to verify app token generation works
- [ ] Verify Renovate opens dependency PRs on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)