### PR TITLE
fix(#2489): retry scaffold push on non-fast-forward (auto_init race)

### DIFF
--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -172,6 +172,11 @@ type FakeClient struct {
 	// so only CommitFilesToBranch reads this value in practice.
 	CommitFilesChanged *bool
 
+	// CommitFilesErrSeq is an error queue for CommitFiles. Each call shifts
+	// the first element; when empty, falls through to Errors["CommitFiles"].
+	// A nil entry means no error for that call.
+	CommitFilesErrSeq []error
+
 	// Pull request head SHA for GetPullRequestHeadSHA.
 	PullRequestHeadSHA string
 
@@ -516,7 +521,13 @@ func (f *FakeClient) CommitFiles(_ context.Context, owner, repo, message string,
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	if e := f.err("CommitFiles"); e != nil {
+	if len(f.CommitFilesErrSeq) > 0 {
+		e := f.CommitFilesErrSeq[0]
+		f.CommitFilesErrSeq = f.CommitFilesErrSeq[1:]
+		if e != nil {
+			return false, e
+		}
+	} else if e := f.err("CommitFiles"); e != nil {
 		return false, e
 	}
 

--- a/internal/forge/fake_test.go
+++ b/internal/forge/fake_test.go
@@ -772,3 +772,39 @@ func TestIsForbidden(t *testing.T) {
 	assert.False(t, IsForbidden(errors.New("some error")))
 	assert.False(t, IsForbidden(nil))
 }
+
+func TestIsNonFastForward(t *testing.T) {
+	assert.True(t, IsNonFastForward(ErrNonFastForward))
+	assert.True(t, IsNonFastForward(errors.Join(errors.New("wrapper"), ErrNonFastForward)))
+	assert.False(t, IsNonFastForward(errors.New("some error")))
+	assert.False(t, IsNonFastForward(nil))
+}
+
+func TestFakeClient_CommitFilesErrSeq(t *testing.T) {
+	ctx := context.Background()
+	files := []TreeFile{{Path: "f.txt", Content: []byte("x"), Mode: "100644"}}
+
+	t.Run("first call errors, second succeeds", func(t *testing.T) {
+		fc := &FakeClient{
+			CommitFilesErrSeq: []error{ErrNonFastForward},
+		}
+		_, err := fc.CommitFiles(ctx, "o", "r", "m", files)
+		require.ErrorIs(t, err, ErrNonFastForward)
+
+		changed, err := fc.CommitFiles(ctx, "o", "r", "m", files)
+		require.NoError(t, err)
+		assert.True(t, changed)
+	})
+
+	t.Run("nil entry means no error for that call", func(t *testing.T) {
+		fc := &FakeClient{
+			CommitFilesErrSeq: []error{nil, ErrNonFastForward},
+		}
+		changed, err := fc.CommitFiles(ctx, "o", "r", "m", files)
+		require.NoError(t, err)
+		assert.True(t, changed)
+
+		_, err = fc.CommitFiles(ctx, "o", "r", "m", files)
+		require.ErrorIs(t, err, ErrNonFastForward)
+	})
+}

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -59,6 +59,15 @@ func IsNoChanges(err error) bool {
 	return errors.Is(err, ErrNoChanges)
 }
 
+// ErrNonFastForward indicates that a ref update was rejected because
+// the update is not a fast-forward (e.g. auto_init race on new repos).
+var ErrNonFastForward = errors.New("non-fast-forward update")
+
+// IsNonFastForward reports whether err indicates a non-fast-forward rejection.
+func IsNonFastForward(err error) bool {
+	return errors.Is(err, ErrNonFastForward)
+}
+
 // Repository represents a repository on a git forge.
 type Repository struct {
 	ID            int64

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -892,15 +892,20 @@ func (c *LiveClient) commitFilesTo(ctx context.Context, owner, repo, branch, mes
 	}
 
 	// 7. Update branch ref to point to new commit.
-	// A 422 here typically means branch protection rules prevent the push.
+	// A 422 may indicate branch protection or a non-fast-forward (e.g. auto_init race).
 	refPayload := map[string]string{
 		"sha": newCommit.SHA,
 	}
 	refUpdateResp, err := c.patch(ctx, fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, branch), refPayload)
 	if err != nil {
 		var apiErr *APIError
-		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnprocessableEntity && isBranchProtectionError(apiErr) {
-			return false, fmt.Errorf("%w: %w", forge.ErrBranchProtected, err)
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnprocessableEntity {
+			if isBranchProtectionError(apiErr) {
+				return false, fmt.Errorf("%w: %w", forge.ErrBranchProtected, err)
+			}
+			if isNonFastForwardError(apiErr) {
+				return false, fmt.Errorf("%w: %w", forge.ErrNonFastForward, err)
+			}
 		}
 		return false, fmt.Errorf("update ref: %w", err)
 	}
@@ -1061,6 +1066,14 @@ func isBranchProtectionError(apiErr *APIError) bool {
 		strings.Contains(msg, "required status") ||
 		strings.Contains(msg, "required review") ||
 		strings.Contains(msg, "rule violation")
+}
+
+func isNonFastForwardError(apiErr *APIError) bool {
+	msg := strings.ToLower(apiErr.Message)
+	for _, d := range apiErr.Errors {
+		msg += " " + strings.ToLower(d.Message)
+	}
+	return strings.Contains(msg, "not a fast forward") || strings.Contains(msg, "not a fast-forward")
 }
 
 func isAlreadyExistsError(apiErr *APIError) bool {

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -900,6 +900,7 @@ func (c *LiveClient) commitFilesTo(ctx context.Context, owner, repo, branch, mes
 	if err != nil {
 		var apiErr *APIError
 		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnprocessableEntity {
+			// Check order matters: protection messages can contain "fast forward"
 			if isBranchProtectionError(apiErr) {
 				return false, fmt.Errorf("%w: %w", forge.ErrBranchProtected, err)
 			}

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -1082,7 +1082,7 @@ func TestIsNonFastForwardError(t *testing.T) {
 			want:   false,
 		},
 		{
-			name: "branch protection with fast forward text",
+			name: "overlaps with branch protection (caller checks protection first)",
 			apiErr: &APIError{
 				StatusCode: 422,
 				Message:    "Update is not a fast forward",

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -1056,6 +1056,53 @@ func TestIsBranchProtectionError(t *testing.T) {
 	}
 }
 
+func TestIsNonFastForwardError(t *testing.T) {
+	tests := []struct {
+		name   string
+		apiErr *APIError
+		want   bool
+	}{
+		{
+			name:   "not a fast forward (no hyphen)",
+			apiErr: &APIError{StatusCode: 422, Message: "Update is not a fast forward"},
+			want:   true,
+		},
+		{
+			name: "not a fast-forward in detail (hyphenated)",
+			apiErr: &APIError{
+				StatusCode: 422,
+				Message:    "Update is not a fast forward",
+				Errors:     []APIErrorDetail{{Message: "Cannot update ref: not a fast-forward"}},
+			},
+			want: true,
+		},
+		{
+			name:   "unrelated 422",
+			apiErr: &APIError{StatusCode: 422, Message: "Reference already exists"},
+			want:   false,
+		},
+		{
+			name: "branch protection with fast forward text",
+			apiErr: &APIError{
+				StatusCode: 422,
+				Message:    "Update is not a fast forward",
+				Errors:     []APIErrorDetail{{Message: "Protected branch update failed for refs/heads/main."}},
+			},
+			want: true,
+		},
+		{
+			name:   "validation failed",
+			apiErr: &APIError{StatusCode: 422, Message: "Validation Failed"},
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isNonFastForwardError(tt.apiErr))
+		})
+	}
+}
+
 func TestIsAlreadyExistsError(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -2388,4 +2435,71 @@ func TestListOrgVariables(t *testing.T) {
 	vars, err := client.ListOrgVariables(context.Background(), "myorg")
 	require.NoError(t, err)
 	require.Len(t, vars, 2)
+}
+
+func TestCommitFiles_NonFastForward(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/repos/org/repo":
+			json.NewEncoder(w).Encode(map[string]string{"default_branch": "main"})
+		case r.Method == "GET" && r.URL.Path == "/repos/org/repo/git/ref/heads/main":
+			json.NewEncoder(w).Encode(map[string]any{"object": map[string]string{"sha": "commit"}})
+		case r.Method == "GET" && r.URL.Path == "/repos/org/repo/git/commits/commit":
+			json.NewEncoder(w).Encode(map[string]any{"tree": map[string]string{"sha": "tree"}})
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/repos/org/repo/git/trees/tree"):
+			json.NewEncoder(w).Encode(map[string]any{"tree": []any{}, "truncated": false})
+		case r.Method == "POST" && r.URL.Path == "/repos/org/repo/git/trees":
+			json.NewEncoder(w).Encode(map[string]string{"sha": "newtree"})
+		case r.Method == "POST" && r.URL.Path == "/repos/org/repo/git/commits":
+			json.NewEncoder(w).Encode(map[string]string{"sha": "newcommit"})
+		case r.Method == "PATCH" && r.URL.Path == "/repos/org/repo/git/refs/heads/main":
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			json.NewEncoder(w).Encode(map[string]any{
+				"message": "Update is not a fast forward",
+				"errors":  []map[string]string{{"message": "Cannot update ref: not a fast-forward"}},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	_, err := client.CommitFiles(context.Background(), "org", "repo", "msg", []forge.TreeFile{
+		{Path: "file.txt", Content: []byte("content"), Mode: "100644"},
+	})
+	require.Error(t, err)
+	assert.True(t, forge.IsNonFastForward(err))
+}
+
+func TestCommitFiles_BranchProtected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/repos/org/repo":
+			json.NewEncoder(w).Encode(map[string]string{"default_branch": "main"})
+		case r.Method == "GET" && r.URL.Path == "/repos/org/repo/git/ref/heads/main":
+			json.NewEncoder(w).Encode(map[string]any{"object": map[string]string{"sha": "commit"}})
+		case r.Method == "GET" && r.URL.Path == "/repos/org/repo/git/commits/commit":
+			json.NewEncoder(w).Encode(map[string]any{"tree": map[string]string{"sha": "tree"}})
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/repos/org/repo/git/trees/tree"):
+			json.NewEncoder(w).Encode(map[string]any{"tree": []any{}, "truncated": false})
+		case r.Method == "POST" && r.URL.Path == "/repos/org/repo/git/trees":
+			json.NewEncoder(w).Encode(map[string]string{"sha": "newtree"})
+		case r.Method == "POST" && r.URL.Path == "/repos/org/repo/git/commits":
+			json.NewEncoder(w).Encode(map[string]string{"sha": "newcommit"})
+		case r.Method == "PATCH" && r.URL.Path == "/repos/org/repo/git/refs/heads/main":
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			json.NewEncoder(w).Encode(map[string]any{
+				"message": "Validation Failed",
+				"errors":  []map[string]string{{"message": "Protected branch update failed for refs/heads/main."}},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	_, err := client.CommitFiles(context.Background(), "org", "repo", "msg", []forge.TreeFile{
+		{Path: "file.txt", Content: []byte("content"), Mode: "100644"},
+	})
+	require.Error(t, err)
+	assert.True(t, forge.IsBranchProtected(err))
+	assert.False(t, forge.IsNonFastForward(err), "should not match non-fast-forward")
 }

--- a/internal/layers/commit.go
+++ b/internal/layers/commit.go
@@ -321,6 +321,10 @@ func commitScaffoldDirect(ctx context.Context, client forge.Client, printer *ui.
 	files []forge.TreeFile, in io.Reader) (bool, error) {
 
 	committed, err := client.CommitFiles(ctx, owner, repo, commitMsg, files)
+	if err != nil && forge.IsNonFastForward(err) {
+		printer.StepWarn("Ref update hit auto_init race — retrying")
+		committed, err = client.CommitFiles(ctx, owner, repo, commitMsg, files)
+	}
 	if err != nil && forge.IsBranchProtected(err) {
 		printer.StepWarn("Default branch is protected — creating scaffold PR instead")
 		fallbackBody := fmt.Sprintf("The default branch (%s) has branch protection rules that prevent direct pushes.\n\n"+

--- a/internal/layers/commit_test.go
+++ b/internal/layers/commit_test.go
@@ -233,6 +233,37 @@ func TestCommitScaffoldDirect_FallbackPreservesIn(t *testing.T) {
 	assert.Equal(t, "acme/widget/fullsend/scaffold-install", client.CreatedBranches[0])
 }
 
+func TestCommitScaffoldDirect_NonFastForwardRetrySucceeds(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.AuthenticatedUser = "acme"
+	client.CommitFilesErrSeq = []error{
+		fmt.Errorf("%w: not a fast forward", forge.ErrNonFastForward),
+	}
+	printer, buf := newTestPrinter()
+
+	committed, err := CommitScaffoldFiles(context.Background(), client, printer,
+		"acme", "widget", "main", "msg", "title", "body", testFiles, true, nil)
+	require.NoError(t, err)
+	assert.True(t, committed)
+	assert.Contains(t, buf.String(), "auto_init race")
+	assert.Len(t, client.CommittedFiles, 1, "retry call should succeed and record")
+}
+
+func TestCommitScaffoldDirect_NonFastForwardRetryFails(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.AuthenticatedUser = "acme"
+	client.CommitFilesErrSeq = []error{
+		fmt.Errorf("%w: not a fast forward", forge.ErrNonFastForward),
+		fmt.Errorf("network error"),
+	}
+	printer, _ := newTestPrinter()
+
+	_, err := CommitScaffoldFiles(context.Background(), client, printer,
+		"acme", "widget", "main", "msg", "title", "body", testFiles, true, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "network error")
+}
+
 func TestPromptForkChoice_DefaultIsFork(t *testing.T) {
 	printer, _ := newTestPrinter()
 	in := strings.NewReader("\n")


### PR DESCRIPTION
Fixes #2489

## Summary

Scaffold pushes now retry once when hitting "Update is not a fast forward" errors. Resolves race where GitHub's async auto_init materializes a commit between ref fetch and ref update.

## Root cause

`CreateRepo` sets `auto_init: true` (line 377 of github.go). GitHub creates initial commit async — can complete after `commitFilesTo` fetches current ref SHA (line 658) but before updating ref (line 899). Scaffold commit built from stale parent → non-fast-forward rejection.

## Impact

Should eliminate most common e2e flake — appeared in nearly every failed run. `TestVendorFromSubdirectory` and `TestAdminInstallUninstall` hit this repeatedly.