### PR TITLE
fix(ci): restore e2e fork PR checkout after actions/checkout@v7 bump

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,6 +107,9 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+          # checkout@v7 blocks fork PR head checkouts on pull_request_target by default.
+          # Safe here: gate job authorizes before this job runs; no pull-requests: write.
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
       - uses: actions/setup-go@v6
         if: steps.changes.outputs.relevant != 'false'


### PR DESCRIPTION
## Summary
- `actions/checkout@v7` (merged in #2457) blocks fork PR head checkouts on `pull_request_target` unless `allow-unsafe-pr-checkout` is set
- Restore the e2e workflow's intentional post-gate PR head checkout, which is required for fork PRs to run e2e with secrets
- No other workflows are affected: e2e is the only workflow that checks out `pull_request.head.sha` under `pull_request_target`

## Context
After #2457 landed, authorized fork PRs pass the e2e gate job but fail at checkout with:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow

This is expected checkout@v7 behavior. The e2e split gate/e2e design already mitigates pwn-request risk: the gate job authorizes on base-branch code only, and the e2e job has no `pull-requests: write`.

## Test plan
- [ ] Open or re-run e2e on a fork PR with e2e-relevant changes; gate passes and e2e job checks out PR head successfully
- [ ] Confirm push/merge_group e2e runs are unchanged (`allow-unsafe-pr-checkout` is false outside `pull_request_target`)


Made with [Cursor](https://cursor.com)