### PR TITLE
fix(#2504): allow checkout@v7 to check out fork PR code in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,6 +107,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true  # Safe: gate job requires ok-to-test label from maintainer before this runs
 
       - uses: actions/setup-go@v6
         if: steps.changes.outputs.relevant != 'false'


### PR DESCRIPTION
## Summary

- PR fullsend-ai/fullsend#2457 upgraded `actions/checkout` to v7, which blocks fork PR checkouts in `pull_request_target` workflows by default
- This breaks e2e CI for all external contributor PRs (e.g., PR fullsend-ai/fullsend#2010)
- The gate job already requires the `ok-to-test` label from a maintainer before the e2e job runs, so opting in with `allow-unsafe-pr-checkout: true` is safe

Fixes fullsend-ai/fullsend#2504

## Test plan

- [ ] Verify this PR's own e2e check passes (it's from an upstream branch, so the fix isn't strictly needed here, but it shouldn't regress)
- [ ] After merge, verify a fork PR (e.g., fullsend-ai/fullsend#2010) gets a passing e2e check