### PR TITLE
fix(#2504): restore e2e fork PR checkout after actions/checkout@v7 bump

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,6 +107,9 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+          # checkout@v7 blocks fork PR head checkouts on pull_request_target by default.
+          # Safe here: gate job authorizes before this job runs; no pull-requests: write.
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
       - uses: actions/setup-go@v6
         if: steps.changes.outputs.relevant != 'false'


### PR DESCRIPTION
## Summary

- `actions/checkout@v7` (merged in #2457) blocks fork PR head checkouts on `pull_request_target` unless `allow-unsafe-pr-checkout` is set
- Safe here: gate job authorizes before this job runs; no `pull-requests: write`
- Upstream branch version of #2503 (@ifireball's fix) so e2e can actually run against this PR

Supersedes #2503. Fixes #2504.

Co-authored-by: Barak Korren <bkorren@redhat.com>

## Test plan

- [ ] e2e passes on this PR (upstream branch, not fork)
- [ ] After merge, fork PRs with `ok-to-test` label get passing e2e