### PR TITLE
chore(ci): add pinact pre-commit hook to enforce SHA-pinned actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,12 @@ jobs:
           echo "1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a  /tmp/lychee.tar.gz" | sha256sum -c
           tar xzf /tmp/lychee.tar.gz -C /usr/local/bin --strip-components=1 lychee-x86_64-unknown-linux-gnu/lychee
 
+      - name: Install pinact
+        run: |
+          curl -sSfL "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.1.0/pinact_linux_amd64.tar.gz" -o /tmp/pinact.tar.gz
+          echo "8fcbf1b3e95551c82fd995535e3c1defa70e23299ce36eb3afd6c98778de6ca0  /tmp/pinact.tar.gz" | sha256sum -c
+          tar xzf /tmp/pinact.tar.gz -C /usr/local/bin pinact
+
       - run: make lint-all
 
       - name: Run Go tests with coverage

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -30,15 +30,15 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           app-id: ${{ vars.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
 
-      - uses: renovatebot/github-action@v46
+      - uses: renovatebot/github-action@6d859fc95779be83a0335ca704879b47e5d79641 # v46.1.16
         with:
           token: ${{ steps.app-token.outputs.token }}
           configurationFile: renovate.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,7 @@ repos:
         files: |
           (?x)^(
             \.github/workflows/
+            |\.github/actions/
             |internal/scaffold/fullsend-repo/\.github/workflows/
           )
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,19 @@ repos:
       - id: shellcheck
         args: ["-x", "-e", "SC1091,SC2001,SC2016"]
 
+  - repo: local
+    hooks:
+      - id: pinact
+        name: pinact (SHA-pin check)
+        entry: pinact run --fix=false --no-api
+        language: system
+        files: |
+          (?x)^(
+            \.github/workflows/
+            |internal/scaffold/fullsend-repo/\.github/workflows/
+          )
+        pass_filenames: false
+
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.11
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ bootstrap:
 	curl -sSfL "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-gnu.tar.gz" -o /tmp/lychee.tar.gz
 	echo "1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a  /tmp/lychee.tar.gz" | sha256sum -c
 	tar xzf /tmp/lychee.tar.gz -C "$(BOOTSTRAP_BIN_DIR)" --strip-components=1 lychee-x86_64-unknown-linux-gnu/lychee
+	@echo "==> Installing pinact (GitHub Actions SHA-pin checker)..."
+	curl -sSfL "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.1.0/pinact_linux_amd64.tar.gz" -o /tmp/pinact.tar.gz
+	echo "8fcbf1b3e95551c82fd995535e3c1defa70e23299ce36eb3afd6c98778de6ca0  /tmp/pinact.tar.gz" | sha256sum -c
+	tar xzf /tmp/pinact.tar.gz -C "$(BOOTSTRAP_BIN_DIR)" pinact
 	@echo "==> Installing pre-commit hooks..."
 	PATH="$(BOOTSTRAP_BIN_DIR):$(PATH)" pre-commit install
 	@echo ""


### PR DESCRIPTION
## Summary

- Add a pre-commit hook that runs `pinact run --fix=false --no-api` to verify all GitHub Actions references use full-length commit SHAs
- Install pinact (v4.1.0, checksum-verified) in the CI lint workflow

The `--no-api` flag ensures the check is purely syntactic (40-char SHA presence) — it won't break when new action versions are released upstream.

## Dependencies

- Stacked on #2508 (SHA-pinning the actions themselves)
- Depends on #1055 (auto-detect pre-commit tool dependencies) for agent/sandbox availability of pinact

## Test plan

- [x] `pre-commit run pinact --all-files` passes locally
- [ ] CI lint job passes with pinact installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)