### PR TITLE
refactor(config): remove OrgConfig.Agents field (ADR-0045 Phase 4 PR 4)

### DIFF
--- a/docs/ADRs/0045-forge-portable-harness-schema.md
+++ b/docs/ADRs/0045-forge-portable-harness-schema.md
@@ -31,7 +31,7 @@ harness. They reside in `config.yaml`'s `agents:` block
 ([ADR 0011](0011-admin-install-org-config-yaml-v1.md)):
 
 ```yaml
-# config.yaml (current)
+# config.yaml (before ADR-0045)
 agents:
   - role: triage
     name: fullsend-ai-triage
@@ -684,14 +684,12 @@ forge-specific artifact. The harness and agent definition are portable.
   duplication. Script-level factoring (shared functions sourced by
   forge-specific scripts) is a convention, not a schema concern.
 
-- **config.yaml schema versioning.** Removing `agents:` (Phase 4) changes
-  the v1 schema contract established by ADR 0011. The current
-  `OrgConfig.Agents` field uses `yaml:"agents"` without `omitempty`,
-  meaning it is part of the v1 contract. Adding `omitempty` and treating
-  absence as "discover from harness files" is likely v1-compatible for
-  Phase 3 (deprecation), but full removal in Phase 4 may warrant a v2
-  schema. Consumers that assume `Agents` is always populated need
-  auditing.
+- **config.yaml schema versioning.** Removing `agents:` (Phase 4) changed
+  the v1 schema contract established by ADR 0011. The `OrgConfig.Agents`
+  field was removed in Phase 4; `yaml.Unmarshal` silently ignores the
+  key in existing config files, so v1 compatibility is preserved.
+  Phase 3 (PR 6) added `omitempty` as a deprecation step; Phase 4
+  completed the removal. No v2 schema bump was needed.
   *Note: Phase 3 PR 6 added `omitempty` to the `Agents` field. The
   Phase 4 plan (`docs/plans/adr-0045-forge-portable-harness-phase4.md`)
   recommends staying on v1 — removal is backward-compatible since

--- a/docs/plans/adr-0045-forge-portable-harness-phase4.md
+++ b/docs/plans/adr-0045-forge-portable-harness-phase4.md
@@ -52,7 +52,7 @@ If a future change requires breaking the v1 contract (e.g., removing `dispatch.p
 
 - Does NOT add new harness schema features (forge blocks, base composition improvements)
 - Does NOT change `PerRepoConfig` -- per-repo mode does not use the `agents:` block
-- Does NOT remove `AgentEntry` from `config.go` -- it is still used by `AgentCredentials` in `internal/layers/secrets.go` for the install flow's credential passing. `AgentEntry` represents credentials obtained during app setup, not config.yaml schema.
+- ~~Does NOT remove `AgentEntry` from `config.go`~~ — **Done:** `AgentEntry` was removed and its fields (Role, Name, Slug) inlined into `layers.AgentCredentials`.
 - Does NOT change harness loading pipelines (`Load`, `LoadWithOpts`, `LoadWithBase`)
 - Does NOT remove `DefaultAgentRoles()` or `ValidRoles()` -- these are used for role validation and app setup, independent of the `agents:` block
 - Does NOT remove the `forge:` section or `base:` field infrastructure (those are permanent schema additions)
@@ -72,9 +72,9 @@ Every consumer of the removed code, and the action taken:
 
 | Consumer | Location | Current behavior | Phase 4 action |
 |---|---|---|---|
-| `OrgConfig.Agents` field | `internal/config/config.go:86` | `yaml:"agents,omitempty"` | Remove field |
-| `AgentSlugs()` method | `internal/config/config.go:259` | Returns `map[role]slug` from `Agents` | Remove method |
-| `HasAgentsBlock()` method | `internal/config/config.go:270` | Returns `len(c.Agents) > 0` | Remove method |
+| `OrgConfig.Agents` field | `internal/config/config.go:86` | `yaml:"agents,omitempty"` | ✅ Remove field (#2517) |
+| `AgentSlugs()` method | `internal/config/config.go:259` | Returns `map[role]slug` from `Agents` | ✅ Remove method (#2517) |
+| `HasAgentsBlock()` method | `internal/config/config.go:270` | Returns `len(c.Agents) > 0` | ✅ Remove method (#2517) |
 | `NewOrgConfig` agents param | `internal/config/config.go:117` | Accepts `[]AgentEntry`, sets `cfg.Agents` | ✅ Remove parameter, stop setting field (#2447) |
 | `NewOrgConfig` caller: `runDryRun` | `internal/cli/admin.go:1196` | Passes `nil` for agents | ✅ Remove agents arg (#2447) |
 | `NewOrgConfig` caller: `runInstall` | `internal/cli/admin.go:1513` | Passes agents built from `agentCreds` | ✅ Remove agents arg (#2447) |
@@ -290,7 +290,7 @@ func discoverAgentSlugs(ctx context.Context, client forge.Client, owner, configR
 - Remove `Agents []AgentEntry` from `OrgConfig` struct (line 86)
 - Remove `AgentSlugs()` method (lines 258-265)
 - Remove `HasAgentsBlock()` method (lines 267-272)
-- Keep `AgentEntry` type (lines 20-24) -- it is still used by `layers.AgentCredentials` for passing app credentials through the install flow. `AgentEntry` describes credentials obtained during app setup, not config.yaml schema.
+- Remove `AgentEntry` type (lines 20-24) -- its fields (Role, Name, Slug) are now inlined directly into `layers.AgentCredentials`.
 
 **Modify `internal/config/config_test.go`:**
 

--- a/docs/superpowers/plans/2026-06-11-triage-prerequisites.md
+++ b/docs/superpowers/plans/2026-06-11-triage-prerequisites.md
@@ -55,7 +55,6 @@ func TestOrgConfig_CreateIssues_OmittedWhenEmpty(t *testing.T) {
 			Roles:                    []string{"fullsend"},
 			MaxImplementationRetries: 2,
 		},
-		Agents: []AgentEntry{},
 		Repos:  map[string]RepoConfig{},
 	}
 	data, err := cfg.Marshal()
@@ -71,7 +70,6 @@ func TestOrgConfig_CreateIssues_Marshal(t *testing.T) {
 			Roles:                    []string{"fullsend"},
 			MaxImplementationRetries: 2,
 		},
-		Agents: []AgentEntry{},
 		Repos:  map[string]RepoConfig{},
 		CreateIssues: &CreateIssuesConfig{
 			AllowTargets: AllowTargets{

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -1204,7 +1204,7 @@ func runDryRun(ctx context.Context, client forge.Client, printer *ui.Printer, or
 	var agentCreds []layers.AgentCredentials
 	for _, role := range roles {
 		agentCreds = append(agentCreds, layers.AgentCredentials{
-			AgentEntry: config.AgentEntry{Role: role},
+			Role: role,
 		})
 	}
 
@@ -1385,16 +1385,7 @@ func runAppSetup(ctx context.Context, client forge.Client, printer *ui.Printer, 
 		if err != nil {
 			return nil, fmt.Errorf("setting up app for role %s: %w", role, err)
 		}
-		creds = append(creds, layers.AgentCredentials{
-			AgentEntry: config.AgentEntry{
-				Role: role,
-				Name: appCreds.Name,
-				Slug: appCreds.Slug,
-			},
-			PEM:      appCreds.PEM,
-			ClientID: appCreds.ClientID,
-			AppID:    appCreds.AppID,
-		})
+		creds = append(creds, toAgentCredentials(role, appCreds))
 	}
 
 	if err := setup.PermissionErrors(); err != nil {
@@ -1783,7 +1774,7 @@ func runAnalyze(ctx context.Context, client forge.Client, printer *ui.Printer, o
 	var agentCreds []layers.AgentCredentials
 	for _, role := range defaultRoles {
 		agentCreds = append(agentCreds, layers.AgentCredentials{
-			AgentEntry: config.AgentEntry{Role: role},
+			Role: role,
 		})
 	}
 
@@ -1996,6 +1987,17 @@ func loadExistingEnabledRepos(ctx context.Context, client forge.Client, org stri
 		return nil
 	}
 	return cfg.EnabledRepos()
+}
+
+func toAgentCredentials(role string, ac *appsetup.AppCredentials) layers.AgentCredentials {
+	return layers.AgentCredentials{
+		Role:     role,
+		Name:     ac.Name,
+		Slug:     ac.Slug,
+		PEM:      ac.PEM,
+		ClientID: ac.ClientID,
+		AppID:    ac.AppID,
+	}
 }
 
 // filterSlugsByAppSet returns a new map containing only entries whose slug

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -1826,7 +1826,7 @@ func TestRunInstall_WithSkipMintCheck(t *testing.T) {
 	var agentCreds []layers.AgentCredentials
 	for _, role := range config.DefaultAgentRoles() {
 		agentCreds = append(agentCreds, layers.AgentCredentials{
-			AgentEntry: config.AgentEntry{Role: role},
+			Role: role,
 		})
 	}
 
@@ -1851,7 +1851,7 @@ func TestRunInstall_DiscoversRepos(t *testing.T) {
 	var agentCreds []layers.AgentCredentials
 	for _, role := range config.DefaultAgentRoles() {
 		agentCreds = append(agentCreds, layers.AgentCredentials{
-			AgentEntry: config.AgentEntry{Role: role},
+			Role: role,
 		})
 	}
 
@@ -1899,7 +1899,7 @@ func TestRunInstall_WithVendorAndSkipMint(t *testing.T) {
 	var agentCreds []layers.AgentCredentials
 	for _, role := range config.DefaultAgentRoles() {
 		agentCreds = append(agentCreds, layers.AgentCredentials{
-			AgentEntry: config.AgentEntry{Role: role},
+			Role: role,
 		})
 	}
 
@@ -2737,4 +2737,23 @@ func TestApplyPerRepoScaffold_ProtectedBranch_BranchUpToDate(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, buf.String(), "up to date")
+}
+
+func TestToAgentCredentials(t *testing.T) {
+	ac := &appsetup.AppCredentials{
+		AppID:    42,
+		Slug:     "test-slug",
+		Name:     "test-name",
+		PEM:      "pem-data",
+		ClientID: "client-id",
+	}
+
+	cred := toAgentCredentials("triage", ac)
+
+	assert.Equal(t, "triage", cred.Role)
+	assert.Equal(t, "test-name", cred.Name)
+	assert.Equal(t, "test-slug", cred.Slug)
+	assert.Equal(t, "pem-data", cred.PEM)
+	assert.Equal(t, "client-id", cred.ClientID)
+	assert.Equal(t, 42, cred.AppID)
 }

--- a/internal/cli/github.go
+++ b/internal/cli/github.go
@@ -426,7 +426,7 @@ func runGitHubSetupPerOrg(ctx context.Context, client forge.Client, printer *ui.
 	var agentCreds []layers.AgentCredentials
 	for _, role := range roles {
 		agentCreds = append(agentCreds, layers.AgentCredentials{
-			AgentEntry: config.AgentEntry{Role: role},
+			Role: role,
 		})
 	}
 

--- a/internal/cli/mint_test.go
+++ b/internal/cli/mint_test.go
@@ -1511,7 +1511,7 @@ func TestResolveAddRoleFromBrowser_Success(t *testing.T) {
 		func(_ context.Context, _ forge.Client, _ *ui.Printer, org string, roles []string, _ string, _ string, _ bool, _ map[string]string, _ string, _ map[string]string) ([]layers.AgentCredentials, error) {
 			assert.Equal(t, "acme-corp", org)
 			assert.Equal(t, []string{"review"}, roles)
-			return []layers.AgentCredentials{{AgentEntry: config.AgentEntry{Slug: "fullsend-ai-review"}, AppID: 424242}}, nil
+			return []layers.AgentCredentials{{Slug: "fullsend-ai-review", AppID: 424242}}, nil
 		},
 	)
 	printer := ui.New(&strings.Builder{})
@@ -1562,7 +1562,7 @@ func TestMintAddRoleCmd_BrowserRegisters(t *testing.T) {
 	withMintAddRoleHooks(t,
 		func() (string, error) { return "test-token", nil },
 		func(context.Context, forge.Client, *ui.Printer, string, []string, string, string, bool, map[string]string, string, map[string]string) ([]layers.AgentCredentials, error) {
-			return []layers.AgentCredentials{{AgentEntry: config.AgentEntry{Slug: "fullsend-ai-review"}, AppID: 55555}}, nil
+			return []layers.AgentCredentials{{Slug: "fullsend-ai-review", AppID: 55555}}, nil
 		},
 	)
 	withMintGCFClient(t, gcf.NewFakeGCFClient(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,13 +16,6 @@ const (
 	DefaultUpstreamRef = "v0"
 )
 
-// AgentEntry represents a configured agent with its role and app identity.
-type AgentEntry struct {
-	Role string `yaml:"role"`
-	Name string `yaml:"name"`
-	Slug string `yaml:"slug"`
-}
-
 // DispatchConfig configures how agent work is dispatched.
 type DispatchConfig struct {
 	Platform string `yaml:"platform"`
@@ -83,7 +76,6 @@ type OrgConfig struct {
 	Dispatch               DispatchConfig        `yaml:"dispatch"`
 	Inference              InferenceConfig       `yaml:"inference,omitempty"`
 	Defaults               RepoDefaults          `yaml:"defaults"`
-	Agents                 []AgentEntry          `yaml:"agents,omitempty"`
 	Repos                  map[string]RepoConfig `yaml:"repos"`
 	AllowedRemoteResources []string              `yaml:"allowed_remote_resources,omitempty"`
 	CreateIssues           *CreateIssuesConfig   `yaml:"create_issues,omitempty"`
@@ -252,22 +244,6 @@ func (c *OrgConfig) DisabledRepos() []string {
 	}
 	sort.Strings(disabled)
 	return disabled
-}
-
-// AgentSlugs returns a map of role to slug from the configured agents.
-func (c *OrgConfig) AgentSlugs() map[string]string {
-	slugs := make(map[string]string, len(c.Agents))
-	for _, a := range c.Agents {
-		slugs[a.Role] = a.Slug
-	}
-	return slugs
-}
-
-// HasAgentsBlock reports whether the config contains a non-empty agents list.
-// CLI commands use this to decide whether to emit a deprecation notice for the
-// legacy agents block (see ADR-0045 Phase 3).
-func (c *OrgConfig) HasAgentsBlock() bool {
-	return len(c.Agents) > 0
 }
 
 // DefaultRoles returns the default roles configured for the organization.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -60,8 +60,6 @@ func TestNewOrgConfig(t *testing.T) {
 	assert.False(t, cfg.Repos["repo-b"].Enabled)
 	assert.True(t, cfg.Repos["repo-c"].Enabled)
 
-	assert.Empty(t, cfg.Agents)
-
 	assert.Equal(t, []string{"https://raw.githubusercontent.com/fullsend-ai/fullsend/"}, cfg.AllowedRemoteResources)
 }
 
@@ -75,9 +73,6 @@ func TestOrgConfigMarshal(t *testing.T) {
 			Roles:                    []string{"fullsend"},
 			MaxImplementationRetries: 2,
 			AutoMerge:                false,
-		},
-		Agents: []AgentEntry{
-			{Role: "fullsend", Name: "test-app", Slug: "test-app-slug"},
 		},
 		Repos: map[string]RepoConfig{
 			"my-repo": {Enabled: true},
@@ -225,20 +220,6 @@ func TestOrgConfigDisabledRepos(t *testing.T) {
 	assert.Equal(t, []string{"alpha", "gamma"}, disabled)
 }
 
-func TestOrgConfigAgentSlugs(t *testing.T) {
-	cfg := &OrgConfig{
-		Agents: []AgentEntry{
-			{Role: "fullsend", Name: "app1", Slug: "slug-1"},
-			{Role: "coder", Name: "app2", Slug: "slug-2"},
-		},
-	}
-
-	slugs := cfg.AgentSlugs()
-	assert.Equal(t, "slug-1", slugs["fullsend"])
-	assert.Equal(t, "slug-2", slugs["coder"])
-	assert.Len(t, slugs, 2)
-}
-
 func TestOrgConfigDefaultRoles(t *testing.T) {
 	cfg := &OrgConfig{
 		Defaults: RepoDefaults{
@@ -261,10 +242,6 @@ defaults:
     - coder
   max_implementation_retries: 3
   auto_merge: true
-agents:
-  - role: fullsend
-    name: my-app
-    slug: my-app-slug
 repos:
   repo-x:
     enabled: true
@@ -280,12 +257,28 @@ repos:
 	assert.Equal(t, 3, cfg.Defaults.MaxImplementationRetries)
 	assert.True(t, cfg.Defaults.AutoMerge)
 	assert.Equal(t, []string{"fullsend", "coder"}, cfg.Defaults.Roles)
-	assert.Len(t, cfg.Agents, 1)
-	assert.Equal(t, "fullsend", cfg.Agents[0].Role)
-	assert.Equal(t, "my-app", cfg.Agents[0].Name)
-	assert.Equal(t, "my-app-slug", cfg.Agents[0].Slug)
 	assert.True(t, cfg.Repos["repo-x"].Enabled)
 	assert.False(t, cfg.Repos["repo-y"].Enabled)
+}
+
+func TestParseOrgConfig_IgnoresLegacyAgentsBlock(t *testing.T) {
+	yamlData := `
+version: "1"
+dispatch:
+  platform: github-actions
+defaults:
+  roles:
+    - fullsend
+  max_implementation_retries: 2
+agents:
+  - role: fullsend
+    name: my-app
+    slug: my-app-slug
+repos: {}
+`
+	cfg, err := ParseOrgConfig([]byte(yamlData))
+	require.NoError(t, err)
+	assert.Equal(t, "1", cfg.Version)
 }
 
 func TestNewOrgConfig_WithInferenceProvider(t *testing.T) {
@@ -369,8 +362,7 @@ func TestOrgConfigMarshal_WithInference(t *testing.T) {
 			Roles:                    []string{"fullsend"},
 			MaxImplementationRetries: 2,
 		},
-		Agents: []AgentEntry{},
-		Repos:  map[string]RepoConfig{},
+		Repos: map[string]RepoConfig{},
 	}
 
 	data, err := cfg.Marshal()
@@ -428,8 +420,7 @@ func TestOrgConfigMarshal_KillSwitch(t *testing.T) {
 			Roles:                    []string{"fullsend"},
 			MaxImplementationRetries: 2,
 		},
-		Agents: []AgentEntry{},
-		Repos:  map[string]RepoConfig{},
+		Repos: map[string]RepoConfig{},
 	}
 
 	data, err := cfg.Marshal()
@@ -463,8 +454,7 @@ func TestOrgConfigMarshal_KillSwitchOmitEmpty(t *testing.T) {
 			Roles:                    []string{"fullsend"},
 			MaxImplementationRetries: 2,
 		},
-		Agents: []AgentEntry{},
-		Repos:  map[string]RepoConfig{},
+		Repos: map[string]RepoConfig{},
 	}
 
 	data, err := cfg.Marshal()
@@ -556,8 +546,7 @@ func TestOrgConfigMarshal_WithDispatchMode(t *testing.T) {
 			Roles:                    []string{"fullsend"},
 			MaxImplementationRetries: 2,
 		},
-		Agents: []AgentEntry{},
-		Repos:  map[string]RepoConfig{},
+		Repos: map[string]RepoConfig{},
 	}
 
 	data, err := cfg.Marshal()
@@ -732,7 +721,6 @@ repos: {}
 				Roles:                    []string{"fullsend"},
 				MaxImplementationRetries: 2,
 			},
-			Agents:                 []AgentEntry{},
 			Repos:                  map[string]RepoConfig{},
 			AllowedRemoteResources: []string{"https://example.com/skills/"},
 		}
@@ -750,8 +738,7 @@ repos: {}
 				Roles:                    []string{"fullsend"},
 				MaxImplementationRetries: 2,
 			},
-			Agents: []AgentEntry{},
-			Repos:  map[string]RepoConfig{},
+			Repos: map[string]RepoConfig{},
 		}
 		data, err := cfg.Marshal()
 		require.NoError(t, err)
@@ -861,8 +848,7 @@ func TestOrgConfigMarshal_WithStatusNotifications(t *testing.T) {
 				Comment: CommentNotificationConfig{Start: "enabled"},
 			},
 		},
-		Agents: []AgentEntry{},
-		Repos:  map[string]RepoConfig{},
+		Repos: map[string]RepoConfig{},
 	}
 	data, err := cfg.Marshal()
 	require.NoError(t, err)
@@ -878,8 +864,7 @@ func TestOrgConfigMarshal_WithoutStatusNotifications(t *testing.T) {
 			Roles:                    []string{"fullsend"},
 			MaxImplementationRetries: 2,
 		},
-		Agents: []AgentEntry{},
-		Repos:  map[string]RepoConfig{},
+		Repos: map[string]RepoConfig{},
 	}
 	data, err := cfg.Marshal()
 	require.NoError(t, err)
@@ -922,8 +907,7 @@ func TestOrgConfig_CreateIssues_OmittedWhenEmpty(t *testing.T) {
 			Roles:                    []string{"fullsend"},
 			MaxImplementationRetries: 2,
 		},
-		Agents: []AgentEntry{},
-		Repos:  map[string]RepoConfig{},
+		Repos: map[string]RepoConfig{},
 	}
 	data, err := cfg.Marshal()
 	require.NoError(t, err)
@@ -938,8 +922,7 @@ func TestOrgConfig_CreateIssues_Marshal(t *testing.T) {
 			Roles:                    []string{"fullsend"},
 			MaxImplementationRetries: 2,
 		},
-		Agents: []AgentEntry{},
-		Repos:  map[string]RepoConfig{},
+		Repos: map[string]RepoConfig{},
 		CreateIssues: &CreateIssuesConfig{
 			AllowTargets: AllowTargets{
 				Orgs:  []string{"my-org"},
@@ -1045,101 +1028,6 @@ func TestOrgConfigValidate_CreateIssues_Nil(t *testing.T) {
 	}
 	err := cfg.Validate()
 	assert.NoError(t, err)
-}
-
-// --- Agents optional (ADR-0045 Phase 3) ---
-
-func TestParseOrgConfig_WithoutAgentsBlock(t *testing.T) {
-	yamlData := `
-version: "1"
-dispatch:
-  platform: github-actions
-defaults:
-  roles:
-    - fullsend
-  max_implementation_retries: 2
-repos: {}
-`
-	cfg, err := ParseOrgConfig([]byte(yamlData))
-	require.NoError(t, err)
-	assert.Nil(t, cfg.Agents)
-	assert.Empty(t, cfg.AgentSlugs())
-}
-
-func TestParseOrgConfig_EmptyAgentsList(t *testing.T) {
-	yamlData := `
-version: "1"
-dispatch:
-  platform: github-actions
-defaults:
-  roles:
-    - fullsend
-  max_implementation_retries: 2
-agents: []
-repos: {}
-`
-	cfg, err := ParseOrgConfig([]byte(yamlData))
-	require.NoError(t, err)
-	assert.Empty(t, cfg.AgentSlugs())
-}
-
-func TestHasAgentsBlock(t *testing.T) {
-	t.Run("returns true when agents has entries", func(t *testing.T) {
-		cfg := &OrgConfig{
-			Agents: []AgentEntry{
-				{Role: "fullsend", Name: "app", Slug: "slug"},
-			},
-		}
-		assert.True(t, cfg.HasAgentsBlock())
-	})
-
-	t.Run("returns false when agents is nil", func(t *testing.T) {
-		cfg := &OrgConfig{Agents: nil}
-		assert.False(t, cfg.HasAgentsBlock())
-	})
-
-	t.Run("returns false when agents is empty slice", func(t *testing.T) {
-		cfg := &OrgConfig{Agents: []AgentEntry{}}
-		assert.False(t, cfg.HasAgentsBlock())
-	})
-}
-
-func TestOrgConfigMarshal_NilAgentsOmitted(t *testing.T) {
-	cfg := &OrgConfig{
-		Version:  "1",
-		Dispatch: DispatchConfig{Platform: "github-actions"},
-		Defaults: RepoDefaults{
-			Roles:                    []string{"fullsend"},
-			MaxImplementationRetries: 2,
-		},
-		Agents: nil,
-		Repos:  map[string]RepoConfig{},
-	}
-
-	data, err := cfg.Marshal()
-	require.NoError(t, err)
-	assert.NotContains(t, string(data), "agents:")
-}
-
-func TestOrgConfigMarshal_EmptyAgentsOmitted(t *testing.T) {
-	// yaml.v3 treats empty (non-nil) slices the same as nil for omitempty:
-	// both are considered "zero" and omitted. This test locks in that behavior.
-	cfg := &OrgConfig{
-		Version:  "1",
-		Dispatch: DispatchConfig{Platform: "github-actions"},
-		Defaults: RepoDefaults{
-			Roles:                    []string{"fullsend"},
-			MaxImplementationRetries: 2,
-		},
-		Agents: []AgentEntry{},
-		Repos:  map[string]RepoConfig{},
-	}
-
-	data, err := cfg.Marshal()
-	require.NoError(t, err)
-	// yaml.v3 omitempty uses Len()==0 for slices, so empty non-nil slices
-	// are also omitted — same as nil.
-	assert.NotContains(t, string(data), "agents:")
 }
 
 func TestNewOrgConfig_CreateIssuesDefaults(t *testing.T) {

--- a/internal/layers/harnesswrappers_test.go
+++ b/internal/layers/harnesswrappers_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/fullsend-ai/fullsend/internal/config"
 	"github.com/fullsend-ai/fullsend/internal/forge"
 	"github.com/fullsend-ai/fullsend/internal/harness"
 	"github.com/fullsend-ai/fullsend/internal/scaffold"
@@ -26,12 +25,12 @@ func testPrinter() *ui.Printer {
 
 func testAgents() []AgentCredentials {
 	return []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "fullsend", Name: "test-fullsend", Slug: "test-fullsend"}},
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "test-triage", Slug: "test-triage"}},
-		{AgentEntry: config.AgentEntry{Role: "coder", Name: "test-coder", Slug: "test-coder"}},
-		{AgentEntry: config.AgentEntry{Role: "review", Name: "test-review", Slug: "test-review"}},
-		{AgentEntry: config.AgentEntry{Role: "retro", Name: "test-retro", Slug: "test-retro"}},
-		{AgentEntry: config.AgentEntry{Role: "prioritize", Name: "test-prioritize", Slug: "test-prioritize"}},
+		{Role: "fullsend", Name: "test-fullsend", Slug: "test-fullsend"},
+		{Role: "triage", Name: "test-triage", Slug: "test-triage"},
+		{Role: "coder", Name: "test-coder", Slug: "test-coder"},
+		{Role: "review", Name: "test-review", Slug: "test-review"},
+		{Role: "retro", Name: "test-retro", Slug: "test-retro"},
+		{Role: "prioritize", Name: "test-prioritize", Slug: "test-prioritize"},
 	}
 }
 
@@ -119,7 +118,7 @@ func TestHarnessWrappersLayer_Install_GeneratesWrappers(t *testing.T) {
 func TestHarnessWrappersLayer_Install_WrapperContainsManagedHeader(t *testing.T) {
 	client := forge.NewFakeClient()
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "t", Slug: "test-triage"}},
+		{Role: "triage", Name: "t", Slug: "test-triage"},
 	}
 	layer := NewHarnessWrappersLayer("org", client, testPrinter(), agents, testCommitSHA)
 
@@ -136,7 +135,7 @@ func TestHarnessWrappersLayer_Install_WrapperContainsManagedHeader(t *testing.T)
 func TestHarnessWrappersLayer_Install_WrapperContainsIntegrityHash(t *testing.T) {
 	client := forge.NewFakeClient()
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "t", Slug: "test-triage"}},
+		{Role: "triage", Name: "t", Slug: "test-triage"},
 	}
 	layer := NewHarnessWrappersLayer("org", client, testPrinter(), agents, testCommitSHA)
 
@@ -153,7 +152,7 @@ func TestHarnessWrappersLayer_Install_SkipsCustomizedFile(t *testing.T) {
 	client.FileContents["org/.fullsend/harness/triage.yaml"] = []byte("agent: agents/custom-triage.md\nmodel: sonnet\n")
 
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "t", Slug: "test-triage"}},
+		{Role: "triage", Name: "t", Slug: "test-triage"},
 	}
 	layer := NewHarnessWrappersLayer("org", client, testPrinter(), agents, testCommitSHA)
 
@@ -170,7 +169,7 @@ func TestHarnessWrappersLayer_Install_OverwritesManagedFile(t *testing.T) {
 	client.FileContents["org/.fullsend/harness/triage.yaml"] = []byte("# This file is managed by fullsend. Do not edit it directly.\nbase: https://old-url\nrole: triage\nslug: old-slug\n")
 
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "t", Slug: "test-triage"}},
+		{Role: "triage", Name: "t", Slug: "test-triage"},
 	}
 	layer := NewHarnessWrappersLayer("org", client, testPrinter(), agents, testCommitSHA)
 
@@ -188,7 +187,7 @@ func TestHarnessWrappersLayer_Install_CommitFilesError(t *testing.T) {
 	client.Errors["CommitFiles"] = errors.New("network error")
 
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "t", Slug: "test-triage"}},
+		{Role: "triage", Name: "t", Slug: "test-triage"},
 	}
 	layer := NewHarnessWrappersLayer("org", client, testPrinter(), agents, testCommitSHA)
 
@@ -209,7 +208,7 @@ func TestHarnessWrappersLayer_Install_NoAgentsNoCommit(t *testing.T) {
 func TestHarnessWrappersLayer_Install_OnlyFullsendRoleNoCommit(t *testing.T) {
 	client := forge.NewFakeClient()
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "fullsend", Name: "fs", Slug: "test-fullsend"}},
+		{Role: "fullsend", Name: "fs", Slug: "test-fullsend"},
 	}
 	layer := NewHarnessWrappersLayer("org", client, testPrinter(), agents, testCommitSHA)
 
@@ -221,7 +220,7 @@ func TestHarnessWrappersLayer_Install_OnlyFullsendRoleNoCommit(t *testing.T) {
 func TestHarnessWrappersLayer_Install_WrapperParsesAsValidHarness(t *testing.T) {
 	client := forge.NewFakeClient()
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "t", Slug: "test-triage"}},
+		{Role: "triage", Name: "t", Slug: "test-triage"},
 	}
 	layer := NewHarnessWrappersLayer("org", client, testPrinter(), agents, testCommitSHA)
 
@@ -246,7 +245,7 @@ func TestHarnessWrappersLayer_Install_WrapperParsesAsValidHarness(t *testing.T) 
 func TestHarnessWrappersLayer_Install_BaseURLMatchesScaffold(t *testing.T) {
 	client := forge.NewFakeClient()
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "t", Slug: "test-triage"}},
+		{Role: "triage", Name: "t", Slug: "test-triage"},
 	}
 	layer := NewHarnessWrappersLayer("org", client, testPrinter(), agents, testCommitSHA)
 
@@ -277,7 +276,7 @@ func TestHarnessWrappersLayer_Analyze_DevBuild(t *testing.T) {
 func TestHarnessWrappersLayer_Analyze_AllPresent(t *testing.T) {
 	client := forge.NewFakeClient()
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "t", Slug: "test-triage"}},
+		{Role: "triage", Name: "t", Slug: "test-triage"},
 	}
 	client.FileContents["org/.fullsend/harness/triage.yaml"] = []byte("role: triage\n")
 
@@ -290,7 +289,7 @@ func TestHarnessWrappersLayer_Analyze_AllPresent(t *testing.T) {
 func TestHarnessWrappersLayer_Analyze_AllMissing(t *testing.T) {
 	client := forge.NewFakeClient()
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "t", Slug: "test-triage"}},
+		{Role: "triage", Name: "t", Slug: "test-triage"},
 	}
 
 	layer := NewHarnessWrappersLayer("org", client, testPrinter(), agents, testCommitSHA)
@@ -304,8 +303,8 @@ func TestHarnessWrappersLayer_Analyze_AllMissing(t *testing.T) {
 func TestHarnessWrappersLayer_Analyze_Degraded(t *testing.T) {
 	client := forge.NewFakeClient()
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "t", Slug: "test-triage"}},
-		{AgentEntry: config.AgentEntry{Role: "review", Name: "r", Slug: "test-review"}},
+		{Role: "triage", Name: "t", Slug: "test-triage"},
+		{Role: "review", Name: "r", Slug: "test-review"},
 	}
 	// Only triage exists
 	client.FileContents["org/.fullsend/harness/triage.yaml"] = []byte("role: triage\n")
@@ -350,7 +349,7 @@ func TestHarnessesForRole(t *testing.T) {
 func TestHarnessWrappersLayer_Install_FileMode(t *testing.T) {
 	client := forge.NewFakeClient()
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "t", Slug: "test-triage"}},
+		{Role: "triage", Name: "t", Slug: "test-triage"},
 	}
 	layer := NewHarnessWrappersLayer("org", client, testPrinter(), agents, testCommitSHA)
 
@@ -366,8 +365,8 @@ func TestHarnessWrappersLayer_Install_FileMode(t *testing.T) {
 func TestHarnessWrappersLayer_Install_CoderFixDedup(t *testing.T) {
 	client := forge.NewFakeClient()
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "coder", Name: "coder-a", Slug: "slug-a"}},
-		{AgentEntry: config.AgentEntry{Role: "coder", Name: "coder-b", Slug: "slug-b"}},
+		{Role: "coder", Name: "coder-a", Slug: "slug-a"},
+		{Role: "coder", Name: "coder-b", Slug: "slug-b"},
 	}
 	layer := NewHarnessWrappersLayer("org", client, testPrinter(), agents, testCommitSHA)
 
@@ -389,7 +388,7 @@ func TestHarnessWrappersLayer_Install_LoadExistingHarnessesError(t *testing.T) {
 	client := forge.NewFakeClient()
 	client.Errors["GetFileContent"] = errors.New("permission denied")
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "t", Slug: "test-triage"}},
+		{Role: "triage", Name: "t", Slug: "test-triage"},
 	}
 	layer := NewHarnessWrappersLayer("org", client, testPrinter(), agents, testCommitSHA)
 
@@ -403,7 +402,7 @@ func TestHarnessWrappersLayer_Install_IdempotentNoChange(t *testing.T) {
 	changed := false
 	client.CommitFilesChanged = &changed
 	agents := []AgentCredentials{
-		{AgentEntry: config.AgentEntry{Role: "triage", Name: "t", Slug: "test-triage"}},
+		{Role: "triage", Name: "t", Slug: "test-triage"},
 	}
 	layer := NewHarnessWrappersLayer("org", client, testPrinter(), agents, testCommitSHA)
 

--- a/internal/layers/secrets.go
+++ b/internal/layers/secrets.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fullsend-ai/fullsend/internal/config"
 	"github.com/fullsend-ai/fullsend/internal/forge"
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
-// AgentCredentials extends AgentEntry with app credentials.
+// AgentCredentials holds agent identity (role, name, slug) and app credentials for layer operations.
 type AgentCredentials struct {
-	config.AgentEntry
+	Role     string
+	Name     string
+	Slug     string
 	PEM      string
 	ClientID string
 	AppID    int

--- a/internal/layers/secrets_test.go
+++ b/internal/layers/secrets_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/fullsend-ai/fullsend/internal/config"
 	"github.com/fullsend-ai/fullsend/internal/forge"
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
@@ -25,14 +24,18 @@ func newSecretsLayer(t *testing.T, client *forge.FakeClient, agents []AgentCrede
 func twoAgents() []AgentCredentials {
 	return []AgentCredentials{
 		{
-			AgentEntry: config.AgentEntry{Role: "fullsend", Name: "FullsendBot", Slug: "fullsend-bot"},
-			PEM:        "-----BEGIN RSA PRIVATE KEY-----\nfullsend-key\n-----END RSA PRIVATE KEY-----",
-			ClientID:   "Iv1.abc111",
+			Role:     "fullsend",
+			Name:     "FullsendBot",
+			Slug:     "fullsend-bot",
+			PEM:      "-----BEGIN RSA PRIVATE KEY-----\nfullsend-key\n-----END RSA PRIVATE KEY-----",
+			ClientID: "Iv1.abc111",
 		},
 		{
-			AgentEntry: config.AgentEntry{Role: "triage", Name: "TriageBot", Slug: "triage-bot"},
-			PEM:        "-----BEGIN RSA PRIVATE KEY-----\ntriage-key\n-----END RSA PRIVATE KEY-----",
-			ClientID:   "Iv1.abc222",
+			Role:     "triage",
+			Name:     "TriageBot",
+			Slug:     "triage-bot",
+			PEM:      "-----BEGIN RSA PRIVATE KEY-----\ntriage-key\n-----END RSA PRIVATE KEY-----",
+			ClientID: "Iv1.abc222",
 		},
 	}
 }
@@ -81,14 +84,18 @@ func TestSecretsLayer_Install_SkipsEmptyPEM(t *testing.T) {
 	client := &forge.FakeClient{}
 	agents := []AgentCredentials{
 		{
-			AgentEntry: config.AgentEntry{Role: "fullsend", Name: "FullsendBot", Slug: "fullsend-bot"},
-			PEM:        "-----BEGIN RSA PRIVATE KEY-----\nfullsend-key\n-----END RSA PRIVATE KEY-----",
-			ClientID:   "Iv1.abc111",
+			Role:     "fullsend",
+			Name:     "FullsendBot",
+			Slug:     "fullsend-bot",
+			PEM:      "-----BEGIN RSA PRIVATE KEY-----\nfullsend-key\n-----END RSA PRIVATE KEY-----",
+			ClientID: "Iv1.abc111",
 		},
 		{
-			AgentEntry: config.AgentEntry{Role: "triage", Name: "TriageBot", Slug: "triage-bot"},
-			PEM:        "", // empty — reused from existing app
-			ClientID:   "Iv1.abc222",
+			Role:     "triage",
+			Name:     "TriageBot",
+			Slug:     "triage-bot",
+			PEM:      "", // empty — reused from existing app
+			ClientID: "Iv1.abc222",
 		},
 	}
 	layer, _ := newSecretsLayer(t, client, agents)

--- a/web/admin/src/lib/layers/fixtures/configrepo/config-valid.yaml
+++ b/web/admin/src/lib/layers/fixtures/configrepo/config-valid.yaml
@@ -5,5 +5,4 @@ defaults:
   roles: [fullsend]
   max_implementation_retries: 2
   auto_merge: false
-agents: []
 repos: {}


### PR DESCRIPTION
## Summary

- Remove `AgentEntry` type, `OrgConfig.Agents` field, `AgentSlugs()`, and `HasAgentsBlock()` from `internal/config/`
- Inline `Role`, `Name`, `Slug` fields directly into `layers.AgentCredentials` (previously embedded via `config.AgentEntry`)
- Update all construction sites in `admin.go`, `github.go`, `mint_test.go`, and layer tests
- Remove all Agents-related tests: `TestOrgConfigAgentSlugs`, `TestParseOrgConfig_WithoutAgentsBlock`, `TestParseOrgConfig_EmptyAgentsList`, `TestHasAgentsBlock`, `TestOrgConfigMarshal_NilAgentsOmitted`, `TestOrgConfigMarshal_EmptyAgentsOmitted`
- Remove `agents: []` from test fixture YAML

## Context

This is **Phase 4, PR 4** of [ADR-0045](docs/ADRs/0045-forge-portable-harness-schema.md) (Forge-Portable Harness Schema) — the final PR. PRs 1-3 required `role` in `Validate()`, stopped writing the `agents:` block during install, and removed legacy discovery fallbacks. This PR removes the field itself, completing the migration: agent identity now lives exclusively in harness wrapper files.

### PR dependency graph (Phase 4)
```
PR 1 (require role in Validate)   [independent, still open as #2446]
PR 2 (#2447, merged) ──────────────> PR 4 (this)
PR 3 (#2448, merged) ──────────────> PR 4 (this)
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/config/... ./internal/layers/... ./internal/cli/...` — all pass
- [x] Pre-commit hooks pass (gofmt, yaml, etc.)
- [x] `grep -rn 'AgentEntry' --include='*.go'` returns no results
- [x] `grep -rn 'agents:' --include='*.yaml'` returns no results in config fixtures
- [x] No remaining callers of `AgentSlugs()` or `HasAgentsBlock()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)