### PR TITLE
ci: add per-script timing to script-test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,18 +105,25 @@ go-tidy:
 lint-md-links:
 	lychee --offline --no-progress --include-fragments --exclude-path node_modules --exclude-path experiments '**/*.md'
 
+define run-timed
+	@start=$$(date +%s); \
+	$(1); \
+	elapsed=$$(($$(date +%s) - $$start)); \
+	printf '::debug::script-test timing: %s completed in %ds\n' '$(1)' "$$elapsed"
+endef
+
 script-test:
-	bash scripts/check-e2e-authorization-test.sh
-	bash internal/scaffold/fullsend-repo/scripts/post-triage-test.sh
-	bash internal/scaffold/fullsend-repo/scripts/post-prioritize-test.sh
-	bash internal/scaffold/fullsend-repo/scripts/post-code-test.sh
-	bash internal/scaffold/fullsend-repo/scripts/post-review-test.sh
-	bash internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh
-	bash internal/scaffold/fullsend-repo/scripts/validate-output-schema-test.sh
-	bash internal/scaffold/fullsend-repo/scripts/pre-code-test.sh
-	bash internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review-test.sh
-	python3 internal/scaffold/fullsend-repo/scripts/process-fix-result-test.py
-	python3 skills/topissues/scripts/topissues_test.py
+	$(call run-timed,bash scripts/check-e2e-authorization-test.sh)
+	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/post-triage-test.sh)
+	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/post-prioritize-test.sh)
+	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/post-code-test.sh)
+	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/post-review-test.sh)
+	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/reconcile-repos-test.sh)
+	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/validate-output-schema-test.sh)
+	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/pre-code-test.sh)
+	$(call run-timed,bash internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review-test.sh)
+	$(call run-timed,python3 internal/scaffold/fullsend-repo/scripts/process-fix-result-test.py)
+	$(call run-timed,python3 skills/topissues/scripts/topissues_test.py)
 
 test: lint-all go-test script-test
 

--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,10 @@ lint-md-links:
 
 define run-timed
 	@start=$$(date +%s); \
-	$(1); \
+	rc=0; $(1) || rc=$$?; \
 	elapsed=$$(($$(date +%s) - $$start)); \
-	printf '::debug::script-test timing: %s completed in %ds\n' '$(1)' "$$elapsed"
+	printf '::debug::script-test timing: %s completed in %ds\n' '$(1)' "$$elapsed"; \
+	exit $$rc
 endef
 
 script-test:


### PR DESCRIPTION
## Summary

- Wraps each `make script-test` invocation in a `run-timed` macro that emits `::debug::` GitHub Actions annotations with elapsed seconds
- Hidden by default; visible when re-running a job with the "Enable debug logging" checkbox
- Local profiling shows `post-prioritize-test.sh` dominates at ~213s of ~225s total — everything else is ≤8s

## Test plan

- [x] `make script-test` passes locally
- [ ] CI passes on this branch
- [ ] Re-run the CI job with "Enable debug logging" to confirm timing lines appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)