### PR TITLE
fix: disable CSMA spread delay in post-prioritize tests

### DIFF
--- a/internal/scaffold/fullsend-repo/scripts/post-prioritize-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-prioritize-test.sh
@@ -136,6 +136,7 @@ export ORG="test-org"
 export PROJECT_NUMBER="1"
 export GITHUB_CSMA_SLOT_MAX_MS=0
 export GITHUB_CSMA_BACKOFF_CAP_SEC=1
+export GITHUB_CSMA_SPREAD_MAX_SEC=0
 
 FIXTURE_JSON='{
   "reach": 3,


### PR DESCRIPTION
## Summary

- `post-prioritize-test.sh` was taking ~213s because it disabled slot jitter and capped backoff but forgot to disable `GITHUB_CSMA_SPREAD_MAX_SEC` (default: 60s)
- Each retry path called `_github_csma_post_reset_spread()` which slept `RANDOM % 60` seconds — adding up across 4 retry test cases
- One-line fix: `export GITHUB_CSMA_SPREAD_MAX_SEC=0`
- Test drops from **~213s to ~10s**, shaving ~3.5 minutes off `make script-test` and the CI `test` job

## Test plan

- [x] `bash internal/scaffold/fullsend-repo/scripts/post-prioritize-test.sh` passes in ~10s
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)