### PR TITLE
feat(install): default to PR-based scaffold delivery

### DIFF
--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -180,11 +180,10 @@ Both per-org and per-repo modes share the same core pipeline. The code follows t
 │  │ Phase 5: Write scaffold + config files                     │ │
 │  │                                                            │ │
 │  │  Both modes: write workflow files + customized/ dirs       │ │
-│  │  CommitScaffoldFiles() handles protected-branch fallback:  │ │
-│  │    1. Try CommitFiles (default branch)                     │ │
-│  │    2. If ErrBranchProtected → create feature branch        │ │
-│  │    3. CommitFilesToBranch on feature branch                 │ │
-│  │    4. Open PR back to default branch                        │ │
+│  │  CommitScaffoldFiles() delivery modes:                      │ │
+│  │    Default (PR):  create feature branch → commit → open PR │ │
+│  │    --direct:      try CommitFiles (default branch)         │ │
+│  │      if ErrBranchProtected → fall back to PR mode          │ │
 │  │  ┌──────────────────────────────────────────┐              │ │
 │  │  │ Per-org:  create .fullsend config repo    │              │ │
 │  │  │           push reusable workflows         │              │ │

--- a/docs/reference/github-setup.md
+++ b/docs/reference/github-setup.md
@@ -121,6 +121,7 @@ fullsend github setup acme-corp \
 | `--vendor` | No | `false` | Vendor binary, reusable workflows, actions, and agent content (see [Vendored vs layered installs](#vendored-vs-layered-installs)) |
 | `--fullsend-source` | No | | Fullsend source checkout for content and cross-compile (requires `--vendor`) |
 | `--fullsend-binary` | No | | Path to a Linux fullsend binary when vendoring (skips auto-resolution) |
+| `--direct` | No | `false` | Push scaffold files directly to the default branch instead of creating a PR (falls back to PR if branch protection blocks the push) |
 | `--dry-run` | No | `false` | Preview changes without making them |
 
 ### Vendored vs layered installs

--- a/docs/reference/installation.md
+++ b/docs/reference/installation.md
@@ -216,7 +216,7 @@ During installation, you'll be prompted to choose repository enrollment:
 
 The installer creates the `.fullsend` config repo as **public** by default. This is required for cross-repo `workflow_call` to work with enrolled repos of any visibility (public, private, or internal) across all GitHub plan tiers. If an admin later makes `.fullsend` private, only other private repos in the org will be able to trigger agent workflows — public and internal repos will fail silently.
 
-If the default branch of the `.fullsend` config repo has branch protection rules, the installer creates a PR with the scaffold files instead of pushing directly. Merge the scaffold PR to complete setup.
+The installer creates a PR with the scaffold files by default. Merge the scaffold PR to complete setup. Pass `--direct` to push scaffold files directly instead; the installer will fall back to a PR automatically if branch protection blocks the direct push.
 
 If the installer fails partway through, run `fullsend admin uninstall "$ORG_NAME"` to clean up before retrying. The uninstall preflight will prompt you to add the `delete_repo` scope if it is missing.
 

--- a/docs/reference/installation.md
+++ b/docs/reference/installation.md
@@ -121,7 +121,7 @@ The `--inference-region` flag defaults to `global` for the broadest model availa
 
 See [Setting up with pre-provisioned infrastructure](github-setup.md) for the full `github setup` reference, including per-repo mode, `--skip-app-setup`, and day-2 operations.
 
-> **Protected default branch:** If the `.fullsend` config repo or target repo has branch protection rules that prevent direct pushes, the installer automatically falls back to creating a PR with the scaffold files instead of pushing directly. Merge the scaffold PR to complete setup.
+> **Scaffold delivery:** The installer creates a PR with the scaffold files by default. Merge the scaffold PR to complete setup. If you prefer to push scaffold files directly to the default branch (e.g., for automation), pass `--direct` to skip PR creation — the installer will fall back to a PR automatically if branch protection blocks the direct push.
 
 ### Step 4: Merge enrollment PRs
 
@@ -263,6 +263,7 @@ The installer automatically provisions [Workload Identity Federation (WIF)](http
 | `--vendor` | `false` | Vendor binary, reusable workflows, actions, and agent content (see [Vendored vs layered installs](#vendored-vs-layered-installs)) |
 | `--fullsend-source` | | Fullsend source checkout for content walks and binary cross-compile (requires `--vendor`) |
 | `--fullsend-binary` | | Path to a Linux fullsend binary to upload when `--vendor` is set (skips auto-resolution) |
+| `--direct` | `false` | Push scaffold files directly to the default branch instead of creating a PR (falls back to PR if branch protection blocks the push) |
 
 The `--skip-mint-check` flag bypasses all mint validation, GCP provisioning, and app setup. It requires `--mint-url` to be set and only validates that the URL uses HTTPS. This is useful when the mint infrastructure is managed externally or you want to skip GCP API calls entirely.
 

--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -143,6 +143,7 @@ func TestAdminInstallUninstall(t *testing.T) {
 		"--app-set", e2eAppSet,
 		"--enroll-all",
 		"--vendor",
+		"--direct",
 	}
 	if env.cfg.gcpProjectID != "" {
 		installArgs = append(installArgs, "--inference-project", env.cfg.gcpProjectID)
@@ -732,6 +733,7 @@ func TestVendorFromSubdirectory(t *testing.T) {
 		"--app-set", e2eAppSet,
 		"--enroll-none",
 		"--vendor",
+		"--direct",
 	}
 	runCLIFromDir(t, env.binary, env.token, subdir, installArgs...)
 

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -153,6 +153,7 @@ type perRepoInstallConfig struct {
 	Vendor               bool
 	FullsendBinary       string
 	FullsendSource       string
+	Direct               bool
 }
 
 // wifProviderPattern validates the full WIF provider resource name format
@@ -244,6 +245,7 @@ func newInstallCmd() *cobra.Command {
 	var skipMintCheck bool
 	var publicApps bool
 	var appSet string
+	var direct bool
 	// Per-repo flags.
 	var mintURL string
 
@@ -315,6 +317,7 @@ Inference authentication:
 					Vendor:               vendor,
 					FullsendBinary:       fullsendBinary,
 					FullsendSource:       fullsendSource,
+					Direct:               direct,
 				})
 			}
 
@@ -544,7 +547,7 @@ Inference authentication:
 				agentCreds = creds
 			}
 
-			return runInstall(ctx, client, printer, org, repos, roles, agentCreds, inferenceProvider, inferenceProviderName, vendor, fullsendBinary, fullsendSource, mintProvider, mintProject, mintRegion, mintSourceDir, mintSkipDeploy, mintURL, skipMintCheck, allRepos)
+			return runInstall(ctx, client, printer, org, repos, roles, agentCreds, inferenceProvider, inferenceProviderName, vendor, fullsendBinary, fullsendSource, mintProvider, mintProject, mintRegion, mintSourceDir, mintSkipDeploy, mintURL, skipMintCheck, direct, allRepos)
 		},
 	}
 
@@ -567,6 +570,7 @@ Inference authentication:
 	cmd.Flags().StringVar(&appSet, "app-set", appsetup.DefaultAppSet, "app set name prefix for GitHub Apps (e.g., myorg creates myorg-fullsend, myorg-coder)")
 	// Shared flags.
 	cmd.Flags().StringVar(&mintURL, "mint-url", DefaultMintURL, "token mint URL for OIDC token exchange (default: hosted public mint)")
+	cmd.Flags().BoolVar(&direct, "direct", false, "push scaffold files directly to the default branch instead of creating a PR")
 
 	return cmd
 }
@@ -1001,7 +1005,7 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 		}
 	}
 
-	if err := applyPerRepoScaffold(ctx, client, printer, owner, repo, files, repoVars, repoSecrets); err != nil {
+	if err := applyPerRepoScaffold(ctx, client, printer, owner, repo, files, repoVars, repoSecrets, c.Direct); err != nil {
 		return err
 	}
 
@@ -1020,22 +1024,25 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 // and configures the repository variables and secrets needed for fullsend.
 func applyPerRepoScaffold(ctx context.Context, client forge.Client, printer *ui.Printer,
 	owner, repo string, files []forge.TreeFile,
-	repoVars, repoSecrets map[string]string) error {
+	repoVars, repoSecrets map[string]string, direct bool) error {
 
 	targetRepo, err := client.GetRepo(ctx, owner, repo)
 	if err != nil {
 		return fmt.Errorf("getting repo info: %w", err)
 	}
 	commitMsg := fmt.Sprintf("chore: initialize fullsend-%s per-repo installation", version)
-	printer.StepStart(fmt.Sprintf("Committing scaffold files to %s/%s (%s branch)",
-		owner, repo, targetRepo.DefaultBranch))
-	prBody := fmt.Sprintf("This PR adds the fullsend scaffold files for per-repo installation.\n\n"+
-		"The default branch (%s) has branch protection rules that prevent direct pushes, "+
-		"so these files are delivered via PR instead.\n\n"+
-		"Merge this PR to activate fullsend workflows.", targetRepo.DefaultBranch)
+	if direct {
+		printer.StepStart(fmt.Sprintf("Committing scaffold files to %s/%s (%s branch)",
+			owner, repo, targetRepo.DefaultBranch))
+	} else {
+		printer.StepStart(fmt.Sprintf("Creating scaffold PR for %s/%s (target: %s)",
+			owner, repo, targetRepo.DefaultBranch))
+	}
+	prBody := "This PR adds the fullsend scaffold files for per-repo installation.\n\n" +
+		"Merge this PR to activate fullsend workflows."
 	if _, err := layers.CommitScaffoldFiles(ctx, client, printer,
 		owner, repo, targetRepo.DefaultBranch,
-		commitMsg, "chore: initialize fullsend per-repo installation", prBody, files); err != nil {
+		commitMsg, "chore: initialize fullsend per-repo installation", prBody, files, direct); err != nil {
 		return err
 	}
 
@@ -1216,7 +1223,7 @@ func runDryRun(ctx context.Context, client forge.Client, printer *ui.Printer, or
 		dispatcher = gcf.NewProvisioner(gcf.Config{}, nil)
 	}
 	vendorFn, vendorCollect := vendorStackArgs(vendor, fullsendBinary, fullsendSource)
-	stack := buildLayerStack(org, client, cfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, vendor, vendorFn, vendorCollect, "", dispatcher, commitSHA)
+	stack := buildLayerStack(org, client, cfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, vendor, vendorFn, vendorCollect, "", dispatcher, commitSHA, false)
 
 	if err := runPreflight(ctx, stack, layers.OpInstall, client, printer); err != nil {
 		return err
@@ -1465,7 +1472,7 @@ func validateEnabledRepos(enabledRepos, discoveredNames []string) error {
 
 // runInstall performs the full installation.
 // If discoveredRepos is non-nil, it will be used instead of calling ListOrgRepos.
-func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, org string, enabledRepos, roles []string, agentCreds []layers.AgentCredentials, inferenceProvider inference.Provider, inferenceProviderName string, vendor bool, fullsendBinary, fullsendSource, mintProvider, mintProject, mintRegion, mintSourceDir string, mintSkipDeploy bool, mintURL string, skipMintCheck bool, discoveredRepos []forge.Repository) error {
+func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, org string, enabledRepos, roles []string, agentCreds []layers.AgentCredentials, inferenceProvider inference.Provider, inferenceProviderName string, vendor bool, fullsendBinary, fullsendSource, mintProvider, mintProject, mintRegion, mintSourceDir string, mintSkipDeploy bool, mintURL string, skipMintCheck, direct bool, discoveredRepos []forge.Repository) error {
 	var allRepos []forge.Repository
 	var err error
 
@@ -1552,7 +1559,7 @@ func runInstall(ctx context.Context, client forge.Client, printer *ui.Printer, o
 	}
 
 	vendorFn, vendorCollect := vendorStackArgs(vendor, fullsendBinary, fullsendSource)
-	stack := buildLayerStack(org, client, cfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, vendor, vendorFn, vendorCollect, "", disp, commitSHA)
+	stack := buildLayerStack(org, client, cfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, vendor, vendorFn, vendorCollect, "", disp, commitSHA, direct)
 
 	if err := runPreflight(ctx, stack, layers.OpInstall, client, printer); err != nil {
 		return err
@@ -1801,7 +1808,7 @@ func runAnalyze(ctx context.Context, client forge.Client, printer *ui.Printer, o
 	}
 
 	dispatcher := gcf.NewProvisioner(gcf.Config{}, nil)
-	stack := buildLayerStack(org, client, cfg, printer, user, privateRepo, nil, agentCreds, nil, inferenceProvider, false, nil, nil, analyzeFullsendSource, dispatcher, commitSHA)
+	stack := buildLayerStack(org, client, cfg, printer, user, privateRepo, nil, agentCreds, nil, inferenceProvider, false, nil, nil, analyzeFullsendSource, dispatcher, commitSHA, false)
 
 	if err := runPreflight(ctx, stack, layers.OpAnalyze, client, printer); err != nil {
 		return err
@@ -1835,6 +1842,7 @@ func buildLayerStack(
 	analyzeFullsendSource string,
 	dispatcher dispatch.Dispatcher,
 	commitSHA string,
+	direct bool,
 ) *layers.Stack {
 	dispatchLayer := layers.NewOIDCDispatchLayer(org, client, enrolledRepoIDs, dispatcher, printer)
 
@@ -1850,7 +1858,7 @@ func buildLayerStack(
 
 	return layers.NewStack(
 		layers.NewConfigRepoLayer(org, client, cfg, printer, privateRepo),
-		workflowsLayer(org, client, printer, user, version, vendor, vendorCollect),
+		workflowsLayer(org, client, printer, user, version, vendor, vendorCollect, direct),
 		layers.NewHarnessWrappersLayer(org, client, printer, agentCreds, commitSHA),
 		vendorLayer(org, client, printer, vendor, vendorFn, vendorCollect, analyzeFullsendSource),
 		layers.NewSecretsLayer(org, client, agentCreds, printer).WithOIDCMode(),
@@ -1860,8 +1868,8 @@ func buildLayerStack(
 	)
 }
 
-func workflowsLayer(org string, client forge.Client, printer *ui.Printer, user, version string, vendor bool, vendorCollect layers.VendorCollectFunc) *layers.WorkflowsLayer {
-	layer := layers.NewWorkflowsLayer(org, client, printer, user, version, vendor)
+func workflowsLayer(org string, client forge.Client, printer *ui.Printer, user, version string, vendor bool, vendorCollect layers.VendorCollectFunc, direct bool) *layers.WorkflowsLayer {
+	layer := layers.NewWorkflowsLayer(org, client, printer, user, version, vendor).WithDirect(direct)
 	if vendorCollect != nil {
 		layer = layer.WithVendorCollect(vendorCollect)
 	}

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -60,6 +60,10 @@ func TestInstallCmd_Flags(t *testing.T) {
 	require.NotNil(t, vendorFlag, "expected --vendor flag")
 	assert.Equal(t, "false", vendorFlag.DefValue)
 
+	directFlag := cmd.Flags().Lookup("direct")
+	require.NotNil(t, directFlag, "expected --direct flag")
+	assert.Equal(t, "false", directFlag.DefValue)
+
 	inferenceProjectFlag := cmd.Flags().Lookup("inference-project")
 	require.NotNil(t, inferenceProjectFlag, "expected --inference-project flag")
 
@@ -1104,6 +1108,7 @@ func TestBuildLayerStack_NilEnabledRepos_SkipsDisabledRepos(t *testing.T) {
 		"",    // analyzeFullsendSource
 		nil,   // dispatcher
 		"dev", // commitSHA
+		false, // direct
 	)
 
 	// The enrollment layer (last in the stack) should have no repos to
@@ -1138,6 +1143,7 @@ func TestBuildLayerStack_EmptyEnabledRepos_IncludesDisabledRepos(t *testing.T) {
 		false,
 		[]string{}, // explicitly empty (not nil)
 		nil, nil, nil, false, nil, nil, "", nil, "dev",
+		false, // direct
 	)
 
 	// The enrollment layer should have disabled repos to reconcile.
@@ -1811,7 +1817,7 @@ func TestRunInstall_RequiresAgentCredsWhenMintEnabled(t *testing.T) {
 		false, "", "",
 		"gcf", "test-project", "us-central1", "", true,
 		"https://mint.example.com/v1/token",
-		false,
+		false, false,
 		discovered,
 	)
 	require.Error(t, err)
@@ -1837,7 +1843,7 @@ func TestRunInstall_WithSkipMintCheck(t *testing.T) {
 		false, "", "",
 		"gcf", "test-project", "us-central1", "", true,
 		"https://mint.example.com/v1/token",
-		true,
+		true, false,
 		client.Repos,
 	)
 	require.NoError(t, err)
@@ -1863,7 +1869,7 @@ func TestRunInstall_DiscoversRepos(t *testing.T) {
 		false, "", "",
 		"gcf", "test-project", "us-central1", "", true,
 		"https://mint.example.com/v1/token",
-		true,
+		true, false,
 		nil,
 	)
 	require.NoError(t, err)
@@ -1884,7 +1890,7 @@ func TestRunInstall_InvalidEnabledRepo(t *testing.T) {
 		false, "", "",
 		"gcf", "test-project", "us-central1", "", true,
 		"https://mint.example.com/v1/token",
-		true,
+		true, false,
 		discovered,
 	)
 	require.Error(t, err)
@@ -1911,7 +1917,7 @@ func TestRunInstall_WithVendorAndSkipMint(t *testing.T) {
 		true, "", "",
 		"gcf", "test-project", "us-central1", "", true,
 		"https://mint.example.com/v1/token",
-		true,
+		true, false,
 		client.Repos,
 	)
 	require.NoError(t, err)
@@ -2327,13 +2333,15 @@ func TestApplyPerRepoScaffold(t *testing.T) {
 	}
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", files, repoVars, repoSecrets)
+		"acme", "widget", files, repoVars, repoSecrets, false)
 	require.NoError(t, err)
 
-	require.Len(t, client.CommittedFiles, 1)
-	assert.Equal(t, "acme", client.CommittedFiles[0].Owner)
-	assert.Equal(t, "widget", client.CommittedFiles[0].Repo)
-	assert.Len(t, client.CommittedFiles[0].Files, 2)
+	require.Len(t, client.CommittedFilesToBranch, 1)
+	assert.Equal(t, "acme", client.CommittedFilesToBranch[0].Owner)
+	assert.Equal(t, "widget", client.CommittedFilesToBranch[0].Repo)
+	assert.Len(t, client.CommittedFilesToBranch[0].Files, 2)
+
+	require.NotEmpty(t, client.CreatedProposals, "expected scaffold PR to be created")
 
 	varNames := make(map[string]string)
 	for _, v := range client.Variables {
@@ -2357,7 +2365,7 @@ func TestApplyPerRepoScaffold_GetRepoError(t *testing.T) {
 	printer := ui.New(&bytes.Buffer{})
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", nil, nil, nil)
+		"acme", "widget", nil, nil, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "getting repo info")
 }
@@ -2373,7 +2381,7 @@ func TestApplyPerRepoScaffold_CommitFilesError(t *testing.T) {
 	}
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", files, nil, nil)
+		"acme", "widget", files, nil, nil, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "committing scaffold files")
 	assert.Empty(t, client.CreatedBranches, "should not attempt fallback for generic error")
@@ -2385,6 +2393,9 @@ func TestApplyPerRepoScaffold_Idempotent(t *testing.T) {
 	client.Repos = []forge.Repository{{FullName: "acme/widget", DefaultBranch: "main"}}
 	noChange := false
 	client.CommitFilesChanged = &noChange
+	client.Errors = map[string]error{
+		"CreateChangeProposal": fmt.Errorf("PR: %w", forge.ErrAlreadyExists),
+	}
 	var buf bytes.Buffer
 	printer := ui.New(&buf)
 
@@ -2393,11 +2404,30 @@ func TestApplyPerRepoScaffold_Idempotent(t *testing.T) {
 	}
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", files, map[string]string{"K": "V"}, map[string]string{"S": "secret"})
+		"acme", "widget", files, map[string]string{"K": "V"}, map[string]string{"S": "secret"}, false)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "up to date")
 	assert.Len(t, client.Variables, 1, "variables should still be set even when files are unchanged")
 	assert.Len(t, client.CreatedSecrets, 1, "secrets should still be set even when files are unchanged")
+}
+
+func TestApplyPerRepoScaffold_DefaultPR_NoChanges(t *testing.T) {
+	client := forge.NewFakeClient()
+	client.Repos = []forge.Repository{{FullName: "acme/widget", DefaultBranch: "main"}}
+	client.Errors = map[string]error{
+		"CreateChangeProposal": fmt.Errorf("PR: %w", forge.ErrNoChanges),
+	}
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+
+	files := []forge.TreeFile{
+		{Path: ".fullsend/config.yaml", Content: []byte("cfg"), Mode: "100644"},
+	}
+
+	err := applyPerRepoScaffold(context.Background(), client, printer,
+		"acme", "widget", files, map[string]string{"K": "V"}, nil, false)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "up to date")
 }
 
 func TestApplyPerRepoScaffold_NonMainBranch(t *testing.T) {
@@ -2411,7 +2441,7 @@ func TestApplyPerRepoScaffold_NonMainBranch(t *testing.T) {
 	}
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", files, nil, nil)
+		"acme", "widget", files, nil, nil, true)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "acme/widget (develop branch)")
 	assert.Contains(t, buf.String(), "Pushed 1 file to develop")
@@ -2426,7 +2456,7 @@ func TestApplyPerRepoScaffold_CreateVariableError(t *testing.T) {
 	printer := ui.New(&bytes.Buffer{})
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", nil, map[string]string{"K": "V"}, nil)
+		"acme", "widget", nil, map[string]string{"K": "V"}, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "setting repo variable")
 }
@@ -2440,7 +2470,7 @@ func TestApplyPerRepoScaffold_CreateSecretError(t *testing.T) {
 	printer := ui.New(&bytes.Buffer{})
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", nil, nil, map[string]string{"S": "V"})
+		"acme", "widget", nil, nil, map[string]string{"S": "V"}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "setting repo secret")
 }
@@ -2459,7 +2489,7 @@ func TestApplyPerRepoScaffold_ProtectedBranchFallback(t *testing.T) {
 	repoSecrets := map[string]string{"S": "secret"}
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", files, repoVars, repoSecrets)
+		"acme", "widget", files, repoVars, repoSecrets, true)
 	require.NoError(t, err)
 
 	require.Len(t, client.CreatedBranches, 1)
@@ -2491,7 +2521,7 @@ func TestApplyPerRepoScaffold_ProtectedBranch_ExistingBranch(t *testing.T) {
 	}
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", files, nil, nil)
+		"acme", "widget", files, nil, nil, true)
 	require.NoError(t, err)
 
 	require.Len(t, client.CommittedFilesToBranch, 1, "should proceed despite branch existing")
@@ -2511,7 +2541,7 @@ func TestApplyPerRepoScaffold_ProtectedBranch_StillSetsVarsAndSecrets(t *testing
 	repoSecrets := map[string]string{"FULLSEND_GCP_PROJECT_ID": "my-project"}
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", files, repoVars, repoSecrets)
+		"acme", "widget", files, repoVars, repoSecrets, true)
 	require.NoError(t, err)
 
 	assert.Len(t, client.Variables, 1, "variables should be set even with PR fallback")
@@ -2530,7 +2560,7 @@ func TestApplyPerRepoScaffold_ProtectedBranch_CreateBranchFails(t *testing.T) {
 	}
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", files, nil, nil)
+		"acme", "widget", files, nil, nil, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating scaffold branch")
 }
@@ -2547,7 +2577,7 @@ func TestApplyPerRepoScaffold_ProtectedBranch_CommitToBranchFails(t *testing.T) 
 	}
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", files, nil, nil)
+		"acme", "widget", files, nil, nil, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "committing scaffold files to branch")
 }
@@ -2564,7 +2594,7 @@ func TestApplyPerRepoScaffold_ProtectedBranch_ScaffoldBranchAlsoProtected(t *tes
 	}
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", files, nil, nil)
+		"acme", "widget", files, nil, nil, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "scaffold branch")
 	assert.Contains(t, err.Error(), "configure branch protection")
@@ -2582,7 +2612,7 @@ func TestApplyPerRepoScaffold_ProtectedBranch_CreatePRFails(t *testing.T) {
 	}
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", files, nil, nil)
+		"acme", "widget", files, nil, nil, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating scaffold PR")
 }
@@ -2600,7 +2630,7 @@ func TestApplyPerRepoScaffold_ProtectedBranch_DuplicatePR(t *testing.T) {
 	}
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", files, nil, nil)
+		"acme", "widget", files, nil, nil, true)
 	require.NoError(t, err)
 
 	output := buf.String()
@@ -2733,7 +2763,7 @@ func TestApplyPerRepoScaffold_ProtectedBranch_BranchUpToDate(t *testing.T) {
 	}
 
 	err := applyPerRepoScaffold(context.Background(), client, printer,
-		"acme", "widget", files, nil, nil)
+		"acme", "widget", files, nil, nil, true)
 	require.NoError(t, err)
 
 	assert.Contains(t, buf.String(), "up to date")

--- a/internal/cli/github.go
+++ b/internal/cli/github.go
@@ -63,6 +63,7 @@ type githubSetupConfig struct {
 	fullsendBinary       string
 	fullsendSource       string
 	dryRun               bool
+	direct               bool
 }
 
 func newGitHubSetupCmd() *cobra.Command {
@@ -139,6 +140,7 @@ values (mint URL, WIF provider, project ID) are provided as flags.`,
 	cmd.Flags().BoolVar(&cfg.enrollAll, "enroll-all", false, "enroll all repositories without prompting")
 	cmd.Flags().BoolVar(&cfg.enrollNone, "enroll-none", false, "skip repository enrollment without prompting")
 	cmd.Flags().BoolVar(&cfg.dryRun, "dry-run", false, "print actions without making changes")
+	cmd.Flags().BoolVar(&cfg.direct, "direct", false, "push scaffold files directly to the default branch instead of creating a PR")
 	addVendorFlags(cmd, &cfg.vendor, &cfg.fullsendBinary, &cfg.fullsendSource)
 
 	return cmd
@@ -290,7 +292,7 @@ func runGitHubSetupPerRepo(ctx context.Context, client forge.Client, printer *ui
 		}
 	}
 
-	if err := applyPerRepoScaffold(ctx, client, printer, owner, repo, files, repoVars, repoSecrets); err != nil {
+	if err := applyPerRepoScaffold(ctx, client, printer, owner, repo, files, repoVars, repoSecrets, cfg.direct); err != nil {
 		return err
 	}
 
@@ -447,7 +449,7 @@ func runGitHubSetupPerOrg(ctx context.Context, client forge.Client, printer *ui.
 		vendorFn, vendorCollect = vendorStackArgs(true, cfg.fullsendBinary, cfg.fullsendSource)
 	}
 
-	stack := buildLayerStack(org, client, orgCfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, cfg.vendor, vendorFn, vendorCollect, "", dispatcher, commitSHA)
+	stack := buildLayerStack(org, client, orgCfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, cfg.vendor, vendorFn, vendorCollect, "", dispatcher, commitSHA, cfg.direct)
 
 	if cfg.dryRun {
 		printer.Header("Dry run — analyzing what setup would do")
@@ -479,7 +481,7 @@ func runGitHubSetupPerOrg(ctx context.Context, client forge.Client, printer *ui.
 		orgCfg = config.NewOrgConfig(repoNames, enabledRepos, roles, inferenceProviderName, org)
 		orgCfg.Dispatch.Mode = "oidc-mint"
 
-		stack = buildLayerStack(org, client, orgCfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, cfg.vendor, vendorFn, vendorCollect, "", dispatcher, commitSHA)
+		stack = buildLayerStack(org, client, orgCfg, printer, user, privateRepo, enabledRepos, agentCreds, enrolledRepoIDs, inferenceProvider, cfg.vendor, vendorFn, vendorCollect, "", dispatcher, commitSHA, cfg.direct)
 	}
 
 	if err := runPreflight(ctx, stack, layers.OpInstall, client, printer); err != nil {
@@ -979,7 +981,7 @@ func runGitHubSyncScaffold(ctx context.Context, client forge.Client, printer *ui
 		return fmt.Errorf("reading config.yaml: %w", cfgErr)
 	}
 
-	workflowsLayer := layers.NewWorkflowsLayer(org, client, printer, user, version, vendored)
+	workflowsLayer := layers.NewWorkflowsLayer(org, client, printer, user, version, vendored).WithDirect(true)
 
 	if err := workflowsLayer.Install(ctx); err != nil {
 		return fmt.Errorf("syncing scaffold: %w", err)

--- a/internal/cli/github_test.go
+++ b/internal/cli/github_test.go
@@ -83,6 +83,10 @@ func TestGitHubSetupCmd_Flags(t *testing.T) {
 	vendorFlag := cmd.Flags().Lookup("vendor")
 	require.NotNil(t, vendorFlag, "expected --vendor flag")
 
+	directFlag := cmd.Flags().Lookup("direct")
+	require.NotNil(t, directFlag, "expected --direct flag")
+	assert.Equal(t, "false", directFlag.DefValue)
+
 	inferenceProjectFlag := cmd.Flags().Lookup("inference-project")
 	require.NotNil(t, inferenceProjectFlag, "expected --inference-project flag")
 
@@ -543,8 +547,8 @@ func TestRunGitHubSyncScaffold_CommitsFiles(t *testing.T) {
 	err := runGitHubSyncScaffold(context.Background(), client, printer, "acme")
 	require.NoError(t, err)
 
-	// Verify at least one file was committed.
-	require.NotEmpty(t, client.CommittedFiles, "expected scaffold files to be committed")
+	// sync-scaffold uses direct mode — files are committed to the default branch.
+	require.NotEmpty(t, client.CommittedFiles, "expected scaffold files to be committed directly")
 }
 
 func TestRunGitHubSyncScaffold_VendoredMarker(t *testing.T) {
@@ -636,8 +640,9 @@ func TestRunGitHubSetupPerRepo(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Verify scaffold files were committed.
-	require.NotEmpty(t, client.CommittedFiles)
+	// Default mode delivers via PR — verify files were committed to the scaffold branch.
+	require.NotEmpty(t, client.CommittedFilesToBranch)
+	require.NotEmpty(t, client.CreatedProposals)
 
 	// Verify repo variables were set.
 	varNames := make(map[string]string)
@@ -767,8 +772,8 @@ func TestRunGitHubSetupPerRepo_ReusesExistingSecrets(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Verify scaffold files were committed.
-	require.NotEmpty(t, client.CommittedFiles)
+	// Default mode delivers via PR — verify files were committed to the scaffold branch.
+	require.NotEmpty(t, client.CommittedFilesToBranch)
 
 	// Verify repo variables were set.
 	varNames := make(map[string]string)

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -41,6 +41,15 @@ func IsBranchProtected(err error) bool {
 	return errors.Is(err, ErrBranchProtected)
 }
 
+// ErrNoChanges indicates that a change proposal could not be created
+// because there are no differences between the head and base branches.
+var ErrNoChanges = errors.New("no changes between branches")
+
+// IsNoChanges reports whether err indicates a no-diff PR creation attempt.
+func IsNoChanges(err error) bool {
+	return errors.Is(err, ErrNoChanges)
+}
+
 // Repository represents a repository on a git forge.
 type Repository struct {
 	ID            int64

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -87,6 +87,9 @@ func (e *APIError) Unwrap() error {
 	if e.StatusCode == http.StatusUnprocessableEntity && isAlreadyExistsError(e) {
 		return forge.ErrAlreadyExists
 	}
+	if e.StatusCode == http.StatusUnprocessableEntity && isNoChangesError(e) {
+		return forge.ErrNoChanges
+	}
 	return nil
 }
 
@@ -965,6 +968,14 @@ func isAlreadyExistsError(apiErr *APIError) bool {
 		msg += " " + strings.ToLower(d.Message)
 	}
 	return strings.Contains(msg, "already exists")
+}
+
+func isNoChangesError(apiErr *APIError) bool {
+	msg := strings.ToLower(apiErr.Message)
+	for _, d := range apiErr.Errors {
+		msg += " " + strings.ToLower(d.Message)
+	}
+	return strings.Contains(msg, "no commits between")
 }
 
 // blobSHA computes the Git blob object SHA-1 for the given content.

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -800,6 +800,57 @@ func TestIsAlreadyExistsError(t *testing.T) {
 	}
 }
 
+func TestIsNoChangesError(t *testing.T) {
+	tests := []struct {
+		name   string
+		apiErr *APIError
+		want   bool
+	}{
+		{
+			name: "no commits between branches",
+			apiErr: &APIError{
+				StatusCode: 422,
+				Message:    "Validation Failed",
+				Errors: []APIErrorDetail{
+					{Resource: "PullRequest", Code: "custom", Message: "No commits between main and main"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no commits between different branches",
+			apiErr: &APIError{
+				StatusCode: 422,
+				Message:    "Validation Failed",
+				Errors: []APIErrorDetail{
+					{Resource: "PullRequest", Code: "custom", Message: "No commits between main and fullsend/scaffold-install"},
+				},
+			},
+			want: true,
+		},
+		{
+			name:   "top-level message only",
+			apiErr: &APIError{StatusCode: 422, Message: "No commits between main and fullsend/scaffold-install"},
+			want:   true,
+		},
+		{
+			name:   "already exists is not no-changes",
+			apiErr: &APIError{StatusCode: 422, Message: "Reference already exists"},
+			want:   false,
+		},
+		{
+			name:   "unrelated 422",
+			apiErr: &APIError{StatusCode: 422, Message: "Update is not a fast forward"},
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isNoChangesError(tt.apiErr))
+		})
+	}
+}
+
 func TestAPIError_Unwrap(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -827,6 +878,17 @@ func TestAPIError_Unwrap(t *testing.T) {
 				},
 			},
 			wantErr: forge.ErrAlreadyExists,
+		},
+		{
+			name: "422 no commits between unwraps to ErrNoChanges",
+			apiErr: &APIError{
+				StatusCode: 422,
+				Message:    "Validation Failed",
+				Errors: []APIErrorDetail{
+					{Resource: "PullRequest", Code: "custom", Message: "No commits between main and fullsend/scaffold-install"},
+				},
+			},
+			wantErr: forge.ErrNoChanges,
 		},
 		{
 			name:    "422 non-fast-forward does not unwrap",

--- a/internal/layers/commit.go
+++ b/internal/layers/commit.go
@@ -8,61 +8,89 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
-// CommitScaffoldFiles commits files to a repo's default branch. If the branch
-// is protected, it falls back to creating a PR from a feature branch.
+// CommitScaffoldFiles delivers scaffold files to a repository. When direct is
+// false (the default), files are committed to a feature branch and delivered
+// via PR. When direct is true, files are pushed directly to the default branch,
+// falling back to a PR if branch protection blocks the push.
+//
 // The returned bool is true when files were committed directly to the default
-// branch (false when idempotent, on protected-branch PR fallback, or unchanged).
+// branch (false for PR-based delivery, idempotent no-ops, or unchanged content).
 func CommitScaffoldFiles(ctx context.Context, client forge.Client, printer *ui.Printer,
+	owner, repo, defaultBranch, commitMsg, prTitle, prBody string,
+	files []forge.TreeFile, direct bool) (bool, error) {
+
+	if direct {
+		return commitScaffoldDirect(ctx, client, printer,
+			owner, repo, defaultBranch, commitMsg, prTitle, prBody, files)
+	}
+	return commitScaffoldViaPR(ctx, client, printer,
+		owner, repo, defaultBranch, commitMsg, prTitle, prBody, files)
+}
+
+// commitScaffoldViaPR creates a feature branch, commits files, and opens a PR.
+func commitScaffoldViaPR(ctx context.Context, client forge.Client, printer *ui.Printer,
+	owner, repo, defaultBranch, commitMsg, prTitle, prBody string,
+	files []forge.TreeFile) (bool, error) {
+
+	// Fixed branch name so re-runs update the same PR rather than creating a
+	// new one each time. If the branch already exists, we commit on top of it.
+	const scaffoldBranch = "fullsend/scaffold-install"
+	if branchErr := client.CreateBranch(ctx, owner, repo, scaffoldBranch); branchErr != nil {
+		if !forge.IsAlreadyExists(branchErr) {
+			printer.StepFail("Failed to create scaffold branch")
+			return false, fmt.Errorf("creating scaffold branch: %w", branchErr)
+		}
+	}
+
+	branchCommitted, commitErr := client.CommitFilesToBranch(ctx, owner, repo, scaffoldBranch, commitMsg, files)
+	if commitErr != nil {
+		if forge.IsBranchProtected(commitErr) {
+			printer.StepFail("Scaffold branch is also protected — cannot commit")
+			return false, fmt.Errorf("scaffold branch %q is protected; configure branch protection to allow pushes to scaffold branches: %w", scaffoldBranch, commitErr)
+		}
+		printer.StepFail("Failed to commit scaffold files to branch")
+		return false, fmt.Errorf("committing scaffold files to branch: %w", commitErr)
+	}
+
+	// Always attempt PR creation even when branchCommitted is false — a prior
+	// run may have committed to the branch but crashed before opening the PR.
+	proposal, prErr := client.CreateChangeProposal(ctx, owner, repo,
+		prTitle, prBody, scaffoldBranch, defaultBranch)
+	if prErr != nil {
+		if forge.IsNoChanges(prErr) {
+			printer.StepDone("Scaffold branch and PR up to date")
+			return false, nil
+		}
+		if !forge.IsAlreadyExists(prErr) {
+			printer.StepFail("Failed to create scaffold PR")
+			return false, fmt.Errorf("creating scaffold PR: %w", prErr)
+		}
+		if branchCommitted {
+			printer.StepDone("Scaffold PR already exists — updated with new files")
+			printer.StepInfo("Merge the PR to activate fullsend workflows")
+		} else {
+			printer.StepDone("Scaffold branch and PR up to date")
+		}
+	} else {
+		printer.StepDone(fmt.Sprintf("Created PR #%d: %s", proposal.Number, proposal.URL))
+		printer.StepInfo("Merge the PR to activate fullsend workflows")
+	}
+	return false, nil
+}
+
+// commitScaffoldDirect pushes files directly to the default branch, falling
+// back to a PR when branch protection blocks the push.
+func commitScaffoldDirect(ctx context.Context, client forge.Client, printer *ui.Printer,
 	owner, repo, defaultBranch, commitMsg, prTitle, prBody string,
 	files []forge.TreeFile) (bool, error) {
 
 	committed, err := client.CommitFiles(ctx, owner, repo, commitMsg, files)
 	if err != nil && forge.IsBranchProtected(err) {
 		printer.StepWarn("Default branch is protected — creating scaffold PR instead")
-
-		// The branch name is fixed so that re-runs update the same PR rather
-		// than creating a new one each time. If the branch already exists from
-		// a prior run, we commit on top of it. The branch may be behind the
-		// current default branch, which can produce merge conflicts in the PR;
-		// this is acceptable because the user must merge the PR manually anyway.
-		const scaffoldBranch = "fullsend/scaffold-install"
-		if branchErr := client.CreateBranch(ctx, owner, repo, scaffoldBranch); branchErr != nil {
-			if !forge.IsAlreadyExists(branchErr) {
-				printer.StepFail("Failed to create scaffold branch")
-				return false, fmt.Errorf("creating scaffold branch: %w", branchErr)
-			}
-		}
-
-		branchCommitted, commitErr := client.CommitFilesToBranch(ctx, owner, repo, scaffoldBranch, commitMsg, files)
-		if commitErr != nil {
-			if forge.IsBranchProtected(commitErr) {
-				printer.StepFail("Scaffold branch is also protected — cannot commit")
-				return false, fmt.Errorf("scaffold branch %q is protected; configure branch protection to allow pushes to scaffold branches: %w", scaffoldBranch, commitErr)
-			}
-			printer.StepFail("Failed to commit scaffold files to branch")
-			return false, fmt.Errorf("committing scaffold files to branch: %w", commitErr)
-		}
-
-		// Always attempt PR creation — even when branchCommitted is false.
-		// A prior run may have committed to the branch but crashed before
-		// creating the PR. ErrAlreadyExists handles the common re-run case.
-		proposal, prErr := client.CreateChangeProposal(ctx, owner, repo,
-			prTitle, prBody, scaffoldBranch, defaultBranch)
-		if prErr != nil {
-			if !forge.IsAlreadyExists(prErr) {
-				printer.StepFail("Failed to create scaffold PR")
-				return false, fmt.Errorf("creating scaffold PR: %w", prErr)
-			}
-			if branchCommitted {
-				printer.StepDone("Scaffold PR already exists — updated with new files")
-			} else {
-				printer.StepDone("Scaffold branch and PR up to date")
-			}
-		} else {
-			printer.StepDone(fmt.Sprintf("Created PR #%d: %s", proposal.Number, proposal.URL))
-		}
-		printer.StepInfo("Merge the PR to activate fullsend workflows")
-		return false, nil
+		fallbackBody := fmt.Sprintf("The default branch (%s) has branch protection rules that prevent direct pushes.\n\n"+
+			"Merge this PR to deliver the scaffold files.", defaultBranch)
+		return commitScaffoldViaPR(ctx, client, printer,
+			owner, repo, defaultBranch, commitMsg, prTitle, fallbackBody, files)
 	} else if err != nil {
 		printer.StepFail("Failed to commit scaffold files")
 		return false, fmt.Errorf("committing scaffold files: %w", err)

--- a/internal/layers/workflows.go
+++ b/internal/layers/workflows.go
@@ -21,6 +21,7 @@ type WorkflowsLayer struct {
 	version           string
 	vendored          bool
 	vendorCollect     VendorCollectFunc
+	direct            bool
 }
 
 var _ Layer = (*WorkflowsLayer)(nil)
@@ -40,6 +41,13 @@ func NewWorkflowsLayer(org string, client forge.Client, printer *ui.Printer, use
 // WithVendorCollect configures combined scaffold+vendor commits for --vendor installs.
 func (l *WorkflowsLayer) WithVendorCollect(fn VendorCollectFunc) *WorkflowsLayer {
 	l.vendorCollect = fn
+	return l
+}
+
+// WithDirect configures direct-commit mode (push to default branch, fall back
+// to PR on branch protection). The default is PR-based delivery.
+func (l *WorkflowsLayer) WithDirect(direct bool) *WorkflowsLayer {
+	l.direct = direct
 	return l
 }
 
@@ -103,21 +111,27 @@ func (l *WorkflowsLayer) Install(ctx context.Context) error {
 	commitMsg := fmt.Sprintf("chore: update fullsend-%s scaffold", l.version)
 	if vendorAssetCount > 0 {
 		commitMsg = fmt.Sprintf("chore: update fullsend-%s scaffold with vendored assets", l.version)
-		l.ui.StepStart(fmt.Sprintf("Writing scaffold and vendored assets (%d content files) to %s/%s (%s branch)",
-			vendorAssetCount, l.org, forge.ConfigRepoName, cfgRepo.DefaultBranch))
-	} else {
+		if l.direct {
+			l.ui.StepStart(fmt.Sprintf("Writing scaffold and vendored assets (%d content files) to %s/%s (%s branch)",
+				vendorAssetCount, l.org, forge.ConfigRepoName, cfgRepo.DefaultBranch))
+		} else {
+			l.ui.StepStart(fmt.Sprintf("Creating scaffold PR with vendored assets (%d content files) for %s/%s (target: %s)",
+				vendorAssetCount, l.org, forge.ConfigRepoName, cfgRepo.DefaultBranch))
+		}
+	} else if l.direct {
 		l.ui.StepStart(fmt.Sprintf("Committing scaffold files to %s/%s (%s branch)",
+			l.org, forge.ConfigRepoName, cfgRepo.DefaultBranch))
+	} else {
+		l.ui.StepStart(fmt.Sprintf("Creating scaffold PR for %s/%s (target: %s)",
 			l.org, forge.ConfigRepoName, cfgRepo.DefaultBranch))
 	}
 	prTitle := "chore: add fullsend scaffold files"
 	prBody := fmt.Sprintf("This PR adds the fullsend scaffold files to the %s config repo.\n\n"+
-		"The default branch (%s) has branch protection rules that prevent direct pushes, "+
-		"so these files are delivered via PR instead.\n\n"+
-		"Merge this PR to activate fullsend workflows.", forge.ConfigRepoName, cfgRepo.DefaultBranch)
+		"Merge this PR to activate fullsend workflows.", forge.ConfigRepoName)
 
 	committed, err := CommitScaffoldFiles(ctx, l.client, l.ui,
 		l.org, forge.ConfigRepoName, cfgRepo.DefaultBranch,
-		commitMsg, prTitle, prBody, files)
+		commitMsg, prTitle, prBody, files, l.direct)
 	if err != nil {
 		return err
 	}

--- a/internal/layers/workflows_test.go
+++ b/internal/layers/workflows_test.go
@@ -21,7 +21,7 @@ func newWorkflowsLayer(t *testing.T, client *forge.FakeClient, vendored bool) (*
 	ensureFakeConfigRepo(client)
 	var buf bytes.Buffer
 	printer := ui.New(&buf)
-	layer := NewWorkflowsLayer("test-org", client, printer, "admin-user", "test-version", vendored)
+	layer := NewWorkflowsLayer("test-org", client, printer, "admin-user", "test-version", vendored).WithDirect(true)
 	return layer, &buf
 }
 
@@ -89,6 +89,33 @@ func TestWorkflowsLayer_Install_WritesAllFiles(t *testing.T) {
 	assert.Equal(t, "chore: activate fullsend workflows", client.CreatedFiles[0].Message)
 }
 
+func TestWorkflowsLayer_Install_DefaultCreatesPR(t *testing.T) {
+	client := forge.NewFakeClient()
+	ensureFakeConfigRepo(client)
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	layer := NewWorkflowsLayer("test-org", client, printer, "admin-user", "test-version", false)
+
+	err := layer.Install(context.Background())
+	require.NoError(t, err)
+
+	assert.Empty(t, client.CommittedFiles, "default mode should not commit directly")
+	require.Len(t, client.CreatedBranches, 1)
+	assert.Equal(t, "test-org/.fullsend/fullsend/scaffold-install", client.CreatedBranches[0])
+
+	require.Len(t, client.CommittedFilesToBranch, 1)
+	assert.Equal(t, "fullsend/scaffold-install", client.CommittedFilesToBranch[0].Branch)
+
+	require.Len(t, client.CreatedProposals, 1)
+	assert.Contains(t, client.CreatedProposals[0].Title, "fullsend")
+
+	assert.Empty(t, client.CreatedFiles, "PR mode should not trigger repo-maintenance activation")
+
+	output := buf.String()
+	assert.Contains(t, output, "PR #1")
+	assert.Contains(t, output, "Merge the PR")
+}
+
 func TestWorkflowsLayer_Install_ActivatesRepoMaintenance(t *testing.T) {
 	client := forge.NewFakeClient()
 	client.FileContents["test-org/.fullsend/config.yaml"] = []byte("repos: {}\n")
@@ -153,7 +180,7 @@ func TestWorkflowsLayer_Install_CombinedVendorCommit(t *testing.T) {
 			{Path: ".defaults/action.yml", Content: []byte("marker"), Mode: "100644"},
 		}, 1, nil
 	}
-	layer := NewWorkflowsLayer("test-org", client, ui.New(&bytes.Buffer{}), "admin-user", "test-version", true)
+	layer := NewWorkflowsLayer("test-org", client, ui.New(&bytes.Buffer{}), "admin-user", "test-version", true).WithDirect(true)
 	layer = layer.WithVendorCollect(collectFn)
 
 	err := layer.Install(context.Background())
@@ -343,6 +370,23 @@ func TestWorkflowsLayer_Install_ProtectedBranch_BranchUpToDate(t *testing.T) {
 	noChange := false
 	client.CommitFilesChanged = &noChange
 	layer, buf := newWorkflowsLayer(t, client, false)
+
+	err := layer.Install(context.Background())
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "up to date")
+}
+
+func TestWorkflowsLayer_Install_DefaultPR_NoChanges(t *testing.T) {
+	client := forge.NewFakeClient()
+	ensureFakeConfigRepo(client)
+	client.Errors = map[string]error{
+		"CreateChangeProposal": fmt.Errorf("PR: %w", forge.ErrNoChanges),
+	}
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	layer := NewWorkflowsLayer("test-org", client, printer, "admin-user", "test-version", false)
 
 	err := layer.Install(context.Background())
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Invert the default scaffold delivery behavior: `fullsend admin install` and `fullsend github setup` now create PRs by default instead of pushing directly to the default branch
- Add `--direct` flag to both commands for users who want the old direct-commit behavior (with automatic PR fallback on branch protection)
- Split `CommitScaffoldFiles` into `commitScaffoldViaPR` (new default) and `commitScaffoldDirect` (`--direct` path)

Closes #483

## Test plan
- [ ] `go test ./internal/layers/... ./internal/cli/... -count=1` passes
- [ ] `make lint` passes
- [ ] New `TestWorkflowsLayer_Install_DefaultCreatesPR` verifies PR-based default
- [ ] Existing protected-branch fallback tests still pass under `--direct` mode
- [ ] Manual: `fullsend admin install` on a test org creates a scaffold PR
- [ ] Manual: `fullsend admin install --direct` pushes directly to default branch