### PR TITLE
fix: sync functional tests openshell version with shared pin

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -114,7 +114,6 @@ jobs:
           OPENSHELL_SSH_HANDSHAKE_SECRET="ci-$(openssl rand -hex 16)"
           export OPENSHELL_SSH_HANDSHAKE_SECRET
           echo "::add-mask::${OPENSHELL_SSH_HANDSHAKE_SECRET}"
-          export OPENSHELL_SUPERVISOR_IMAGE="ghcr.io/nvidia/openshell/supervisor:${OPENSHELL_SHA}"
           "${{ runner.temp }}/openshell-gateway" \
             --bind-address 0.0.0.0 \
             --health-port 8081 \

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -63,10 +63,8 @@ jobs:
 
       - name: Configure OpenShell gateway
         run: |
-          mkdir -p $HOME/.config/openshell/
-          cat > $HOME/.config/openshell/gateway.env << EOF
-          OPENSHELL_BIND_ADDRESS=0.0.0.0
-          EOF
+          mkdir -p "$HOME/.config/openshell"
+          echo "OPENSHELL_BIND_ADDRESS=0.0.0.0" > "$HOME/.config/openshell/gateway.env"
 
       - name: Install OpenShell CLI
         run: .github/scripts/install-openshell.sh

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -61,28 +61,15 @@ jobs:
       - name: Add bin to PATH
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
 
-      - name: Set OpenShell version
-        run: source .github/scripts/openshell-version.sh
+      - name: Configure OpenShell gateway
+        run: |
+          mkdir -p $HOME/.config/openshell/
+          cat > $HOME/.config/openshell/gateway.env << EOF
+          OPENSHELL_BIND_ADDRESS=0.0.0.0
+          EOF
 
       - name: Install OpenShell CLI
-        run: |
-          uv tool install "openshell==${OPENSHELL_VERSION}"
-          openshell --version
-
-      - name: Download openshell-gateway
-        run: |
-          set -euo pipefail
-          arch="$(uname -m)"
-          case "${arch}" in
-            x86_64) ;;
-            aarch64|arm64) arch=aarch64 ;;
-            *) echo "::error::Unsupported architecture: ${arch}"; exit 1 ;;
-          esac
-          GATEWAY_ASSET="openshell-gateway-${arch}-unknown-linux-gnu.tar.gz"
-          GATEWAY_URL="https://github.com/NVIDIA/OpenShell/releases/download/v${OPENSHELL_VERSION}/${GATEWAY_ASSET}"
-          curl -fsSL "${GATEWAY_URL}" -o "/tmp/${GATEWAY_ASSET}"
-          tar xzf "/tmp/${GATEWAY_ASSET}" -C "${{ runner.temp }}"
-          rm -f "/tmp/${GATEWAY_ASSET}"
+        run: .github/scripts/install-openshell.sh
 
       - name: Install Podman
         run: |
@@ -107,31 +94,6 @@ jobs:
             done
             [ -S "${SOCKET_PATH}" ] || { echo "::error::Podman socket not ready"; exit 1; }
           fi
-
-      - name: Start openshell-gateway
-        run: |
-          set -euo pipefail
-          OPENSHELL_SSH_HANDSHAKE_SECRET="ci-$(openssl rand -hex 16)"
-          export OPENSHELL_SSH_HANDSHAKE_SECRET
-          echo "::add-mask::${OPENSHELL_SSH_HANDSHAKE_SECRET}"
-          "${{ runner.temp }}/openshell-gateway" \
-            --bind-address 0.0.0.0 \
-            --health-port 8081 \
-            --drivers podman \
-            --disable-tls \
-            --db-url "sqlite:/tmp/gateway.db?mode=rwc" \
-            >/tmp/gateway.log 2>&1 &
-          for _i in $(seq 1 30); do
-            curl -sf http://127.0.0.1:8081/healthz >/dev/null 2>&1 && break
-            sleep 2
-          done
-          curl -sf http://127.0.0.1:8081/healthz >/dev/null 2>&1 || {
-            echo "::error::Gateway health check failed"
-            cat /tmp/gateway.log 2>/dev/null || true
-            exit 1
-          }
-          openshell gateway add http://127.0.0.1:8080 --local --name local
-          openshell gateway select local
 
       - name: Install validation dependencies
         run: pip install --quiet "jsonschema>=4.18.0"

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -61,12 +61,8 @@ jobs:
       - name: Add bin to PATH
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
 
-      # TODO: The openshell setup below (version, CLI, gateway, Podman,
-      # gateway start) is duplicated from action.yml. Extract into a
-      # shared script (e.g. .github/scripts/setup-openshell.sh) so the
-      # version and config stay in sync across both places.
       - name: Set OpenShell version
-        run: echo "OPENSHELL_VERSION=0.0.38" >> "${GITHUB_ENV}"
+        run: source .github/scripts/openshell-version.sh
 
       - name: Install OpenShell CLI
         run: |
@@ -118,7 +114,7 @@ jobs:
           OPENSHELL_SSH_HANDSHAKE_SECRET="ci-$(openssl rand -hex 16)"
           export OPENSHELL_SSH_HANDSHAKE_SECRET
           echo "::add-mask::${OPENSHELL_SSH_HANDSHAKE_SECRET}"
-          export OPENSHELL_SUPERVISOR_IMAGE="ghcr.io/nvidia/openshell/supervisor:dfd47683e7da4f1a4a8fa5d77f92d3696e6a41f9"
+          export OPENSHELL_SUPERVISOR_IMAGE="ghcr.io/nvidia/openshell/supervisor:${OPENSHELL_SHA}"
           "${{ runner.temp }}/openshell-gateway" \
             --bind-address 0.0.0.0 \
             --health-port 8081 \

--- a/eval/run-functional.sh
+++ b/eval/run-functional.sh
@@ -50,6 +50,20 @@ if ! python3 -c "import agent_eval" 2>/dev/null; then
   exit 1
 fi
 
+# Fail fast if openshell version doesn't match the repo pin
+if command -v openshell >/dev/null 2>&1; then
+  source "${REPO_ROOT}/.github/scripts/openshell-version.sh"
+  installed="$(openshell --version | awk '{print $NF}')"
+  installed="${installed#v}"
+  if [[ "${installed}" != "${OPENSHELL_VERSION}" ]]; then
+    echo "ERROR: OpenShell version mismatch: installed ${installed}, expected ${OPENSHELL_VERSION}" >&2
+    exit 1
+  fi
+else
+  echo "ERROR: openshell is not installed" >&2
+  exit 1
+fi
+
 WORKSPACE_PY="${HARNESS_DIR}/skills/eval-run/scripts/workspace.py"
 EXECUTE_PY="${HARNESS_DIR}/skills/eval-run/scripts/execute.py"
 SCORE_PY="${HARNESS_DIR}/skills/eval-run/scripts/score.py"


### PR DESCRIPTION
## Summary

- The functional-tests workflow hardcoded openshell `0.0.38` while the rest of the repo pins `0.0.63` via `.github/scripts/openshell-version.sh`. Sources the shared script instead.
- Adds an early version-mismatch guard in `eval/run-functional.sh` so drift is caught regardless of how tests are invoked (CI or locally).
- Uses `${OPENSHELL_SHA}` for the supervisor image tag instead of a hardcoded SHA.

Spotted in #2534.

## Test plan

- [ ] Functional tests workflow picks up `0.0.63` from the shared script
- [ ] `eval/run-functional.sh` fails fast if an old openshell is installed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)