### PR TITLE
feat: add autonomy-readiness skill for retro agent

### DIFF
--- a/docs/superpowers/plans/2026-06-22-autonomy-readiness-skill.md
+++ b/docs/superpowers/plans/2026-06-22-autonomy-readiness-skill.md
@@ -1,0 +1,362 @@
+# Autonomy Readiness Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create an agent-agnostic skill for analyzing the delta between agent review and human review, and integrate it with the retro agent.
+
+**Architecture:** A single SKILL.md file containing the full methodology (phases 1-3 and proposal templates), a one-line addition to the retro harness, and a short addition to the retro agent prompt. Existing scaffold tests validate the wiring automatically.
+
+**Tech Stack:** Markdown (skill definition), YAML (harness config), Go (existing scaffold tests)
+
+**Spec:** `docs/superpowers/specs/2026-06-22-autonomy-readiness-skill-design.md`
+
+---
+
+### Task 1: Create the autonomy-readiness skill directory and SKILL.md
+
+**Files:**
+- Create: `internal/scaffold/fullsend-repo/skills/autonomy-readiness/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory**
+
+```bash
+mkdir -p internal/scaffold/fullsend-repo/skills/autonomy-readiness
+```
+
+- [ ] **Step 2: Write the SKILL.md file**
+
+Create `internal/scaffold/fullsend-repo/skills/autonomy-readiness/SKILL.md` with the following content:
+
+```markdown
+---
+name: autonomy-readiness
+description: >
+  Use when you need to analyze the delta between agent review and human review
+  on a PR to identify structural repo improvements that would close review gaps
+  or justify increased agent autonomy.
+---
+
+# Autonomy Readiness Analysis
+
+Analyze what humans caught that agents missed (and vice versa) on a PR review.
+Diagnose structural root causes in the repo and propose changes that close
+gaps or justify increased agent autonomy.
+
+## When to use this skill
+
+Use after you have access to:
+- The review agent's posted findings on a PR (severity, category, file, description).
+- The human review feedback on the same PR (comments, requested changes, inline suggestions).
+
+## Phase 1: Extract the delta
+
+Build two sets from the PR timeline:
+
+**Agent findings** — each finding the review agent posted, with its severity, category, file, and description.
+
+**Human findings** — each piece of human review feedback: inline comments, review-level comments, and requested changes.
+
+Classify each human finding:
+
+- **Matched** — the agent raised a finding of similar substance and severity. Wording differences do not matter. If the agent said "this nil check is missing" and the human said "what happens when this is null?", that is a match.
+- **Gap** — the agent missed it entirely, or raised it at meaningfully lower severity (e.g., agent said `info`, human flagged it as a blocking concern).
+
+Classify each agent finding that has no human counterpart:
+
+- **Novel** — the agent raised something the humans did not. This is not a gap, but note it. A pattern of unmatched novel findings may indicate false positives worth investigating.
+
+## Phase 2: Diagnose root causes (for gaps)
+
+For each gap, ask: why did the human catch this and the agent did not?
+
+Work through this diagnostic checklist in order. Stop at the first category that fits — most gaps have one primary root cause.
+
+### 1. Missing context
+
+The human had domain knowledge the agent could not access. Examples:
+- Knowledge of downstream consumers or production behavior not documented in the repo.
+- Team conventions that exist only as tribal knowledge.
+- History of past incidents related to this code path.
+
+**Repo change:** Document the missing context. Add it to a CONTRIBUTING.md, architecture doc, or inline code comment so the agent can access it on future reviews.
+
+### 2. Missing test coverage
+
+A test for the behavior in question would have let the review agent flag the change as inadequately tested. Examples:
+- Human pointed out an edge case — if a test existed for that edge case, the review agent could have noticed the change did not update the test.
+- Human flagged a regression risk — if regression tests existed, the review agent could have flagged missing coverage.
+
+**Repo change:** Add or improve tests that make the gap detectable. Specify which test, what it should assert, and why its absence prevented the agent from catching the issue.
+
+### 3. Missing CI gate
+
+A linter rule, static analysis check, or CI validation would have caught this deterministically. Examples:
+- Human flagged a naming convention violation — a linter rule would catch this without LLM involvement.
+- Human caught a security anti-pattern — a static analysis rule would flag it.
+
+**Repo change:** Add the specific linter rule, static analysis check, or CI gate. Name the tool and rule ID if applicable.
+
+### 4. Missing skill or prompt guidance
+
+The review agent lacks guidance for this class of issue. The agent's skills and sub-agent prompts do not cover the pattern the human recognized. Examples:
+- Human caught an API contract violation that the review agent's correctness sub-agent is not trained to look for.
+- Human applied a repo-specific architectural principle the agent has no access to.
+
+**Repo change:** This is primarily an upstream fullsend improvement (new skill content or sub-agent prompt refinement). Note it, but focus your proposal on what the *repo* can do — often a combination of documentation (category 1) and tests (category 2) can compensate.
+
+### 5. Insufficient repo documentation
+
+Conventions, architectural decisions, or constraints are not written down anywhere in the repo. The human relied on experience that is not encoded. Examples:
+- "We never use pattern X in this codebase because of Y" — not documented.
+- Architectural decision records that would explain why a certain approach is wrong — not written.
+
+**Repo change:** Write the missing documentation. ADRs, CONTRIBUTING.md sections, or README updates that encode the knowledge the human used.
+
+## Phase 3: Assess successes
+
+When the agent's findings fully cover the human review — all human findings are matched, no gaps — this PR is evidence that the agent could have handled this review with more autonomy.
+
+Characterize the success:
+- **Paths touched** — which directories and file types were in the PR.
+- **Change type** — bug fix, feature, refactor, docs, tests, config.
+- **Complexity** — number of files, lines changed, number of review findings.
+- **Agent outcome** — what action did the agent take (approve, request-changes, comment).
+
+Look for patterns: has this class of change been reliably reviewed by the agent across multiple PRs? A single success is not a pattern. If you can identify 3+ PRs where the agent matched or exceeded human review for similar changes, that is a signal worth proposing on.
+
+Identify what specific autonomy mechanism could be relaxed:
+- CODEOWNERS for the affected paths.
+- Protected paths list.
+- Agent permissions or team membership in the repo.
+- Auto-merge eligibility for this class of change.
+
+## Proposal framing
+
+### Gap-closing proposals
+
+Each proposal identifies:
+
+- **The gap** — what the human caught, what the agent missed, on which PR (link to the specific comment).
+- **The root cause** — which diagnostic category, with reasoning about why you chose it.
+- **The proposed repo change** — the specific file, config, or documentation to add or modify.
+- **Validation criteria** — how to verify the change closes the gap. Prefer concrete checks: "re-run the review agent on the original PR diff and confirm it raises a finding about X" or "the next PR that touches this path should trigger CI gate Y."
+
+### Autonomy-increasing proposals
+
+Each proposal identifies:
+
+- **The evidence** — which PRs, what class of change, how agent findings compared to human findings. Link to each PR.
+- **The proposed change** — the specific autonomy mechanism to relax and the exact scope (one directory, one file pattern, one change type).
+- **The experiment** — a conservative trial before full enactment. Examples:
+  - Shadow mode: apply the change but require a human to verify the agent's decision for N PRs before removing the human gate.
+  - Scoped trial: apply only to the narrowest possible scope (one subdirectory, test-only changes) for a defined period.
+  - Gradual expansion: start with the least-risky subset and expand if no regressions occur.
+- **Rollback criteria** — what triggers reverting the change. Be specific: "if a human overrides the agent's review decision on any PR in this scope during the trial period, revert the change and investigate."
+
+### Conservatism principle
+
+When in doubt, propose the smaller change. One directory before a subtree. Shadow mode before real autonomy. Every proposal must be individually reversible. If you cannot define a rollback criterion, the proposal is too aggressive.
+
+## In-scope repo changes
+
+- Tests (unit, integration, end-to-end).
+- CI gates and linting rules.
+- Documentation (CONTRIBUTING.md, ADRs, architecture docs, inline comments).
+- CODEOWNERS modifications.
+- Protected paths list modifications.
+- Agent permissions and team membership in the repo.
+- Auto-merge scope configuration.
+
+## Out of scope
+
+- Upstream changes to fullsend skills, prompts, or sub-agents. Note these if relevant, but do not propose them as the primary action.
+- Changes to the review agent's model or architecture.
+```
+
+- [ ] **Step 3: Verify the skill frontmatter parses correctly**
+
+Run: `go test ./internal/skill/ -run TestParseFrontmatter -v`
+Expected: PASS (existing frontmatter parsing tests confirm the parser works; this validates the parser is not broken, not the new file specifically)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/scaffold/fullsend-repo/skills/autonomy-readiness/SKILL.md
+git commit -S -s -m "feat: add autonomy-readiness skill
+
+Agent-agnostic methodology for analyzing the delta between agent review
+and human review on a PR. Identifies structural repo improvements that
+close review gaps or justify increased agent autonomy.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>"
+```
+
+### Task 2: Wire the skill into the retro harness
+
+**Files:**
+- Modify: `internal/scaffold/fullsend-repo/harness/retro.yaml:24-27` (skills list)
+
+- [ ] **Step 1: Add autonomy-readiness to the retro harness skills list**
+
+In `internal/scaffold/fullsend-repo/harness/retro.yaml`, add `skills/autonomy-readiness` to the `skills` array. The current skills list is:
+
+```yaml
+skills:
+  - skills/retro-analysis
+  - skills/finding-agent-runs
+  - skills/agent-scaffolding
+```
+
+Change it to:
+
+```yaml
+skills:
+  - skills/retro-analysis
+  - skills/finding-agent-runs
+  - skills/agent-scaffolding
+  - skills/autonomy-readiness
+```
+
+- [ ] **Step 2: Run scaffold validation tests**
+
+Run: `go test ./internal/scaffold/ -run TestHarnessesLoadAndValidate -v`
+Expected: PASS — this test extracts the scaffold to a temp dir, loads all harness YAMLs, and calls `ValidateFilesExist()` which confirms that every skill directory in the `skills` array exists. This validates the wiring end-to-end.
+
+- [ ] **Step 3: Run the full scaffold test suite to check for regressions**
+
+Run: `go test ./internal/scaffold/ -v`
+Expected: PASS — all existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/scaffold/fullsend-repo/harness/retro.yaml
+git commit -S -s -m "feat(retro): wire autonomy-readiness skill into harness
+
+Adds the autonomy-readiness skill to retro's skill list so it is
+available during retrospective analysis.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>"
+```
+
+### Task 3: Add autonomy-readiness guidance to the retro agent prompt
+
+**Files:**
+- Modify: `internal/scaffold/fullsend-repo/agents/retro.md:38-44` (optimization goals section)
+
+- [ ] **Step 1: Add autonomy readiness as an optimization goal**
+
+In `internal/scaffold/fullsend-repo/agents/retro.md`, the current optimization goals are:
+
+```markdown
+## Optimization goals
+
+Evaluate workflows through these lenses (in priority order):
+
+1. **Review quality** — Are reviews catching real issues? Are they missing things? Are they flagging false positives that waste human time?
+2. **Rework rate** — How many iterations did it take? Could the code agent have gotten it right the first time with better context or instructions?
+3. **Token cost** — Are agents doing redundant work? Reading files they don't need? Exploring dead ends?
+4. **Time to resolution** — Could the pipeline have moved faster without sacrificing quality?
+```
+
+Add a fifth goal after the existing four:
+
+```markdown
+5. **Autonomy readiness** — What did human reviewers catch that the review agent missed? What repo-level changes would close those gaps? Where did the review agent match or exceed human review, and could the repo grant it more autonomy for that class of change? Use the `autonomy-readiness` skill for structured analysis.
+```
+
+- [ ] **Step 2: Run scaffold tests to confirm the agent definition still loads**
+
+Run: `go test ./internal/scaffold/ -run TestHarnessesLoadAndValidate -v`
+Expected: PASS — the harness validation confirms the agent file path is valid and the file is readable.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/scaffold/fullsend-repo/agents/retro.md
+git commit -S -s -m "feat(retro): add autonomy readiness as optimization goal
+
+Directs the retro agent to analyze the delta between agent review and
+human review, using the autonomy-readiness skill for structured analysis.
+Proposals from this lens compete for the standard 3-proposal budget.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>"
+```
+
+### Task 4: Update the retro agent skills list in frontmatter
+
+**Files:**
+- Modify: `internal/scaffold/fullsend-repo/agents/retro.md:1-15` (frontmatter)
+
+- [ ] **Step 1: Add autonomy-readiness to the agent frontmatter skills list**
+
+The agent frontmatter currently lists:
+
+```yaml
+skills:
+  - retro-analysis
+  - finding-agent-runs
+```
+
+Change it to:
+
+```yaml
+skills:
+  - retro-analysis
+  - finding-agent-runs
+  - autonomy-readiness
+```
+
+Note: The agent frontmatter uses short names (without the `skills/` prefix), while the harness uses full paths. Follow the existing pattern.
+
+- [ ] **Step 2: Run scaffold tests**
+
+Run: `go test ./internal/scaffold/ -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/scaffold/fullsend-repo/agents/retro.md
+git commit -S -s -m "feat(retro): list autonomy-readiness in agent frontmatter
+
+Adds the skill to the agent's declared skill list so it appears in
+the agent's system prompt alongside retro-analysis and finding-agent-runs.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>"
+```
+
+### Task 5: Add the skill to the scaffold file existence test
+
+**Files:**
+- Modify: `internal/scaffold/scaffold_test.go` (TestFullsendRepoFilesExist)
+
+- [ ] **Step 1: Read the current test to find the skills entries**
+
+Read `internal/scaffold/scaffold_test.go` and find the `TestFullsendRepoFilesExist` function. Locate the list of expected files that includes other skill paths like `skills/code-implementation/SKILL.md` and `skills/issue-labels/SKILL.md`.
+
+- [ ] **Step 2: Add the new skill to the expected files list**
+
+Add `"skills/autonomy-readiness/SKILL.md"` to the expected files list, following the alphabetical or existing ordering convention used by other skill entries.
+
+- [ ] **Step 3: Run the test**
+
+Run: `go test ./internal/scaffold/ -run TestFullsendRepoFilesExist -v`
+Expected: PASS
+
+- [ ] **Step 4: Run the full scaffold test suite**
+
+Run: `go test ./internal/scaffold/ -v`
+Expected: PASS — all tests pass, including the new file existence check.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/scaffold/scaffold_test.go
+git commit -S -s -m "test: add autonomy-readiness skill to scaffold file checks
+
+Ensures the skill directory and SKILL.md are included in the scaffold
+file existence test alongside other skills.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-06-22-autonomy-readiness-skill-design.md
+++ b/docs/superpowers/specs/2026-06-22-autonomy-readiness-skill-design.md
@@ -1,0 +1,144 @@
+# Autonomy Readiness Skill Design
+
+**Date:** 2026-06-22
+**Status:** Draft
+
+## Purpose
+
+A new skill that provides a structured methodology for analyzing the delta between agent review and human review on a PR. It identifies structural repo improvements that would close review gaps or justify increased agent autonomy.
+
+The skill is agent-agnostic. Any agent (or human) with access to a PR timeline can use it. The initial consumer is the retro agent, but the retro-specific framing lives in the retro agent's prompt, not in the skill.
+
+## Description (for skill frontmatter)
+
+"Use when you need to analyze the delta between agent review and human review on a PR to identify structural repo improvements that would close review gaps or justify increased agent autonomy."
+
+## What It Produces
+
+Zero or more proposals that either:
+
+- **Close a gap** between human and agent review by diagnosing a structural root cause in the repo and proposing a specific change.
+- **Increase autonomy** by identifying a pattern of agent review success and proposing a specific, conservative expansion of agent authority.
+
+Proposals compete for whatever budget the consuming agent has. The skill does not define a budget; it defines a methodology.
+
+## Analysis Methodology
+
+### Phase 1: Extract the Delta
+
+For a given PR, build two sets:
+
+- **Agent findings** — the review agent's posted findings (severity, category, file, description).
+- **Human findings** — every piece of human review feedback (comments, requested changes, inline suggestions).
+
+Classify each human finding:
+
+- **Matched** — the agent raised a finding of similar substance and severity. Wording differences do not matter.
+- **Gap** — the agent missed it entirely, or raised it at significantly lower severity.
+
+Classify each agent finding:
+
+- **Novel** — the agent raised something the humans did not. Not a gap, but worth noting as potential false-positive signal.
+
+### Phase 2: Diagnose Root Causes (for gaps)
+
+For each gap, ask: why did the human catch this and the agent did not? Apply the following diagnostic checklist:
+
+1. **Missing context** — the human had domain knowledge the agent could not access (knowledge of downstream consumers, production behavior, team conventions not documented anywhere).
+2. **Missing test coverage** — a test for the behavior in question would have let the review agent flag the change as inadequately tested.
+3. **Missing CI gate** — a linter rule, static analysis check, or CI validation would have caught this deterministically.
+4. **Missing skill or prompt guidance** — the review agent lacks guidance for this class of issue. This is an upstream improvement to fullsend; note it but it is not the primary focus of this skill.
+5. **Insufficient repo documentation** — conventions, architectural decisions, or constraints are undocumented, forcing the human to rely on tribal knowledge.
+
+### Phase 3: Assess Successes (for matched findings)
+
+When the agent's findings fully cover the human review (all human findings are matched, no gaps):
+
+- Note the PR characteristics: what paths were touched, what kind of change, how complex.
+- Look for patterns: has this class of change been reliably reviewed by the agent across multiple PRs?
+- Identify what specific autonomy mechanism could be relaxed for this class of change.
+
+## Proposal Framing
+
+### Gap-Closing Proposals
+
+Each proposal identifies:
+
+- **The gap** — what the human caught, what the agent missed, on which PR.
+- **The root cause** — which diagnostic category from Phase 2, with reasoning.
+- **The proposed repo change** — one of:
+  - Add or improve a test that would make the gap detectable.
+  - Add a CI gate or linting rule that catches it deterministically.
+  - Document a convention or constraint so the agent has access to it.
+  - Improve CODEOWNERS coverage so a domain expert is required on that path.
+- **Validation criteria** — how to verify the change actually closes the gap (e.g., re-run review agent on the original PR diff and confirm it now raises the finding).
+
+### Autonomy-Increasing Proposals
+
+Each proposal identifies:
+
+- **The evidence** — which PRs, what class of change, how agent findings compared to human findings.
+- **The proposed change** — one of:
+  - Relax CODEOWNERS for a specific path.
+  - Remove a path from the protected paths list.
+  - Grant the review agent additional repo permissions or team membership.
+  - Enable auto-merge for a narrowly scoped class of PR.
+- **The experiment** — a conservative trial before full enactment (e.g., run in shadow mode for N PRs, or apply to test-only changes for 2 weeks before expanding scope).
+- **Rollback criteria** — what would trigger reverting the change (e.g., if a human overrides agent review on a PR in this scope within the trial period).
+
+### Conservatism Principle
+
+When in doubt, propose the smaller change. Relax CODEOWNERS for one directory before proposing it for a whole subtree. Propose shadow mode before real autonomy. Every proposal must be individually reversible.
+
+## Scope of Repo-Level Changes
+
+The following are in scope for proposals:
+
+- Tests (unit, integration, end-to-end)
+- CI gates and linting rules
+- Documentation of conventions and constraints
+- CODEOWNERS modifications
+- Protected paths list modifications
+- Agent permissions and team membership in the repo
+- Auto-merge scope configuration
+
+The following are out of scope (note them, but do not propose them as the primary action):
+
+- Upstream changes to fullsend skills, prompts, or sub-agents
+- Changes to the review agent's model or architecture
+
+## Integration with Retro Agent
+
+The skill is agent-agnostic. Retro-specific integration requires:
+
+### `agents/retro.md`
+
+Add a section instructing the retro agent to invoke the `autonomy-readiness` skill after reconstructing the PR timeline. Proposals from this analysis compete for the standard 3-proposal budget alongside other improvement proposals.
+
+### `harness/retro.yaml`
+
+Add `autonomy-readiness` to the skills list alongside `retro-analysis`, `finding-agent-runs`, and `agent-scaffolding`.
+
+### No other changes
+
+No schema changes (proposals use existing format: `target_repo`, `title`, `what_happened`, `what_could_go_better`, `proposed_change`, `validation_criteria`). No workflow changes (same trigger, same output mechanism, same proposal cap).
+
+Field mapping:
+
+- `what_happened` — the delta analysis (what agent caught, what human caught).
+- `what_could_go_better` — the root cause diagnosis.
+- `proposed_change` — the specific repo change.
+- `validation_criteria` — the experiment and rollback criteria.
+
+## Skill File Structure
+
+`internal/scaffold/fullsend-repo/skills/autonomy-readiness/SKILL.md` containing:
+
+1. Frontmatter (name, description)
+2. Overview
+3. Phase 1: Extract the delta
+4. Phase 2: Diagnose root causes
+5. Phase 3: Assess successes
+6. Proposal framing (gap-closing and autonomy-increasing templates)
+7. What's in scope for proposals
+8. What's out of scope

--- a/internal/scaffold/fullsend-repo/agents/retro.md
+++ b/internal/scaffold/fullsend-repo/agents/retro.md
@@ -7,6 +7,7 @@ description: >-
 skills:
   - retro-analysis
   - finding-agent-runs
+  - autonomy-readiness
 tools: >-
   Read, Grep, Glob, Bash(gh,jq)
 disallowedTools: >-

--- a/internal/scaffold/fullsend-repo/agents/retro.md
+++ b/internal/scaffold/fullsend-repo/agents/retro.md
@@ -41,6 +41,7 @@ Evaluate workflows through these lenses (in priority order):
 2. **Rework rate** — How many iterations did it take? Could the code agent have gotten it right the first time with better context or instructions?
 3. **Token cost** — Are agents doing redundant work? Reading files they don't need? Exploring dead ends?
 4. **Time to resolution** — Could the pipeline have moved faster without sacrificing quality?
+5. **Autonomy readiness** — What did human reviewers catch that the review agent missed? What repo-level changes would close those gaps? Where did the review agent match or exceed human review, and could the repo grant it more autonomy for that class of change? Use the `autonomy-readiness` skill for structured analysis.
 
 These are defaults. If RETRO_COMMENT provides different focus areas, prioritize those instead.
 

--- a/internal/scaffold/fullsend-repo/harness/retro.yaml
+++ b/internal/scaffold/fullsend-repo/harness/retro.yaml
@@ -25,6 +25,7 @@ skills:
   - skills/retro-analysis
   - skills/finding-agent-runs
   - skills/agent-scaffolding
+  - skills/autonomy-readiness
 
 pre_script: scripts/pre-retro.sh
 post_script: scripts/post-retro.sh

--- a/internal/scaffold/fullsend-repo/skills/autonomy-readiness/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/autonomy-readiness/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: autonomy-readiness
+description: >
+  Use when you need to analyze the delta between agent review and human review
+  on a PR to identify structural repo improvements that would close review gaps
+  or justify increased agent autonomy.
+---
+
+# Autonomy Readiness Analysis
+
+Analyze the difference between what the review agent found on a PR and what human reviewers found on the same PR. Use those deltas to propose concrete repo changes that either close gaps or, when agent coverage is strong, justify relaxing human oversight.
+
+## When to use this skill
+
+Use this skill after you have access to both the review agent's posted findings on a PR and the human review feedback on the same PR. You need the full PR timeline -- agent comments, human comments, requested changes, and inline suggestions -- before you can extract a meaningful delta.
+
+## Phase 1: Extract the delta
+
+Build two sets from the PR timeline:
+
+**Agent findings** -- for each finding, record:
+- Severity (as the agent expressed it)
+- Category (e.g., correctness, style, security, testing, documentation)
+- File and location
+- Description of the issue raised
+
+**Human findings** -- for each piece of human feedback, record:
+- The comment, requested change, or inline suggestion
+- The file and location (if applicable)
+- The substance of the concern
+
+**Classify each human finding:**
+
+- **Matched** -- the agent raised a finding of similar substance and severity. Wording differences do not matter; what matters is whether the agent identified the same underlying problem at a comparable severity level.
+- **Gap** -- the agent missed the issue entirely, or raised it at a significantly lower severity than the human reviewer judged appropriate.
+
+**Classify each agent finding with no human counterpart:**
+
+- **Novel** -- the agent raised something no human commented on. This is not a gap, but it is worth noting: a pattern of novel findings with no human agreement may signal false positives.
+
+## Phase 2: Diagnose root causes (for gaps)
+
+For each gap, work through the following diagnostic checklist. Stop at the first category that fits:
+
+1. **Missing context** -- the human had domain knowledge the agent could not access: downstream consumers, production behavior, undocumented team conventions, deployment topology. Repo change: document the missing context so that future reviews (agent or human) can reference it.
+
+2. **Missing test coverage** -- a test would have let the agent flag inadequate testing or catch a behavioral regression. Repo change: add or improve tests that cover the gap.
+
+3. **Missing CI gate** -- a linter rule, static analysis check, or CI validation would catch this class of issue deterministically. Repo change: add the specific rule or check.
+
+4. **Missing skill or prompt guidance** -- the review agent lacks guidance for this class of issue. Note this as an upstream improvement opportunity, but focus proposals on what the repo itself can do. Documentation and tests often compensate for missing agent guidance.
+
+5. **Insufficient repo documentation** -- conventions, constraints, or architectural decisions are not written down. Repo change: write the missing documentation (ADRs, AGENTS.md updates, inline comments, README sections).
+
+## Phase 3: Assess successes
+
+When agent findings fully cover human review (all findings matched, no gaps), characterize the success:
+
+- Paths touched in the PR
+- Change type (bug fix, feature, refactor, docs, config)
+- Complexity (lines changed, files touched, cross-cutting vs. localized)
+- Agent outcome (approved, requested changes that human agreed with)
+
+Look for patterns across multiple PRs. A single success is an anecdote, not a pattern. Three or more similar PRs where the agent fully covered human review is a signal worth acting on.
+
+When a pattern emerges, identify what autonomy mechanism could be relaxed:
+- CODEOWNERS entries (removing human reviewers for specific paths)
+- Protected path rules
+- Agent permissions or team membership
+- Auto-merge scope (allowing agent-approved PRs to merge without human sign-off for specific change types)
+
+## Proposal framing
+
+### Gap-closing proposals
+
+For each gap-closing proposal, include:
+
+- **Identified gap:** what the human caught, what the agent missed, and a link to the PR where it occurred.
+- **Root cause:** which diagnostic category from Phase 2 applies and why.
+- **Proposed repo change:** the specific file, config, test, or documentation change. Be concrete enough for an implementer to act on.
+- **Validation criteria:** how to verify the gap is closed. Define a measurable or observable outcome with a timeframe or sample size.
+
+### Autonomy-increasing proposals
+
+For each autonomy-increasing proposal, include:
+
+- **Evidence:** which PRs demonstrate the pattern, what class of change they represent, and how agent and human review compared.
+- **Proposed change:** the specific mechanism to relax and the exact scope (e.g., "remove `@backend-team` from CODEOWNERS for `internal/utils/`", not "give the agent more autonomy").
+- **Experiment:** how to trial the change safely. Shadow mode before real autonomy. Scoped trial before broad rollout. Gradual expansion with checkpoints.
+- **Rollback criteria:** the conditions under which the change should be reverted. Be specific.
+
+### Conservatism principle
+
+When in doubt, prefer the smaller change. One directory before an entire subtree. Shadow mode before real autonomy. Every proposal must be individually reversible. If you cannot define rollback criteria for a proposal, the proposal is too aggressive -- narrow the scope until rollback is straightforward.
+
+## In-scope repo changes
+
+1. Tests (unit, integration, or end-to-end)
+2. CI gates and linting rules
+3. Documentation (ADRs, AGENTS.md, README, inline comments)
+4. CODEOWNERS entries
+5. Protected path rules
+6. Agent permissions and team membership
+7. Auto-merge scope
+
+## Out of scope
+
+- Upstream changes to fullsend skills, prompts, or sub-agents. Note these when relevant, but do not propose them as the primary action. The repo should be self-sufficient.
+- Changes to review agent model or architecture.

--- a/internal/scaffold/fullsend-repo/skills/autonomy-readiness/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/autonomy-readiness/SKILL.md
@@ -8,11 +8,7 @@ description: >
 
 # Autonomy Readiness Analysis
 
-Analyze the difference between what the review agent found on a PR and what human reviewers found on the same PR. Use those deltas to propose concrete repo changes that either close gaps or, when agent coverage is strong, justify relaxing human oversight.
-
-## When to use this skill
-
-Use this skill after you have access to both the review agent's posted findings on a PR and the human review feedback on the same PR. You need the full PR timeline -- agent comments, human comments, requested changes, and inline suggestions -- before you can extract a meaningful delta.
+Analyze the difference between what the review agent found on a PR and what human reviewers found on the same PR. Use those deltas to propose concrete changes that either close gaps or, when agent coverage is strong, justify relaxing human oversight. You need the full PR timeline -- agent findings, human comments, requested changes, and inline suggestions -- before you can extract a meaningful delta.
 
 ## Phase 1: Extract the delta
 
@@ -93,21 +89,8 @@ For each autonomy-increasing proposal, include:
 
 When in doubt, prefer the smaller change. One directory before an entire subtree. Shadow mode before real autonomy. Every proposal must be individually reversible. If you cannot define rollback criteria for a proposal, the proposal is too aggressive -- narrow the scope until rollback is straightforward.
 
-## In-scope repo changes
+## What to propose
 
-1. Tests (unit, integration, or end-to-end)
-2. CI gates and linting rules
-3. Documentation (ADRs, AGENTS.md, README, inline comments)
-4. CODEOWNERS entries
-5. Protected path rules
-6. Agent permissions and team membership
-7. Auto-merge scope
+Think broadly about what would make a difference. Common categories include tests, CI gates, documentation, CODEOWNERS changes, protected path rules, agent permissions, and auto-merge scope -- but do not limit yourself to these. If you identify a novel change that would close a gap or justify more autonomy, propose it.
 
-## Out of scope
-
-- Upstream changes to fullsend skills, prompts, or sub-agents. Note these when relevant, but do not propose them as the primary action. The repo should be self-sufficient.
-- Changes to review agent model or architecture.
-
-## Constraints
-
-The consuming agent's definition is the authoritative source of prohibitions and output constraints. This skill does not restate them.
+In particular, consider adding new agent skills to the target repo's `.claude/` directory. Skills added there are automatically picked up by both the fullsend review agent and casual Claude Code users. If a human reviewer consistently catches a class of issue that the agent misses, a repo-level skill teaching that pattern may be more effective than any other single change.

--- a/internal/scaffold/fullsend-repo/skills/autonomy-readiness/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/autonomy-readiness/SKILL.md
@@ -107,3 +107,7 @@ When in doubt, prefer the smaller change. One directory before an entire subtree
 
 - Upstream changes to fullsend skills, prompts, or sub-agents. Note these when relevant, but do not propose them as the primary action. The repo should be self-sufficient.
 - Changes to review agent model or architecture.
+
+## Constraints
+
+The consuming agent's definition is the authoritative source of prohibitions and output constraints. This skill does not restate them.

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -79,6 +79,7 @@ func TestFullsendRepoFilesExist(t *testing.T) {
 		"scripts/validate-output-schema.sh",
 		"scripts/fullsend-check-output",
 		"scripts/validate-source-repo.sh",
+		"skills/autonomy-readiness/SKILL.md",
 		"skills/code-implementation/SKILL.md",
 		"skills/issue-labels/SKILL.md",
 		"templates/shim-workflow-call.yaml",


### PR DESCRIPTION
## Summary

- Adds a new `autonomy-readiness` skill that provides a structured methodology for analyzing the delta between agent review and human review on a PR
- The skill is agent-agnostic (any agent can use it), with the retro agent as the initial consumer
- Wires the skill into retro's harness, agent frontmatter, and optimization goals as a 5th lens
- Adds scaffold test coverage for the new skill directory

## What the skill does

Three-phase analysis:
1. **Extract the delta** — classify each human review finding as Matched (agent caught it), Gap (agent missed it), or Novel (agent-only)
2. **Diagnose root causes** — for gaps, walk a 5-item diagnostic checklist (missing context, tests, CI gates, skill guidance, documentation) to identify structural repo changes
3. **Assess successes** — for fully-matched PRs, identify patterns that could justify relaxing CODEOWNERS, protected paths, agent permissions, or auto-merge scope

Proposals follow a conservatism principle: smaller changes first, shadow mode before real autonomy, every proposal individually reversible.

## Motivation

Nobody has auto-merge for review agent today. Getting there requires incremental trust-building. This skill lets the retro agent systematically propose per-repo changes that close review gaps and, when evidence supports it, propose specific autonomy increases with experiments and rollback criteria.

Design spec: `docs/superpowers/specs/2026-06-22-autonomy-readiness-skill-design.md`

## Test plan

- [x] `go test ./internal/scaffold/` — all tests pass including `TestHarnessesLoadAndValidate` (validates skill directory exists) and `TestFullsendRepoFilesExist` (new entry)
- [x] `go test ./internal/skill/` — frontmatter parsing tests pass
- [x] `go test ./internal/harness/` — harness validation tests pass