### PR TITLE
feat(renovate): enable automerge for low-risk PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "automergeType": "pr",
+  "platformAutomerge": true,
   "prHourlyLimit": 1,
+  "packageRules": [
+    {
+      "description": "Automerge low-risk updates (patch bumps and pin updates)",
+      "matchUpdateTypes": ["patch", "pin"],
+      "automerge": true
+    },
+    {
+      "description": "Ignore fullsend self-references (own reusable workflows and actions)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["/^fullsend-ai\\//"],
+      "enabled": false
+    }
+  ],
   "postUpdateOptions": ["gomodTidy"],
   "git-submodules": {
     "enabled": true
@@ -11,14 +26,6 @@
       "^internal/scaffold/.*\\.github/workflows/[^/]+\\.ya?ml$"
     ]
   },
-  "packageRules": [
-    {
-      "description": "Ignore fullsend self-references (own reusable workflows and actions)",
-      "matchManagers": ["github-actions"],
-      "matchPackageNames": ["/^fullsend-ai\\//"],
-      "enabled": false
-    }
-  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

- Scope automerge to `patch` and `pin` update types via `packageRules`
- `automergeType: pr` and `platformAutomerge: true` configure merge behavior
- Repo-level `allow_auto_merge` already enabled via API
- `renovate-fullsend` app added as bypass actor on main ruleset via API

Low-risk dependency updates (patch bumps and pin updates) will merge automatically after CI passes. Major/minor updates still require human review.

Closes #2506

## Test plan

- [ ] Verify a patch update PR gets automerge enabled
- [ ] Verify a minor/major update PR does NOT get automerge

🤖 Generated with [Claude Code](https://claude.com/claude-code)