### PR TITLE
fix(deps): restore toml-eslint-parser for CI deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "stylelint-config-standard": "^40.0.0",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
+        "toml-eslint-parser": "^1.0.3",
         "typescript": "^5.6.0",
         "typescript-eslint": "^8.59.1",
         "vite": "^6.0.0",
@@ -9818,6 +9819,22 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toml-eslint-parser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-1.0.3.tgz",
+      "integrity": "sha512-A5F0cM6+mDleacLIEUkmfpkBbnHJFV1d2rprHU2MXNk7mlxHq2zGojA+SRvQD1RoMo9gqjZPWEaKG4v1BQ48lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
       }
     },
     "node_modules/tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "stylelint-config-standard": "^40.0.0",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
+    "toml-eslint-parser": "^1.0.3",
     "typescript": "^5.6.0",
     "typescript-eslint": "^8.59.1",
     "vite": "^6.0.0",


### PR DESCRIPTION
## Summary
- Restores `toml-eslint-parser` to devDependencies — it was removed in 758ce3e4 as "unused" but is imported by `cloudflare_site/scripts/patch-wrangler-rate-limit-namespace-ids.mjs`, which runs in the site-deploy workflow
- Fixes: https://github.com/fullsend-ai/fullsend/actions/runs/28042265276/job/83011287095

## Test plan
- [ ] site-deploy workflow passes the "Patch wrangler.toml for CI" step