### PR TITLE
docs: add maintainer nomination process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,10 @@ When in doubt about whether something warrants a PR, start with an issue. Issues
 
 To find open issues for human contribution, use the [contributor issue search](https://github.com/fullsend-ai/fullsend/issues?q=is%3Aissue%20is%3Aopen%20-author%3Aapp%2Ffullsend-ai-fullsend%20-author%3Aapp%2Ffullsend-ai-triage%20-author%3Aapp%2Ffullsend-ai-review%20-author%3Aapp%2Ffullsend-ai-prioritize%20-author%3Aapp%2Ffullsend-ai-coder%20-author%3Aapp%2Ffullsend-ai-retro%20-label%3Aready-to-code). This search excludes issues reserved for agents.
 
+## Maintainers
+
+See [MAINTAINERS.md](MAINTAINERS.md) for how to become a maintainer (merge and approval rights).
+
 ## License
 
 All contributions to this project are made under the [Apache License, Version 2.0](LICENSE). By submitting a pull request, you agree that your contributions will be licensed under this license.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,17 @@
+# Becoming a Maintainer
+
+Maintainers have merge and approval rights on this repository. They are members of the [@fullsend-ai/core](https://github.com/orgs/fullsend-ai/teams/core) team referenced in [CODEOWNERS](CODEOWNERS).
+
+## Eligibility
+
+You should have a track record of participating in this project — sending PRs, reviewing PRs, or both.
+
+## Process
+
+1. **File an issue** titled "Maintainer nomination: \<your GitHub handle\>". In the issue, link to PRs you have authored or reviewed that demonstrate your familiarity with the project.
+2. **Current maintainers discuss.** The maintainers will review your contributions and discuss among themselves.
+3. **Decision within one week.** A maintainer will follow up on the issue with the outcome. If approved, you will be added to the `@fullsend-ai/core` team.
+
+## Expectations
+
+Maintainers are expected to review PRs constructively, follow the project's [contributing guidelines](CONTRIBUTING.md), and help keep the backlog healthy. There is no minimum time commitment — contribute what you can.


### PR DESCRIPTION
## Summary

- Adds `MAINTAINERS.md` documenting how to become a maintainer (file an issue, link prior PRs, maintainers respond within a week)
- Links to it from `CONTRIBUTING.md`

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify link from CONTRIBUTING.md resolves

Generated with [Claude Code](https://claude.com/claude-code)