### PR TITLE
feat(scaffold): pin workflow refs to release commit SHA

### DIFF
--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -663,7 +663,8 @@ func runPerRepoInstall(ctx context.Context, c perRepoInstallConfig) error {
 		return fmt.Errorf("marshaling per-repo config: %w", err)
 	}
 
-	installFiles, err := scaffold.CollectPerRepoInstallFiles(vendor)
+	upstreamRef, upstreamTag := resolveUpstreamRef()
+	installFiles, err := scaffold.CollectPerRepoInstallFiles(vendor, upstreamRef, upstreamTag)
 	if err != nil {
 		return fmt.Errorf("collecting per-repo scaffold files: %w", err)
 	}
@@ -1861,7 +1862,8 @@ func buildLayerStack(
 }
 
 func workflowsLayer(ctx context.Context, org string, client forge.Client, printer *ui.Printer, user, version string, vendor bool, vendorCollect layers.VendorCollectFunc, direct bool) *layers.WorkflowsLayer {
-	layer := layers.NewWorkflowsLayer(org, client, printer, user, version, vendor).WithDirect(direct)
+	upstreamRef, upstreamTag := resolveUpstreamRef()
+	layer := layers.NewWorkflowsLayer(org, client, printer, user, version, vendor).WithDirect(direct).WithUpstreamRef(upstreamRef, upstreamTag)
 	if vendorCollect != nil {
 		layer = layer.WithVendorCollect(vendorCollect)
 	}

--- a/internal/cli/github.go
+++ b/internal/cli/github.go
@@ -220,7 +220,8 @@ func runGitHubSetupPerRepo(ctx context.Context, client forge.Client, printer *ui
 		return fmt.Errorf("marshaling per-repo config: %w", err)
 	}
 
-	installFiles, err := scaffold.CollectPerRepoInstallFiles(cfg.vendor)
+	upstreamRef, upstreamTag := resolveUpstreamRef()
+	installFiles, err := scaffold.CollectPerRepoInstallFiles(cfg.vendor, upstreamRef, upstreamTag)
 	if err != nil {
 		return fmt.Errorf("collecting per-repo scaffold files: %w", err)
 	}
@@ -981,7 +982,8 @@ func runGitHubSyncScaffold(ctx context.Context, client forge.Client, printer *ui
 		return fmt.Errorf("reading config.yaml: %w", cfgErr)
 	}
 
-	wfLayer := layers.NewWorkflowsLayer(org, client, printer, user, version, vendored).WithDirect(true)
+	upstreamRef, upstreamTag := resolveUpstreamRef()
+	wfLayer := layers.NewWorkflowsLayer(org, client, printer, user, version, vendored).WithDirect(true).WithUpstreamRef(upstreamRef, upstreamTag)
 	if id, idErr := client.GetAuthenticatedUserIdentity(ctx); idErr == nil {
 		wfLayer = wfLayer.WithSignOff(id.Name, id.Email)
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -19,6 +19,17 @@ func CommitSHA() string {
 	return commitSHA
 }
 
+// resolveUpstreamRef returns the SHA and version tag for pinning scaffold
+// workflow refs. Release builds (commitSHA is a real SHA) return the SHA
+// and the corresponding version tag. Dev builds return empty strings,
+// causing the render layer to fall back to config.DefaultUpstreamRef.
+func resolveUpstreamRef() (ref, tag string) {
+	if commitSHA != "" && commitSHA != "dev" {
+		return commitSHA, "v" + version
+	}
+	return "", ""
+}
+
 func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "fullsend",

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -28,3 +28,27 @@ func TestRootCommand_SilencesUsageOnError(t *testing.T) {
 	assert.True(t, cmd.SilenceUsage)
 	assert.True(t, cmd.SilenceErrors)
 }
+
+func TestResolveUpstreamRef(t *testing.T) {
+	tests := []struct {
+		name    string
+		sha     string
+		ver     string
+		wantRef string
+		wantTag string
+	}{
+		{"dev build", "dev", "dev", "", ""},
+		{"empty SHA", "", "dev", "", ""},
+		{"release", "abc123def456", "0.19.0", "abc123def456", "v0.19.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origSHA, origVer := commitSHA, version
+			t.Cleanup(func() { commitSHA, version = origSHA, origVer })
+			commitSHA, version = tt.sha, tt.ver
+			ref, tag := resolveUpstreamRef()
+			assert.Equal(t, tt.wantRef, ref)
+			assert.Equal(t, tt.wantTag, tag)
+		})
+	}
+}

--- a/internal/layers/workflows.go
+++ b/internal/layers/workflows.go
@@ -23,6 +23,8 @@ type WorkflowsLayer struct {
 	vendorCollect     VendorCollectFunc
 	direct            bool
 	signOffTrailer    string // e.g. "Signed-off-by: Name <email>"
+	upstreamRef       string // commit SHA to pin workflow refs to
+	upstreamTag       string // version tag for traceability comment
 }
 
 var _ Layer = (*WorkflowsLayer)(nil)
@@ -37,6 +39,13 @@ func NewWorkflowsLayer(org string, client forge.Client, printer *ui.Printer, use
 		version:           version,
 		vendored:          vendored,
 	}
+}
+
+// WithUpstreamRef configures SHA pinning for scaffolded workflow refs.
+func (l *WorkflowsLayer) WithUpstreamRef(ref, tag string) *WorkflowsLayer {
+	l.upstreamRef = ref
+	l.upstreamTag = tag
+	return l
 }
 
 // WithVendorCollect configures combined scaffold+vendor commits for --vendor installs.
@@ -81,7 +90,7 @@ func (l *WorkflowsLayer) RequiredScopes(op Operation) []string {
 
 func (l *WorkflowsLayer) Install(ctx context.Context) error {
 	installFiles, err := scaffold.CollectInstallFiles(scaffold.CollectInstallFilesOptions{
-		RenderOptions: scaffold.RenderOptionsForInstall(l.vendored, false),
+		RenderOptions: scaffold.RenderOptionsForInstall(l.vendored, false, l.upstreamRef, l.upstreamTag),
 		PathPrefix:    "",
 	})
 	if err != nil {

--- a/internal/layers/workflows_test.go
+++ b/internal/layers/workflows_test.go
@@ -161,7 +161,7 @@ func TestWorkflowsLayer_Install_TriageWorkflowContent(t *testing.T) {
 
 	raw, err := scaffold.FullsendRepoFile(".github/workflows/triage.yml")
 	require.NoError(t, err)
-	rendered, err := scaffold.RenderTemplate(".github/workflows/triage.yml", raw, scaffold.RenderOptionsForInstall(false, false))
+	rendered, err := scaffold.RenderTemplate(".github/workflows/triage.yml", raw, scaffold.RenderOptionsForInstall(false, false, "", ""))
 	require.NoError(t, err)
 	expected := string(scaffold.PrependManagedHeader(".github/workflows/triage.yml", rendered))
 	assert.Equal(t, expected, triageContent)
@@ -235,10 +235,32 @@ func TestWorkflowsLayer_Install_RepoMaintenanceContent(t *testing.T) {
 
 	raw, err := scaffold.FullsendRepoFile(".github/workflows/repo-maintenance.yml")
 	require.NoError(t, err)
-	rendered, err := scaffold.RenderTemplate(".github/workflows/repo-maintenance.yml", raw, scaffold.RenderOptionsForInstall(false, false))
+	rendered, err := scaffold.RenderTemplate(".github/workflows/repo-maintenance.yml", raw, scaffold.RenderOptionsForInstall(false, false, "", ""))
 	require.NoError(t, err)
 	expected := string(scaffold.PrependManagedHeader(".github/workflows/repo-maintenance.yml", rendered))
 	assert.Equal(t, expected, maintenanceContent)
+}
+
+func TestWorkflowsLayer_Install_PinnedSHA(t *testing.T) {
+	client := forge.NewFakeClient()
+	layer, _ := newWorkflowsLayer(t, client, false)
+	layer = layer.WithUpstreamRef("abc123def456abc123def456abc123def456abcd", "v0.19.0")
+
+	err := layer.Install(context.Background())
+	require.NoError(t, err)
+
+	var triageContent string
+	for _, f := range client.CommittedFiles[0].Files {
+		if f.Path == ".github/workflows/triage.yml" {
+			triageContent = string(f.Content)
+			break
+		}
+	}
+	require.NotEmpty(t, triageContent, "triage.yml should have been written")
+	assert.Contains(t, triageContent, "@abc123def456abc123def456abc123def456abcd")
+	assert.Contains(t, triageContent, "# v0.19.0")
+	assert.Contains(t, triageContent, "fullsend_ai_ref: abc123def456abc123def456abc123def456abcd # v0.19.0")
+	assert.NotContains(t, triageContent, "@v0")
 }
 
 func TestWorkflowsLayer_Install_ManagedHeaders(t *testing.T) {

--- a/internal/scaffold/fullsend-repo/.github/workflows/code.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/code.yml
@@ -37,7 +37,7 @@ jobs:
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
-      fullsend_ai_ref: v0
+      fullsend_ai_ref: __FULLSEND_AI_REF__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
@@ -61,7 +61,7 @@ jobs:
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
-      fullsend_ai_ref: v0
+      fullsend_ai_ref: __FULLSEND_AI_REF__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/prioritize.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/prioritize.yml
@@ -36,7 +36,7 @@ jobs:
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       project_number: ${{ vars.FULLSEND_PROJECT_NUMBER }}
       install_mode: per-org
-      fullsend_ai_ref: v0
+      fullsend_ai_ref: __FULLSEND_AI_REF__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/retro.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/retro.yml
@@ -42,7 +42,7 @@ jobs:
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
-      fullsend_ai_ref: v0
+      fullsend_ai_ref: __FULLSEND_AI_REF__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/review.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/review.yml
@@ -36,7 +36,7 @@ jobs:
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
-      fullsend_ai_ref: v0
+      fullsend_ai_ref: __FULLSEND_AI_REF__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/triage.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/triage.yml
@@ -35,7 +35,7 @@ jobs:
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
-      fullsend_ai_ref: v0
+      fullsend_ai_ref: __FULLSEND_AI_REF__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/internal/scaffold/fullsend-repo/templates/shim-per-repo.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-per-repo.yaml
@@ -48,7 +48,7 @@ jobs:
       install_mode: per-repo
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
-      fullsend_ai_ref: v0 # Should match the above `uses` version
+      fullsend_ai_ref: __FULLSEND_AI_REF__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/internal/scaffold/installfiles.go
+++ b/internal/scaffold/installfiles.go
@@ -58,8 +58,8 @@ func customizedDirsForPrefix(prefix string) []string {
 }
 
 // CollectPerRepoInstallFiles gathers files for per-repo installation.
-func CollectPerRepoInstallFiles(vendored bool) (InstallFiles, error) {
-	opts := RenderOptionsForInstall(vendored, true)
+func CollectPerRepoInstallFiles(vendored bool, upstreamRef, upstreamTag string) (InstallFiles, error) {
+	opts := RenderOptionsForInstall(vendored, true, upstreamRef, upstreamTag)
 
 	shimRaw, err := PerRepoShimTemplate()
 	if err != nil {
@@ -91,7 +91,7 @@ func CollectPerRepoInstallFiles(vendored bool) (InstallFiles, error) {
 // Vendored content is reported separately by the vendor layer.
 func ManagedPaths(_ bool, pathPrefix string) ([]string, error) {
 	opts := CollectInstallFilesOptions{
-		RenderOptions: RenderOptionsForInstall(false, pathPrefix != ""),
+		RenderOptions: RenderOptionsForInstall(false, pathPrefix != "", "", ""),
 		PathPrefix:    pathPrefix,
 	}
 	files, err := CollectInstallFiles(opts)

--- a/internal/scaffold/installfiles_test.go
+++ b/internal/scaffold/installfiles_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestCollectInstallFiles_PerOrg(t *testing.T) {
 	files, err := CollectInstallFiles(CollectInstallFilesOptions{
-		RenderOptions: RenderOptionsForInstall(false, false),
+		RenderOptions: RenderOptionsForInstall(false, false, "", ""),
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, files)
@@ -24,7 +24,7 @@ func TestCollectInstallFiles_PerOrg(t *testing.T) {
 
 func TestCollectInstallFiles_PerRepoPrefix(t *testing.T) {
 	files, err := CollectInstallFiles(CollectInstallFilesOptions{
-		RenderOptions: RenderOptionsForInstall(false, true),
+		RenderOptions: RenderOptionsForInstall(false, true, "", ""),
 		PathPrefix:    ".fullsend/",
 	})
 	require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestCollectInstallFiles_PerRepoPrefix(t *testing.T) {
 }
 
 func TestCollectPerRepoInstallFiles(t *testing.T) {
-	files, err := CollectPerRepoInstallFiles(false)
+	files, err := CollectPerRepoInstallFiles(false, "", "")
 	require.NoError(t, err)
 	require.NotEmpty(t, files)
 	assert.Equal(t, ".github/workflows/fullsend.yaml", files[0].Path)
@@ -55,7 +55,7 @@ func TestManagedPaths(t *testing.T) {
 
 func TestCollectInstallFiles_Vendored(t *testing.T) {
 	files, err := CollectInstallFiles(CollectInstallFilesOptions{
-		RenderOptions: RenderOptionsForInstall(true, false),
+		RenderOptions: RenderOptionsForInstall(true, false, "", ""),
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, files)
@@ -72,7 +72,7 @@ func TestCollectInstallFiles_Vendored(t *testing.T) {
 }
 
 func TestCollectPerRepoInstallFiles_Vendored(t *testing.T) {
-	files, err := CollectPerRepoInstallFiles(true)
+	files, err := CollectPerRepoInstallFiles(true, "", "")
 	require.NoError(t, err)
 	require.NotEmpty(t, files)
 	assert.Contains(t, string(files[0].Content), "reusable-")

--- a/internal/scaffold/render.go
+++ b/internal/scaffold/render.go
@@ -10,13 +10,15 @@ import (
 
 // RenderOptions controls install-time substitution for shim and thin-caller templates.
 type RenderOptions struct {
-	Vendored bool
-	PerRepo  bool
+	Vendored    bool
+	PerRepo     bool
+	UpstreamRef string // commit SHA to pin workflow refs to; empty = use DefaultUpstreamRef
+	UpstreamTag string // version tag for traceability comment (e.g. "v0.19.0")
 }
 
 // RenderOptionsForInstall builds render options from the --vendor flag.
-func RenderOptionsForInstall(vendored, perRepo bool) RenderOptions {
-	return RenderOptions{Vendored: vendored, PerRepo: perRepo}
+func RenderOptionsForInstall(vendored, perRepo bool, upstreamRef, upstreamTag string) RenderOptions {
+	return RenderOptions{Vendored: vendored, PerRepo: perRepo, UpstreamRef: upstreamRef, UpstreamTag: upstreamTag}
 }
 
 // thinStageWorkflows lists thin caller paths and their stage markers. Keep in sync
@@ -50,6 +52,8 @@ func RenderTemplate(path string, content []byte, opts RenderOptions) ([]byte, er
 		out = strings.ReplaceAll(out, "__REUSABLE_DISPATCH__", reusableDispatchUses(opts))
 	}
 
+	out = strings.ReplaceAll(out, "__FULLSEND_AI_REF__", resolvedRefWithComment(opts))
+
 	return []byte(out), nil
 }
 
@@ -71,6 +75,21 @@ func thinStageName(content string) (string, error) {
 	return "", fmt.Errorf("could not determine thin caller stage")
 }
 
+func resolvedRef(opts RenderOptions) string {
+	if opts.UpstreamRef != "" {
+		return opts.UpstreamRef
+	}
+	return config.DefaultUpstreamRef
+}
+
+func resolvedRefWithComment(opts RenderOptions) string {
+	ref := resolvedRef(opts)
+	if opts.UpstreamTag != "" && opts.UpstreamTag != ref {
+		return ref + " # " + opts.UpstreamTag
+	}
+	return ref
+}
+
 func reusableWorkflowUses(stage string, opts RenderOptions) string {
 	if opts.Vendored {
 		if opts.PerRepo {
@@ -78,14 +97,24 @@ func reusableWorkflowUses(stage string, opts RenderOptions) string {
 		}
 		return "./.github/workflows/reusable-" + stage + ".yml"
 	}
-	return config.DefaultUpstreamRepo + "/.github/workflows/reusable-" + stage + ".yml@" + config.DefaultUpstreamRef
+	ref := resolvedRef(opts)
+	uses := config.DefaultUpstreamRepo + "/.github/workflows/reusable-" + stage + ".yml@" + ref
+	if opts.UpstreamTag != "" && opts.UpstreamTag != ref {
+		uses += " # " + opts.UpstreamTag
+	}
+	return uses
 }
 
 func reusableDispatchUses(opts RenderOptions) string {
 	if opts.Vendored {
 		return "./.fullsend/.github/workflows/reusable-dispatch.yml"
 	}
-	return config.DefaultUpstreamRepo + "/.github/workflows/reusable-dispatch.yml@" + config.DefaultUpstreamRef
+	ref := resolvedRef(opts)
+	uses := config.DefaultUpstreamRepo + "/.github/workflows/reusable-dispatch.yml@" + ref
+	if opts.UpstreamTag != "" && opts.UpstreamTag != ref {
+		uses += " # " + opts.UpstreamTag
+	}
+	return uses
 }
 
 // RenderDispatchPerRepoStagePaths rewrites stage workflow paths for vendored

--- a/internal/scaffold/render_test.go
+++ b/internal/scaffold/render_test.go
@@ -108,6 +108,7 @@ func assertFreeOfRenderPlaceholders(t *testing.T, out string) {
 		"__REUSABLE_DISPATCH__",
 		"__UPSTREAM_REF__",
 		"__DISTRIBUTION_MODE__",
+		"__FULLSEND_AI_REF__",
 	} {
 		assert.NotContains(t, out, placeholder)
 	}
@@ -141,4 +142,48 @@ func TestRenderAllThinCallersFreeOfPlaceholders(t *testing.T) {
 			assertFreeOfRenderPlaceholders(t, string(rendered))
 		}
 	}
+}
+
+func TestRenderThinCallerPinnedSHA(t *testing.T) {
+	raw, err := FullsendRepoFile(".github/workflows/triage.yml")
+	require.NoError(t, err)
+
+	rendered, err := RenderTemplate(".github/workflows/triage.yml", raw, RenderOptions{
+		UpstreamRef: "abc123def456",
+		UpstreamTag: "v0.19.0",
+	})
+	require.NoError(t, err)
+	out := string(rendered)
+	assert.Contains(t, out, "uses: fullsend-ai/fullsend/.github/workflows/reusable-triage.yml@abc123def456")
+	assert.Contains(t, out, "# v0.19.0")
+	assert.Contains(t, out, "fullsend_ai_ref: abc123def456 # v0.19.0")
+	assertFreeOfRenderPlaceholders(t, out)
+}
+
+func TestRenderPerRepoShimPinnedSHA(t *testing.T) {
+	raw, err := PerRepoShimTemplate()
+	require.NoError(t, err)
+
+	rendered, err := RenderTemplate("templates/shim-per-repo.yaml", raw, RenderOptions{
+		PerRepo:     true,
+		UpstreamRef: "abc123def456",
+		UpstreamTag: "v0.19.0",
+	})
+	require.NoError(t, err)
+	out := string(rendered)
+	assert.Contains(t, out, "uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@abc123def456")
+	assert.Contains(t, out, "# v0.19.0")
+	assert.Contains(t, out, "fullsend_ai_ref: abc123def456 # v0.19.0")
+	assertFreeOfRenderPlaceholders(t, out)
+}
+
+func TestRenderFallbackToDefaultRef(t *testing.T) {
+	raw, err := FullsendRepoFile(".github/workflows/triage.yml")
+	require.NoError(t, err)
+
+	rendered, err := RenderTemplate(".github/workflows/triage.yml", raw, RenderOptions{})
+	require.NoError(t, err)
+	out := string(rendered)
+	assert.Contains(t, out, "@v0")
+	assert.Contains(t, out, "fullsend_ai_ref: v0")
 }

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -159,7 +159,7 @@ func loadRenderedScaffoldCaller(path string) func(t *testing.T) []byte {
 		t.Helper()
 		raw, err := FullsendRepoFile(path)
 		require.NoError(t, err)
-		rendered, err := RenderTemplate(path, raw, RenderOptionsForInstall(false, false))
+		rendered, err := RenderTemplate(path, raw, RenderOptionsForInstall(false, false, "", ""))
 		require.NoError(t, err)
 		return rendered
 	}


### PR DESCRIPTION
## Summary
- Pin scaffolded `uses:` and `fullsend_ai_ref` to the release commit SHA instead of the mutable `@v0` tag
- Dev builds (`commitSHA="dev"`) fall back to `@v0`
- Covers both per-repo shim and per-org thin-caller workflows

Closes #1933

## Test plan
- [x] `go build ./cmd/fullsend/` passes
- [x] `go test ./internal/scaffold/...` passes (new pinned-SHA tests + fallback test)
- [x] `go test ./internal/layers/...` passes
- [x] `go test ./internal/cli/...` passes
- [x] `make lint` passes