### PR TITLE
fix(ci): skip e2e/functional tests in merge queue for irrelevant paths

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,6 +99,12 @@ jobs:
               echo "relevant=true" >> "$GITHUB_OUTPUT"
               exit 0
             }
+            FILE_COUNT=$(echo "$FILES" | wc -l)
+            if [ "$FILE_COUNT" -ge 300 ]; then
+              echo "::warning::Compare API returned $FILE_COUNT files (possible truncation at 300) — running e2e tests as a precaution"
+              echo "relevant=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           else
             FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename') || {
               echo "::warning::Failed to fetch PR files — running e2e tests as a precaution"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,18 +83,29 @@ jobs:
     steps:
       - name: Check for e2e-relevant changes
         id: changes
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' || github.event_name == 'merge_group'
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          MERGE_GROUP_BASE: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD: ${{ github.event.merge_group.head_sha }}
         # SYNC-WITH: push.paths filter above
         run: |
-          FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename') || {
-            echo "::warning::Failed to fetch PR files — running e2e tests as a precaution"
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          }
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            FILES=$(gh api "repos/${REPO}/compare/${MERGE_GROUP_BASE}...${MERGE_GROUP_HEAD}" --jq '.files[].filename') || {
+              echo "::warning::Failed to fetch merge group files — running e2e tests as a precaution"
+              echo "relevant=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            }
+          else
+            FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename') || {
+              echo "::warning::Failed to fetch PR files — running e2e tests as a precaution"
+              echo "relevant=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            }
+          fi
           if echo "$FILES" | grep -qE '\.go$|^go\.(mod|sum)$|^e2e/|^internal/scaffold/fullsend-repo/|^internal/security/hooks/|^internal/dispatch/gcf/mintsrc/|^internal/sentencetoken/english\.json$|^Makefile$|^\.github/workflows/e2e\.yml$|^\.github/actions/check-e2e-authorization/|^scripts/check-e2e-authorization\.sh$'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -91,6 +91,12 @@ jobs:
               echo "relevant=true" >> "$GITHUB_OUTPUT"
               exit 0
             }
+            FILE_COUNT=$(echo "$FILES" | wc -l)
+            if [ "$FILE_COUNT" -ge 300 ]; then
+              echo "::warning::Compare API returned $FILE_COUNT files (possible truncation at 300) — running functional tests as a precaution"
+              echo "relevant=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           else
             FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename') || {
               echo "::warning::Failed to fetch PR files — running functional tests as a precaution"

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -75,18 +75,29 @@ jobs:
     steps:
       - name: Check for functional-test-relevant changes
         id: changes
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' || github.event_name == 'merge_group'
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          MERGE_GROUP_BASE: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD: ${{ github.event.merge_group.head_sha }}
         # SYNC-WITH: push.paths filter above
         run: |
-          FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename') || {
-            echo "::warning::Failed to fetch PR files — running functional tests as a precaution"
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          }
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            FILES=$(gh api "repos/${REPO}/compare/${MERGE_GROUP_BASE}...${MERGE_GROUP_HEAD}" --jq '.files[].filename') || {
+              echo "::warning::Failed to fetch merge group files — running functional tests as a precaution"
+              echo "relevant=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            }
+          else
+            FILES=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename') || {
+              echo "::warning::Failed to fetch PR files — running functional tests as a precaution"
+              echo "relevant=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            }
+          fi
           if echo "$FILES" | grep -qE '^eval/|^internal/scaffold/|^\.github/workflows/functional-tests\.yml$|^\.github/scripts/'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

- The `merge_group` trigger on e2e.yml and functional-tests.yml had no path filter, and the relevance-check step only ran for `pull_request_target` events
- Every PR entering the merge queue ran the full e2e and functional test suites regardless of what files changed (e.g. #2514 which only touched `lint.yml`)
- Extend the relevance check to also run on `merge_group` events, using the compare API with the merge group base/head SHAs to determine changed files

## Test plan

- [ ] A PR that only touches non-relevant files (e.g. docs, lint config) should skip e2e/functional tests in the merge queue
- [ ] A PR that touches relevant files (e.g. `*.go`, `eval/**`) should still run tests in the merge queue
- [ ] If the compare API call fails, tests run as a precaution (fail-open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)