### PR TITLE
fix(ci): pin third-party actions in root action.yml to commit SHAs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -229,7 +229,7 @@ runs:
 
     - name: Set up Go for source build
       if: steps.detect.outputs.install-method == 'source'
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: ${{ runner.temp }}/fullsend-src/go.mod
         cache-dependency-path: ${{ runner.temp }}/fullsend-src/go.sum
@@ -280,7 +280,7 @@ runs:
 
     - name: Restore cached sandbox image
       id: sandbox-cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: /tmp/sandbox-image.tar
         key: sandbox-image-${{ runner.os }}-${{ runner.arch }}-${{ env.FULLSEND_SANDBOX_IMAGE || 'ghcr.io/fullsend-ai/fullsend-code:latest' }}
@@ -334,7 +334,7 @@ runs:
 
     - name: Update sandbox image cache
       if: steps.sandbox-cache.outputs.cache-hit != 'true' || steps.sandbox-pull.outputs.changed == 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: /tmp/sandbox-image.tar
         key: sandbox-image-${{ runner.os }}-${{ runner.arch }}-${{ env.FULLSEND_SANDBOX_IMAGE || 'ghcr.io/fullsend-ai/fullsend-code:latest' }}
@@ -345,7 +345,7 @@ runs:
 
     - name: Set up Go for target repo pre-commit hooks
       if: hashFiles(format('{0}/go.mod', inputs.target-repo)) != ''
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: ${{ inputs.target-repo }}/go.mod
         cache: false
@@ -423,7 +423,7 @@ runs:
 
     - name: Upload fullsend artifacts
       if: always() && inputs.agent != '__install_only__'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: fullsend-${{ inputs.agent }}
         path: ${{ github.workspace }}/output


### PR DESCRIPTION
## Summary
- Pin 5 remaining unpinned third-party action refs in root `action.yml` to full-length commit SHAs
- `actions/setup-go@v6` → `@4a3601121dd01d1626a1e23e37211e3254c1c06c` (v6.4.0) ×2
- `actions/cache/restore@v4` and `actions/cache/save@v4` → `@0057852bfaa89a56745cba8c7296529d2fc39830` (v4.3.0)
- `actions/upload-artifact@v7` → `@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v7.0.1)

## Context
PR #2508 pinned actions in `.github/workflows/` and `.github/actions/setup-gcp/` but missed the root composite `action.yml`. Repos with strict SHA-pinning policies (e.g. `openkaiden/kaiden`) reject the unpinned tag refs, failing agent jobs:

> The actions actions/setup-go@v6, actions/cache/restore@v4, and actions/upload-artifact@v7 are not allowed in openkaiden/kaiden because all actions must be pinned to a full-length commit SHA.

SHAs match those already used in the workflow files pinned by #2508.

## Test plan
- [ ] Verify `pinact` pre-commit hook passes (no unpinned refs flagged)
- [ ] Re-run openkaiden/kaiden dispatch after next release includes this fix