### PR TITLE
fix(ci): include root action.yml in pinact and pre-commit checks

### DIFF
--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -6,6 +6,7 @@ files:
   - pattern: ".github/workflows/*.yml"
   - pattern: "internal/scaffold/fullsend-repo/.github/workflows/*.yml"
   - pattern: ".github/actions/*/action.yml"
+  - pattern: "action.yml"
 
 rules:
   # Ignore self-references to this repo's own reusable workflows and actions.

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -4,7 +4,9 @@ version: 3
 
 files:
   - pattern: ".github/workflows/*.yml"
+  - pattern: ".github/workflows/*.yaml"
   - pattern: "internal/scaffold/fullsend-repo/.github/workflows/*.yml"
+  - pattern: "internal/scaffold/fullsend-repo/.github/workflows/*.yaml"
   - pattern: ".github/actions/*/action.yml"
   - pattern: "action.yml"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,7 @@ repos:
             \.github/workflows/
             |\.github/actions/
             |internal/scaffold/fullsend-repo/\.github/workflows/
+            |action\.yml$
           )
         pass_filenames: false
 


### PR DESCRIPTION
## Summary

- Add `action.yml` to `.pinact.yaml` file patterns
- Add `action\.yml$` to the pinact pre-commit hook's file regex

## Context

PR #2508 pinned actions across `.github/workflows/` and `.github/actions/` but missed the root `action.yml` because neither pinact nor the pre-commit hook was configured to scan it. PR #2621 fixes the unpinned refs themselves; this PR closes the gap in the tooling so future unpinned refs are caught automatically.

## Test plan

- [x] `pinact run --fix=false --no-api` now flags unpinned refs in root `action.yml`
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)