### PR TITLE
fix: use skill directory name from URL instead of cache-internal "tree"

### DIFF
--- a/internal/fetch/cache.go
+++ b/internal/fetch/cache.go
@@ -340,6 +340,30 @@ func CacheGetDir(workspaceRoot, hash string) (string, *DirCacheEntry, error) {
 	return treeDir, &entry, nil
 }
 
+// CacheNamedSymlink creates a symlink in a cache directory so that the
+// directory can be referenced by a human-readable skill name instead of the
+// cache-internal "tree" directory name. It sanitizes the skill name, handles
+// race conditions (concurrent symlink creation), and returns the symlinked
+// path. If the skill name is invalid or matches a reserved cache file, the
+// original treePath is returned unchanged.
+func CacheNamedSymlink(treePath, skillName string) (string, error) {
+	if skillName == "" || skillName == "." || skillName == ".." || skillName == "metadata.json" {
+		skillName = "tree"
+	}
+	namedPath := filepath.Join(filepath.Dir(treePath), skillName)
+	if namedPath == treePath {
+		return treePath, nil
+	}
+	if _, err := os.Lstat(namedPath); os.IsNotExist(err) {
+		if err := os.Symlink("tree", namedPath); err != nil && !os.IsExist(err) {
+			return "", fmt.Errorf("creating named symlink: %w", err)
+		}
+	} else if err != nil {
+		return "", fmt.Errorf("checking named symlink: %w", err)
+	}
+	return namedPath, nil
+}
+
 // atomicWrite writes data to a temporary file in dir, then renames it to the
 // final name. This ensures readers never see a partially-written file.
 func atomicWrite(dir, name string, data []byte) error {

--- a/internal/fetch/cache_test.go
+++ b/internal/fetch/cache_test.go
@@ -373,3 +373,61 @@ func TestCacheConcurrentPut(t *testing.T) {
 	assert.Equal(t, content, got)
 	assert.Equal(t, hash, entry.SHA256)
 }
+
+func TestCacheNamedSymlink(t *testing.T) {
+	t.Run("creates symlink with skill name", func(t *testing.T) {
+		dir := t.TempDir()
+		treePath := filepath.Join(dir, "tree")
+		require.NoError(t, os.Mkdir(treePath, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(treePath, "SKILL.md"), []byte("hi"), 0o600))
+
+		got, err := CacheNamedSymlink(treePath, "pr-review")
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(dir, "pr-review"), got)
+		assert.FileExists(t, filepath.Join(got, "SKILL.md"))
+	})
+
+	t.Run("idempotent on second call", func(t *testing.T) {
+		dir := t.TempDir()
+		treePath := filepath.Join(dir, "tree")
+		require.NoError(t, os.Mkdir(treePath, 0o755))
+
+		_, err := CacheNamedSymlink(treePath, "review")
+		require.NoError(t, err)
+		got, err := CacheNamedSymlink(treePath, "review")
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(dir, "review"), got)
+	})
+
+	t.Run("reserved names fall back to tree", func(t *testing.T) {
+		for _, name := range []string{"", ".", "..", "metadata.json"} {
+			dir := t.TempDir()
+			treePath := filepath.Join(dir, "tree")
+			require.NoError(t, os.Mkdir(treePath, 0o755))
+
+			got, err := CacheNamedSymlink(treePath, name)
+			require.NoError(t, err)
+			assert.Equal(t, treePath, got, "reserved name %q should return treePath unchanged", name)
+		}
+	})
+
+	t.Run("concurrent creation tolerates EEXIST", func(t *testing.T) {
+		dir := t.TempDir()
+		treePath := filepath.Join(dir, "tree")
+		require.NoError(t, os.Mkdir(treePath, 0o755))
+
+		var wg sync.WaitGroup
+		errs := make([]error, 10)
+		for i := range errs {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				_, errs[idx] = CacheNamedSymlink(treePath, "skill")
+			}(i)
+		}
+		wg.Wait()
+		for i, err := range errs {
+			assert.NoError(t, err, "goroutine %d", i)
+		}
+	})
+}

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -992,6 +992,24 @@ func fetchBaseSkillDir(ctx context.Context, field, skillDirURL, skillFileURL, sk
 		return Dependency{}, "", fmt.Errorf("base %s: reading cached skill directory: %w", field, err)
 	}
 
+	// Create a symlink named after the skill directory so downstream consumers
+	// (sandbox upload, logging) see the real skill name instead of "tree".
+	skillName := filepath.Base(forgeInfo.Path)
+	if skillName == "" || skillName == "." || skillName == ".." || skillName == "metadata.json" {
+		skillName = "tree"
+	}
+	namedPath := filepath.Join(filepath.Dir(treePath), skillName)
+	if namedPath != treePath {
+		if _, err := os.Lstat(namedPath); os.IsNotExist(err) {
+			if err := os.Symlink("tree", namedPath); err != nil && !os.IsExist(err) {
+				return Dependency{}, "", fmt.Errorf("base %s: creating named symlink: %w", field, err)
+			}
+		} else if err != nil {
+			return Dependency{}, "", fmt.Errorf("base %s: checking named symlink: %w", field, err)
+		}
+		treePath = namedPath
+	}
+
 	if iErr := urlIndexPut(opts.WorkspaceRoot, skillFileURL, treeHash); iErr != nil {
 		return Dependency{}, "", fmt.Errorf("base %s: updating URL index: %w", field, iErr)
 	}

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -902,6 +902,23 @@ func fetchBaseSkill(ctx context.Context, field, baseURLDir, skillPath string, al
 		if ok {
 			treePath, entry, err := fetch.CacheGetDir(opts.WorkspaceRoot, treeHash)
 			if err == nil && treePath != "" {
+				// Apply the same symlink renaming as fetchBaseSkillDir so
+				// cache-hit paths return the real skill name, not "tree".
+				skillName := filepath.Base(skillPath)
+				if skillName == "" || skillName == "." || skillName == ".." || skillName == "metadata.json" {
+					skillName = "tree"
+				}
+				namedPath := filepath.Join(filepath.Dir(treePath), skillName)
+				if namedPath != treePath {
+					if _, lErr := os.Lstat(namedPath); os.IsNotExist(lErr) {
+						if sErr := os.Symlink("tree", namedPath); sErr != nil && !os.IsExist(sErr) {
+							return Dependency{}, "", fmt.Errorf("base %s: creating named symlink: %w", field, sErr)
+						}
+					} else if lErr != nil {
+						return Dependency{}, "", fmt.Errorf("base %s: checking named symlink: %w", field, lErr)
+					}
+					treePath = namedPath
+				}
 				cachedDep := Dependency{
 					Field:     field,
 					URL:       skillFileURL,

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -904,20 +904,9 @@ func fetchBaseSkill(ctx context.Context, field, baseURLDir, skillPath string, al
 			if err == nil && treePath != "" {
 				// Apply the same symlink renaming as fetchBaseSkillDir so
 				// cache-hit paths return the real skill name, not "tree".
-				skillName := filepath.Base(skillPath)
-				if skillName == "" || skillName == "." || skillName == ".." || skillName == "metadata.json" {
-					skillName = "tree"
-				}
-				namedPath := filepath.Join(filepath.Dir(treePath), skillName)
-				if namedPath != treePath {
-					if _, lErr := os.Lstat(namedPath); os.IsNotExist(lErr) {
-						if sErr := os.Symlink("tree", namedPath); sErr != nil && !os.IsExist(sErr) {
-							return Dependency{}, "", fmt.Errorf("base %s: creating named symlink: %w", field, sErr)
-						}
-					} else if lErr != nil {
-						return Dependency{}, "", fmt.Errorf("base %s: checking named symlink: %w", field, lErr)
-					}
-					treePath = namedPath
+				treePath, err = fetch.CacheNamedSymlink(treePath, filepath.Base(skillPath))
+				if err != nil {
+					return Dependency{}, "", fmt.Errorf("base %s: %w", field, err)
 				}
 				cachedDep := Dependency{
 					Field:     field,
@@ -1011,20 +1000,9 @@ func fetchBaseSkillDir(ctx context.Context, field, skillDirURL, skillFileURL, sk
 
 	// Create a symlink named after the skill directory so downstream consumers
 	// (sandbox upload, logging) see the real skill name instead of "tree".
-	skillName := filepath.Base(forgeInfo.Path)
-	if skillName == "" || skillName == "." || skillName == ".." || skillName == "metadata.json" {
-		skillName = "tree"
-	}
-	namedPath := filepath.Join(filepath.Dir(treePath), skillName)
-	if namedPath != treePath {
-		if _, err := os.Lstat(namedPath); os.IsNotExist(err) {
-			if err := os.Symlink("tree", namedPath); err != nil && !os.IsExist(err) {
-				return Dependency{}, "", fmt.Errorf("base %s: creating named symlink: %w", field, err)
-			}
-		} else if err != nil {
-			return Dependency{}, "", fmt.Errorf("base %s: checking named symlink: %w", field, err)
-		}
-		treePath = namedPath
+	treePath, err = fetch.CacheNamedSymlink(treePath, filepath.Base(forgeInfo.Path))
+	if err != nil {
+		return Dependency{}, "", fmt.Errorf("base %s: %w", field, err)
 	}
 
 	if iErr := urlIndexPut(opts.WorkspaceRoot, skillFileURL, treeHash); iErr != nil {

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -2798,6 +2798,31 @@ func TestFetchBaseSkill_CacheHit_AuditError(t *testing.T) {
 	assert.Contains(t, err.Error(), "audit")
 }
 
+func TestFetchBaseSkill_CacheHit_UsesSkillNameNotTree(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	skillFileURL := "https://raw.githubusercontent.com/org/repo/ref1/skills/pr-review/SKILL.md"
+	allowlist := []string{"https://raw.githubusercontent.com/org/repo/"}
+
+	files := map[string][]byte{"SKILL.md": []byte("# PR Review")}
+	treeHash, err := fetch.CachePutDir(cacheDir, skillFileURL, files, fetch.DirCachePutOpts{FullListing: true})
+	require.NoError(t, err)
+	require.NoError(t, urlIndexPut(cacheDir, skillFileURL, treeHash))
+	require.NoError(t, urlIndexPut(cacheDir, "skill:"+skillFileURL, treeHash))
+
+	dep, localDir, err := fetchBaseSkill(context.Background(), "skills[0]",
+		"https://raw.githubusercontent.com/org/repo/ref1/",
+		"skills/pr-review", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			FetchPolicy:   fetch.FetchPolicy{Offline: true},
+		})
+	require.NoError(t, err)
+	assert.True(t, dep.CacheHit)
+	assert.Equal(t, "pr-review", filepath.Base(localDir), "cache-hit path should return skill name, not 'tree'")
+	assert.FileExists(t, filepath.Join(localDir, "SKILL.md"))
+}
+
 func TestFetchBaseSkill_DefaultTreeFetcherUsed(t *testing.T) {
 	dir := t.TempDir()
 	cacheDir := filepath.Join(dir, "cache")

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -3005,6 +3005,7 @@ func TestFetchBaseSkill_FullDirectory(t *testing.T) {
 	assert.Equal(t, "directory", dep.Type)
 	assert.Empty(t, dep.Warning)
 	assert.False(t, dep.CacheHit)
+	assert.Equal(t, "pr-review", filepath.Base(localDir), "fresh-fetch path should return skill name, not 'tree'")
 
 	// Verify all companion files exist in the cached directory.
 	skillMD, err := os.ReadFile(filepath.Join(localDir, "SKILL.md"))

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -369,9 +369,11 @@ func resolveSkillDirURL(ctx context.Context, field, rawURL string, h *harness.Ha
 	if namedPath != treePath {
 		// Idempotent: only create if it doesn't already exist.
 		if _, err := os.Lstat(namedPath); os.IsNotExist(err) {
-			if err := os.Symlink("tree", namedPath); err != nil {
+			if err := os.Symlink("tree", namedPath); err != nil && !os.IsExist(err) {
 				return Dependency{}, "", fmt.Errorf("creating named symlink for %s: %w", field, err)
 			}
+		} else if err != nil {
+			return Dependency{}, "", fmt.Errorf("checking named symlink for %s: %w", field, err)
 		}
 		treePath = namedPath
 	}

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -359,6 +359,23 @@ func resolveSkillDirURL(ctx context.Context, field, rawURL string, h *harness.Ha
 		fetchedAt = dirEntry.FetchTime
 	}
 
+	// Create a symlink named after the skill directory so downstream consumers
+	// (sandbox upload, logging) see the real skill name instead of "tree".
+	skillName := filepath.Base(forgeInfo.Path)
+	if skillName == "" || skillName == "." {
+		skillName = "tree"
+	}
+	namedPath := filepath.Join(filepath.Dir(treePath), skillName)
+	if namedPath != treePath {
+		// Idempotent: only create if it doesn't already exist.
+		if _, err := os.Lstat(namedPath); os.IsNotExist(err) {
+			if err := os.Symlink("tree", namedPath); err != nil {
+				return Dependency{}, "", fmt.Errorf("creating named symlink for %s: %w", field, err)
+			}
+		}
+		treePath = namedPath
+	}
+
 	if opts.AuditLogPath != "" {
 		if err := fetch.AppendFetchAudit(opts.AuditLogPath, fetch.FetchAuditEntry{
 			TraceID:   opts.TraceID,

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -362,7 +362,7 @@ func resolveSkillDirURL(ctx context.Context, field, rawURL string, h *harness.Ha
 	// Create a symlink named after the skill directory so downstream consumers
 	// (sandbox upload, logging) see the real skill name instead of "tree".
 	skillName := filepath.Base(forgeInfo.Path)
-	if skillName == "" || skillName == "." {
+	if skillName == "" || skillName == "." || skillName == ".." {
 		skillName = "tree"
 	}
 	namedPath := filepath.Join(filepath.Dir(treePath), skillName)

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -362,7 +362,7 @@ func resolveSkillDirURL(ctx context.Context, field, rawURL string, h *harness.Ha
 	// Create a symlink named after the skill directory so downstream consumers
 	// (sandbox upload, logging) see the real skill name instead of "tree".
 	skillName := filepath.Base(forgeInfo.Path)
-	if skillName == "" || skillName == "." || skillName == ".." {
+	if skillName == "" || skillName == "." || skillName == ".." || skillName == "metadata.json" {
 		skillName = "tree"
 	}
 	namedPath := filepath.Join(filepath.Dir(treePath), skillName)

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -361,21 +361,9 @@ func resolveSkillDirURL(ctx context.Context, field, rawURL string, h *harness.Ha
 
 	// Create a symlink named after the skill directory so downstream consumers
 	// (sandbox upload, logging) see the real skill name instead of "tree".
-	skillName := filepath.Base(forgeInfo.Path)
-	if skillName == "" || skillName == "." || skillName == ".." || skillName == "metadata.json" {
-		skillName = "tree"
-	}
-	namedPath := filepath.Join(filepath.Dir(treePath), skillName)
-	if namedPath != treePath {
-		// Idempotent: only create if it doesn't already exist.
-		if _, err := os.Lstat(namedPath); os.IsNotExist(err) {
-			if err := os.Symlink("tree", namedPath); err != nil && !os.IsExist(err) {
-				return Dependency{}, "", fmt.Errorf("creating named symlink for %s: %w", field, err)
-			}
-		} else if err != nil {
-			return Dependency{}, "", fmt.Errorf("checking named symlink for %s: %w", field, err)
-		}
-		treePath = namedPath
+	treePath, err = fetch.CacheNamedSymlink(treePath, filepath.Base(forgeInfo.Path))
+	if err != nil {
+		return Dependency{}, "", fmt.Errorf("naming cached skill for %s: %w", field, err)
 	}
 
 	if opts.AuditLogPath != "" {

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -261,6 +261,29 @@ func TestResolveHarness_SkillDirCacheHit(t *testing.T) {
 		"cache-hit skill path basename should be the skill directory name from the URL")
 }
 
+func TestResolveHarness_SkillDirDotDotFallsBackToTree(t *testing.T) {
+	skillMD := []byte("# DotDot skill")
+
+	reg := newSkillRegistry()
+	files := map[string][]byte{"SKILL.md": skillMD}
+	treeHash := reg.register("skills/..", files)
+
+	root := t.TempDir()
+	h := &harness.Harness{
+		Skills:                 []string{forgeSkillURL("skills/..", treeHash)},
+		AllowedRemoteResources: []string{testForgeBase},
+	}
+
+	deps, err := ResolveHarness(context.Background(), h, ResolveOpts{
+		WorkspaceRoot: root,
+		TreeFetcher:   reg.fetcher(),
+	})
+	require.NoError(t, err)
+	require.Len(t, deps, 1)
+	assert.Equal(t, "tree", filepath.Base(h.Skills[0]),
+		"skill path with '..' basename should fall back to 'tree' to prevent traversal")
+}
+
 func TestResolveHarness_SkillDirHashMismatch(t *testing.T) {
 	reg := newSkillRegistry()
 	reg.register("skills/tampered", map[string][]byte{"SKILL.md": []byte("wrong content")})

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -214,10 +214,13 @@ func TestResolveHarness_SkillDirFetchAndCache(t *testing.T) {
 	assert.Equal(t, treeHash, deps[0].SHA256)
 	assert.False(t, deps[0].CacheHit)
 
-	// Verify h.Skills[0] is a directory path (the tree/ subdirectory).
+	// Verify h.Skills[0] is a directory path whose basename is the skill
+	// directory name from the URL ("review"), not the cache-internal "tree".
 	info, err := os.Stat(h.Skills[0])
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())
+	assert.Equal(t, "review", filepath.Base(h.Skills[0]),
+		"skill path basename should be the skill directory name from the URL, not 'tree'")
 
 	// Verify SKILL.md is inside the cached directory.
 	got, err := os.ReadFile(filepath.Join(h.Skills[0], "SKILL.md"))
@@ -254,6 +257,8 @@ func TestResolveHarness_SkillDirCacheHit(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, deps, 1)
 	assert.True(t, deps[0].CacheHit)
+	assert.Equal(t, "cached", filepath.Base(h.Skills[0]),
+		"cache-hit skill path basename should be the skill directory name from the URL")
 }
 
 func TestResolveHarness_SkillDirHashMismatch(t *testing.T) {
@@ -606,6 +611,10 @@ func TestResolveHarness_MultipleSkills(t *testing.T) {
 	assert.Equal(t, "/local/skills/debug", h.Skills[0])
 	assert.False(t, harness.IsURL(h.Skills[1]))
 	assert.False(t, harness.IsURL(h.Skills[2]))
+
+	// Verify skills resolve to directories named after the URL path, not "tree".
+	assert.Equal(t, "one", filepath.Base(h.Skills[1]))
+	assert.Equal(t, "two", filepath.Base(h.Skills[2]))
 
 	// Verify skills resolve to directories with SKILL.md inside.
 	got1, err := os.ReadFile(filepath.Join(h.Skills[1], "SKILL.md"))

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -284,6 +284,29 @@ func TestResolveHarness_SkillDirDotDotFallsBackToTree(t *testing.T) {
 		"skill path with '..' basename should fall back to 'tree' to prevent traversal")
 }
 
+func TestResolveHarness_SkillDirMetadataJsonFallsBackToTree(t *testing.T) {
+	skillMD := []byte("# MetadataJson skill")
+
+	reg := newSkillRegistry()
+	files := map[string][]byte{"SKILL.md": skillMD}
+	treeHash := reg.register("skills/metadata.json", files)
+
+	root := t.TempDir()
+	h := &harness.Harness{
+		Skills:                 []string{forgeSkillURL("skills/metadata.json", treeHash)},
+		AllowedRemoteResources: []string{testForgeBase},
+	}
+
+	deps, err := ResolveHarness(context.Background(), h, ResolveOpts{
+		WorkspaceRoot: root,
+		TreeFetcher:   reg.fetcher(),
+	})
+	require.NoError(t, err)
+	require.Len(t, deps, 1)
+	assert.Equal(t, "tree", filepath.Base(h.Skills[0]),
+		"skill path with 'metadata.json' basename should fall back to 'tree' to avoid cache file collision")
+}
+
 func TestResolveHarness_SkillDirHashMismatch(t *testing.T) {
 	reg := newSkillRegistry()
 	reg.register("skills/tampered", map[string][]byte{"SKILL.md": []byte("wrong content")})


### PR DESCRIPTION
## Summary

- URL-resolved skills were named "tree" in the sandbox instead of their actual name (e.g., "architecture") because the cache stores content under a `tree/` subdirectory and `filepath.Base()` picked that up
- Fix creates a symlink named after the skill directory (from the URL path) alongside `tree` in the cache, so all downstream consumers (sandbox upload, logging) see the correct name
- Multiple URL-resolved skills no longer collide on the name "tree"

Discovered via https://github.com/konflux-ci/refinement/actions/runs/28116641395/job/83257718265 where the `architecture` skill showed up as `Skill "tree": uploaded to sandbox`.

## Test plan

- [x] Added basename assertions to `TestResolveHarness_SkillDirFetchAndCache` (fresh fetch)
- [x] Added basename assertion to `TestResolveHarness_SkillDirCacheHit` (cache hit path)
- [x] Added basename assertions to `TestResolveHarness_MultipleSkills` (two URL skills get distinct names)
- [x] All 27 resolve package tests pass
- [x] `internal/runtime` and `internal/fetchsvc` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)