### PR TITLE
fix(ci): use GitHub PR titles for release notes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,6 +32,7 @@ checksum:
   name_template: checksums.txt
 
 changelog:
+  use: github
   sort: asc
   filters:
     exclude:


### PR DESCRIPTION
## Summary

- Adds `use: github` to the GoReleaser changelog config so release notes list **merged PR titles** instead of every individual commit
- Existing group and filter rules still apply — they match against PR titles, so our conventional-commit PR title convention carries over
- No workflow changes for contributors

## Why

Release notes currently show every commit in every PR, which is noisy — especially when PRs have fixup, review-feedback, or WIP commits. With `use: github`, GoReleaser pulls from the GitHub API and lists one entry per merged PR.

## Test plan

- [ ] Cut a release candidate after merge and verify the notes list PRs, not commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)