### PR TITLE
fix(scaffold): use __FULLSEND_AI_REF__ for mint-token action refs

### DIFF
--- a/internal/scaffold/fullsend-repo/.github/workflows/prioritize-scheduler.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/prioritize-scheduler.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Mint fullsend token
         id: app-token
-        uses: fullsend-ai/fullsend/.github/actions/mint-token@v0
+        uses: fullsend-ai/fullsend/.github/actions/mint-token@__FULLSEND_AI_REF__
         with:
           role: fullsend
           repos: .fullsend

--- a/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Mint fullsend token
         if: steps.repo-list.outputs.skip != 'true'
         id: app-token
-        uses: fullsend-ai/fullsend/.github/actions/mint-token@v0
+        uses: fullsend-ai/fullsend/.github/actions/mint-token@__FULLSEND_AI_REF__
         with:
           role: fullsend
           repos: ${{ steps.repo-list.outputs.names }}

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -718,7 +718,7 @@ func TestRepoMaintenanceWorkflowContent(t *testing.T) {
 		"push trigger must include workflow_call shim template so changes propagate to enrolled repos")
 	assert.NotContains(t, s, "templates/shim-workflow.yaml",
 		"PAT shim template reference should be removed")
-	assert.Contains(t, s, "fullsend-ai/fullsend/.github/actions/mint-token@v0")
+	assert.Contains(t, s, "fullsend-ai/fullsend/.github/actions/mint-token@__FULLSEND_AI_REF__")
 	assert.Contains(t, s, "Checkout upstream scripts")
 	assert.Contains(t, s, "Prepare scripts")
 	assert.Contains(t, s, "customized/scripts")
@@ -799,7 +799,7 @@ func TestPrioritizeSchedulerWorkflowContent(t *testing.T) {
 	require.NotEqual(t, -1, guardIndex)
 	require.NotEqual(t, -1, projectViewIndex)
 	assert.Less(t, guardIndex, projectViewIndex, "PROJECT_NUMBER must be checked before gh project view")
-	assert.Contains(t, s, "fullsend-ai/fullsend/.github/actions/mint-token@v0")
+	assert.Contains(t, s, "fullsend-ai/fullsend/.github/actions/mint-token@__FULLSEND_AI_REF__")
 	assert.Contains(t, s, "role: fullsend")
 	assert.Contains(t, s, "id-token: write")
 	assert.NotContains(t, s, "create-github-app-token")


### PR DESCRIPTION
## Summary

- Replace hardcoded `@v0` with `@__FULLSEND_AI_REF__` for `mint-token` composite action in `prioritize-scheduler.yml` and `repo-maintenance.yml` scaffold templates
- Matches the pattern already used by reusable workflow `uses:` refs (from #2615)

Without this, downstream `.fullsend` repos that enable `sha_pinning_required` reject `mint-token@v0` as an unpinned action ref. Confirmed by triggering `prioritize-scheduler` on `fullsend-ai/.fullsend` after enabling the policy — run [28122373431](https://github.com/fullsend-ai/.fullsend/actions/runs/28122373431) failed with:

> The action fullsend-ai/fullsend/.github/actions/mint-token@v0 is not allowed in fullsend-ai/.fullsend because all actions must be pinned to a full-length commit SHA.

## Test plan

- [ ] After merge + release + scaffold sync, trigger `prioritize-scheduler` on `fullsend-ai/.fullsend` and confirm it passes
- [ ] Verify `repo-maintenance` also passes