### PR TITLE
fix(renovate): add repository target and fork guard

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -28,6 +28,7 @@ permissions: {}
 
 jobs:
   renovate:
+    if: github.repository_owner == 'fullsend-ai'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -44,4 +45,5 @@ jobs:
           configurationFile: renovate.json
         env:
           LOG_LEVEL: info
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_DRY_RUN: ${{ inputs.dry-run || 'false' }}


### PR DESCRIPTION
## Summary
- Add `RENOVATE_REPOSITORIES` env var so Renovate discovers this repo
- Gate job with `if: github.repository_owner == 'fullsend-ai'` to skip forks

## Test plan
- [ ] Re-run Renovate workflow dispatch and confirm no "No repositories found" warning
- [ ] Verify fork CI skips the Renovate job

Closes #2645

🤖 Generated with [Claude Code](https://claude.com/claude-code)