### PR TITLE
feat(#2611): pin runners to ubuntu-24.04 with configurable __GH_RUNNER__

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Delete stale branches

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,7 +45,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request_target' &&
       (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: read
@@ -75,7 +75,7 @@ jobs:
     if: >-
       !cancelled() &&
       (github.event_name != 'pull_request_target' || needs.gate.outputs.authorized == 'true')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -62,7 +62,7 @@ jobs:
           || github.event.comment.author_association == 'CONTRIBUTOR'
           || github.event.comment.user.login == github.event.issue.user.login
         )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -37,7 +37,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request_target' &&
       (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: read
@@ -67,7 +67,7 @@ jobs:
     if: >-
       !cancelled() &&
       (github.event_name != 'pull_request_target' || needs.gate.outputs.authorized == 'true')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
       contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -78,7 +78,7 @@ jobs:
     # Lint each commit on push/merge_group.
     # The merge queue uses merge (not squash), so individual commit
     # messages matter — catch bad prefixes before the merge queue rejects them.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -125,7 +125,7 @@ jobs:
           fi
 
   web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/notify-adr-slack.yml
+++ b/.github/workflows/notify-adr-slack.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   notify:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Identify changed ADRs
         id: changed

--- a/.github/workflows/pat-cleanup.yml
+++ b/.github/workflows/pat-cleanup.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -28,7 +28,7 @@ permissions: {}
 
 jobs:
   renovate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 

--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -49,7 +49,7 @@ concurrency:
 jobs:
   code:
     name: Code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -36,6 +36,11 @@ on:
         type: string
         required: false
         default: v0
+      runner_image:
+        description: GitHub Actions runner image for agent jobs.
+        type: string
+        required: false
+        default: "ubuntu-24.04"
     secrets:
       FULLSEND_GCP_WIF_PROVIDER:
         required: true
@@ -49,7 +54,7 @@ concurrency:
 jobs:
   code:
     name: Code
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runner_image }}
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -64,7 +64,7 @@ on:
 jobs:
   route:
     name: Route
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -55,6 +55,11 @@ on:
         required: false
         type: string
         default: ""
+      runner_image:
+        description: GitHub Actions runner image for agent jobs.
+        type: string
+        required: false
+        default: "ubuntu-24.04"
     secrets:
       FULLSEND_GCP_WIF_PROVIDER:
         required: false
@@ -64,7 +69,7 @@ on:
 jobs:
   route:
     name: Route
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runner_image }}
     permissions:
       contents: read
       pull-requests: read
@@ -433,6 +438,7 @@ jobs:
       gcp_region: ${{ inputs.gcp_region }}
       fullsend_version: ${{ inputs.fullsend_version }}
       fullsend_ai_ref: ${{ inputs.fullsend_ai_ref }}
+      runner_image: ${{ inputs.runner_image }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
@@ -454,6 +460,7 @@ jobs:
       gcp_region: ${{ inputs.gcp_region }}
       fullsend_version: ${{ inputs.fullsend_version }}
       fullsend_ai_ref: ${{ inputs.fullsend_ai_ref }}
+      runner_image: ${{ inputs.runner_image }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
@@ -475,6 +482,7 @@ jobs:
       gcp_region: ${{ inputs.gcp_region }}
       fullsend_version: ${{ inputs.fullsend_version }}
       fullsend_ai_ref: ${{ inputs.fullsend_ai_ref }}
+      runner_image: ${{ inputs.runner_image }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
@@ -497,6 +505,7 @@ jobs:
       gcp_region: ${{ inputs.gcp_region }}
       fullsend_version: ${{ inputs.fullsend_version }}
       fullsend_ai_ref: ${{ inputs.fullsend_ai_ref }}
+      runner_image: ${{ inputs.runner_image }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
@@ -518,6 +527,7 @@ jobs:
       gcp_region: ${{ inputs.gcp_region }}
       fullsend_version: ${{ inputs.fullsend_version }}
       fullsend_ai_ref: ${{ inputs.fullsend_ai_ref }}
+      runner_image: ${{ inputs.runner_image }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
@@ -540,6 +550,7 @@ jobs:
       project_number: ${{ inputs.project_number }}
       fullsend_version: ${{ inputs.fullsend_version }}
       fullsend_ai_ref: ${{ inputs.fullsend_ai_ref }}
+      runner_image: ${{ inputs.runner_image }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -66,7 +66,7 @@ concurrency:
 jobs:
   fix:
     name: Fix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -48,6 +48,11 @@ on:
         type: string
         required: false
         default: v0
+      runner_image:
+        description: GitHub Actions runner image for agent jobs.
+        type: string
+        required: false
+        default: "ubuntu-24.04"
     secrets:
       FULLSEND_GCP_WIF_PROVIDER:
         required: true
@@ -66,7 +71,7 @@ concurrency:
 jobs:
   fix:
     name: Fix
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runner_image }}
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/reusable-prioritize.yml
+++ b/.github/workflows/reusable-prioritize.yml
@@ -53,7 +53,7 @@ concurrency:
 jobs:
   prioritize:
     name: Prioritize
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/reusable-prioritize.yml
+++ b/.github/workflows/reusable-prioritize.yml
@@ -40,6 +40,11 @@ on:
         type: string
         required: false
         default: v0
+      runner_image:
+        description: GitHub Actions runner image for agent jobs.
+        type: string
+        required: false
+        default: "ubuntu-24.04"
     secrets:
       FULLSEND_GCP_WIF_PROVIDER:
         required: true
@@ -53,7 +58,7 @@ concurrency:
 jobs:
   prioritize:
     name: Prioritize
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runner_image }}
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/reusable-retro.yml
+++ b/.github/workflows/reusable-retro.yml
@@ -49,7 +49,7 @@ concurrency:
 jobs:
   retro:
     name: Retro
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/reusable-retro.yml
+++ b/.github/workflows/reusable-retro.yml
@@ -36,6 +36,11 @@ on:
         type: string
         required: false
         default: v0
+      runner_image:
+        description: GitHub Actions runner image for agent jobs.
+        type: string
+        required: false
+        default: "ubuntu-24.04"
     secrets:
       FULLSEND_GCP_WIF_PROVIDER:
         required: true
@@ -49,7 +54,7 @@ concurrency:
 jobs:
   retro:
     name: Retro
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runner_image }}
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -49,7 +49,7 @@ concurrency:
 jobs:
   review:
     name: Review
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -36,6 +36,11 @@ on:
         type: string
         required: false
         default: v0
+      runner_image:
+        description: GitHub Actions runner image for agent jobs.
+        type: string
+        required: false
+        default: "ubuntu-24.04"
     secrets:
       FULLSEND_GCP_WIF_PROVIDER:
         required: true
@@ -49,7 +54,7 @@ concurrency:
 jobs:
   review:
     name: Review
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runner_image }}
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/reusable-triage.yml
+++ b/.github/workflows/reusable-triage.yml
@@ -50,7 +50,7 @@ concurrency:
 jobs:
   triage:
     name: Triage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/reusable-triage.yml
+++ b/.github/workflows/reusable-triage.yml
@@ -37,6 +37,11 @@ on:
         type: string
         required: false
         default: v0
+      runner_image:
+        description: GitHub Actions runner image for agent jobs.
+        type: string
+        required: false
+        default: "ubuntu-24.04"
     secrets:
       FULLSEND_GCP_WIF_PROVIDER:
         required: true
@@ -50,7 +55,7 @@ concurrency:
 jobs:
   triage:
     name: Triage
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runner_image }}
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/sandbox-images.yml
+++ b/.github/workflows/sandbox-images.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build-base:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -89,7 +89,7 @@ jobs:
 
   build-code:
     needs: build-base
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.repository.full_name == github.repository &&

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,6 +91,8 @@ repos:
           - SC2016
           - -ignore
           - '__REUSABLE_(WORKFLOW|DISPATCH)__'
+          - -ignore
+          - '__GH_RUNNER__'
 
   - repo: local
     hooks:

--- a/docs/guides/user/building-custom-agents.md
+++ b/docs/guides/user/building-custom-agents.md
@@ -370,7 +370,7 @@ concurrency:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository for harness reading
         uses: actions/checkout@v6
@@ -492,7 +492,7 @@ jobs:
     if: >-
       github.event.comment.user.type != 'Bot'
       && startsWith(github.event.comment.body, '/my-command')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Dispatch
         env:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,8 @@ const (
 	DefaultUpstreamRepo = "fullsend-ai/fullsend"
 	// DefaultUpstreamRef is the default tag for layered upstream workflow calls.
 	DefaultUpstreamRef = "v0"
+	// DefaultGHRunner is the default GitHub Actions runner image for scaffold workflows.
+	DefaultGHRunner = "ubuntu-24.04"
 )
 
 // DispatchConfig configures how agent work is dispatched.

--- a/internal/scaffold/fullsend-repo/.github/workflows/code.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/code.yml
@@ -38,6 +38,7 @@ jobs:
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
       fullsend_ai_ref: __FULLSEND_AI_REF__
+      runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
   dispatch:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       contents: read

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
   dispatch:
-    runs-on: ubuntu-24.04
+    runs-on: __GH_RUNNER__
     permissions:
       actions: write
       contents: read

--- a/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
@@ -62,6 +62,7 @@ jobs:
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
       fullsend_ai_ref: __FULLSEND_AI_REF__
+      runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/prioritize-scheduler.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/prioritize-scheduler.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   dispatch:
     name: Find and dispatch issues for RICE scoring
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       actions: write

--- a/internal/scaffold/fullsend-repo/.github/workflows/prioritize-scheduler.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/prioritize-scheduler.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   dispatch:
     name: Find and dispatch issues for RICE scoring
-    runs-on: ubuntu-24.04
+    runs-on: __GH_RUNNER__
     timeout-minutes: 5
     permissions:
       actions: write

--- a/internal/scaffold/fullsend-repo/.github/workflows/prioritize.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/prioritize.yml
@@ -37,6 +37,7 @@ jobs:
       project_number: ${{ vars.FULLSEND_PROJECT_NUMBER }}
       install_mode: per-org
       fullsend_ai_ref: __FULLSEND_AI_REF__
+      runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   reconcile:
     name: Reconcile enrollment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout .fullsend
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/repo-maintenance.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   reconcile:
     name: Reconcile enrollment
-    runs-on: ubuntu-24.04
+    runs-on: __GH_RUNNER__
     steps:
       - name: Checkout .fullsend
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/internal/scaffold/fullsend-repo/.github/workflows/retro.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/retro.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   debounce:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions: {}
     steps:
       - run: sleep 60

--- a/internal/scaffold/fullsend-repo/.github/workflows/retro.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/retro.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   debounce:
-    runs-on: ubuntu-24.04
+    runs-on: __GH_RUNNER__
     permissions: {}
     steps:
       - run: sleep 60
@@ -43,6 +43,7 @@ jobs:
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
       fullsend_ai_ref: __FULLSEND_AI_REF__
+      runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/review.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/review.yml
@@ -37,6 +37,7 @@ jobs:
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
       fullsend_ai_ref: __FULLSEND_AI_REF__
+      runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/triage.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/triage.yml
@@ -36,6 +36,7 @@ jobs:
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
       fullsend_ai_ref: __FULLSEND_AI_REF__
+      runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}

--- a/internal/scaffold/fullsend-repo/templates/shim-per-repo.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-per-repo.yaml
@@ -66,7 +66,7 @@ jobs:
           || github.event.comment.author_association == 'CONTRIBUTOR'
           || github.event.comment.user.login == github.event.issue.user.login
         )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       issues: write

--- a/internal/scaffold/fullsend-repo/templates/shim-per-repo.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-per-repo.yaml
@@ -49,6 +49,7 @@ jobs:
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       fullsend_ai_ref: __FULLSEND_AI_REF__
+      runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
       FULLSEND_GCP_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
@@ -66,7 +67,7 @@ jobs:
           || github.event.comment.author_association == 'CONTRIBUTOR'
           || github.event.comment.user.login == github.event.issue.user.login
         )
-    runs-on: ubuntu-24.04
+    runs-on: __GH_RUNNER__
     permissions:
       contents: read
       issues: write

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow-call.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow-call.yaml
@@ -60,7 +60,7 @@ jobs:
           || github.event.comment.author_association == 'CONTRIBUTOR'
           || github.event.comment.user.login == github.event.issue.user.login
         )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       issues: write

--- a/internal/scaffold/fullsend-repo/templates/shim-workflow-call.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-workflow-call.yaml
@@ -60,7 +60,7 @@ jobs:
           || github.event.comment.author_association == 'CONTRIBUTOR'
           || github.event.comment.user.login == github.event.issue.user.login
         )
-    runs-on: ubuntu-24.04
+    runs-on: __GH_RUNNER__
     permissions:
       contents: read
       issues: write

--- a/internal/scaffold/render.go
+++ b/internal/scaffold/render.go
@@ -14,6 +14,7 @@ type RenderOptions struct {
 	PerRepo     bool
 	UpstreamRef string // commit SHA to pin workflow refs to; empty = use DefaultUpstreamRef
 	UpstreamTag string // version tag for traceability comment (e.g. "v0.19.0")
+	RunnerImage string // GitHub Actions runner image; empty = use DefaultGHRunner
 }
 
 // RenderOptionsForInstall builds render options from the --vendor flag.
@@ -53,6 +54,7 @@ func RenderTemplate(path string, content []byte, opts RenderOptions) ([]byte, er
 	}
 
 	out = strings.ReplaceAll(out, "__FULLSEND_AI_REF__", resolvedRefWithComment(opts))
+	out = strings.ReplaceAll(out, "__GH_RUNNER__", resolvedRunner(opts))
 
 	return []byte(out), nil
 }
@@ -73,6 +75,13 @@ func thinStageName(content string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("could not determine thin caller stage")
+}
+
+func resolvedRunner(opts RenderOptions) string {
+	if opts.RunnerImage != "" {
+		return opts.RunnerImage
+	}
+	return config.DefaultGHRunner
 }
 
 func resolvedRef(opts RenderOptions) string {

--- a/internal/scaffold/render_test.go
+++ b/internal/scaffold/render_test.go
@@ -109,6 +109,7 @@ func assertFreeOfRenderPlaceholders(t *testing.T, out string) {
 		"__UPSTREAM_REF__",
 		"__DISTRIBUTION_MODE__",
 		"__FULLSEND_AI_REF__",
+		"__GH_RUNNER__",
 	} {
 		assert.NotContains(t, out, placeholder)
 	}
@@ -175,6 +176,45 @@ func TestRenderPerRepoShimPinnedSHA(t *testing.T) {
 	assert.Contains(t, out, "# v0.19.0")
 	assert.Contains(t, out, "fullsend_ai_ref: abc123def456 # v0.19.0")
 	assertFreeOfRenderPlaceholders(t, out)
+}
+
+func TestRenderDefaultRunner(t *testing.T) {
+	raw, err := FullsendRepoFile(".github/workflows/triage.yml")
+	require.NoError(t, err)
+
+	rendered, err := RenderTemplate(".github/workflows/triage.yml", raw, RenderOptions{})
+	require.NoError(t, err)
+	out := string(rendered)
+	assert.Contains(t, out, "runner_image: ubuntu-24.04")
+	assert.NotContains(t, out, "__GH_RUNNER__")
+}
+
+func TestRenderCustomRunner(t *testing.T) {
+	raw, err := FullsendRepoFile(".github/workflows/triage.yml")
+	require.NoError(t, err)
+
+	rendered, err := RenderTemplate(".github/workflows/triage.yml", raw, RenderOptions{
+		RunnerImage: "ubuntu-22.04",
+	})
+	require.NoError(t, err)
+	out := string(rendered)
+	assert.Contains(t, out, "runner_image: ubuntu-22.04")
+	assert.NotContains(t, out, "ubuntu-24.04")
+	assert.NotContains(t, out, "__GH_RUNNER__")
+}
+
+func TestRenderPerRepoShimRunner(t *testing.T) {
+	raw, err := PerRepoShimTemplate()
+	require.NoError(t, err)
+
+	rendered, err := RenderTemplate("templates/shim-per-repo.yaml", raw, RenderOptions{
+		PerRepo: true,
+	})
+	require.NoError(t, err)
+	out := string(rendered)
+	assert.Contains(t, out, "runner_image: ubuntu-24.04")
+	assert.Contains(t, out, "runs-on: ubuntu-24.04")
+	assert.NotContains(t, out, "__GH_RUNNER__")
 }
 
 func TestRenderFallbackToDefaultRef(t *testing.T) {

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -275,6 +275,7 @@ func TestReusableWorkflowsShareCommonInputs(t *testing.T) {
 		"fullsend_version",
 		"install_mode",
 		"fullsend_ai_ref",
+		"runner_image",
 	}
 
 	commonSecrets := []string{


### PR DESCRIPTION
## Summary

- Pin all `runs-on: ubuntu-latest` to `ubuntu-24.04` across repo CI workflows and user-facing docs
- Make the runner image configurable for scaffold templates via `__GH_RUNNER__` placeholder, resolved at install time from `config.DefaultGHRunner`
- Add `runner_image` input (default: `ubuntu-24.04`) to all reusable workflows so callers can override

### Architecture

| Layer | Mechanism | Override |
|-------|-----------|---------|
| Repo CI (`.github/workflows/`) | Hardcoded `ubuntu-24.04` | Edit the workflow directly |
| Scaffold templates (`internal/scaffold/`) | `__GH_RUNNER__` placeholder, resolved by `render.go` | Pass `RunnerImage` in `RenderOptions` |
| Reusable workflows (`reusable-*.yml`) | `runner_image` input with default | Caller passes `runner_image` in `with:` |

### Commits

1. **ci**: Pin repo CI workflows and user guide to `ubuntu-24.04`
2. **feat(scaffold)**: Add `DefaultGHRunner` constant, wire `__GH_RUNNER__` through render pipeline, update templates and tests
3. **feat(dispatch)**: Add `runner_image` input to all reusable workflows, pass through dispatch

Closes #2611

## Test plan

- [x] `grep -r 'ubuntu-latest' .github/workflows/ internal/scaffold/` returns nothing
- [x] `go test ./internal/scaffold/ ./internal/config/` passes
- [x] `make lint` passes
- [ ] CI workflows pass on `ubuntu-24.04`
- [ ] Scaffold templates render correctly with pinned version