### PR TITLE
feat(scaffold): per-repo pre-commit tools registry (L2 additive merge)

### DIFF
--- a/docs/ADRs/0056-per-repo-precommit-tools-registry.md
+++ b/docs/ADRs/0056-per-repo-precommit-tools-registry.md
@@ -1,0 +1,64 @@
+---
+title: "56. Per-repo pre-commit tools registry"
+status: Accepted
+relates_to:
+  - agent-infrastructure
+  - security-threat-model
+topics:
+  - tool-dependencies
+  - additive-merge
+  - supply-chain-security
+---
+
+# 56. Per-repo pre-commit tools registry
+
+Date: 2026-06-25
+
+## Status
+
+Accepted
+
+Extends [PR #1055](https://github.com/fullsend-ai/fullsend/pull/1055).
+Related: [#1270](https://github.com/fullsend-ai/fullsend/issues/1270)
+
+## Context
+
+PR #1055 introduced `.pre-commit-tools.yaml` — a registry mapping
+pre-commit hooks to the system tools they require. The registry can be
+fully replaced at the org level via `customized/scripts/` (L1 override,
+ADR 0035), but repos needing one extra tool must copy the entire file.
+
+## Decision
+
+Add L2 additive merge: the resolver discovers a per-repo
+`.pre-commit-tools.yaml` at the target repo root and merges it with
+upstream/org defaults. New entries extend, matching `(repo, hook_id)`
+entries override, and `exclude: true` suppresses.
+
+### Resolution order
+
+```
+upstream defaults → org L1 (full replacement) → per-repo L2 (additive merge)
+```
+
+### Security
+
+The per-repo registry is untrusted input that feeds the tool installer
+running outside the sandbox. Caller scripts read it from the **base
+branch** only (`git show origin/${TARGET_BRANCH}:...`), not the working
+tree. PR-contributed registries don't take effect until merged.
+
+### Interface
+
+The resolver accepts `--local-registry <path>`. Caller scripts extract
+the base-branch file to a temp file and pass it via this flag.
+Malformed input emits warnings and falls back to upstream unchanged.
+
+## Consequences
+
+- Repos extend the registry without duplicating it.
+- L1 full-replacement remains available for orgs needing complete control.
+- New per-repo registries take effect only after merge to the base
+  branch (deliberate security trade-off).
+- Two per-repo paths exist: `.fullsend/customized/scripts/` (L1 full
+  replacement) vs `.pre-commit-tools.yaml` at root (L2 additive).

--- a/docs/ADRs/0056-per-repo-precommit-tools-registry.md
+++ b/docs/ADRs/0056-per-repo-precommit-tools-registry.md
@@ -26,7 +26,7 @@ Related: [#1270](https://github.com/fullsend-ai/fullsend/issues/1270)
 PR #1055 introduced `.pre-commit-tools.yaml` — a registry mapping
 pre-commit hooks to the system tools they require. The registry can be
 fully replaced at the org level via `customized/scripts/` (L1 override,
-ADR 0035), but repos needing one extra tool must copy the entire file.
+[ADR 0035](0035-layered-content-resolution.md)), but repos needing one extra tool must copy the entire file.
 
 ## Decision
 
@@ -56,9 +56,7 @@ Malformed input emits warnings and falls back to upstream unchanged.
 
 ## Consequences
 
-- Repos extend the registry without duplicating it.
+- Repos can extend the upstream registry without duplicating the entire file.
 - L1 full-replacement remains available for orgs needing complete control.
-- New per-repo registries take effect only after merge to the base
-  branch (deliberate security trade-off).
-- Two per-repo paths exist: `.fullsend/customized/scripts/` (L1 full
-  replacement) vs `.pre-commit-tools.yaml` at root (L2 additive).
+- Per-repo registries only take effect after merge to the base branch, preventing untrusted PR input.
+- Two customization paths coexist: L1 full replacement via `.fullsend/customized/scripts/` and L2 additive merge via `.pre-commit-tools.yaml` at root.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -362,7 +362,10 @@ See [ADR 0003](ADRs/0003-org-config-repo-convention.md) for the config repo conv
   [ADR 0047](ADRs/0047-vendored-installs-with-vendor-flag.md)). The
   scaffold installs only org-specific files and a `customized/` directory for org
   overrides. Org files in `customized/` overwrite upstream defaults at runtime
-  ([ADR 0035](ADRs/0035-layered-content-resolution.md)).
+  ([ADR 0035](ADRs/0035-layered-content-resolution.md)). Per-repo
+  `.pre-commit-tools.yaml` files extend the tools registry additively (L2
+  merge) without replacing it
+  ([ADR 0056](ADRs/0056-per-repo-precommit-tools-registry.md)).
 
 ## Multi-org deployment model
 

--- a/docs/guides/user/customizing-agents.md
+++ b/docs/guides/user/customizing-agents.md
@@ -194,6 +194,11 @@ Only hooks that pre-commit **cannot self-serve** need registry entries:
 
 Hooks using `language: python`, `language: node`, or `language: docker_image` are handled natively by pre-commit and need no registry entry.
 
+#### Prerequisites
+
+- A `.pre-commit-config.yaml` in the target repo with hooks that use `language: system` or `language: golang`.
+- Access to commit to the target repo's base branch (L2 per-repo registries only take effect after merge).
+
 #### Three-layer resolution
 
 ```
@@ -216,37 +221,40 @@ upstream defaults (fullsend-ai/fullsend)
 > - `.fullsend/customized/scripts/.pre-commit-tools.yaml` — L1 full replacement (same overlay mechanism as other layered dirs)
 > - `.pre-commit-tools.yaml` at repo root — L2 additive merge (resolver discovers and merges)
 
-#### Example: adding a custom binary tool
+#### Adding a custom binary tool
 
-Place `.pre-commit-tools.yaml` at your repo root:
+1. Create a `.pre-commit-tools.yaml` file at your repo root.
+2. Add an entry with the `hook_id`, `repo`, and `install` fields:
 
-```yaml
-tools:
-  - hook_id: my-linter
-    repo: https://github.com/example/my-linter
-    install:
-      type: binary
-      name: my-linter
-      version: "1.2.3"
-      url_template: "https://github.com/example/my-linter/releases/download/v{version}/my-linter-{triple}.tar.gz"
-      checksums:
-        x86_64: "abc123..."
-        aarch64: "def456..."
-      binary_name: my-linter
-```
+    ```yaml
+    tools:
+      - hook_id: my-linter
+        repo: https://github.com/example/my-linter
+        install:
+          type: binary
+          name: my-linter
+          version: "1.2.3"
+          url_template: "https://github.com/example/my-linter/releases/download/v{version}/my-linter-{triple}.tar.gz"
+          checksums:
+            x86_64: "abc123..."
+            aarch64: "def456..."
+          binary_name: my-linter
+    ```
 
-This entry is merged with the upstream registry — all upstream tools remain available.
+3. Commit and merge to the base branch. The entry is merged with the upstream registry — all upstream tools remain available.
 
-#### Example: suppressing an upstream entry
+#### Suppressing an upstream entry
 
-To prevent an upstream tool from being installed (e.g., if your repo handles it differently):
+1. Add an entry to `.pre-commit-tools.yaml` with the matching `hook_id` and `repo`, plus `exclude: true`:
 
-```yaml
-tools:
-  - hook_id: gitleaks
-    repo: https://github.com/zricethezav/gitleaks
-    exclude: true
-```
+    ```yaml
+    tools:
+      - hook_id: gitleaks
+        repo: https://github.com/zricethezav/gitleaks
+        exclude: true
+    ```
+
+2. Commit and merge to the base branch. The upstream tool will no longer be installed for this repo.
 
 #### Security
 

--- a/docs/guides/user/customizing-agents.md
+++ b/docs/guides/user/customizing-agents.md
@@ -184,6 +184,76 @@ To add a custom skill to the code agent's harness:
 
 **Important:** You must maintain the full harness structure. You cannot add just a `skills:` field—the entire YAML file must be present and valid.
 
+### Customizing Pre-commit Tool Dependencies
+
+Fullsend auto-detects and installs tools required by a target repo's pre-commit hooks. The resolver reads `.pre-commit-config.yaml`, matches hooks against a tools registry, and installs missing dependencies before the authoritative pre-commit check runs.
+
+Only hooks that pre-commit **cannot self-serve** need registry entries:
+- `language: system` — the tool must already be on `PATH`
+- `language: golang` — binary download is faster than Go compilation
+
+Hooks using `language: python`, `language: node`, or `language: docker_image` are handled natively by pre-commit and need no registry entry.
+
+#### Three-layer resolution
+
+```
+upstream defaults (fullsend-ai/fullsend)
+  → org replacement:  customized/scripts/.pre-commit-tools.yaml  (L1)
+    → per-repo additive:  .pre-commit-tools.yaml at repo root    (L2)
+```
+
+| Layer | Location | Behavior |
+|-------|----------|----------|
+| Upstream | Provided at runtime by reusable workflow | Base registry shipped with fullsend |
+| L1 org replacement | `customized/scripts/.pre-commit-tools.yaml` in `.fullsend` config repo | **Completely replaces** upstream registry |
+| L2 per-repo additive | `.pre-commit-tools.yaml` at target repo root | **Merges** with upstream/org registry |
+
+**L1 replacement** works via the layered overlay — the file is copied over the upstream registry at runtime. Use this when your org needs a completely different set of tools.
+
+**L2 additive merge** is designed for repos that need to extend the registry with one or two entries. New entries are appended, entries matching an existing `(repo, hook_id)` key override it, and entries with `exclude: true` suppress the matching upstream entry.
+
+> **Note:** There are two per-repo customization paths with different semantics:
+> - `.fullsend/customized/scripts/.pre-commit-tools.yaml` — L1 full replacement (same overlay mechanism as other layered dirs)
+> - `.pre-commit-tools.yaml` at repo root — L2 additive merge (resolver discovers and merges)
+
+#### Example: adding a custom binary tool
+
+Place `.pre-commit-tools.yaml` at your repo root:
+
+```yaml
+tools:
+  - hook_id: my-linter
+    repo: https://github.com/example/my-linter
+    install:
+      type: binary
+      name: my-linter
+      version: "1.2.3"
+      url_template: "https://github.com/example/my-linter/releases/download/v{version}/my-linter-{triple}.tar.gz"
+      checksums:
+        x86_64: "abc123..."
+        aarch64: "def456..."
+      binary_name: my-linter
+```
+
+This entry is merged with the upstream registry — all upstream tools remain available.
+
+#### Example: suppressing an upstream entry
+
+To prevent an upstream tool from being installed (e.g., if your repo handles it differently):
+
+```yaml
+tools:
+  - hook_id: gitleaks
+    repo: https://github.com/zricethezav/gitleaks
+    exclude: true
+```
+
+#### Security
+
+Per-repo registries are read from the **base branch**, not from the PR's working tree. This means changes to `.pre-commit-tools.yaml` in a PR do not take effect until the PR is merged. This is intentional — the tool installation pipeline runs outside the sandbox with elevated permissions, and PR content is untrusted.
+
+See [ADR 0056](../../ADRs/0056-per-repo-precommit-tools-registry.md) for the full security rationale.
+
 ## Agent Roles
 
 Each agent role has its own identity, permissions, and purpose:

--- a/internal/scaffold/fullsend-repo/scripts/.pre-commit-tools.yaml
+++ b/internal/scaffold/fullsend-repo/scripts/.pre-commit-tools.yaml
@@ -32,10 +32,17 @@
 #   language: node    → pre-commit handles via npm (DO NOT add)
 #   language: docker_image → pre-commit handles via docker pull (DO NOT add)
 #
-# Customization:
-#   Per-org:  place .pre-commit-tools.yaml in customized/scripts/
-#   Per-repo: place .pre-commit-tools.yaml in .fullsend/customized/scripts/
-#   The customized file completely replaces these defaults.
+# Customization (three layers, highest priority wins):
+#   L1 full replacement:
+#     Per-org:  customized/scripts/.pre-commit-tools.yaml in .fullsend config repo
+#     Per-repo: .fullsend/customized/scripts/.pre-commit-tools.yaml in target repo
+#     The customized file completely replaces these defaults.
+#   L2 additive merge:
+#     Per-repo: .pre-commit-tools.yaml at target repo root
+#     Entries are merged with upstream/org defaults. New entries extend,
+#     matching (repo, hook_id) entries override, exclude: true suppresses.
+#     Read from the base branch only (not the PR head) for security.
+#     See ADR 0056 for details.
 
 tools:
   # ── lychee (markdown link checker) ────────────────────────────────
@@ -88,9 +95,26 @@ tools:
       binary_name: actionlint
 
   # ── uv / uvx (Python package manager, needed for ty check) ───────
+  # Two match entries: hooks may use "uvx <tool>" or "uv run <tool>".
+  # Both resolve to the same install (dedup via seen_names on "uv").
   - hook_id: ty
     repo: local
     match_entry: "uvx"
+    install:
+      type: binary
+      name: uv
+      version: "0.11.14"
+      url_template: "https://github.com/astral-sh/uv/releases/download/{version}/uv-{triple}.tar.gz"
+      checksums:
+        x86_64: "f3b623eb0e6141a7053d571d59a0bdc341e0f238ea8f5f0b4815ddbec9a2a296"
+        aarch64: "c4958f729e216f1610632574ed927b8cf0af1bd02cb88cb30d948571727aee43"
+      strip_prefix: "uv-{triple}"
+      binary_name: uv
+      extra_binaries:
+        - uvx
+  - hook_id: uv-run
+    repo: local
+    match_entry: "uv"
     install:
       type: binary
       name: uv
@@ -110,4 +134,5 @@ tools:
 #   language: golang  → warns that Go toolchain is needed
 #   language: rust    → warns that Rust toolchain is needed
 # Hooks using python/node/docker_image/script need no registry
-# entry — pre-commit handles them natively.
+# entry — pre-commit handles them natively. For example,
+# shellcheck-py (language: python) is auto-managed by pre-commit.

--- a/internal/scaffold/fullsend-repo/scripts/post-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-code.sh
@@ -274,14 +274,19 @@ if [ -f .pre-commit-config.yaml ] \
    && [ -f "${RESOLVE_SCRIPT}" ] \
    && [ -f "${INSTALL_SCRIPT}" ]; then
   MANIFEST="$(mktemp)"
-  if python3 "${RESOLVE_SCRIPT}" "." > "${MANIFEST}"; then
+  LOCAL_REG="$(mktemp)"
+  RESOLVE_ARGS=(".")
+  if git show "origin/${TARGET_BRANCH}:.pre-commit-tools.yaml" > "${LOCAL_REG}" 2>/dev/null; then
+    RESOLVE_ARGS+=("--local-registry" "${LOCAL_REG}")
+  fi
+  if python3 "${RESOLVE_SCRIPT}" "${RESOLVE_ARGS[@]}" > "${MANIFEST}"; then
     if [ -s "${MANIFEST}" ] && jq -e '.tools | length > 0' "${MANIFEST}" >/dev/null 2>&1; then
       bash "${INSTALL_SCRIPT}" "${MANIFEST}"
     fi
   else
     echo "::warning::Pre-commit tool resolution failed — continuing without auto-install"
   fi
-  rm -f "${MANIFEST}"
+  rm -f "${MANIFEST}" "${LOCAL_REG}"
 fi
 export PATH="${HOME}/.local/bin:${PATH}"
 

--- a/internal/scaffold/fullsend-repo/scripts/post-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-fix.sh
@@ -186,14 +186,19 @@ if [ -f .pre-commit-config.yaml ] \
    && [ -f "${RESOLVE_SCRIPT}" ] \
    && [ -f "${INSTALL_SCRIPT}" ]; then
   MANIFEST="$(mktemp)"
-  if python3 "${RESOLVE_SCRIPT}" "." > "${MANIFEST}"; then
+  LOCAL_REG="$(mktemp)"
+  RESOLVE_ARGS=(".")
+  if git show "origin/${TARGET_BRANCH}:.pre-commit-tools.yaml" > "${LOCAL_REG}" 2>/dev/null; then
+    RESOLVE_ARGS+=("--local-registry" "${LOCAL_REG}")
+  fi
+  if python3 "${RESOLVE_SCRIPT}" "${RESOLVE_ARGS[@]}" > "${MANIFEST}"; then
     if [ -s "${MANIFEST}" ] && jq -e '.tools | length > 0' "${MANIFEST}" >/dev/null 2>&1; then
       bash "${INSTALL_SCRIPT}" "${MANIFEST}"
     fi
   else
     echo "::warning::Pre-commit tool resolution failed — continuing without auto-install"
   fi
-  rm -f "${MANIFEST}"
+  rm -f "${MANIFEST}" "${LOCAL_REG}"
 fi
 export PATH="${HOME}/.local/bin:${PATH}"
 

--- a/internal/scaffold/fullsend-repo/scripts/pre-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-code.sh
@@ -135,7 +135,14 @@ if [ -f "${TARGET_REPO}/.pre-commit-config.yaml" ] \
    && [ -f "${INSTALL_SCRIPT}" ]; then
   echo "Resolving pre-commit tool dependencies..."
   MANIFEST="$(mktemp)"
-  if python3 "${RESOLVE_SCRIPT}" "${TARGET_REPO}" > "${MANIFEST}"; then
+  LOCAL_REG="$(mktemp)"
+  RESOLVE_ARGS=("${TARGET_REPO}")
+  DEFAULT_BR="$(git -C "${TARGET_REPO}" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')" || DEFAULT_BR=""
+  if [ -n "${DEFAULT_BR}" ] \
+     && git -C "${TARGET_REPO}" show "origin/${DEFAULT_BR}:.pre-commit-tools.yaml" > "${LOCAL_REG}" 2>/dev/null; then
+    RESOLVE_ARGS+=("--local-registry" "${LOCAL_REG}")
+  fi
+  if python3 "${RESOLVE_SCRIPT}" "${RESOLVE_ARGS[@]}" > "${MANIFEST}"; then
     if [ -s "${MANIFEST}" ] && jq -e '.tools | length > 0' "${MANIFEST}" >/dev/null 2>&1; then
       bash "${INSTALL_SCRIPT}" "${MANIFEST}"
     else
@@ -144,7 +151,7 @@ if [ -f "${TARGET_REPO}/.pre-commit-config.yaml" ] \
   else
     echo "::warning::Pre-commit tool resolution failed — continuing without auto-install"
   fi
-  rm -f "${MANIFEST}"
+  rm -f "${MANIFEST}" "${LOCAL_REG}"
 fi
 export PATH="${HOME}/.local/bin:${PATH}"
 echo "${HOME}/.local/bin" >> "${GITHUB_PATH:-/dev/null}"

--- a/internal/scaffold/fullsend-repo/scripts/pre-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-fix.sh
@@ -115,7 +115,17 @@ if [ -f "${TARGET_REPO}/.pre-commit-config.yaml" ] \
    && [ -f "${INSTALL_SCRIPT}" ]; then
   echo "Resolving pre-commit tool dependencies..."
   MANIFEST="$(mktemp)"
-  if python3 "${RESOLVE_SCRIPT}" "${TARGET_REPO}" > "${MANIFEST}"; then
+  LOCAL_REG="$(mktemp)"
+  RESOLVE_ARGS=("${TARGET_REPO}")
+  _BASE_BR="${TARGET_BRANCH:-}"
+  if [ -z "${_BASE_BR}" ]; then
+    _BASE_BR="$(git -C "${TARGET_REPO}" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')" || _BASE_BR=""
+  fi
+  if [ -n "${_BASE_BR}" ] \
+     && git -C "${TARGET_REPO}" show "origin/${_BASE_BR}:.pre-commit-tools.yaml" > "${LOCAL_REG}" 2>/dev/null; then
+    RESOLVE_ARGS+=("--local-registry" "${LOCAL_REG}")
+  fi
+  if python3 "${RESOLVE_SCRIPT}" "${RESOLVE_ARGS[@]}" > "${MANIFEST}"; then
     if [ -s "${MANIFEST}" ] && jq -e '.tools | length > 0' "${MANIFEST}" >/dev/null 2>&1; then
       bash "${INSTALL_SCRIPT}" "${MANIFEST}"
     else
@@ -124,7 +134,7 @@ if [ -f "${TARGET_REPO}/.pre-commit-config.yaml" ] \
   else
     echo "::warning::Pre-commit tool resolution failed — continuing without auto-install"
   fi
-  rm -f "${MANIFEST}"
+  rm -f "${MANIFEST}" "${LOCAL_REG}"
 fi
 export PATH="${HOME}/.local/bin:${PATH}"
 echo "${HOME}/.local/bin" >> "${GITHUB_PATH:-/dev/null}"

--- a/internal/scaffold/fullsend-repo/scripts/resolve-precommit-tools-test.py
+++ b/internal/scaffold/fullsend-repo/scripts/resolve-precommit-tools-test.py
@@ -8,8 +8,8 @@ import tempfile
 import textwrap
 import unittest
 
-# Load the resolver module from the scaffold scripts directory.
-_SCRIPT_DIR = os.path.join(os.path.dirname(__file__), "..", "fullsend-repo", "scripts")
+# Load the resolver module from the same directory.
+_SCRIPT_DIR = os.path.dirname(__file__)
 _RESOLVER = os.path.join(_SCRIPT_DIR, "resolve-precommit-tools.py")
 spec = importlib.util.spec_from_file_location("resolver", _RESOLVER)
 assert spec is not None and spec.loader is not None
@@ -180,6 +180,58 @@ class TestMergeRegistries(unittest.TestCase):
         self.assertIn("lint-a", names)
         self.assertIn("lint-b", names)
         self.assertEqual(warnings, [])
+
+    def test_match_entry_collision_warns(self):
+        """Local entry with same match_entry as a different upstream entry emits a warning."""
+        upstream = {
+            "tools": [
+                {
+                    "hook_id": "uv-run",
+                    "repo": "local",
+                    "match_entry": "uv",
+                    "install": {"type": "binary", "name": "uv", "version": "0.11.14"},
+                },
+            ]
+        }
+        local = {
+            "tools": [
+                {
+                    "hook_id": "custom-uv",
+                    "repo": "https://example.com/custom",
+                    "match_entry": "uv",
+                    "install": {"type": "binary", "name": "custom-uv", "version": "1.0"},
+                },
+            ]
+        }
+        merged, warnings = resolver.merge_registries(upstream, local)
+        self.assertEqual(len(merged["tools"]), 2)
+        self.assertTrue(any("collides" in w and "match_entry" in w for w in warnings))
+
+    def test_match_entry_same_key_no_collision(self):
+        """Override of the same (repo, hook_id) should not warn on match_entry."""
+        upstream = {
+            "tools": [
+                {
+                    "hook_id": "uv-run",
+                    "repo": "local",
+                    "match_entry": "uv",
+                    "install": {"type": "binary", "name": "uv", "version": "0.11.14"},
+                },
+            ]
+        }
+        local = {
+            "tools": [
+                {
+                    "hook_id": "uv-run",
+                    "repo": "local",
+                    "match_entry": "uv",
+                    "install": {"type": "binary", "name": "uv", "version": "0.12.0"},
+                },
+            ]
+        }
+        merged, warnings = resolver.merge_registries(upstream, local)
+        self.assertEqual(len(merged["tools"]), 1)
+        self.assertFalse(any("collides" in w for w in warnings))
 
     def test_exclude_nonexistent_entry(self):
         upstream = {

--- a/internal/scaffold/fullsend-repo/scripts/resolve-precommit-tools.py
+++ b/internal/scaffold/fullsend-repo/scripts/resolve-precommit-tools.py
@@ -6,9 +6,10 @@ the known-tools registry (.pre-commit-tools.yaml), and outputs a JSON
 manifest to stdout.
 
 Usage:
-    resolve-precommit-tools.py <target-repo-path>
+    resolve-precommit-tools.py <target-repo-path> [--local-registry <path>]
 """
 
+import argparse
 import json
 import os
 import subprocess
@@ -38,17 +39,61 @@ except ImportError:
         sys.exit(0)
 
 
-def resolve(precommit_path: str, registry_path: str) -> dict:
+def merge_registries(upstream: dict, local: dict) -> tuple[dict, list[str]]:
+    """Merge a per-repo local registry into the upstream/org registry.
+
+    Returns (merged_registry, warnings). Local entries extend by default,
+    override by matching (repo, hook_id) key, or suppress with exclude: true.
+    """
+    warnings: list[str] = []
+
+    if not isinstance(local, dict) or "tools" not in local:
+        warnings.append("per-repo registry is invalid (missing 'tools' key) — using upstream only")
+        return upstream, warnings
+
+    local_tools = local.get("tools")
+    if not isinstance(local_tools, list):
+        warnings.append("per-repo registry 'tools' is not a list — using upstream only")
+        return upstream, warnings
+
+    upstream_tools = (upstream.get("tools") or [])[:]
+    keyed: dict[tuple[str, str], int] = {}
+    for i, tool in enumerate(upstream_tools):
+        if isinstance(tool, dict) and "hook_id" in tool:
+            keyed[(tool.get("repo", ""), tool["hook_id"])] = i
+
+    for entry in local_tools:
+        if not isinstance(entry, dict) or "hook_id" not in entry:
+            warnings.append(f"skipping invalid per-repo entry (missing hook_id): {entry!r}")
+            continue
+
+        key = (entry.get("repo", ""), entry["hook_id"])
+
+        if entry.get("exclude") is True:
+            idx = keyed.get(key)
+            if idx is not None:
+                upstream_tools[idx] = None  # type: ignore[assignment]
+                del keyed[key]
+            continue
+
+        idx = keyed.get(key)
+        if idx is not None:
+            upstream_tools[idx] = entry
+        else:
+            keyed[key] = len(upstream_tools)
+            upstream_tools.append(entry)
+
+    merged = [t for t in upstream_tools if t is not None]
+    return {"tools": merged}, warnings
+
+
+def resolve(precommit_path: str, registry: dict) -> dict:
+    """Resolve tool dependencies from a .pre-commit-config.yaml against a registry dict."""
     try:
         with open(precommit_path) as f:
             precommit = yaml.safe_load(f)
     except (yaml.YAMLError, OSError) as exc:
         return {"tools": [], "warnings": [f"failed to parse .pre-commit-config.yaml: {exc}"]}
-    try:
-        with open(registry_path) as f:
-            registry = yaml.safe_load(f)
-    except (yaml.YAMLError, OSError) as exc:
-        return {"tools": [], "warnings": [f"failed to parse tools registry: {exc}"]}
 
     if not isinstance(precommit, dict) or "repos" not in precommit:
         return {"tools": [], "warnings": ["empty or invalid .pre-commit-config.yaml"]}
@@ -124,26 +169,58 @@ def resolve(precommit_path: str, registry_path: str) -> dict:
     return {"tools": resolved, "warnings": warnings}
 
 
-def main():
-    if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <target-repo-path>", file=sys.stderr)
-        sys.exit(1)
+def load_yaml_file(path: str) -> tuple[dict | None, str | None]:
+    """Load and parse a YAML file. Returns (data, error_message)."""
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        return data, None
+    except (yaml.YAMLError, OSError) as exc:
+        return None, str(exc)
 
-    target_repo = sys.argv[1]
-    precommit_config = os.path.join(target_repo, ".pre-commit-config.yaml")
+
+def main():
+    parser = argparse.ArgumentParser(description="Resolve pre-commit tool dependencies")
+    parser.add_argument("target_repo", help="Path to the target repository")
+    parser.add_argument(
+        "--local-registry",
+        help="Path to a per-repo .pre-commit-tools.yaml (extracted from base branch)",
+    )
+    args = parser.parse_args()
+
+    precommit_config = os.path.join(args.target_repo, ".pre-commit-config.yaml")
 
     if not os.path.isfile(precommit_config):
         print('{"tools":[],"warnings":["no .pre-commit-config.yaml found"]}')
         sys.exit(0)
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    registry = os.path.join(script_dir, ".pre-commit-tools.yaml")
+    registry_path = os.path.join(script_dir, ".pre-commit-tools.yaml")
 
-    if not os.path.isfile(registry):
+    if not os.path.isfile(registry_path):
         print('{"tools":[],"warnings":["tools registry not found"]}')
         sys.exit(0)
 
+    registry, err = load_yaml_file(registry_path)
+    if err or not isinstance(registry, dict):
+        print(json.dumps({"tools": [], "warnings": [f"failed to parse tools registry: {err}"]}))
+        sys.exit(0)
+
+    all_warnings: list[str] = []
+
+    if args.local_registry and os.path.isfile(args.local_registry):
+        local, err = load_yaml_file(args.local_registry)
+        if err:
+            all_warnings.append(f"failed to parse per-repo registry: {err}")
+        elif local is None:
+            all_warnings.append("per-repo registry is empty — using upstream only")
+        elif isinstance(local, dict):
+            registry, merge_warnings = merge_registries(registry, local)
+            all_warnings.extend(merge_warnings)
+
     result = resolve(precommit_config, registry)
+    if all_warnings:
+        result.setdefault("warnings", []).extend(all_warnings)
     print(json.dumps(result))
 
 

--- a/internal/scaffold/fullsend-repo/scripts/resolve-precommit-tools.py
+++ b/internal/scaffold/fullsend-repo/scripts/resolve-precommit-tools.py
@@ -58,9 +58,13 @@ def merge_registries(upstream: dict, local: dict) -> tuple[dict, list[str]]:
 
     upstream_tools = (upstream.get("tools") or [])[:]
     keyed: dict[tuple[str, str], int] = {}
+    match_entry_owners: dict[str, tuple[str, str]] = {}
     for i, tool in enumerate(upstream_tools):
         if isinstance(tool, dict) and "hook_id" in tool:
-            keyed[(tool.get("repo", ""), tool["hook_id"])] = i
+            key = (tool.get("repo", ""), tool["hook_id"])
+            keyed[key] = i
+            if "match_entry" in tool:
+                match_entry_owners[tool["match_entry"]] = key
 
     for entry in local_tools:
         if not isinstance(entry, dict) or "hook_id" not in entry:
@@ -73,8 +77,22 @@ def merge_registries(upstream: dict, local: dict) -> tuple[dict, list[str]]:
             idx = keyed.get(key)
             if idx is not None:
                 upstream_tools[idx] = None  # type: ignore[assignment]
+                match_val = entry.get("match_entry")
+                if match_val and match_entry_owners.get(match_val) == key:
+                    del match_entry_owners[match_val]
                 del keyed[key]
             continue
+
+        if "match_entry" in entry:
+            match_val = entry["match_entry"]
+            existing_owner = match_entry_owners.get(match_val)
+            if existing_owner is not None and existing_owner != key:
+                warnings.append(
+                    f"per-repo entry {key} has match_entry '{match_val}' "
+                    f"that collides with upstream entry {existing_owner} "
+                    f"— the upstream match will be shadowed"
+                )
+            match_entry_owners[match_val] = key
 
         idx = keyed.get(key)
         if idx is not None:

--- a/internal/scaffold/scripts-tests/test_resolve_precommit_tools.py
+++ b/internal/scaffold/scripts-tests/test_resolve_precommit_tools.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Tests for resolve-precommit-tools.py merge and resolution logic."""
+
+import importlib.util
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+
+# Load the resolver module from the scaffold scripts directory.
+_SCRIPT_DIR = os.path.join(os.path.dirname(__file__), "..", "fullsend-repo", "scripts")
+_RESOLVER = os.path.join(_SCRIPT_DIR, "resolve-precommit-tools.py")
+spec = importlib.util.spec_from_file_location("resolver", _RESOLVER)
+assert spec is not None and spec.loader is not None
+resolver = importlib.util.module_from_spec(spec)
+sys.modules["resolver"] = resolver
+spec.loader.exec_module(resolver)
+
+
+def _write_yaml(content: str) -> str:
+    """Write YAML content to a temp file and return its path."""
+    fd, path = tempfile.mkstemp(suffix=".yaml")
+    with os.fdopen(fd, "w") as f:
+        f.write(textwrap.dedent(content))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# merge_registries tests
+# ---------------------------------------------------------------------------
+
+
+class TestMergeRegistries(unittest.TestCase):
+    def test_merge_new_entry(self):
+        upstream = {
+            "tools": [
+                {"hook_id": "lint", "repo": "local", "install": {"name": "linter"}},
+            ]
+        }
+        local = {
+            "tools": [
+                {"hook_id": "fmt", "repo": "local", "install": {"name": "formatter"}},
+            ]
+        }
+        merged, warnings = resolver.merge_registries(upstream, local)
+        self.assertEqual(len(merged["tools"]), 2)
+        self.assertEqual(merged["tools"][0]["hook_id"], "lint")
+        self.assertEqual(merged["tools"][1]["hook_id"], "fmt")
+        self.assertEqual(warnings, [])
+
+    def test_merge_override(self):
+        upstream = {
+            "tools": [
+                {
+                    "hook_id": "lint",
+                    "repo": "https://github.com/example/lint",
+                    "install": {"name": "linter", "version": "1.0"},
+                },
+            ]
+        }
+        local = {
+            "tools": [
+                {
+                    "hook_id": "lint",
+                    "repo": "https://github.com/example/lint",
+                    "install": {"name": "linter", "version": "2.0"},
+                },
+            ]
+        }
+        merged, warnings = resolver.merge_registries(upstream, local)
+        self.assertEqual(len(merged["tools"]), 1)
+        self.assertEqual(merged["tools"][0]["install"]["version"], "2.0")
+        self.assertEqual(warnings, [])
+
+    def test_merge_exclude(self):
+        upstream = {
+            "tools": [
+                {"hook_id": "lint", "repo": "local", "install": {"name": "linter"}},
+                {"hook_id": "fmt", "repo": "local", "install": {"name": "formatter"}},
+            ]
+        }
+        local = {
+            "tools": [
+                {"hook_id": "lint", "repo": "local", "exclude": True},
+            ]
+        }
+        merged, warnings = resolver.merge_registries(upstream, local)
+        self.assertEqual(len(merged["tools"]), 1)
+        self.assertEqual(merged["tools"][0]["hook_id"], "fmt")
+        self.assertEqual(warnings, [])
+
+    def test_merge_empty_local(self):
+        upstream = {
+            "tools": [
+                {"hook_id": "lint", "repo": "local", "install": {"name": "linter"}},
+            ]
+        }
+        local = {"tools": []}
+        merged, warnings = resolver.merge_registries(upstream, local)
+        self.assertEqual(len(merged["tools"]), 1)
+        self.assertEqual(warnings, [])
+
+    def test_merge_preserves_order(self):
+        upstream = {
+            "tools": [
+                {"hook_id": "a", "repo": "local", "install": {"name": "tool-a"}},
+                {"hook_id": "b", "repo": "local", "install": {"name": "tool-b"}},
+                {"hook_id": "c", "repo": "local", "install": {"name": "tool-c"}},
+            ]
+        }
+        local = {
+            "tools": [
+                {"hook_id": "d", "repo": "local", "install": {"name": "tool-d"}},
+            ]
+        }
+        merged, _ = resolver.merge_registries(upstream, local)
+        ids = [t["hook_id"] for t in merged["tools"]]
+        self.assertEqual(ids, ["a", "b", "c", "d"])
+
+    def test_merge_malformed_local_missing_tools(self):
+        upstream = {
+            "tools": [
+                {"hook_id": "lint", "repo": "local", "install": {"name": "linter"}},
+            ]
+        }
+        local = {"not_tools": []}
+        merged, warnings = resolver.merge_registries(upstream, local)
+        self.assertEqual(len(merged["tools"]), 1)
+        self.assertTrue(any("invalid" in w for w in warnings))
+
+    def test_merge_malformed_local_not_dict(self):
+        upstream = {
+            "tools": [
+                {"hook_id": "lint", "repo": "local", "install": {"name": "linter"}},
+            ]
+        }
+        merged, warnings = resolver.merge_registries(upstream, "not a dict")
+        self.assertEqual(len(merged["tools"]), 1)
+        self.assertTrue(any("invalid" in w for w in warnings))
+
+    def test_merge_entry_missing_hook_id(self):
+        upstream = {
+            "tools": [
+                {"hook_id": "lint", "repo": "local", "install": {"name": "linter"}},
+            ]
+        }
+        local = {
+            "tools": [
+                {"repo": "local", "install": {"name": "orphan"}},
+            ]
+        }
+        merged, warnings = resolver.merge_registries(upstream, local)
+        self.assertEqual(len(merged["tools"]), 1)
+        self.assertTrue(any("missing hook_id" in w for w in warnings))
+
+    def test_same_hook_id_different_repo(self):
+        """Same hook_id but different repos should coexist, not override."""
+        upstream = {
+            "tools": [
+                {
+                    "hook_id": "lint",
+                    "repo": "https://github.com/org-a/lint",
+                    "install": {"name": "lint-a"},
+                },
+            ]
+        }
+        local = {
+            "tools": [
+                {
+                    "hook_id": "lint",
+                    "repo": "https://github.com/org-b/lint",
+                    "install": {"name": "lint-b"},
+                },
+            ]
+        }
+        merged, warnings = resolver.merge_registries(upstream, local)
+        self.assertEqual(len(merged["tools"]), 2)
+        names = [t["install"]["name"] for t in merged["tools"]]
+        self.assertIn("lint-a", names)
+        self.assertIn("lint-b", names)
+        self.assertEqual(warnings, [])
+
+    def test_exclude_nonexistent_entry(self):
+        upstream = {
+            "tools": [
+                {"hook_id": "lint", "repo": "local", "install": {"name": "linter"}},
+            ]
+        }
+        local = {
+            "tools": [
+                {"hook_id": "ghost", "repo": "local", "exclude": True},
+            ]
+        }
+        merged, warnings = resolver.merge_registries(upstream, local)
+        self.assertEqual(len(merged["tools"]), 1)
+        self.assertEqual(warnings, [])
+
+
+# ---------------------------------------------------------------------------
+# resolve tests (with parsed dict registry)
+# ---------------------------------------------------------------------------
+
+
+class TestResolve(unittest.TestCase):
+    def _precommit_file(self, content: str) -> str:
+        path = _write_yaml(content)
+        self.addCleanup(lambda p=path: os.unlink(p) if os.path.exists(p) else None)
+        return path
+
+    def test_resolve_uv_match(self):
+        """Hooks with entry: 'uv run ...' should match the uv match_entry."""
+        precommit = self._precommit_file("""\
+            repos:
+              - repo: local
+                hooks:
+                  - id: mypy-check
+                    entry: "uv run mypy"
+                    language: system
+        """)
+        registry = {
+            "tools": [
+                {
+                    "hook_id": "uv-run",
+                    "repo": "local",
+                    "match_entry": "uv",
+                    "install": {"type": "binary", "name": "uv", "version": "0.11.14"},
+                },
+            ]
+        }
+        result = resolver.resolve(precommit, registry)
+        self.assertEqual(len(result["tools"]), 1)
+        self.assertEqual(result["tools"][0]["name"], "uv")
+
+    def test_resolve_uvx_match(self):
+        """Hooks with entry: 'uvx ...' should match the uvx match_entry."""
+        precommit = self._precommit_file("""\
+            repos:
+              - repo: local
+                hooks:
+                  - id: ty
+                    entry: "uvx ty check"
+                    language: system
+        """)
+        registry = {
+            "tools": [
+                {
+                    "hook_id": "ty",
+                    "repo": "local",
+                    "match_entry": "uvx",
+                    "install": {"type": "binary", "name": "uv", "version": "0.11.14"},
+                },
+            ]
+        }
+        result = resolver.resolve(precommit, registry)
+        self.assertEqual(len(result["tools"]), 1)
+        self.assertEqual(result["tools"][0]["name"], "uv")
+
+    def test_resolve_dedup(self):
+        """Both uv and uvx hooks resolve to one install via seen_names dedup."""
+        precommit = self._precommit_file("""\
+            repos:
+              - repo: local
+                hooks:
+                  - id: ty
+                    entry: "uvx ty check"
+                    language: system
+                  - id: mypy-check
+                    entry: "uv run mypy"
+                    language: system
+        """)
+        registry = {
+            "tools": [
+                {
+                    "hook_id": "ty",
+                    "repo": "local",
+                    "match_entry": "uvx",
+                    "install": {"type": "binary", "name": "uv", "version": "0.11.14"},
+                },
+                {
+                    "hook_id": "uv-run",
+                    "repo": "local",
+                    "match_entry": "uv",
+                    "install": {"type": "binary", "name": "uv", "version": "0.11.14"},
+                },
+            ]
+        }
+        result = resolver.resolve(precommit, registry)
+        self.assertEqual(len(result["tools"]), 1)
+        self.assertEqual(result["tools"][0]["name"], "uv")
+
+    def test_resolve_with_merged_registry(self):
+        """End-to-end: upstream + local merged, then resolved."""
+        upstream = {
+            "tools": [
+                {
+                    "hook_id": "lint",
+                    "repo": "local",
+                    "match_entry": "lychee",
+                    "install": {"type": "binary", "name": "lychee", "version": "0.24.2"},
+                },
+            ]
+        }
+        local = {
+            "tools": [
+                {
+                    "hook_id": "fmt",
+                    "repo": "local",
+                    "match_entry": "myfmt",
+                    "install": {"type": "binary", "name": "myfmt", "version": "1.0"},
+                },
+            ]
+        }
+        merged, _ = resolver.merge_registries(upstream, local)
+
+        precommit = self._precommit_file("""\
+            repos:
+              - repo: local
+                hooks:
+                  - id: check-links
+                    entry: "lychee ."
+                    language: system
+                  - id: format-code
+                    entry: "myfmt --fix"
+                    language: system
+        """)
+        result = resolver.resolve(precommit, merged)
+        os.unlink(precommit)
+        names = [t["name"] for t in result["tools"]]
+        self.assertIn("lychee", names)
+        self.assertIn("myfmt", names)
+        self.assertEqual(len(result["tools"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Extends the pre-commit tools registry (#1055) with per-repo additive merge:

- **L2 additive merge**: Target repos place `.pre-commit-tools.yaml` at repo root to extend the upstream/org registry. New entries append, matching `(repo, hook_id)` entries override, `exclude: true` suppresses.
- **Supply-chain security**: Per-repo registries are read from the base branch (`git show origin/${TARGET_BRANCH}:...`), not the PR head. Changes take effect only after merge.
- **P1 fix**: Add `uv` match entry so hooks with `entry: "uv run ..."` are recognized alongside `uvx`.
- **P2 fix**: Document that `shellcheck-py` is auto-managed by pre-commit (no registry entry needed).

### Three-layer resolution

```
upstream defaults (fullsend-ai/fullsend)
  → org override: customized/scripts/.pre-commit-tools.yaml  (L1, full replacement)
    → per-repo additive: .pre-commit-tools.yaml at repo root (L2, additive merge)
```

## Changes

| File | Change |
|------|--------|
| `docs/ADRs/0056-per-repo-precommit-tools-registry.md` | New ADR documenting design, security model, merge semantics |
| `resolve-precommit-tools.py` | Refactor `resolve()` to accept dict, add `merge_registries()`, add `--local-registry` CLI arg |
| `.pre-commit-tools.yaml` | Add `uv` match entry (P1), shellcheck-py note (P2), update header docs |
| `post-code.sh`, `post-fix.sh`, `pre-code.sh`, `pre-fix.sh` | Extract base-branch registry and pass `--local-registry` |
| `customizing-agents.md` | New "Customizing Pre-commit Tool Dependencies" section |
| `test_resolve_precommit_tools.py` | 13 unit tests for merge, exclude, dedup, uv match, malformed input |

## Test plan

- [ ] `python3 internal/scaffold/scripts-tests/test_resolve_precommit_tools.py` — 13/13 pass
- [ ] `go test ./internal/scaffold/...` — existing Go tests pass
- [ ] `make lint` — passes
- [ ] Manual: hook with `entry: "uv run mypy"` matches the `uv` registry entry
- [ ] Manual: `exclude: true` on gitleaks suppresses the upstream entry
- [ ] Manual: local registry extends upstream without replacing it

Closes #1270