### PR TITLE
fix(ci): fall back to collaborator permission API in e2e/functional gate

### DIFF
--- a/.github/actions/check-e2e-authorization/action.yml
+++ b/.github/actions/check-e2e-authorization/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: github.event.pull_request.author_association (frozen event payload)
     required: false
     default: ""
+  pr_author_login:
+    description: github.event.pull_request.user.login (for collaborator permission API fallback)
+    required: false
+    default: ""
   docs_url:
     description: Link to e2e testing documentation
     required: false
@@ -51,6 +55,7 @@ runs:
         PR_UPDATED_AT: ${{ inputs.pr_updated_at }}
         EVENT_ACTION: ${{ inputs.event_action }}
         PR_AUTHOR_ASSOCIATION: ${{ inputs.pr_author_association }}
+        PR_AUTHOR_LOGIN: ${{ inputs.pr_author_login }}
       run: bash "${GITHUB_WORKSPACE}/scripts/check-e2e-authorization.sh" "${PR_NUMBER}" "${REPOSITORY}"
 
     - name: Post gate comment

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,6 +66,7 @@ jobs:
           pr_updated_at: ${{ github.event.pull_request.updated_at }}
           event_action: ${{ github.event.action }}
           pr_author_association: ${{ github.event.pull_request.author_association }}
+          pr_author_login: ${{ github.event.pull_request.user.login }}
 
   e2e:
     # For pull_request_target, runs only when gate sets authorized=true.

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -58,6 +58,7 @@ jobs:
           pr_updated_at: ${{ github.event.pull_request.updated_at }}
           event_action: ${{ github.event.action }}
           pr_author_association: ${{ github.event.pull_request.author_association }}
+          pr_author_login: ${{ github.event.pull_request.user.login }}
 
   functional-tests:
     # For pull_request_target, runs only when gate sets authorized=true.

--- a/scripts/check-e2e-authorization-test.sh
+++ b/scripts/check-e2e-authorization-test.sh
@@ -17,8 +17,12 @@ mkdir -p "${MOCK_BIN}"
 
 PR_JSON="${TMPDIR}/pr.json"
 EVENTS_JSON="${TMPDIR}/events.json"
+COLLAB_ROLE="${TMPDIR}/collab_role"
 GH_LOG="${TMPDIR}/gh.log"
 GH_FAIL="false"
+
+# Default: no collaborator role configured (API returns failure)
+echo "" >"${COLLAB_ROLE}"
 
 write_pr() {
   local assoc="$1"
@@ -45,6 +49,14 @@ if [[ "\${GH_FAIL}" == "events" && "\$*" == *"/issues/"*"/events"* ]]; then
   exit 1
 fi
 case "\$*" in
+  *"/collaborators/"*"/permission"*)
+    role=\$(cat "${COLLAB_ROLE}")
+    if [[ -z "\${role}" ]]; then
+      echo "not a collaborator" >&2
+      exit 1
+    fi
+    echo "{\"role_name\": \"\${role}\"}"
+    ;;
   *"/issues/"*"/events"*)
     cat "${EVENTS_JSON}"
     ;;
@@ -66,7 +78,7 @@ export PATH="${MOCK_BIN}:${PATH}"
 export GH_TOKEN="test-token"
 export CHECK_E2E_AUTH_DRY_RUN="true"
 export GH_FAIL="false"
-unset EVENT_ACTION PR_UPDATED_AT
+unset EVENT_ACTION PR_UPDATED_AT PR_AUTHOR_LOGIN
 
 run_case() {
   local name="$1"
@@ -196,6 +208,65 @@ write_pr "NONE" '[{"name":"ok-to-test"}]'
 write_events '[]'
 export GH_FAIL="true"
 run_case "gh api failure on pull fetch returns error reason" "false" "error" "false"
+export GH_FAIL="false"
+
+# --- Collaborator permission API fallback tests ---
+
+# Private org member: event payload says CONTRIBUTOR, but collaborator API says write+
+unset EVENT_ACTION PR_UPDATED_AT
+export PR_AUTHOR_ASSOCIATION="CONTRIBUTOR"
+export PR_AUTHOR_LOGIN="maruiz93"
+echo "admin" >"${COLLAB_ROLE}"
+write_pr "NONE" '[]'
+: >"${GH_LOG}"
+run_case "private org member: collaborator API fallback authorizes admin" "true" "trusted_author" "false"
+if ! grep -q '/collaborators/' "${GH_LOG}"; then
+  echo "FAIL: should have called collaborator permission API"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "PASS: called collaborator permission API for fallback"
+fi
+
+echo "write" >"${COLLAB_ROLE}"
+: >"${GH_LOG}"
+run_case "private org member: collaborator API fallback authorizes write" "true" "trusted_author" "false"
+
+echo "maintain" >"${COLLAB_ROLE}"
+: >"${GH_LOG}"
+run_case "private org member: collaborator API fallback authorizes maintain" "true" "trusted_author" "false"
+
+# Collaborator API says read — should NOT authorize
+echo "read" >"${COLLAB_ROLE}"
+write_pr "NONE" '[]'
+: >"${GH_LOG}"
+run_case "collaborator API read permission denied" "false" "unauthorized" "false"
+
+# Collaborator API fails — should fall through to ok-to-test label path
+echo "" >"${COLLAB_ROLE}"
+export EVENT_ACTION="synchronize"
+export PR_UPDATED_AT="2026-06-01T10:00:00Z"
+write_pr "NONE" '[{"name":"ok-to-test"}]'
+write_events '[{"event":"labeled","label":{"name":"ok-to-test"},"created_at":"2026-06-01T11:00:00Z"}]'
+: >"${GH_LOG}"
+run_case "collaborator API failure falls through to ok-to-test" "true" "ok_to_test" "false"
+
+# No PR_AUTHOR_LOGIN set — should skip collaborator API entirely
+unset PR_AUTHOR_LOGIN EVENT_ACTION PR_UPDATED_AT
+export PR_AUTHOR_ASSOCIATION="CONTRIBUTOR"
+echo "admin" >"${COLLAB_ROLE}"
+write_pr "NONE" '[]'
+: >"${GH_LOG}"
+run_case "no PR_AUTHOR_LOGIN skips collaborator API fallback" "false" "unauthorized" "false"
+if grep -q '/collaborators/' "${GH_LOG}"; then
+  echo "FAIL: should NOT have called collaborator API without PR_AUTHOR_LOGIN"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "PASS: skipped collaborator API without PR_AUTHOR_LOGIN"
+fi
+
+# Clean up
+unset PR_AUTHOR_ASSOCIATION PR_AUTHOR_LOGIN
+echo "" >"${COLLAB_ROLE}"
 export GH_FAIL="false"
 
 if [[ "${FAILURES}" -gt 0 ]]; then

--- a/scripts/check-e2e-authorization.sh
+++ b/scripts/check-e2e-authorization.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # check-e2e-authorization.sh — Decide whether a PR may run e2e tests in CI.
 #
-# Authorized when the PR author is OWNER/MEMBER/COLLABORATOR, or when a fresh
+# Authorized when the PR author is OWNER/MEMBER/COLLABORATOR, or when the
+# collaborator permission API confirms write+ access, or when a fresh
 # ok-to-test label was applied after the latest push.
+#
+# The author_association field from the event payload can misreport org members
+# whose membership visibility is private (returns CONTRIBUTOR/NONE instead of
+# MEMBER). When author_association is untrusted, the script falls back to the
+# collaborator permission API which correctly resolves regardless of visibility.
 #
 # Freshness uses PR updated_at from the frozen workflow event (PR_UPDATED_AT).
 # On ok-to-test labeled events, authorization is immediate. Does not use
@@ -12,6 +18,7 @@
 #
 # Environment (optional, from workflow):
 #   PR_AUTHOR_ASSOCIATION — github.event.pull_request.author_association
+#   PR_AUTHOR_LOGIN — github.event.pull_request.user.login
 #   PR_UPDATED_AT — github.event.pull_request.updated_at
 #   EVENT_ACTION  — github.event.action
 #
@@ -48,13 +55,30 @@ is_trusted_author() {
   esac
 }
 
+# Fallback: check actor has write+ permission via the collaborator permission
+# API, which correctly resolves org membership regardless of visibility
+# (private vs public). Same approach as the dispatch workflow.
+has_write_permission() {
+  local username="${1:-}"
+  if [[ -z "${username}" ]]; then
+    return 1
+  fi
+  local perm_json role
+  perm_json=$(gh api "repos/${REPOSITORY}/collaborators/${username}/permission" 2>/dev/null) || return 1
+  role=$(jq -r '.role_name' <<<"${perm_json}") || return 1
+  case "${role}" in
+    admin|maintain|write) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 label_removed=false
 authorized=false
 reason="unauthorized"
 
-# Prefer the frozen workflow event payload. GITHUB_TOKEN cannot see org
-# membership (read:org), so pulls.get often returns NONE/CONTRIBUTOR for
-# org members — especially when membership visibility is private.
+# Try the frozen workflow event payload first (fast path). If it reports an
+# untrusted association, has_write_permission falls back to the collaborator
+# permission API which resolves correctly regardless of membership visibility.
 if [[ -n "${PR_AUTHOR_ASSOCIATION:-}" ]]; then
   author_association="${PR_AUTHOR_ASSOCIATION}"
 else
@@ -63,6 +87,11 @@ else
 fi
 
 if is_trusted_author "${author_association}"; then
+  authorized=true
+  reason="trusted_author"
+elif has_write_permission "${PR_AUTHOR_LOGIN:-}" 2>/dev/null; then
+  # author_association was wrong (e.g. private org membership); collaborator
+  # permission API confirms write+ access.
   authorized=true
   reason="trusted_author"
 else


### PR DESCRIPTION
## Summary

- The `author_association` field in `pull_request_target` event payloads misreports org members with **private membership visibility** — returning `CONTRIBUTOR` or `NONE` instead of `MEMBER`. This blocked e2e and functional tests for maintainers like @maruiz93 on #2671.
- Adds a `has_write_permission` fallback using the collaborator permission API (`repos/{owner}/{repo}/collaborators/{user}/permission`), which resolves correctly regardless of visibility. Works with existing `GITHUB_TOKEN` permissions (`contents: read`).
- Follows the same pattern already adopted for agent dispatch authorization in #1688.

## Test plan

- [x] All 28 existing + new authorization tests pass (`bash scripts/check-e2e-authorization-test.sh`)
- [ ] Verify on #2671: re-run e2e gate after merge to confirm maruiz93 is authorized

🤖 Generated with [Claude Code](https://claude.com/claude-code)