### PR TITLE
refactor(workflows): replace fullsend_ai_ref by job.workflow_sha

### DIFF
--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -32,7 +32,7 @@ on:
         type: string
         default: "per-org"
       fullsend_ai_ref:
-        description: Ref of fullsend-ai/fullsend to load actions from. Must match the ref used in the `uses:` line that calls this workflow.
+        description: "Deprecated: upstream defaults now use job.workflow_sha. Kept for per-org caller compatibility."
         type: string
         required: false
         default: v0
@@ -72,8 +72,8 @@ jobs:
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: fullsend-ai/fullsend
-          ref: ${{ inputs.fullsend_ai_ref }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .defaults
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -46,7 +46,7 @@ on:
         type: string
         default: "latest"
       fullsend_ai_ref:
-        description: Ref of fullsend-ai/fullsend to load actions from. Must match the ref used in the `uses:` line that calls this workflow.
+        description: "Deprecated: stage workflows now use job.workflow_sha. Kept so existing shims that pass this input do not break."
         type: string
         required: false
         default: v0
@@ -427,7 +427,7 @@ jobs:
       group: fullsend-triage-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: true
     # @v0 is hardcoded — GHA does not support expressions in uses:.
-    # fullsend_ai_ref controls the ref for composite actions inside stage workflows.
+    # Stage workflows use job.workflow_sha to self-checkout upstream defaults.
     uses: fullsend-ai/fullsend/.github/workflows/reusable-triage.yml@v0
     with:
       event_type: ${{ github.event_name }}
@@ -437,7 +437,6 @@ jobs:
       mint_url: ${{ inputs.mint_url }}
       gcp_region: ${{ inputs.gcp_region }}
       fullsend_version: ${{ inputs.fullsend_version }}
-      fullsend_ai_ref: ${{ inputs.fullsend_ai_ref }}
       runner_image: ${{ inputs.runner_image }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
@@ -459,7 +458,6 @@ jobs:
       mint_url: ${{ inputs.mint_url }}
       gcp_region: ${{ inputs.gcp_region }}
       fullsend_version: ${{ inputs.fullsend_version }}
-      fullsend_ai_ref: ${{ inputs.fullsend_ai_ref }}
       runner_image: ${{ inputs.runner_image }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
@@ -481,7 +479,6 @@ jobs:
       mint_url: ${{ inputs.mint_url }}
       gcp_region: ${{ inputs.gcp_region }}
       fullsend_version: ${{ inputs.fullsend_version }}
-      fullsend_ai_ref: ${{ inputs.fullsend_ai_ref }}
       runner_image: ${{ inputs.runner_image }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
@@ -504,7 +501,6 @@ jobs:
       mint_url: ${{ inputs.mint_url }}
       gcp_region: ${{ inputs.gcp_region }}
       fullsend_version: ${{ inputs.fullsend_version }}
-      fullsend_ai_ref: ${{ inputs.fullsend_ai_ref }}
       runner_image: ${{ inputs.runner_image }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
@@ -526,7 +522,6 @@ jobs:
       mint_url: ${{ inputs.mint_url }}
       gcp_region: ${{ inputs.gcp_region }}
       fullsend_version: ${{ inputs.fullsend_version }}
-      fullsend_ai_ref: ${{ inputs.fullsend_ai_ref }}
       runner_image: ${{ inputs.runner_image }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
@@ -549,7 +544,6 @@ jobs:
       gcp_region: ${{ inputs.gcp_region }}
       project_number: ${{ inputs.project_number }}
       fullsend_version: ${{ inputs.fullsend_version }}
-      fullsend_ai_ref: ${{ inputs.fullsend_ai_ref }}
       runner_image: ${{ inputs.runner_image }}
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -44,7 +44,7 @@ on:
         type: string
         default: "per-org"
       fullsend_ai_ref:
-        description: Ref of fullsend-ai/fullsend to load actions from. Must match the ref used in the `uses:` line that calls this workflow.
+        description: "Deprecated: upstream defaults now use job.workflow_sha. Kept for per-org caller compatibility."
         type: string
         required: false
         default: v0
@@ -88,8 +88,8 @@ jobs:
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: fullsend-ai/fullsend
-          ref: ${{ inputs.fullsend_ai_ref }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .defaults
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/reusable-prioritize.yml
+++ b/.github/workflows/reusable-prioritize.yml
@@ -36,7 +36,7 @@ on:
         type: string
         default: "per-org"
       fullsend_ai_ref:
-        description: Ref of fullsend-ai/fullsend to load actions from. Must match the ref used in the `uses:` line that calls this workflow.
+        description: "Deprecated: upstream defaults now use job.workflow_sha. Kept for per-org caller compatibility."
         type: string
         required: false
         default: v0
@@ -73,8 +73,8 @@ jobs:
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: fullsend-ai/fullsend
-          ref: ${{ inputs.fullsend_ai_ref }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .defaults
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/reusable-retro.yml
+++ b/.github/workflows/reusable-retro.yml
@@ -32,7 +32,7 @@ on:
         type: string
         default: "per-org"
       fullsend_ai_ref:
-        description: Ref of fullsend-ai/fullsend to load actions from. Must match the ref used in the `uses:` line that calls this workflow.
+        description: "Deprecated: upstream defaults now use job.workflow_sha. Kept for per-org caller compatibility."
         type: string
         required: false
         default: v0
@@ -69,8 +69,8 @@ jobs:
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: fullsend-ai/fullsend
-          ref: ${{ inputs.fullsend_ai_ref }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .defaults
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -32,7 +32,7 @@ on:
         type: string
         default: "per-org"
       fullsend_ai_ref:
-        description: Ref of fullsend-ai/fullsend to load actions from. Must match the ref used in the `uses:` line that calls this workflow.
+        description: "Deprecated: upstream defaults now use job.workflow_sha. Kept for per-org caller compatibility."
         type: string
         required: false
         default: v0
@@ -70,8 +70,8 @@ jobs:
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: fullsend-ai/fullsend
-          ref: ${{ inputs.fullsend_ai_ref }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .defaults
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/reusable-triage.yml
+++ b/.github/workflows/reusable-triage.yml
@@ -33,7 +33,7 @@ on:
         type: string
         default: "per-org"
       fullsend_ai_ref:
-        description: Ref of fullsend-ai/fullsend to load actions from. Must match the ref used in the `uses:` line that calls this workflow.
+        description: "Deprecated: upstream defaults now use job.workflow_sha. Kept for per-org caller compatibility."
         type: string
         required: false
         default: v0
@@ -70,8 +70,8 @@ jobs:
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: fullsend-ai/fullsend
-          ref: ${{ inputs.fullsend_ai_ref }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .defaults
           fetch-depth: 1
           sparse-checkout: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,6 +88,8 @@ repos:
           - -ignore
           - property "workflow_repository" is not defined
           - -ignore
+          - property "workflow_sha" is not defined
+          - -ignore
           - SC2016
           - -ignore
           - '__REUSABLE_(WORKFLOW|DISPATCH)__'

--- a/docs/ADRs/0035-layered-content-resolution.md
+++ b/docs/ADRs/0035-layered-content-resolution.md
@@ -61,7 +61,9 @@ they are populated at runtime from upstream.
 "Prepare workspace" step that checks out upstream defaults from
 `fullsend-ai/fullsend` at the ref supplied via `fullsend_ai_ref` (PR #1278
 replaced the earlier checkout at `@v0` with a checkout at a
-caller-controlled ref), copies them into the main dirs (`agents/`, `skills/`,
+caller-controlled ref; since superseded by `job.workflow_sha` which
+eliminates the need for the caller to pass a ref — see PR #2689),
+copies them into the main dirs (`agents/`, `skills/`,
 etc.), then copies customizations on top so override files replace upstream
 defaults. When `--vendor` has committed upstream mirror content under
 `.defaults/`, the sparse checkout is skipped (see

--- a/docs/guides/dev/testing-workflows.md
+++ b/docs/guides/dev/testing-workflows.md
@@ -9,13 +9,12 @@ There are independent version reference inputs that control different parts of t
 | Input | Controls | Where set |
 |-------|----------|-----------|
 | `@<ref>` on `uses:` | Which reusable workflow YAML runs | The `uses:` line in the caller workflow |
-| `fullsend_ai_ref` | Which ref composite actions (`action.yml`) and defaults are loaded from at runtime | Passed as a `with:` input |
 | `fullsend_version` | Which fullsend CLI binary is installed | Passed as a `with:` input |
 
 When no release exists for `fullsend_version`, `action.yml` falls back to cloning
 and building from source at that ref (see the `install-method=source` path).
 
-If `uses:`, `fullsend_ai_ref` and `fullsend_version` diverge, the workflows, agents and harnesses, and
+If `uses:` and `fullsend_version` diverge, the workflows/agents and
 CLI diverge, potentially causing mismatch in behavior and failures.
 
 ## Vendored installs (recommended for PR testing)
@@ -65,7 +64,6 @@ jobs:
     uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@<YOUR_BRANCH>
     with:
       # [...]
-      fullsend_ai_ref: <YOUR_BRANCH>
       fullsend_version: <YOUR_BRANCH>
       # [...]
 ```
@@ -86,7 +84,6 @@ jobs:
     uses: fullsend-ai/fullsend/.github/workflows/reusable-triage.yml@<YOUR_BRANCH>
     with:
       # [...]
-      fullsend_ai_ref: <YOUR_BRANCH>
       fullsend_version: <YOUR_BRANCH>
       # [...]
 ```

--- a/internal/layers/workflows_test.go
+++ b/internal/layers/workflows_test.go
@@ -259,7 +259,7 @@ func TestWorkflowsLayer_Install_PinnedSHA(t *testing.T) {
 	require.NotEmpty(t, triageContent, "triage.yml should have been written")
 	assert.Contains(t, triageContent, "@abc123def456abc123def456abc123def456abcd")
 	assert.Contains(t, triageContent, "# v0.19.0")
-	assert.Contains(t, triageContent, "fullsend_ai_ref: abc123def456abc123def456abc123def456abcd # v0.19.0")
+	assert.NotContains(t, triageContent, "fullsend_ai_ref:")
 	assert.NotContains(t, triageContent, "@v0")
 }
 

--- a/internal/scaffold/fullsend-repo/.github/workflows/code.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/code.yml
@@ -37,7 +37,6 @@ jobs:
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
-      fullsend_ai_ref: __FULLSEND_AI_REF__
       runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/fix.yml
@@ -61,7 +61,6 @@ jobs:
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
-      fullsend_ai_ref: __FULLSEND_AI_REF__
       runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/prioritize.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/prioritize.yml
@@ -36,7 +36,6 @@ jobs:
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       project_number: ${{ vars.FULLSEND_PROJECT_NUMBER }}
       install_mode: per-org
-      fullsend_ai_ref: __FULLSEND_AI_REF__
       runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/retro.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/retro.yml
@@ -42,7 +42,6 @@ jobs:
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
-      fullsend_ai_ref: __FULLSEND_AI_REF__
       runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/review.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/review.yml
@@ -36,7 +36,6 @@ jobs:
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
-      fullsend_ai_ref: __FULLSEND_AI_REF__
       runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}

--- a/internal/scaffold/fullsend-repo/.github/workflows/triage.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/triage.yml
@@ -35,7 +35,6 @@ jobs:
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
       install_mode: per-org
-      fullsend_ai_ref: __FULLSEND_AI_REF__
       runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}

--- a/internal/scaffold/fullsend-repo/templates/shim-per-repo.yaml
+++ b/internal/scaffold/fullsend-repo/templates/shim-per-repo.yaml
@@ -48,7 +48,6 @@ jobs:
       install_mode: per-repo
       mint_url: ${{ vars.FULLSEND_MINT_URL }}
       gcp_region: ${{ vars.FULLSEND_GCP_REGION }}
-      fullsend_ai_ref: __FULLSEND_AI_REF__
       runner_image: __GH_RUNNER__
     secrets:
       FULLSEND_GCP_WIF_PROVIDER: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}

--- a/internal/scaffold/render_test.go
+++ b/internal/scaffold/render_test.go
@@ -157,7 +157,7 @@ func TestRenderThinCallerPinnedSHA(t *testing.T) {
 	out := string(rendered)
 	assert.Contains(t, out, "uses: fullsend-ai/fullsend/.github/workflows/reusable-triage.yml@abc123def456")
 	assert.Contains(t, out, "# v0.19.0")
-	assert.Contains(t, out, "fullsend_ai_ref: abc123def456 # v0.19.0")
+	assert.NotContains(t, out, "fullsend_ai_ref:")
 	assertFreeOfRenderPlaceholders(t, out)
 }
 
@@ -174,7 +174,7 @@ func TestRenderPerRepoShimPinnedSHA(t *testing.T) {
 	out := string(rendered)
 	assert.Contains(t, out, "uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@abc123def456")
 	assert.Contains(t, out, "# v0.19.0")
-	assert.Contains(t, out, "fullsend_ai_ref: abc123def456 # v0.19.0")
+	assert.NotContains(t, out, "fullsend_ai_ref:")
 	assertFreeOfRenderPlaceholders(t, out)
 }
 
@@ -225,5 +225,5 @@ func TestRenderFallbackToDefaultRef(t *testing.T) {
 	require.NoError(t, err)
 	out := string(rendered)
 	assert.Contains(t, out, "@v0")
-	assert.Contains(t, out, "fullsend_ai_ref: v0")
+	assert.NotContains(t, out, "fullsend_ai_ref:")
 }


### PR DESCRIPTION
Resolves #2683

## Summary

- Stage workflows use `job.workflow_repository`/`job.workflow_sha` to checkout upstream defaults instead of caller-provided `fullsend_ai_ref`
- No caller passes `fullsend_ai_ref` anymore (shim-per-repo, dispatch, per-org thin callers)
- Input kept (deprecated) in stage workflows and dispatch so existing deployed shims don't break when `v0` moves
- ADR 35 annotated with supersession note
- actionlint ignore added for `job.workflow_sha` (not in actionlint's type defs yet)

## Context

GitHub Actions [`job.workflow_*` context](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#example-usage-of-job-context-workflow-identity) lets a reusable workflow identify its own source repo and SHA — guaranteed consistent with the `uses:` line. Eliminates drift between `fullsend_ai_ref` and the `@ref`.

## Test plan

- [x] `go test ./internal/scaffold/...` passes
- [x] All pre-commit hooks pass
- [x] Trigger per-repo run to verify upstream defaults checkout resolves correctly
- [x] Verify per-org run still works (deployed thin callers may still pass `fullsend_ai_ref` — accepted and ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)