### PR TITLE
fix(renovate): group OpenShell base image and version pin updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,14 @@
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["/^fullsend-ai\\//"],
       "enabled": false
+    },
+    {
+      "description": "Group OpenShell base image and version pin into one PR",
+      "matchPackageNames": [
+        "ghcr.io/nvidia/openshell-community/sandboxes/base",
+        "NVIDIA/OpenShell"
+      ],
+      "groupName": "openshell"
     }
   ],
   "postUpdateOptions": ["gomodTidy"],


### PR DESCRIPTION
## Summary
- Add Renovate `groupName` rule so the OpenShell base image digest and version pin update in a single PR instead of two

Closes #2692

## Test plan
- [ ] Verify next Renovate run produces one combined `openshell` PR
- [ ] Close stale PR #2685 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)