### PR TITLE
fix(harness): warn when URL-base skill is fetched with only SKILL.md

### DIFF
--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -122,13 +122,7 @@ func runLock(ctx context.Context, agentName, fullsendDir, forgeFlag string, upda
 	}
 	printer.StepDone(fmt.Sprintf("Locked %d dependencies for %s -> %s", len(result.deps), agentName, lockPath))
 
-	for _, dep := range result.deps {
-		if dep.CacheHit {
-			printer.StepInfo(fmt.Sprintf("  %s: %s (cached)", dep.Field, dep.URL))
-		} else {
-			printer.StepInfo(fmt.Sprintf("  %s: %s (fetched)", dep.Field, dep.URL))
-		}
-	}
+	printResolvedDeps(printer, result.deps)
 
 	return nil
 }
@@ -137,6 +131,19 @@ func runLock(ctx context.Context, agentName, fullsendDir, forgeFlag string, upda
 type lockResult struct {
 	harnessLock lock.HarnessLock
 	deps        []resolve.Dependency
+}
+
+func printResolvedDeps(printer *ui.Printer, deps []resolve.Dependency) {
+	for _, dep := range deps {
+		if dep.CacheHit {
+			printer.StepInfo(fmt.Sprintf("  %s: %s (cached)", dep.Field, dep.URL))
+		} else {
+			printer.StepInfo(fmt.Sprintf("  %s: %s (fetched)", dep.Field, dep.URL))
+		}
+		if dep.Warning != "" {
+			printer.StepWarn(fmt.Sprintf("  %s: %s", dep.Field, dep.Warning))
+		}
+	}
 }
 
 // lockOneAgent resolves dependencies for a single harness and returns the
@@ -230,6 +237,7 @@ func lockOneAgent(ctx context.Context, agentName, absFullsendDir, forgeFlag stri
 					FetchedAt: bd.FetchedAt,
 					CacheHit:  bd.CacheHit,
 					Type:      bd.Type,
+					Warning:   bd.Warning,
 				})
 			}
 		}
@@ -417,6 +425,7 @@ func runLockAll(ctx context.Context, fullsendDir, forgeFlag string, update bool,
 			return fmt.Errorf("%s: %w", name, lockErr)
 		}
 		if result != nil {
+			printResolvedDeps(printer, result.deps)
 			lf.SetHarness(name, result.harnessLock)
 			locked = append(locked, name)
 		} else if entry := lf.Lookup(name); entry != nil {

--- a/internal/cli/lock_test.go
+++ b/internal/cli/lock_test.go
@@ -976,6 +976,15 @@ func TestRunLock_URLBaseOnlyDeps(t *testing.T) {
 	assert.Equal(t, "base", entry.Dependencies[0].Field)
 	assert.Equal(t, fmt.Sprintf("%s/base.yaml", srv.URL), entry.Dependencies[0].URL)
 	assert.Equal(t, baseHash, entry.Dependencies[0].SHA256)
+	assert.Equal(t, "file", entry.Dependencies[0].Type)
+
+	assert.Equal(t, "agent", entry.Dependencies[1].Field)
+	assert.Equal(t, fmt.Sprintf("%s/agents/shared.md", srv.URL), entry.Dependencies[1].URL)
+	assert.Equal(t, "resource", entry.Dependencies[1].Type)
+
+	assert.Equal(t, "skills[0]", entry.Dependencies[2].Field)
+	assert.Equal(t, fmt.Sprintf("%s/skills/common/SKILL.md", srv.URL), entry.Dependencies[2].URL)
+	assert.Equal(t, "directory", entry.Dependencies[2].Type)
 }
 
 func TestRunLock_URLBaseOnlyDepsWithPlatform(t *testing.T) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -228,6 +228,9 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		} else {
 			printer.StepInfo(fmt.Sprintf("Base: %s (fetched)", dep.URL))
 		}
+		if dep.Warning != "" {
+			printer.StepWarn(fmt.Sprintf("Base: %s", dep.Warning))
+		}
 	}
 
 	if err := h.ResolveRelativeTo(absFullsendDir); err != nil {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -313,13 +313,15 @@ func TestRunAgent_URLRefsNoOrgConfig(t *testing.T) {
 }
 
 func TestRunAgent_WithURLBase(t *testing.T) {
-	// Harness with a URL base — exercises the baseDeps logging loop.
-	baseContent := []byte("agent: agents/shared.md\nrole: test\n")
+	// Harness with a URL base — exercises the baseDeps logging loop
+	// including the Warning path for skills fetched with only SKILL.md.
+	baseContent := []byte("agent: agents/shared.md\nrole: test\nskills:\n  - skills/common\n")
 	baseHash := fetch.ComputeSHA256(baseContent)
 
 	srv, policy := newLockTestServer(t, map[string][]byte{
-		"/base.yaml":        baseContent,
-		"/agents/shared.md": []byte("# shared agent"),
+		"/base.yaml":              baseContent,
+		"/agents/shared.md":       []byte("# shared agent"),
+		"/skills/common/SKILL.md": []byte("# common skill"),
 	})
 
 	dir := t.TempDir()

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -29,6 +29,7 @@ type Dependency struct {
 	FetchedAt time.Time
 	CacheHit  bool
 	Type      string // "file" for base harnesses
+	Warning   string // non-fatal warning about this dependency (e.g., partial skill fetch)
 }
 
 // ComposeOpts controls base composition behavior.
@@ -762,12 +763,16 @@ func fetchBaseFile(ctx context.Context, field, baseURLDir, relPath string, allow
 
 // fetchBaseSkill fetches a skill directory from a URL-referenced base harness.
 // Only SKILL.md is fetched (plain HTTP has no directory listing); skills with
-// companion files (scripts/) must use forge-format URLs resolved by
-// ResolveHarness instead. The file is fetched from
+// companion files (sub-agents, scripts, meta-prompts) will be missing at
+// runtime. A warning is attached to the returned Dependency when this
+// limitation applies. Multi-file skills should use forge-format URLs resolved
+// by ResolveHarness instead. The file is fetched from
 // <baseURLDir>/<skillPath>/SKILL.md, cached as a directory via CachePutDir,
 // and the local tree directory path is returned.
 func fetchBaseSkill(ctx context.Context, field, baseURLDir, skillPath string, allowlist []string, opts ComposeOpts) (Dependency, string, error) {
 	skillFileURL := baseURLDir + skillPath + "/SKILL.md"
+
+	warn := fmt.Sprintf("skill %q was fetched from a URL base with only SKILL.md; companion files (sub-agents, scripts, meta-prompts) may be missing — use a forge-format URL for multi-file skills", skillPath)
 
 	allowedBy := matchingAllowedPrefix(skillFileURL, allowlist)
 	if allowedBy == "" {
@@ -791,6 +796,7 @@ func fetchBaseSkill(ctx context.Context, field, baseURLDir, skillPath string, al
 					FetchedAt: entry.FetchTime,
 					CacheHit:  true,
 					Type:      "directory",
+					Warning:   warn,
 				}, treePath, nil
 			}
 		}
@@ -837,6 +843,7 @@ func fetchBaseSkill(ctx context.Context, field, baseURLDir, skillPath string, al
 		FetchedAt: fetchedAt,
 		CacheHit:  false,
 		Type:      "directory",
+		Warning:   warn,
 	}, treePath, nil
 }
 

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -2245,6 +2245,7 @@ base: `+baseURL+`
 	assert.True(t, deps[1].CacheHit, "agent should be cache hit")
 	assert.True(t, deps[2].CacheHit, "skill should be cache hit")
 	assert.Equal(t, "directory", deps[2].Type)
+	assert.Contains(t, deps[2].Warning, "only SKILL.md")
 }
 
 func TestLoadWithBase_URLBase_ResourceOfflineCacheHit(t *testing.T) {
@@ -2680,6 +2681,7 @@ func TestFetchBaseSkill_PartialIndexHit(t *testing.T) {
 	assert.NotEmpty(t, localDir)
 	assert.Equal(t, "directory", dep.Type)
 	assert.False(t, dep.CacheHit)
+	assert.Contains(t, dep.Warning, "only SKILL.md")
 }
 
 func TestResolveBaseResources_InvalidBaseURL(t *testing.T) {
@@ -2715,6 +2717,8 @@ func TestFetchBaseSkill_OnlySKILLMDFetched(t *testing.T) {
 		})
 	require.NoError(t, err)
 	assert.Equal(t, "directory", dep.Type)
+	assert.Contains(t, dep.Warning, "only SKILL.md")
+	assert.Contains(t, dep.Warning, "skills/common")
 
 	// Only SKILL.md is fetched — companion files (scripts/, sub-agents)
 	// are not available via plain HTTP directory listing.

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -28,6 +28,7 @@ type Dependency struct {
 	FetchedAt time.Time
 	CacheHit  bool
 	Type      string // "file" or "directory"
+	Warning   string // non-fatal warning about this dependency
 }
 
 // ResolveOpts controls how URL-referenced resources are resolved.


### PR DESCRIPTION
## Summary

Addresses review feedback on #2690:

- **[important]** `fetchBaseSkill` only fetches `SKILL.md`, silently losing companion files (sub-agents, scripts, meta-prompts). Now attaches a warning to the `Dependency` so CLI emits it during `fullsend lock` and `fullsend run`, guiding users to use forge-format URLs for multi-file skills.
- **[minor]** `lock_test.go` asserted only `deps[0]` after bumping count to 3 — now verifies Field, URL, and Type for all 3 deps (base, agent, skill).
- Propagates the `Warning` field through `harness.Dependency` → `resolve.Dependency` → CLI output.

## Test plan

- [x] All `internal/harness` tests pass (including new warning assertions on `TestFetchBaseSkill_OnlySKILLMDFetched`, `TestFetchBaseSkill_PartialIndexHit`, cache-hit path)
- [x] All `internal/cli` tests pass (including strengthened `TestRunLock_URLBaseOnlyDeps`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)