### PR TITLE
chore: update copyright from Red Hat, Inc to Red Hat, LLC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 Red Hat, Inc.
+   Copyright 2026 Red Hat, LLC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Update LICENSE copyright holder from "Red Hat, Inc." to "Red Hat, LLC." to reflect the company's legal entity name change