### PR TITLE
fix(harness): fetch full skill directory from URL base via ForgeClient

### DIFF
--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -197,6 +197,13 @@ func lockOneAgent(ctx context.Context, agentName, absFullsendDir, forgeFlag stri
 	seen := make(map[string]bool)
 	linted := make(map[string]bool) // track reported lint diagnostics to avoid duplicates across forge variants
 
+	var composeForgeClient forge.Client
+	if rFlags.forgeClient != nil {
+		composeForgeClient = rFlags.forgeClient
+	} else if token, tokenErr := resolveToken(); tokenErr == nil {
+		composeForgeClient = gh.New(token)
+	}
+
 	for _, platform := range forgePlatforms {
 		h, baseDeps, loadErr := harness.LoadWithBase(ctx, harnessPath, harness.ComposeOpts{
 			WorkspaceRoot: absFullsendDir,
@@ -204,6 +211,7 @@ func lockOneAgent(ctx context.Context, agentName, absFullsendDir, forgeFlag stri
 			AuditLogPath:  filepath.Join(absFullsendDir, ".fullsend-cache", "fetch-audit.jsonl"),
 			ForgePlatform: platform,
 			OrgAllowlist:  orgAllowlist,
+			ForgeClient:   composeForgeClient,
 		})
 		if loadErr != nil {
 			printer.StepFail(fmt.Sprintf("Failed to load harness (forge: %s)", platform))

--- a/internal/cli/lock_test.go
+++ b/internal/cli/lock_test.go
@@ -934,13 +934,12 @@ func TestRunLock_URLBaseOnlyDeps(t *testing.T) {
 	// A child harness with a URL base and no other URL references.
 	// The baseDeps conversion loop runs and the base-only-deps path is taken
 	// (skip ResolveHarness, still record deps in lock file).
-	baseContent := []byte("agent: agents/shared.md\nrole: test\nskills:\n  - skills/common\n")
+	baseContent := []byte("agent: agents/shared.md\nrole: test\n")
 	baseHash := fetch.ComputeSHA256(baseContent)
 
 	srv, policy := newLockTestServer(t, map[string][]byte{
-		"/base.yaml":              baseContent,
-		"/agents/shared.md":       []byte("# shared agent"),
-		"/skills/common/SKILL.md": []byte("# common skill"),
+		"/base.yaml":        baseContent,
+		"/agents/shared.md": []byte("# shared agent"),
 	})
 
 	dir := t.TempDir()
@@ -971,8 +970,8 @@ func TestRunLock_URLBaseOnlyDeps(t *testing.T) {
 	entry := lf.Lookup("urlbase")
 	require.NotNil(t, entry)
 
-	// Dependencies: base + agent resource + skill resource
-	require.Len(t, entry.Dependencies, 3)
+	// Dependencies: base + agent resource
+	require.Len(t, entry.Dependencies, 2)
 	assert.Equal(t, "base", entry.Dependencies[0].Field)
 	assert.Equal(t, fmt.Sprintf("%s/base.yaml", srv.URL), entry.Dependencies[0].URL)
 	assert.Equal(t, baseHash, entry.Dependencies[0].SHA256)
@@ -981,22 +980,17 @@ func TestRunLock_URLBaseOnlyDeps(t *testing.T) {
 	assert.Equal(t, "agent", entry.Dependencies[1].Field)
 	assert.Equal(t, fmt.Sprintf("%s/agents/shared.md", srv.URL), entry.Dependencies[1].URL)
 	assert.Equal(t, "resource", entry.Dependencies[1].Type)
-
-	assert.Equal(t, "skills[0]", entry.Dependencies[2].Field)
-	assert.Equal(t, fmt.Sprintf("%s/skills/common/SKILL.md", srv.URL), entry.Dependencies[2].URL)
-	assert.Equal(t, "directory", entry.Dependencies[2].Type)
 }
 
 func TestRunLock_URLBaseOnlyDepsWithPlatform(t *testing.T) {
 	// Same as above but with a forge platform set, exercising the platform != "" branch
 	// in the base-only-deps logging path.
-	baseContent := []byte("agent: agents/shared.md\nrole: test\nskills:\n  - skills/common\n")
+	baseContent := []byte("agent: agents/shared.md\nrole: test\n")
 	baseHash := fetch.ComputeSHA256(baseContent)
 
 	srv, policy := newLockTestServer(t, map[string][]byte{
-		"/base.yaml":              baseContent,
-		"/agents/shared.md":       []byte("# shared agent"),
-		"/skills/common/SKILL.md": []byte("# common skill"),
+		"/base.yaml":        baseContent,
+		"/agents/shared.md": []byte("# shared agent"),
 	})
 
 	dir := t.TempDir()
@@ -1026,7 +1020,7 @@ func TestRunLock_URLBaseOnlyDepsWithPlatform(t *testing.T) {
 
 	entry := lf.Lookup("urlbase-forge")
 	require.NotNil(t, entry)
-	require.Len(t, entry.Dependencies, 3)
+	require.Len(t, entry.Dependencies, 2)
 	assert.Equal(t, "base", entry.Dependencies[0].Field)
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -210,12 +210,20 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		}
 	}
 
+	var composeForgeClient forge.Client
+	if rFlags.forgeClient != nil {
+		composeForgeClient = rFlags.forgeClient
+	} else if token, tokenErr := resolveToken(); tokenErr == nil {
+		composeForgeClient = gh.New(token)
+	}
+
 	h, baseDeps, err := harness.LoadWithBase(ctx, harnessPath, harness.ComposeOpts{
 		WorkspaceRoot: absFullsendDir,
 		FetchPolicy:   policy,
 		AuditLogPath:  filepath.Join(absFullsendDir, ".fullsend-cache", "fetch-audit.jsonl"),
 		ForgePlatform: forgePlatform,
 		OrgAllowlist:  orgAllowlist,
+		ForgeClient:   composeForgeClient,
 	})
 	if err != nil {
 		printer.StepFail("Failed to load harness")

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -313,15 +313,13 @@ func TestRunAgent_URLRefsNoOrgConfig(t *testing.T) {
 }
 
 func TestRunAgent_WithURLBase(t *testing.T) {
-	// Harness with a URL base — exercises the baseDeps logging loop
-	// including the Warning path for skills fetched with only SKILL.md.
-	baseContent := []byte("agent: agents/shared.md\nrole: test\nskills:\n  - skills/common\n")
+	// Harness with a URL base — exercises the baseDeps logging loop.
+	baseContent := []byte("agent: agents/shared.md\nrole: test\n")
 	baseHash := fetch.ComputeSHA256(baseContent)
 
 	srv, policy := newLockTestServer(t, map[string][]byte{
-		"/base.yaml":              baseContent,
-		"/agents/shared.md":       []byte("# shared agent"),
-		"/skills/common/SKILL.md": []byte("# common skill"),
+		"/base.yaml":        baseContent,
+		"/agents/shared.md": []byte("# shared agent"),
 	})
 
 	dir := t.TempDir()

--- a/internal/fetch/cache.go
+++ b/internal/fetch/cache.go
@@ -156,11 +156,12 @@ func validateCachePath(workspaceRoot, dir string) error {
 
 // DirCacheEntry is metadata for a cached directory resource (e.g., a skill).
 type DirCacheEntry struct {
-	URL       string         `json:"url"`
-	FetchTime time.Time      `json:"fetch_time"`
-	SHA256    string         `json:"sha256"` // tree hash
-	Type      string         `json:"type"`   // always "directory"
-	Files     []DirFileEntry `json:"files"`
+	URL         string         `json:"url"`
+	FetchTime   time.Time      `json:"fetch_time"`
+	SHA256      string         `json:"sha256"` // tree hash
+	Type        string         `json:"type"`   // always "directory"
+	Files       []DirFileEntry `json:"files"`
+	FullListing bool           `json:"full_listing,omitempty"` // true when fetched via ForgeClient directory listing
 }
 
 // DirFileEntry records one file within a cached directory tree.
@@ -183,6 +184,11 @@ func ComputeTreeHash(files map[string][]byte) string {
 	return ComputeSHA256([]byte(joined))
 }
 
+// DirCachePutOpts controls optional behavior for CachePutDir.
+type DirCachePutOpts struct {
+	FullListing bool // mark entry as fetched via directory listing (not single-file fallback)
+}
+
 // CachePutDir stores a directory tree in the content-addressed cache.
 // files maps relative paths to their content bytes. Returns the computed
 // tree hash. The directory is stored under:
@@ -190,7 +196,7 @@ func ComputeTreeHash(files map[string][]byte) string {
 //	<workspaceRoot>/.fullsend-cache/resources/sha256/<treeHash>/tree/<path>
 //
 // Uses atomic file writes within the tree directory.
-func CachePutDir(workspaceRoot, url string, files map[string][]byte) (string, error) {
+func CachePutDir(workspaceRoot, url string, files map[string][]byte, opts ...DirCachePutOpts) (string, error) {
 	if len(files) == 0 {
 		return "", fmt.Errorf("cannot cache empty directory")
 	}
@@ -242,12 +248,17 @@ func CachePutDir(workspaceRoot, url string, files map[string][]byte) (string, er
 	})
 
 	// Write metadata.
+	var fullListing bool
+	if len(opts) > 0 {
+		fullListing = opts[0].FullListing
+	}
 	entry := DirCacheEntry{
-		URL:       url,
-		FetchTime: time.Now().UTC(),
-		SHA256:    treeHash,
-		Type:      "directory",
-		Files:     fileEntries,
+		URL:         url,
+		FetchTime:   time.Now().UTC(),
+		SHA256:      treeHash,
+		Type:        "directory",
+		Files:       fileEntries,
+		FullListing: fullListing,
 	}
 	metadataBytes, err := json.MarshalIndent(entry, "", "  ")
 	if err != nil {

--- a/internal/forge/url.go
+++ b/internal/forge/url.go
@@ -92,6 +92,71 @@ func ParseForgeURL(rawURL string) (*ForgeURLInfo, error) {
 	}, nil
 }
 
+// ParseRawContentURL extracts forge, owner, repo, path, and ref from a
+// raw.githubusercontent.com URL.
+//
+// Accepted format:
+//
+//	https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path...}
+//
+// The ref is a commit SHA, tag, or branch name. Everything after it is the
+// file/directory path within the repo (may be empty).
+func ParseRawContentURL(rawURL string) (*ForgeURLInfo, error) {
+	if idx := strings.LastIndex(rawURL, "#"); idx != -1 {
+		rawURL = rawURL[:idx]
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported scheme %q: only https is accepted", u.Scheme)
+	}
+	if u.Hostname() != "raw.githubusercontent.com" {
+		return nil, fmt.Errorf("not a raw.githubusercontent.com URL: %s", u.Hostname())
+	}
+
+	var segments []string
+	for _, s := range strings.Split(u.Path, "/") {
+		if s != "" {
+			segments = append(segments, s)
+		}
+	}
+
+	// Need at least 3 segments: owner, repo, ref.
+	if len(segments) < 3 {
+		return nil, fmt.Errorf("URL path too short: need at least /{owner}/{repo}/{ref}")
+	}
+
+	owner := segments[0]
+	repo := segments[1]
+	ref := segments[2]
+
+	if owner == "" {
+		return nil, fmt.Errorf("empty owner in URL")
+	}
+	if repo == "" {
+		return nil, fmt.Errorf("empty repo in URL")
+	}
+	if ref == "" {
+		return nil, fmt.Errorf("empty ref in URL")
+	}
+
+	var repoPath string
+	if len(segments) > 3 {
+		repoPath = strings.Join(segments[3:], "/")
+	}
+
+	return &ForgeURLInfo{
+		Forge: "github",
+		Owner: owner,
+		Repo:  repo,
+		Path:  repoPath,
+		Ref:   ref,
+	}, nil
+}
+
 // IsSupportedForge returns true if the hostname belongs to a recognized forge.
 func IsSupportedForge(hostname string) bool {
 	return hostname == "github.com"

--- a/internal/forge/url_test.go
+++ b/internal/forge/url_test.go
@@ -115,6 +115,92 @@ func TestParseForgeURL(t *testing.T) {
 	}
 }
 
+func TestParseRawContentURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *ForgeURLInfo
+		wantErr string
+	}{
+		{
+			name:  "valid raw URL with SHA ref and path",
+			input: "https://raw.githubusercontent.com/fullsend-ai/fullsend/a06f8626/skills/pr-review",
+			want: &ForgeURLInfo{
+				Forge: "github",
+				Owner: "fullsend-ai",
+				Repo:  "fullsend",
+				Ref:   "a06f8626",
+				Path:  "skills/pr-review",
+			},
+		},
+		{
+			name:  "URL with fragment stripped",
+			input: "https://raw.githubusercontent.com/org/repo/abc123/path/to/file#sha256=def456",
+			want: &ForgeURLInfo{
+				Forge: "github",
+				Owner: "org",
+				Repo:  "repo",
+				Ref:   "abc123",
+				Path:  "path/to/file",
+			},
+		},
+		{
+			name:  "ref only, no path",
+			input: "https://raw.githubusercontent.com/owner/repo/main",
+			want: &ForgeURLInfo{
+				Forge: "github",
+				Owner: "owner",
+				Repo:  "repo",
+				Ref:   "main",
+				Path:  "",
+			},
+		},
+		{
+			name:  "deep nested path",
+			input: "https://raw.githubusercontent.com/org/repo/v1.0.0/a/b/c/d/e",
+			want: &ForgeURLInfo{
+				Forge: "github",
+				Owner: "org",
+				Repo:  "repo",
+				Ref:   "v1.0.0",
+				Path:  "a/b/c/d/e",
+			},
+		},
+		{
+			name:    "wrong host",
+			input:   "https://github.com/owner/repo/tree/main/path",
+			wantErr: "not a raw.githubusercontent.com URL",
+		},
+		{
+			name:    "HTTP not HTTPS",
+			input:   "http://raw.githubusercontent.com/owner/repo/ref",
+			wantErr: "unsupported scheme",
+		},
+		{
+			name:    "too few segments — only owner and repo",
+			input:   "https://raw.githubusercontent.com/owner/repo",
+			wantErr: "URL path too short",
+		},
+		{
+			name:    "too few segments — only owner",
+			input:   "https://raw.githubusercontent.com/owner",
+			wantErr: "URL path too short",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseRawContentURL(tt.input)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestIsSupportedForge(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/fullsend-ai/fullsend/internal/fetch"
+	"github.com/fullsend-ai/fullsend/internal/forge"
 	"gopkg.in/yaml.v3"
 )
 
@@ -54,6 +55,13 @@ type ComposeOpts struct {
 	// OrgAllowlist is the org-level allowed_remote_resources from config.yaml.
 	// Base URLs must match a prefix in this list.
 	OrgAllowlist []string
+
+	// ForgeClient enables full-directory skill fetches from URL bases.
+	// When set, fetchBaseSkill uses the GitHub Contents API to retrieve all
+	// files in a skill directory (sub-agents, scripts, meta-prompts).
+	// When nil, fetchBaseSkill fails fast with an error directing users to
+	// set GITHUB_TOKEN or use 'fullsend lock' for offline pre-caching.
+	ForgeClient forge.Client
 
 	// allowSelfAllowlist permits using the child harness's own AllowedRemoteResources
 	// when OrgAllowlist is empty. This is for testing only; production callers should
@@ -762,42 +770,44 @@ func fetchBaseFile(ctx context.Context, field, baseURLDir, relPath string, allow
 }
 
 // fetchBaseSkill fetches a skill directory from a URL-referenced base harness.
-// Only SKILL.md is fetched (plain HTTP has no directory listing); skills with
-// companion files (sub-agents, scripts, meta-prompts) will be missing at
-// runtime. A warning is attached to the returned Dependency when this
-// limitation applies. Multi-file skills should use forge-format URLs resolved
-// by ResolveHarness instead. The file is fetched from
-// <baseURLDir>/<skillPath>/SKILL.md, cached as a directory via CachePutDir,
-// and the local tree directory path is returned.
+// It requires a ForgeClient to fetch the full directory tree (SKILL.md plus
+// companion files like sub-agents/, scripts/, meta-prompts/) via the GitHub
+// Contents API. If no ForgeClient is available, composition fails fast rather
+// than silently degrading to a SKILL.md-only fetch.
 func fetchBaseSkill(ctx context.Context, field, baseURLDir, skillPath string, allowlist []string, opts ComposeOpts) (Dependency, string, error) {
-	skillFileURL := baseURLDir + skillPath + "/SKILL.md"
-
-	warn := fmt.Sprintf("skill %q was fetched from a URL base with only SKILL.md; companion files (sub-agents, scripts, meta-prompts) may be missing — use a forge-format URL for multi-file skills", skillPath)
+	skillDirURL := baseURLDir + skillPath
+	skillFileURL := skillDirURL + "/SKILL.md"
 
 	allowedBy := matchingAllowedPrefix(skillFileURL, allowlist)
 	if allowedBy == "" {
 		return Dependency{}, "", fmt.Errorf("base %s: URL %q is not in allowed_remote_resources", field, skillFileURL)
 	}
 
+	// Check cache first (keyed by SKILL.md URL for backward compat).
 	hash, indexHit := urlIndexLookup(opts.WorkspaceRoot, skillFileURL)
 	if indexHit {
 		treeHash, ok := urlIndexLookup(opts.WorkspaceRoot, "skill:"+skillFileURL)
 		if ok {
 			treePath, entry, err := fetch.CacheGetDir(opts.WorkspaceRoot, treeHash)
 			if err == nil && treePath != "" {
-				if aErr := auditBaseFetch(opts, skillFileURL, treeHash, allowedBy, true, entry.FetchTime, "skill"); aErr != nil {
-					return Dependency{}, "", aErr
+				// Stale cache from v0.22.0: entries without FullListing
+				// may lack companion files. Re-fetch when online with
+				// a ForgeClient; serve stale in offline mode.
+				stale := !entry.FullListing && opts.ForgeClient != nil && !opts.FetchPolicy.Offline
+				if !stale {
+					if aErr := auditBaseFetch(opts, skillFileURL, treeHash, allowedBy, true, entry.FetchTime, "skill"); aErr != nil {
+						return Dependency{}, "", aErr
+					}
+					return Dependency{
+						Field:     field,
+						URL:       skillFileURL,
+						LocalPath: treePath,
+						SHA256:    treeHash,
+						FetchedAt: entry.FetchTime,
+						CacheHit:  true,
+						Type:      "directory",
+					}, treePath, nil
 				}
-				return Dependency{
-					Field:     field,
-					URL:       skillFileURL,
-					LocalPath: treePath,
-					SHA256:    treeHash,
-					FetchedAt: entry.FetchTime,
-					CacheHit:  true,
-					Type:      "directory",
-					Warning:   warn,
-				}, treePath, nil
 			}
 		}
 		_ = hash
@@ -807,13 +817,55 @@ func fetchBaseSkill(ctx context.Context, field, baseURLDir, skillPath string, al
 		return Dependency{}, "", fmt.Errorf("base %s: URL %s not in cache and offline mode is enabled (run 'fullsend lock' first)", field, skillFileURL)
 	}
 
-	content, err := fetch.FetchURL(ctx, skillFileURL, opts.FetchPolicy)
-	if err != nil {
-		return Dependency{}, "", fmt.Errorf("base %s: fetching %s: %w", field, skillFileURL, err)
+	if opts.ForgeClient == nil {
+		return Dependency{}, "", fmt.Errorf("base %s: skill directory fetch requires a GitHub token; set GH_TOKEN, GITHUB_TOKEN, or run 'gh auth login' — alternatively use 'fullsend lock' to pre-cache skills", field)
 	}
 
-	files := map[string][]byte{"SKILL.md": content}
-	treeHash, err := fetch.CachePutDir(opts.WorkspaceRoot, skillFileURL, files)
+	return fetchBaseSkillDir(ctx, field, skillDirURL, skillFileURL, skillPath, allowedBy, allowlist, opts)
+}
+
+// fetchBaseSkillDir fetches the full skill directory via ForgeClient.
+// It parses the raw.githubusercontent.com URL to extract owner/repo/ref/path,
+// then uses ListDirectoryContents + GetFileContentAtRef to retrieve all files.
+func fetchBaseSkillDir(ctx context.Context, field, skillDirURL, skillFileURL, skillPath, allowedBy string, allowlist []string, opts ComposeOpts) (Dependency, string, error) {
+	dirPrefix := skillDirURL + "/"
+	if ab := matchingAllowedPrefix(dirPrefix, allowlist); ab == "" {
+		return Dependency{}, "", fmt.Errorf("base %s: skill directory URL %q is not in allowed_remote_resources", field, dirPrefix)
+	}
+
+	forgeInfo, err := forge.ParseRawContentURL(skillDirURL)
+	if err != nil {
+		return Dependency{}, "", fmt.Errorf("base %s: parsing raw URL for skill directory fetch: %w", field, err)
+	}
+
+	entries, err := opts.ForgeClient.ListDirectoryContents(ctx, forgeInfo.Owner, forgeInfo.Repo, forgeInfo.Path, forgeInfo.Ref, true)
+	if err != nil {
+		return Dependency{}, "", fmt.Errorf("base %s: listing skill directory %s: %w", field, skillPath, err)
+	}
+
+	files := make(map[string][]byte)
+	for _, e := range entries {
+		if e.Type != "file" {
+			continue
+		}
+		var fullPath string
+		if forgeInfo.Path == "" {
+			fullPath = e.Path
+		} else {
+			fullPath = forgeInfo.Path + "/" + e.Path
+		}
+		content, fErr := opts.ForgeClient.GetFileContentAtRef(ctx, forgeInfo.Owner, forgeInfo.Repo, fullPath, forgeInfo.Ref)
+		if fErr != nil {
+			return Dependency{}, "", fmt.Errorf("base %s: fetching file %s for skill %s: %w", field, e.Path, skillPath, fErr)
+		}
+		files[e.Path] = content
+	}
+
+	if _, ok := files["SKILL.md"]; !ok {
+		return Dependency{}, "", fmt.Errorf("base %s: skill directory %s has no SKILL.md", field, skillPath)
+	}
+
+	treeHash, err := fetch.CachePutDir(opts.WorkspaceRoot, skillFileURL, files, fetch.DirCachePutOpts{FullListing: true})
 	if err != nil {
 		return Dependency{}, "", fmt.Errorf("base %s: caching skill directory: %w", field, err)
 	}
@@ -823,7 +875,7 @@ func fetchBaseSkill(ctx context.Context, field, baseURLDir, skillPath string, al
 		return Dependency{}, "", fmt.Errorf("base %s: reading cached skill directory: %w", field, err)
 	}
 
-	if iErr := urlIndexPut(opts.WorkspaceRoot, skillFileURL, fetch.ComputeSHA256(content)); iErr != nil {
+	if iErr := urlIndexPut(opts.WorkspaceRoot, skillFileURL, treeHash); iErr != nil {
 		return Dependency{}, "", fmt.Errorf("base %s: updating URL index: %w", field, iErr)
 	}
 	if iErr := urlIndexPut(opts.WorkspaceRoot, "skill:"+skillFileURL, treeHash); iErr != nil {
@@ -843,7 +895,6 @@ func fetchBaseSkill(ctx context.Context, field, baseURLDir, skillPath string, al
 		FetchedAt: fetchedAt,
 		CacheHit:  false,
 		Type:      "directory",
-		Warning:   warn,
 	}, treePath, nil
 }
 

--- a/internal/harness/compose_test.go
+++ b/internal/harness/compose_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/fullsend-ai/fullsend/internal/fetch"
+	"github.com/fullsend-ai/fullsend/internal/forge"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -433,8 +434,6 @@ func TestLoadWithBase_URLBase(t *testing.T) {
 agent: agents/remote.md
 role: test
 model: sonnet
-skills:
-  - remote-skill
 `)
 	hash := computeHash(baseContent)
 
@@ -472,20 +471,16 @@ allowed_remote_resources:
 
 	// Child overrides agent
 	assert.Equal(t, "agents/child.md", h.Agent)
-	// Base provides model and skills (skill resolved to cache path)
+	// Base provides model
 	assert.Equal(t, "sonnet", h.Model)
-	require.Len(t, h.Skills, 1)
-	assert.True(t, filepath.IsAbs(h.Skills[0]), "skill should be resolved to cache path")
 
-	// Dependencies: 1 base + 1 agent resource + 1 skill
-	require.Len(t, deps, 3)
+	// Dependencies: 1 base + 1 agent resource
+	require.Len(t, deps, 2)
 	assert.Equal(t, "base", deps[0].Field)
 	assert.Equal(t, server.URL+"/base.yaml", deps[0].URL)
 	assert.Equal(t, hash, deps[0].SHA256)
 	assert.Equal(t, "agent", deps[1].Field)
 	assert.Equal(t, "resource", deps[1].Type)
-	assert.Equal(t, "skills[0]", deps[2].Field)
-	assert.Equal(t, "directory", deps[2].Type)
 }
 
 func TestLoadWithBase_ChainedURLBases(t *testing.T) {
@@ -500,8 +495,6 @@ model: opus
 	parentContent := []byte(`
 agent: agents/parent.md
 role: test
-skills:
-  - parent-skill
 `)
 
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -509,7 +502,6 @@ skills:
 			w.WriteHeader(http.StatusOK)
 			w.Write(grandparentContent)
 		} else if r.URL.Path == "/parent.yaml" {
-			// Parent's base field will be set dynamically
 			w.WriteHeader(http.StatusOK)
 			w.Write(parentContent)
 		} else {
@@ -523,8 +515,6 @@ skills:
 agent: agents/parent.md
 role: test
 base: %s/grandparent.yaml#sha256=%s
-skills:
-  - parent-skill
 `, server.URL, grandparentHash))
 	parentHash := computeHash(parentContentWithBase)
 
@@ -536,8 +526,7 @@ skills:
 		} else if r.URL.Path == "/parent.yaml" {
 			w.WriteHeader(http.StatusOK)
 			w.Write(parentContentWithBase)
-		} else if strings.HasPrefix(r.URL.Path, "/agents/") ||
-			strings.HasSuffix(r.URL.Path, "/SKILL.md") {
+		} else if strings.HasPrefix(r.URL.Path, "/agents/") {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("# test resource"))
 		} else {
@@ -554,8 +543,6 @@ skills:
 agent: agents/child.md
 role: test
 base: `+parentURL+`
-skills:
-  - child-skill
 `)
 
 	policy := fetch.NewTestPolicy(
@@ -575,13 +562,10 @@ skills:
 	assert.Equal(t, "agents/child.md", h.Agent)
 	// Grandparent provides model
 	assert.Equal(t, "opus", h.Model)
-	// Skills: child's "child-skill" (local) + parent's "parent-skill" (resolved to cache path)
-	assert.Contains(t, h.Skills, "child-skill")
-	require.True(t, len(h.Skills) >= 2, "should have child-skill and resolved parent-skill")
 
-	// Dependencies: parent base + parent agent + parent skill +
+	// Dependencies: parent base + parent agent +
 	// grandparent base + grandparent agent
-	require.Len(t, deps, 5)
+	require.Len(t, deps, 4)
 }
 
 func TestLoadWithBase_URLBase_HashMismatch(t *testing.T) {
@@ -2154,30 +2138,17 @@ role: test
 base: `+baseURL+`
 `)
 
-	h, deps, err := LoadWithBase(context.Background(), path, ComposeOpts{
+	// ForgeClient is required for URL-base skill resolution; without it
+	// fetchBaseSkill returns an error. The test server URL is not a
+	// raw.githubusercontent.com URL so the ForgeClient path will fail,
+	// and skill resolution will error.
+	_, _, err := LoadWithBase(context.Background(), path, ComposeOpts{
 		WorkspaceRoot: cacheDir,
 		FetchPolicy:   policy,
 		OrgAllowlist:  []string{server.URL + "/"},
 	})
-	require.NoError(t, err)
-
-	// Skill resolved to a cache directory
-	require.Len(t, h.Skills, 1)
-	assert.True(t, filepath.IsAbs(h.Skills[0]), "skill should be resolved to cache dir")
-
-	// Verify SKILL.md exists in the cached directory
-	cachedSkillMD := filepath.Join(h.Skills[0], "SKILL.md")
-	content, err := os.ReadFile(cachedSkillMD)
-	require.NoError(t, err)
-	assert.Equal(t, skillContent, content)
-
-	// 1 base + 1 agent resource + 1 skill
-	require.Len(t, deps, 3)
-	assert.Equal(t, "agent", deps[1].Field)
-	assert.Equal(t, "resource", deps[1].Type)
-	assert.Equal(t, "skills[0]", deps[2].Field)
-	assert.Equal(t, "directory", deps[2].Type)
-	assert.False(t, deps[2].CacheHit)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GitHub token")
 }
 
 func TestLoadWithBase_URLBase_SkillOfflineCacheHit(t *testing.T) {
@@ -2245,7 +2216,6 @@ base: `+baseURL+`
 	assert.True(t, deps[1].CacheHit, "agent should be cache hit")
 	assert.True(t, deps[2].CacheHit, "skill should be cache hit")
 	assert.Equal(t, "directory", deps[2].Type)
-	assert.Contains(t, deps[2].Warning, "only SKILL.md")
 }
 
 func TestLoadWithBase_URLBase_ResourceOfflineCacheHit(t *testing.T) {
@@ -2600,88 +2570,54 @@ func TestFetchBaseSkill_CacheHit_AuditError(t *testing.T) {
 	assert.Contains(t, err.Error(), "audit")
 }
 
-func TestFetchBaseSkill_OnlineFetch_AuditError(t *testing.T) {
-	content := []byte("# skill")
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(content)
-	}))
-	t.Cleanup(server.Close)
-
-	policy := fetch.NewTestPolicy(
-		server.Client().Transport.(*http.Transport).TLSClientConfig,
-		[]string{"127.0.0.1"},
-		[]string{server.Listener.Addr().String()[len("127.0.0.1:"):]},
-	)
-
+func TestFetchBaseSkill_NoForgeClient_Error(t *testing.T) {
 	dir := t.TempDir()
 	cacheDir := filepath.Join(dir, "cache")
 
-	_, _, err := fetchBaseSkill(context.Background(), "skills[0]", server.URL+"/",
-		"skills/common", []string{server.URL + "/"}, ComposeOpts{
+	_, _, err := fetchBaseSkill(context.Background(), "skills[0]",
+		"https://raw.githubusercontent.com/org/repo/ref/",
+		"skills/common", []string{"https://raw.githubusercontent.com/org/repo/"}, ComposeOpts{
 			WorkspaceRoot: cacheDir,
-			FetchPolicy:   policy,
-			AuditLogPath:  brokenAuditPath(t),
 		})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "audit")
+	assert.Contains(t, err.Error(), "GitHub token")
 }
 
-func TestFetchBaseSkill_FetchURLError(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	t.Cleanup(server.Close)
-
-	policy := fetch.NewTestPolicy(
-		server.Client().Transport.(*http.Transport).TLSClientConfig,
-		[]string{"127.0.0.1"},
-		[]string{server.Listener.Addr().String()[len("127.0.0.1:"):]},
-	)
-
+func TestFetchBaseSkill_ForgeClient_ListError(t *testing.T) {
 	dir := t.TempDir()
 	cacheDir := filepath.Join(dir, "cache")
 
-	_, _, err := fetchBaseSkill(context.Background(), "skills[0]", server.URL+"/",
-		"skills/common", []string{server.URL + "/"}, ComposeOpts{
+	fc := forge.NewFakeClient()
+	fc.Errors["ListDirectoryContents"] = fmt.Errorf("API rate limited")
+
+	_, _, err := fetchBaseSkill(context.Background(), "skills[0]",
+		"https://raw.githubusercontent.com/org/repo/ref/",
+		"skills/common", []string{"https://raw.githubusercontent.com/org/repo/"}, ComposeOpts{
 			WorkspaceRoot: cacheDir,
-			FetchPolicy:   policy,
+			ForgeClient:   fc,
 		})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "fetching")
+	assert.Contains(t, err.Error(), "listing skill directory")
 }
 
-func TestFetchBaseSkill_PartialIndexHit(t *testing.T) {
-	content := []byte("# skill")
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(content)
-	}))
-	t.Cleanup(server.Close)
-
-	policy := fetch.NewTestPolicy(
-		server.Client().Transport.(*http.Transport).TLSClientConfig,
-		[]string{"127.0.0.1"},
-		[]string{server.Listener.Addr().String()[len("127.0.0.1:"):]},
-	)
-
+func TestFetchBaseSkill_PartialIndexHit_RequiresForgeClient(t *testing.T) {
 	dir := t.TempDir()
 	cacheDir := filepath.Join(dir, "cache")
 
-	skillFileURL := server.URL + "/skills/common/SKILL.md"
+	skillFileURL := "https://raw.githubusercontent.com/org/repo/ref/skills/common/SKILL.md"
+	content := []byte("# skill")
 	require.NoError(t, fetch.CachePut(cacheDir, skillFileURL, content))
 	fileHash := fetch.ComputeSHA256(content)
 	require.NoError(t, urlIndexPut(cacheDir, skillFileURL, fileHash))
 	// Deliberately omit the "skill:" tree hash entry to trigger partial index hit
 
-	dep, localDir, err := fetchBaseSkill(context.Background(), "skills[0]", server.URL+"/",
-		"skills/common", []string{server.URL + "/"}, ComposeOpts{
+	_, _, err := fetchBaseSkill(context.Background(), "skills[0]",
+		"https://raw.githubusercontent.com/org/repo/ref/",
+		"skills/common", []string{"https://raw.githubusercontent.com/org/repo/"}, ComposeOpts{
 			WorkspaceRoot: cacheDir,
-			FetchPolicy:   policy,
 		})
-	require.NoError(t, err)
-	assert.NotEmpty(t, localDir)
-	assert.Equal(t, "directory", dep.Type)
-	assert.False(t, dep.CacheHit)
-	assert.Contains(t, dep.Warning, "only SKILL.md")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GitHub token")
 }
 
 func TestResolveBaseResources_InvalidBaseURL(t *testing.T) {
@@ -2691,41 +2627,25 @@ func TestResolveBaseResources_InvalidBaseURL(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot determine directory")
 }
 
-func TestFetchBaseSkill_OnlySKILLMDFetched(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/skills/common/SKILL.md" {
-			w.Write([]byte("# Common Skill\nDo the thing."))
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	t.Cleanup(server.Close)
-
-	policy := fetch.NewTestPolicy(
-		server.Client().Transport.(*http.Transport).TLSClientConfig,
-		[]string{"127.0.0.1"},
-		[]string{server.Listener.Addr().String()[len("127.0.0.1:"):]},
-	)
-
+func TestFetchBaseSkill_ForgeClient_AuditError(t *testing.T) {
 	dir := t.TempDir()
 	cacheDir := filepath.Join(dir, "cache")
 
-	dep, localDir, err := fetchBaseSkill(context.Background(), "skills[0]", server.URL+"/",
-		"skills/common", []string{server.URL + "/"}, ComposeOpts{
-			WorkspaceRoot: cacheDir,
-			FetchPolicy:   policy,
-		})
-	require.NoError(t, err)
-	assert.Equal(t, "directory", dep.Type)
-	assert.Contains(t, dep.Warning, "only SKILL.md")
-	assert.Contains(t, dep.Warning, "skills/common")
+	fc := forge.NewFakeClient()
+	fc.DirContents["org/repo/skills/common@ref"] = []forge.DirectoryEntry{
+		{Path: "SKILL.md", Type: "file", Size: 10},
+	}
+	fc.FileContentsRef["org/repo/skills/common/SKILL.md@ref"] = []byte("# skill")
 
-	// Only SKILL.md is fetched — companion files (scripts/, sub-agents)
-	// are not available via plain HTTP directory listing.
-	entries, err := os.ReadDir(localDir)
-	require.NoError(t, err)
-	require.Len(t, entries, 1)
-	assert.Equal(t, "SKILL.md", entries[0].Name())
+	_, _, err := fetchBaseSkill(context.Background(), "skills[0]",
+		"https://raw.githubusercontent.com/org/repo/ref/",
+		"skills/common", []string{"https://raw.githubusercontent.com/org/repo/"}, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			ForgeClient:   fc,
+			AuditLogPath:  brokenAuditPath(t),
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "audit")
 }
 
 func TestLoadWithBase_RuntimeFetchFieldsNotInherited(t *testing.T) {
@@ -2750,4 +2670,210 @@ base: base.yaml
 	assert.False(t, h.AllowRuntimeFetch)
 	assert.Nil(t, h.MaxRuntimeFetches)
 	assert.Empty(t, h.AllowedRemoteResources)
+}
+
+func TestFetchBaseSkill_ForgeClient_FullDirectory(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	fc := forge.NewFakeClient()
+	fc.DirContents["fullsend-ai/fullsend/skills/pr-review@abc123"] = []forge.DirectoryEntry{
+		{Path: "SKILL.md", Type: "file", Size: 10},
+		{Path: "meta-prompt.md", Type: "file", Size: 20},
+		{Path: "sub-agents", Type: "dir", Size: 0},
+		{Path: "sub-agents/code-review.md", Type: "file", Size: 30},
+	}
+	fc.FileContentsRef["fullsend-ai/fullsend/skills/pr-review/SKILL.md@abc123"] = []byte("# PR Review Skill")
+	fc.FileContentsRef["fullsend-ai/fullsend/skills/pr-review/meta-prompt.md@abc123"] = []byte("meta prompt content")
+	fc.FileContentsRef["fullsend-ai/fullsend/skills/pr-review/sub-agents/code-review.md@abc123"] = []byte("sub-agent content")
+
+	baseURLDir := "https://raw.githubusercontent.com/fullsend-ai/fullsend/abc123/"
+	allowlist := []string{"https://raw.githubusercontent.com/fullsend-ai/fullsend/"}
+
+	dep, localDir, err := fetchBaseSkill(context.Background(), "skills[0]", baseURLDir,
+		"skills/pr-review", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			ForgeClient:   fc,
+		})
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, localDir)
+	assert.Equal(t, "directory", dep.Type)
+	assert.Empty(t, dep.Warning)
+	assert.False(t, dep.CacheHit)
+
+	// Verify all companion files exist in the cached directory.
+	skillMD, err := os.ReadFile(filepath.Join(localDir, "SKILL.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "# PR Review Skill", string(skillMD))
+
+	metaPrompt, err := os.ReadFile(filepath.Join(localDir, "meta-prompt.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "meta prompt content", string(metaPrompt))
+
+	subAgent, err := os.ReadFile(filepath.Join(localDir, "sub-agents", "code-review.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "sub-agent content", string(subAgent))
+}
+
+func TestFetchBaseSkill_ForgeClient_ParseError(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	fc := forge.NewFakeClient()
+
+	// Non-raw URL fails ParseRawContentURL — no fallback, just error.
+	_, _, err := fetchBaseSkill(context.Background(), "skills[0]",
+		"https://example.com/",
+		"skills/common", []string{"https://example.com/"}, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			ForgeClient:   fc,
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing raw URL")
+}
+
+func TestFetchBaseSkill_ForgeClient_NoSKILLMD(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	fc := forge.NewFakeClient()
+	fc.DirContents["org/repo/skills/broken@ref1"] = []forge.DirectoryEntry{
+		{Path: "meta-prompt.md", Type: "file", Size: 20},
+	}
+	fc.FileContentsRef["org/repo/skills/broken/meta-prompt.md@ref1"] = []byte("no skill file")
+
+	_, _, err := fetchBaseSkill(context.Background(), "skills[0]",
+		"https://raw.githubusercontent.com/org/repo/ref1/",
+		"skills/broken", []string{"https://raw.githubusercontent.com/org/repo/"}, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			ForgeClient:   fc,
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no SKILL.md")
+}
+
+func TestFetchBaseSkill_ForgeClient_GetFileError(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	fc := forge.NewFakeClient()
+	fc.DirContents["org/repo/skills/common@ref1"] = []forge.DirectoryEntry{
+		{Path: "SKILL.md", Type: "file", Size: 10},
+		{Path: "meta-prompt.md", Type: "file", Size: 20},
+	}
+	fc.FileContentsRef["org/repo/skills/common/SKILL.md@ref1"] = []byte("# Skill")
+	// Omit meta-prompt.md from FileContentsRef to trigger GetFileContentAtRef error.
+
+	allowlist := []string{"https://raw.githubusercontent.com/org/repo/"}
+
+	_, _, err := fetchBaseSkill(context.Background(), "skills[0]",
+		"https://raw.githubusercontent.com/org/repo/ref1/",
+		"skills/common", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			ForgeClient:   fc,
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetching file")
+	assert.Contains(t, err.Error(), "meta-prompt.md")
+}
+
+func TestFetchBaseSkill_StaleCacheInvalidation(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	baseURLDir := "https://raw.githubusercontent.com/org/repo/ref1/"
+	skillFileURL := baseURLDir + "skills/common/SKILL.md"
+	allowlist := []string{"https://raw.githubusercontent.com/org/repo/"}
+
+	// Pre-populate cache with a v0.22.0-style single-file entry (no FullListing).
+	oldFiles := map[string][]byte{"SKILL.md": []byte("# old")}
+	oldHash, err := fetch.CachePutDir(cacheDir, skillFileURL, oldFiles)
+	require.NoError(t, err)
+	require.NoError(t, urlIndexPut(cacheDir, skillFileURL, oldHash))
+	require.NoError(t, urlIndexPut(cacheDir, "skill:"+skillFileURL, oldHash))
+
+	// Set up ForgeClient with multi-file directory.
+	fc := forge.NewFakeClient()
+	fc.DirContents["org/repo/skills/common@ref1"] = []forge.DirectoryEntry{
+		{Path: "SKILL.md", Type: "file", Size: 10},
+		{Path: "meta-prompt.md", Type: "file", Size: 20},
+	}
+	fc.FileContentsRef["org/repo/skills/common/SKILL.md@ref1"] = []byte("# new skill")
+	fc.FileContentsRef["org/repo/skills/common/meta-prompt.md@ref1"] = []byte("meta")
+
+	dep, localDir, err := fetchBaseSkill(context.Background(), "skills[0]",
+		baseURLDir, "skills/common", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			ForgeClient:   fc,
+		})
+	require.NoError(t, err)
+	assert.False(t, dep.CacheHit, "stale cache should be bypassed")
+
+	// Verify both files exist.
+	assert.FileExists(t, filepath.Join(localDir, "SKILL.md"))
+	assert.FileExists(t, filepath.Join(localDir, "meta-prompt.md"))
+
+	// Second call should hit cache (FullListing=true, no re-fetch).
+	dep2, _, err := fetchBaseSkill(context.Background(), "skills[0]",
+		baseURLDir, "skills/common", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			ForgeClient:   fc,
+		})
+	require.NoError(t, err)
+	assert.True(t, dep2.CacheHit, "re-fetched entry should be cached")
+}
+
+func TestFetchBaseSkill_StaleCacheOfflineServesStale(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	baseURLDir := "https://raw.githubusercontent.com/org/repo/ref1/"
+	skillFileURL := baseURLDir + "skills/common/SKILL.md"
+	allowlist := []string{"https://raw.githubusercontent.com/org/repo/"}
+
+	// Pre-populate cache with a v0.22.0-style single-file entry.
+	oldFiles := map[string][]byte{"SKILL.md": []byte("# old")}
+	oldHash, err := fetch.CachePutDir(cacheDir, skillFileURL, oldFiles)
+	require.NoError(t, err)
+	require.NoError(t, urlIndexPut(cacheDir, skillFileURL, oldHash))
+	require.NoError(t, urlIndexPut(cacheDir, "skill:"+skillFileURL, oldHash))
+
+	fc := forge.NewFakeClient()
+
+	// Offline mode with a ForgeClient — should serve stale cache, not error.
+	dep, localDir, err := fetchBaseSkill(context.Background(), "skills[0]",
+		baseURLDir, "skills/common", allowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			ForgeClient:   fc,
+			FetchPolicy:   fetch.FetchPolicy{Offline: true},
+		})
+	require.NoError(t, err)
+	assert.True(t, dep.CacheHit)
+	assert.FileExists(t, filepath.Join(localDir, "SKILL.md"))
+}
+
+func TestFetchBaseSkill_ForgeClient_NarrowAllowlist(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+
+	fc := forge.NewFakeClient()
+	fc.DirContents["org/repo/skills/pr-review@ref1"] = []forge.DirectoryEntry{
+		{Path: "SKILL.md", Type: "file", Size: 10},
+		{Path: "meta-prompt.md", Type: "file", Size: 20},
+	}
+	fc.FileContentsRef["org/repo/skills/pr-review/SKILL.md@ref1"] = []byte("# Skill")
+	fc.FileContentsRef["org/repo/skills/pr-review/meta-prompt.md@ref1"] = []byte("meta")
+
+	// Allowlist covers SKILL.md specifically but not the directory prefix.
+	narrowAllowlist := []string{"https://raw.githubusercontent.com/org/repo/ref1/skills/pr-review/SKILL.md"}
+
+	_, _, err := fetchBaseSkill(context.Background(), "skills[0]",
+		"https://raw.githubusercontent.com/org/repo/ref1/",
+		"skills/pr-review", narrowAllowlist, ComposeOpts{
+			WorkspaceRoot: cacheDir,
+			ForgeClient:   fc,
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not in allowed_remote_resources")
 }


### PR DESCRIPTION
## Summary

- **Fixes #2705** — URL-base skill resolution in v0.22.0 drops companion files (sub-agents/, scripts/, meta-prompts/), breaking the review agent for all per-org installations
- Adds `ParseRawContentURL()` to parse `raw.githubusercontent.com` URLs into forge info (owner/repo/ref/path)
- Adds `ForgeClient` field to `ComposeOpts` so `fetchBaseSkill()` can use `ListDirectoryContents` + `GetFileContentAtRef` to fetch the full skill directory tree
- Requires ForgeClient (set GITHUB_TOKEN) or fails fast with a clear error directing users to run `fullsend lock` for offline pre-caching
- Adds empty-field validation to `ParseRawContentURL`
- Fixes ForgeClient injection in `lock.go` to match the `run.go` pattern
- Wires `ForgeClient` into `ComposeOpts` in both `run.go` and `lock.go` CLI callers

## Impact

Only the `pr-review` skill has companion files today (`meta-prompt.md`, `sub-agents/`). Other skills (`code-review`, `code-implementation`, `fix-review`, `issue-labels`, `retro-analysis`) are SKILL.md-only and are unaffected by this bug or this fix.

## Test plan

- [x] `ParseRawContentURL()` — 8 unit tests covering valid URLs, edge cases, wrong host, missing segments
- [x] `fetchBaseSkill()` with `FakeClient` — full-directory fetch, API error, missing SKILL.md, no ForgeClient error, parse error, audit error
- [x] Cache hit path — offline cache hit test preserved
- [x] CLI tests — lock and run tests updated to match new fail-fast behavior
- [x] `go build ./...` — compiles cleanly
- [x] `go test ./internal/forge/... ./internal/harness/... ./internal/cli/...` — all pass