### PR TITLE
feat(config): add triage-agent to default allowed_remote_resources

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,7 @@ func NewOrgConfig(allRepos, enabledRepos, roles []string, inferenceProvider, org
 		// Default allowlist for base: composition in harness wrappers (ADR-0045 Phase 2).
 		AllowedRemoteResources: []string{
 			"https://raw.githubusercontent.com/fullsend-ai/fullsend/",
+			"https://raw.githubusercontent.com/fullsend-ai/triage-agent/",
 		},
 	}
 	if inferenceProvider != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -60,7 +60,10 @@ func TestNewOrgConfig(t *testing.T) {
 	assert.False(t, cfg.Repos["repo-b"].Enabled)
 	assert.True(t, cfg.Repos["repo-c"].Enabled)
 
-	assert.Equal(t, []string{"https://raw.githubusercontent.com/fullsend-ai/fullsend/"}, cfg.AllowedRemoteResources)
+	assert.Equal(t, []string{
+		"https://raw.githubusercontent.com/fullsend-ai/fullsend/",
+		"https://raw.githubusercontent.com/fullsend-ai/triage-agent/",
+	}, cfg.AllowedRemoteResources)
 }
 
 func TestOrgConfigMarshal(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `https://raw.githubusercontent.com/fullsend-ai/triage-agent/` to the default `AllowedRemoteResources` in `NewOrgConfig()` so harness wrappers can reference the external triage agent via `base:` composition (ADR-0045)
- Inert for existing installations that don't reference triage-agent URLs yet; new installs and `fullsend admin upgrade` will have the entry ready

Part of the triage agent migration to `fullsend-ai/triage-agent`.

## Test plan

- [x] `TestNewOrgConfig` updated to assert the new entry
- [x] All `internal/config/` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)