### PR TITLE
fix(config): rename triage-agent to agents in allowlist

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,7 +130,7 @@ func NewOrgConfig(allRepos, enabledRepos, roles []string, inferenceProvider, org
 		// Default allowlist for base: composition in harness wrappers (ADR-0045 Phase 2).
 		AllowedRemoteResources: []string{
 			"https://raw.githubusercontent.com/fullsend-ai/fullsend/",
-			"https://raw.githubusercontent.com/fullsend-ai/triage-agent/",
+			"https://raw.githubusercontent.com/fullsend-ai/agents/",
 		},
 	}
 	if inferenceProvider != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -62,7 +62,7 @@ func TestNewOrgConfig(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"https://raw.githubusercontent.com/fullsend-ai/fullsend/",
-		"https://raw.githubusercontent.com/fullsend-ai/triage-agent/",
+		"https://raw.githubusercontent.com/fullsend-ai/agents/",
 	}, cfg.AllowedRemoteResources)
 }
 


### PR DESCRIPTION
## Summary

- Updates the default `allowed_remote_resources` URL from `fullsend-ai/triage-agent` to `fullsend-ai/agents` to match the repo rename

## Test plan

- [x] `go test ./internal/config/...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)