### PR TITLE
refactor(harness): migrate prioritize agent to env.runner/env.sandbox (ADR 0055)

### DIFF
--- a/internal/harness/scaffold_integration_test.go
+++ b/internal/harness/scaffold_integration_test.go
@@ -130,7 +130,8 @@ func TestLoadWithOpts_ScaffoldTemplatesForgeResolution(t *testing.T) {
 
 			assert.NotEmpty(t, h.PreScript, "PreScript should be set after forge resolution")
 			assert.NotEmpty(t, h.PostScript, "PostScript should be set after forge resolution")
-			assert.NotEmpty(t, h.RunnerEnv, "RunnerEnv should be non-empty after merge")
+			hasRunnerEnv := len(h.RunnerEnv) > 0 || (h.Env != nil && len(h.Env.Runner) > 0)
+			assert.True(t, hasRunnerEnv, "RunnerEnv or Env.Runner should be non-empty after merge")
 			assert.Nil(t, h.Forge, "Forge should be nil after resolution")
 			assert.NotEmpty(t, h.Role, "Role should be set in scaffold template")
 			assert.NotEmpty(t, h.Slug, "Slug should be set in scaffold template")
@@ -333,11 +334,22 @@ func TestResolveForge_ScaffoldRunnerEnvMerge(t *testing.T) {
 			h, loadErr := LoadWithOpts(path, LoadOpts{ForgePlatform: "github"})
 			require.NoError(t, loadErr)
 
+			// Build a combined env map from both legacy RunnerEnv and new Env.Runner.
+			combined := make(map[string]string)
+			for k, v := range h.RunnerEnv {
+				combined[k] = v
+			}
+			if h.Env != nil {
+				for k, v := range h.Env.Runner {
+					combined[k] = v
+				}
+			}
+
 			for _, key := range tt.topLevelKeys {
-				assert.Contains(t, h.RunnerEnv, key, "merged RunnerEnv should contain top-level key %s", key)
+				assert.Contains(t, combined, key, "merged env should contain top-level key %s", key)
 			}
 			for _, key := range tt.forgeGithubKeys {
-				assert.Contains(t, h.RunnerEnv, key, "merged RunnerEnv should contain forge.github key %s", key)
+				assert.Contains(t, combined, key, "merged env should contain forge.github key %s", key)
 			}
 		})
 	}

--- a/internal/scaffold/fullsend-repo/env/prioritize.env
+++ b/internal/scaffold/fullsend-repo/env/prioritize.env
@@ -1,2 +1,0 @@
-export GITHUB_ISSUE_URL="${GITHUB_ISSUE_URL}"
-export GH_TOKEN=${GH_TOKEN}

--- a/internal/scaffold/fullsend-repo/harness/prioritize.yaml
+++ b/internal/scaffold/fullsend-repo/harness/prioritize.yaml
@@ -17,9 +17,6 @@ host_files:
   - src: ${GCP_OIDC_TOKEN_FILE}
     dest: /sandbox/workspace/.gcp-oidc-token
     optional: true
-  - src: env/prioritize.env
-    dest: /sandbox/workspace/.env.d/prioritize.env
-    expand: true
 
 pre_script: scripts/pre-prioritize.sh
 post_script: scripts/post-prioritize.sh
@@ -28,8 +25,9 @@ validation_loop:
   script: scripts/validate-output-schema.sh
   max_iterations: 2
 
-runner_env:
-  FULLSEND_OUTPUT_SCHEMA: ${FULLSEND_DIR}/schemas/prioritize-result.schema.json
+env:
+  runner:
+    FULLSEND_OUTPUT_SCHEMA: ${FULLSEND_DIR}/schemas/prioritize-result.schema.json
 
 timeout_minutes: 10
 
@@ -37,8 +35,12 @@ forge:
   github:
     pre_script: scripts/pre-prioritize.sh
     post_script: scripts/post-prioritize.sh
-    runner_env:
-      GITHUB_ISSUE_URL: ${GITHUB_ISSUE_URL}
-      GH_TOKEN: ${GH_TOKEN}
-      ORG: ${ORG}
-      PROJECT_NUMBER: ${PROJECT_NUMBER}
+    env:
+      runner:
+        GITHUB_ISSUE_URL: ${GITHUB_ISSUE_URL}
+        GH_TOKEN: ${GH_TOKEN}
+        ORG: ${ORG}
+        PROJECT_NUMBER: ${PROJECT_NUMBER}
+      sandbox:
+        GITHUB_ISSUE_URL: "${GITHUB_ISSUE_URL}"
+        GH_TOKEN: "${GH_TOKEN}"

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -84,7 +84,6 @@ func TestFullsendRepoFilesExist(t *testing.T) {
 		"skills/issue-labels/SKILL.md",
 		"templates/shim-workflow-call.yaml",
 		"agents/prioritize.md",
-		"env/prioritize.env",
 		"harness/prioritize.yaml",
 		"policies/prioritize.yaml",
 		"schemas/prioritize-result.schema.json",
@@ -632,7 +631,8 @@ func TestHarnessesLoadAndValidate(t *testing.T) {
 				assert.Nil(t, h.Forge, "Forge should be nil after resolution")
 				assert.NotEmpty(t, h.PreScript, "PreScript should be set after forge resolution")
 				assert.NotEmpty(t, h.PostScript, "PostScript should be set after forge resolution")
-				assert.NotEmpty(t, h.RunnerEnv, "RunnerEnv should be non-empty after merge")
+				hasRunnerEnv := len(h.RunnerEnv) > 0 || (h.Env != nil && len(h.Env.Runner) > 0)
+				assert.True(t, hasRunnerEnv, "RunnerEnv or Env.Runner should be non-empty after merge")
 
 				resolveErr := h.ResolveRelativeTo(dir)
 				require.NoError(t, resolveErr, "ResolveRelativeTo should succeed")
@@ -700,11 +700,22 @@ func TestHarnessForgeRunnerEnvMerge(t *testing.T) {
 			h, loadErr := harness.LoadWithOpts(harnessPath, harness.LoadOpts{ForgePlatform: "github"})
 			require.NoError(t, loadErr)
 
+			// Build a combined env map from both legacy RunnerEnv and new Env.Runner.
+			combined := make(map[string]string)
+			for k, v := range h.RunnerEnv {
+				combined[k] = v
+			}
+			if h.Env != nil {
+				for k, v := range h.Env.Runner {
+					combined[k] = v
+				}
+			}
+
 			for _, key := range tt.topLevelKeys {
-				assert.Contains(t, h.RunnerEnv, key, "merged RunnerEnv should contain top-level key %s", key)
+				assert.Contains(t, combined, key, "merged env should contain top-level key %s", key)
 			}
 			for _, key := range tt.forgeGithubKeys {
-				assert.Contains(t, h.RunnerEnv, key, "merged RunnerEnv should contain forge.github key %s", key)
+				assert.Contains(t, combined, key, "merged env should contain forge.github key %s", key)
 			}
 		})
 	}
@@ -897,7 +908,9 @@ func TestPrioritizeHarnessContent(t *testing.T) {
 	assert.Contains(t, s, "agents/prioritize.md")
 	assert.Contains(t, s, "pre_script")
 	assert.Contains(t, s, "post_script")
-	assert.Contains(t, s, "runner_env")
+	assert.Contains(t, s, "env:")
+	assert.Contains(t, s, "runner:")
+	assert.Contains(t, s, "sandbox:")
 	assert.Contains(t, s, "PROJECT_NUMBER")
 }
 


### PR DESCRIPTION
Migrate prioritize harness from deprecated runner_env to env.runner/env.sandbox per ADR 0055. Move sandbox env vars from prioritize.env host file into forge.github.env.sandbox. Delete the now-unused env file. Update tests for backward compatibility.