### PR TITLE
refactor(harness): migrate retro agent to env.runner/env.sandbox (ADR 0055)

### DIFF
--- a/internal/harness/scaffold_integration_test.go
+++ b/internal/harness/scaffold_integration_test.go
@@ -296,8 +296,9 @@ func TestResolveForge_ScaffoldRunnerEnvMerge(t *testing.T) {
 
 	tests := []struct {
 		file            string
-		topLevelKeys    []string
-		forgeGithubKeys []string
+		topLevelKeys    []string // keys expected in RunnerEnv (deprecated)
+		forgeGithubKeys []string // keys expected in RunnerEnv from forge (deprecated)
+		envRunnerKeys   []string // keys expected in Env.Runner (ADR 0055)
 	}{
 		{
 			file:            "triage.yaml",
@@ -321,8 +322,9 @@ func TestResolveForge_ScaffoldRunnerEnvMerge(t *testing.T) {
 		},
 		{
 			file:            "retro.yaml",
-			topLevelKeys:    []string{"FULLSEND_OUTPUT_SCHEMA"},
-			forgeGithubKeys: []string{"ORIGINATING_URL", "REPO_FULL_NAME", "GH_TOKEN"},
+			topLevelKeys:    []string{}, // migrated to env.runner (ADR 0055)
+			forgeGithubKeys: []string{}, // migrated to env.runner (ADR 0055)
+			envRunnerKeys:   []string{"FULLSEND_OUTPUT_SCHEMA", "ORIGINATING_URL", "REPO_FULL_NAME", "GH_TOKEN"},
 		},
 		{
 			file:            "prioritize.yaml",
@@ -354,6 +356,10 @@ func TestResolveForge_ScaffoldRunnerEnvMerge(t *testing.T) {
 			}
 			for _, key := range tt.forgeGithubKeys {
 				assert.Contains(t, combined, key, "merged env should contain forge.github key %s", key)
+			}
+			for _, key := range tt.envRunnerKeys {
+				require.NotNil(t, h.Env, "Env should be non-nil for template with env.runner keys")
+				assert.Contains(t, h.Env.Runner, key, "merged Env.Runner should contain key %s", key)
 			}
 		})
 	}

--- a/internal/scaffold/fullsend-repo/env/retro.env
+++ b/internal/scaffold/fullsend-repo/env/retro.env
@@ -1,5 +1,0 @@
-export ORIGINATING_URL="${ORIGINATING_URL}"
-export RETRO_COMMENT="${RETRO_COMMENT:-}"
-export REPO_FULL_NAME="${REPO_FULL_NAME}"
-# GH_TOKEN is set by setup-agent-env.sh (strips RETRO_ prefix from RETRO_GH_TOKEN).
-export GH_TOKEN=${GH_TOKEN}

--- a/internal/scaffold/fullsend-repo/harness/retro.yaml
+++ b/internal/scaffold/fullsend-repo/harness/retro.yaml
@@ -12,9 +12,6 @@ host_files:
   - src: env/gcp-vertex.env
     dest: /sandbox/workspace/.env.d/gcp-vertex.env
     expand: true
-  - src: env/retro.env
-    dest: /sandbox/workspace/.env.d/retro.env
-    expand: true
   - src: ${GOOGLE_APPLICATION_CREDENTIALS}
     dest: /tmp/.gcp-credentials.json
   - src: ${GCP_OIDC_TOKEN_FILE}
@@ -34,8 +31,11 @@ validation_loop:
   script: scripts/validate-output-schema.sh
   max_iterations: 2
 
-runner_env:
-  FULLSEND_OUTPUT_SCHEMA: ${FULLSEND_DIR}/schemas/retro-result.schema.json
+env:
+  runner:
+    FULLSEND_OUTPUT_SCHEMA: ${FULLSEND_DIR}/schemas/retro-result.schema.json
+  sandbox:
+    RETRO_COMMENT: "${RETRO_COMMENT}"
 
 timeout_minutes: 30
 
@@ -43,7 +43,12 @@ forge:
   github:
     pre_script: scripts/pre-retro.sh
     post_script: scripts/post-retro.sh
-    runner_env:
-      ORIGINATING_URL: "${ORIGINATING_URL}"
-      REPO_FULL_NAME: "${REPO_FULL_NAME}"
-      GH_TOKEN: "${GH_TOKEN}"
+    env:
+      runner:
+        ORIGINATING_URL: "${ORIGINATING_URL}"
+        REPO_FULL_NAME: "${REPO_FULL_NAME}"
+        GH_TOKEN: "${GH_TOKEN}"
+      sandbox:
+        ORIGINATING_URL: "${ORIGINATING_URL}"
+        REPO_FULL_NAME: "${REPO_FULL_NAME}"
+        GH_TOKEN: "${GH_TOKEN}"


### PR DESCRIPTION
Migrate retro harness from deprecated runner_env to env.runner/env.sandbox per ADR 0055. Move env/retro.env passthrough variables into the harness YAML directly. Delete retro.env and its host_files entry. Update scaffold_integration_test.go to check Env.Runner for retro template.