### PR TITLE
refactor(harness): migrate triage to env.runner/env.sandbox (ADR 0055)

### DIFF
--- a/internal/harness/scaffold_integration_test.go
+++ b/internal/harness/scaffold_integration_test.go
@@ -61,13 +61,17 @@ slug: test-triage
 	assert.NotEmpty(t, h.PreScript, "PreScript should be set after forge resolution")
 	assert.NotEmpty(t, h.PostScript, "PostScript should be set after forge resolution")
 
-	// RunnerEnv contains both top-level keys and forge.github keys after merge.
-	assert.Contains(t, h.RunnerEnv, "FULLSEND_OUTPUT_SCHEMA", "should have top-level runner_env key")
-	assert.Contains(t, h.RunnerEnv, "GH_TOKEN", "should have forge.github runner_env key")
-	assert.Contains(t, h.RunnerEnv, "GITHUB_ISSUE_URL", "should have forge.github runner_env key")
+	// Env.Runner contains both top-level keys and forge.github keys after merge.
+	assert.Contains(t, h.Env.Runner, "FULLSEND_OUTPUT_SCHEMA", "should have top-level env.runner key")
+	assert.Contains(t, h.Env.Runner, "GH_TOKEN", "should have forge.github env.runner key")
+	assert.Contains(t, h.Env.Runner, "GITHUB_ISSUE_URL", "should have forge.github env.runner key")
+
+	// Env.Sandbox contains forge.github sandbox vars.
+	assert.Contains(t, h.Env.Sandbox, "GH_TOKEN", "should have forge.github env.sandbox key")
+	assert.Contains(t, h.Env.Sandbox, "GITHUB_ISSUE_URL", "should have forge.github env.sandbox key")
 
 	// Skills includes base top-level skills (forge skills are concatenated by ResolveForge,
-	// but the triage template has no forge-specific skills — only runner_env and scripts).
+	// but the triage template has no forge-specific skills — only env and scripts).
 	assert.Contains(t, h.Skills, "skills/issue-labels")
 
 	// Forge map is nil (consumed by ResolveForge).
@@ -130,7 +134,8 @@ func TestLoadWithOpts_ScaffoldTemplatesForgeResolution(t *testing.T) {
 
 			assert.NotEmpty(t, h.PreScript, "PreScript should be set after forge resolution")
 			assert.NotEmpty(t, h.PostScript, "PostScript should be set after forge resolution")
-			assert.NotEmpty(t, h.RunnerEnv, "RunnerEnv should be non-empty after merge")
+			hasRunnerEnv := len(h.RunnerEnv) > 0 || (h.Env != nil && len(h.Env.Runner) > 0)
+			assert.True(t, hasRunnerEnv, "RunnerEnv or Env.Runner should be non-empty after merge")
 			assert.Nil(t, h.Forge, "Forge should be nil after resolution")
 			assert.NotEmpty(t, h.Role, "Role should be set in scaffold template")
 			assert.NotEmpty(t, h.Slug, "Slug should be set in scaffold template")
@@ -333,11 +338,22 @@ func TestResolveForge_ScaffoldRunnerEnvMerge(t *testing.T) {
 			h, loadErr := LoadWithOpts(path, LoadOpts{ForgePlatform: "github"})
 			require.NoError(t, loadErr)
 
+			// Build a combined env map from both legacy RunnerEnv and new Env.Runner.
+			combined := make(map[string]string)
+			for k, v := range h.RunnerEnv {
+				combined[k] = v
+			}
+			if h.Env != nil {
+				for k, v := range h.Env.Runner {
+					combined[k] = v
+				}
+			}
+
 			for _, key := range tt.topLevelKeys {
-				assert.Contains(t, h.RunnerEnv, key, "merged RunnerEnv should contain top-level key %s", key)
+				assert.Contains(t, combined, key, "merged env should contain top-level key %s", key)
 			}
 			for _, key := range tt.forgeGithubKeys {
-				assert.Contains(t, h.RunnerEnv, key, "merged RunnerEnv should contain forge.github key %s", key)
+				assert.Contains(t, combined, key, "merged env should contain forge.github key %s", key)
 			}
 		})
 	}

--- a/internal/scaffold/fullsend-repo/env/triage.env
+++ b/internal/scaffold/fullsend-repo/env/triage.env
@@ -1,2 +1,0 @@
-export GITHUB_ISSUE_URL="${GITHUB_ISSUE_URL}"
-export GH_TOKEN=${GH_TOKEN}

--- a/internal/scaffold/fullsend-repo/harness/triage.yaml
+++ b/internal/scaffold/fullsend-repo/harness/triage.yaml
@@ -17,9 +17,6 @@ host_files:
   - src: ${GCP_OIDC_TOKEN_FILE}
     dest: /sandbox/workspace/.gcp-oidc-token
     optional: true
-  - src: env/triage.env
-    dest: /sandbox/workspace/.env.d/triage.env
-    expand: true
 
 skills:
   - skills/issue-labels
@@ -31,8 +28,9 @@ validation_loop:
   script: scripts/validate-output-schema.sh
   max_iterations: 2
 
-runner_env:
-  FULLSEND_OUTPUT_SCHEMA: ${FULLSEND_DIR}/schemas/triage-result.schema.json
+env:
+  runner:
+    FULLSEND_OUTPUT_SCHEMA: ${FULLSEND_DIR}/schemas/triage-result.schema.json
 
 timeout_minutes: 10
 
@@ -40,6 +38,10 @@ forge:
   github:
     pre_script: scripts/pre-triage.sh
     post_script: scripts/post-triage.sh
-    runner_env:
-      GITHUB_ISSUE_URL: ${GITHUB_ISSUE_URL}
-      GH_TOKEN: ${GH_TOKEN}
+    env:
+      runner:
+        GITHUB_ISSUE_URL: ${GITHUB_ISSUE_URL}
+        GH_TOKEN: ${GH_TOKEN}
+      sandbox:
+        GITHUB_ISSUE_URL: "${GITHUB_ISSUE_URL}"
+        GH_TOKEN: "${GH_TOKEN}"

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -61,7 +61,6 @@ func TestFullsendRepoFilesExist(t *testing.T) {
 		"agents/triage.md",
 		"agents/code.md",
 		"env/gcp-vertex.env",
-		"env/triage.env",
 		"env/code-agent.env",
 		"harness/triage.yaml",
 		"harness/code.yaml",
@@ -632,7 +631,8 @@ func TestHarnessesLoadAndValidate(t *testing.T) {
 				assert.Nil(t, h.Forge, "Forge should be nil after resolution")
 				assert.NotEmpty(t, h.PreScript, "PreScript should be set after forge resolution")
 				assert.NotEmpty(t, h.PostScript, "PostScript should be set after forge resolution")
-				assert.NotEmpty(t, h.RunnerEnv, "RunnerEnv should be non-empty after merge")
+				hasRunnerEnv := len(h.RunnerEnv) > 0 || (h.Env != nil && len(h.Env.Runner) > 0)
+				assert.True(t, hasRunnerEnv, "RunnerEnv or Env.Runner should be non-empty after merge")
 
 				resolveErr := h.ResolveRelativeTo(dir)
 				require.NoError(t, resolveErr, "ResolveRelativeTo should succeed")
@@ -700,11 +700,22 @@ func TestHarnessForgeRunnerEnvMerge(t *testing.T) {
 			h, loadErr := harness.LoadWithOpts(harnessPath, harness.LoadOpts{ForgePlatform: "github"})
 			require.NoError(t, loadErr)
 
+			// Build a combined env map from both legacy RunnerEnv and new Env.Runner.
+			combined := make(map[string]string)
+			for k, v := range h.RunnerEnv {
+				combined[k] = v
+			}
+			if h.Env != nil {
+				for k, v := range h.Env.Runner {
+					combined[k] = v
+				}
+			}
+
 			for _, key := range tt.topLevelKeys {
-				assert.Contains(t, h.RunnerEnv, key, "merged RunnerEnv should contain top-level key %s", key)
+				assert.Contains(t, combined, key, "merged env should contain top-level key %s", key)
 			}
 			for _, key := range tt.forgeGithubKeys {
-				assert.Contains(t, h.RunnerEnv, key, "merged RunnerEnv should contain forge.github key %s", key)
+				assert.Contains(t, combined, key, "merged env should contain forge.github key %s", key)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Replace `runner_env` with `env.runner` (top-level and forge.github)
- Move `triage.env` passthroughs to `forge.github.env.sandbox`, delete the `.env` file
- Update scaffold and integration tests for new env schema

Phase 2 of ADR 0055 (#2582).

## Test plan

- [x] `go test ./internal/harness/` passes
- [x] `go test ./internal/scaffold/` passes
- [ ] Trigger a triage agent run and verify env vars reach both runner and sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)