### PR TITLE
fix(github): increase retry attempts and add jitter to backoff

### DIFF
--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -99,7 +100,7 @@ func (e *APIError) Unwrap() error {
 	return nil
 }
 
-const maxRetries = 3
+const maxRetries = 5
 
 // do performs an HTTP request against the GitHub API with retry on rate limits.
 func (c *LiveClient) do(ctx context.Context, method, path string, body any) (*http.Response, error) {
@@ -213,19 +214,26 @@ func isRetryable(resp *http.Response) (bool, []byte) {
 var secondaryRateLimitBackoff = 60 * time.Second
 
 // retryDelay calculates how long to wait before retrying.
-// It uses the Retry-After header if present, otherwise exponential backoff.
+// It uses the Retry-After header if present, otherwise exponential backoff
+// with jitter to prevent thundering-herd effects.
 func retryDelay(resp *http.Response, attempt int) time.Duration {
 	if ra := resp.Header.Get("Retry-After"); ra != "" {
 		if secs, err := strconv.Atoi(ra); err == nil && secs > 0 && secs <= 300 {
 			return time.Duration(secs) * time.Second
 		}
 	}
-	// For secondary rate limits (403), use a longer backoff.
+	var base time.Duration
 	if resp.StatusCode == http.StatusForbidden {
-		return secondaryRateLimitBackoff + time.Duration(math.Pow(2, float64(attempt)))*time.Second
+		// For secondary rate limits (403), use a longer backoff.
+		base = secondaryRateLimitBackoff + time.Duration(math.Pow(2, float64(attempt)))*time.Second
+	} else {
+		// Exponential backoff: 1s, 2s, 4s, 8s, 16s
+		base = time.Duration(math.Pow(2, float64(attempt))) * time.Second
 	}
-	// Exponential backoff: 1s, 2s, 4s
-	return time.Duration(math.Pow(2, float64(attempt))) * time.Second
+	// Add jitter: randomize between 50-100% of base to desynchronize
+	// concurrent callers (e.g. parallel e2e test runners).
+	half := base / 2
+	return half + time.Duration(rand.Int64N(int64(half)+1))
 }
 
 // checkStatus verifies the response has an acceptable status code and returns

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -1726,7 +1726,7 @@ func TestCreateOrUpdateFile_NoRetryOnNon5xx(t *testing.T) {
 
 func TestCreateOrUpdateFile_MaxRetriesExceeded(t *testing.T) {
 	// 5xx errors are retried at the do() level, not retryOnRepoRace.
-	// With a persistent 504 on PUT, do() exhausts its 3 attempts and
+	// With a persistent 504 on PUT, do() exhausts its 5 attempts and
 	// returns immediately — retryOnRepoRace does not retry 5xx.
 	callNum := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1746,7 +1746,7 @@ func TestCreateOrUpdateFile_MaxRetriesExceeded(t *testing.T) {
 	client := newTestClient(t, srv)
 	err := client.CreateOrUpdateFile(context.Background(), "owner", "repo", "test.txt", "add", []byte("data"))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "retryable error after 3 attempts")
+	assert.Contains(t, err.Error(), "retryable error after 5 attempts")
 }
 
 func TestIsTransientStatus(t *testing.T) {
@@ -1793,6 +1793,71 @@ func TestDo_RetriesOnServerError(t *testing.T) {
 	require.NoError(t, err)
 	resp.Body.Close()
 	assert.Equal(t, 2, attempt, "expected exactly 2 attempts (1 retry)")
+}
+
+func TestDo_MaxRetries5(t *testing.T) {
+	// do() should attempt up to 5 times before giving up on retryable errors.
+	attempt := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt++
+		w.WriteHeader(http.StatusBadGateway)
+		fmt.Fprintln(w, `{"message":"Bad Gateway"}`)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	_, err := client.get(context.Background(), "/test")
+	require.Error(t, err)
+	assert.Equal(t, 5, attempt, "expected 5 attempts total")
+	assert.Contains(t, err.Error(), "retryable error after 5 attempts")
+}
+
+func TestRetryDelay_HasJitter(t *testing.T) {
+	// retryDelay should add jitter so that repeated calls with the same
+	// inputs produce varying delays, preventing thundering-herd effects.
+	resp := &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Header:     http.Header{},
+	}
+
+	seen := make(map[time.Duration]bool)
+	for range 50 {
+		d := retryDelay(resp, 2) // attempt 2 → base 4s
+		seen[d] = true
+	}
+	assert.Greater(t, len(seen), 1, "retryDelay should produce varying results due to jitter")
+}
+
+func TestRetryDelay_SecondaryRateLimit_HasJitter(t *testing.T) {
+	origBackoff := secondaryRateLimitBackoff
+	defer func() { secondaryRateLimitBackoff = origBackoff }()
+	secondaryRateLimitBackoff = 100 * time.Millisecond
+
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     http.Header{},
+	}
+
+	seen := make(map[time.Duration]bool)
+	for range 50 {
+		d := retryDelay(resp, 1)
+		seen[d] = true
+	}
+	assert.Greater(t, len(seen), 1, "secondary rate limit retryDelay should have jitter")
+}
+
+func TestRetryDelay_RespectsRetryAfterHeader(t *testing.T) {
+	// When Retry-After header is present, jitter should NOT apply —
+	// the server told us exactly how long to wait.
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": []string{"30"}},
+	}
+
+	for range 10 {
+		d := retryDelay(resp, 0)
+		assert.Equal(t, 30*time.Second, d, "Retry-After should be used exactly, no jitter")
+	}
 }
 
 func TestBlobSHA(t *testing.T) {


### PR DESCRIPTION
## Summary

- Increases `maxRetries` from 3 to 5 in the GitHub API client, giving ~5 minutes of patience for secondary rate limits (60s+ base backoff per attempt)
- Adds jitter (randomizes delay between 50-100% of base) to prevent thundering-herd effects when parallel callers hit rate limits simultaneously
- `Retry-After` header values are still respected exactly (no jitter applied)

## Context

E2e tests were failing with `403 retryable error after 3 attempts on POST /orgs/halfsend-06/repos` — the client gave up too quickly on secondary rate limits. The shell-side CSMA library (`github-api-csma.sh`) already uses 8 attempts with jitter; this brings the Go client closer to parity.

## Test plan

- [x] New test: `TestDo_MaxRetries5` — verifies 5 attempts before exhaustion
- [x] New test: `TestRetryDelay_HasJitter` — verifies non-deterministic delays for 5xx
- [x] New test: `TestRetryDelay_SecondaryRateLimit_HasJitter` — verifies jitter on 403 backoff
- [x] New test: `TestRetryDelay_RespectsRetryAfterHeader` — verifies Retry-After is exact
- [x] Updated existing `TestCreateOrUpdateFile_MaxRetriesExceeded` for new retry count
- [x] Full `go test ./internal/forge/github/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)