### PR TITLE
fix(site): rewrite broken README.md and out-of-docs links

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -330,8 +330,9 @@ export default defineConfig({
         return defaultCodeInline(tokens, idx, options, env, self)
       }
 
-      // Rewrite README.md links to directory index (README→index rewrite),
-      // and convert relative links pointing outside docs/ to GitHub URLs.
+      // Rewrite relative links that escape the docs/ directory to GitHub
+      // source URLs, and rewrite README.md links to directory index paths
+      // (only for links that stay within docs/).
       md.core.ruler.push('rewrite-links', (state) => {
         for (const token of state.tokens) {
           if (!token.children) continue
@@ -340,23 +341,24 @@ export default defineConfig({
             const href = child.attrGet('href')
             if (!href || href.startsWith('http') || href.startsWith('#') || href.startsWith('mailto:')) continue
 
-            if (/README\.md(#.*)?$/.test(href)) {
-              child.attrSet('href', href.replace(/README\.md(#.*)?$/, (_: string, anchor: string) => anchor || './'))
+            // Check if the link escapes docs/ (more ../  than directory depth)
+            const docPath = state.env?.relativePath || ''
+            const docDir = docPath.split('/').slice(0, -1)
+            const parts = href.split('#')
+            const linkPath = parts[0]
+            const anchor = parts[1] ? '#' + parts[1] : ''
+            const segments = linkPath.split('/')
+            let depth = 0
+            for (const s of segments) { if (s === '..') depth++; else break }
+            if (depth > docDir.length) {
+              const remainder = segments.slice(depth).join('/')
+              child.attrSet('href', 'https://github.com/fullsend-ai/fullsend/tree/main/' + remainder + anchor)
+              continue
             }
 
-            if (/\.\.\/(\.\.\/)*[^.][^/]*/.test(href)) {
-              const docPath = state.env?.relativePath || ''
-              const docDir = docPath.split('/').slice(0, -1)
-              const parts = href.split('#')
-              const linkPath = parts[0]
-              const anchor = parts[1] ? '#' + parts[1] : ''
-              const segments = linkPath.split('/')
-              let depth = 0
-              for (const s of segments) { if (s === '..') depth++; else break }
-              if (depth > docDir.length) {
-                const remainder = segments.slice(depth).join('/')
-                child.attrSet('href', 'https://github.com/fullsend-ai/fullsend/tree/main/' + remainder + anchor)
-              }
+            // For links staying within docs/, rewrite README.md to directory index
+            if (/README\.md(#.*)?$/.test(href)) {
+              child.attrSet('href', href.replace(/README\.md(#.*)?$/, (_: string, a: string) => a || './'))
             }
           }
         }

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -59,7 +59,7 @@ function escapeVueSyntax(src: string): string {
   }).join('\n')
 }
 
-const KNOWN_TAGS = /^<\/?(?:a|abbr|address|area|article|aside|audio|b|base|bdi|bdo|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|fieldset|figcaption|figure|footer|form|h[1-6]|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|label|legend|li|link|main|map|mark|menu|meta|meter|nav|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|ruby|s|samp|script|search|section|select|slot|small|source|span|strong|style|sub|summary|sup|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|u|ul|var|video|wbr|svg|path|g|circle|rect|line|polyline|polygon|text|defs|use|symbol)[\s>\/!]/i
+const KNOWN_TAGS = /^<\/?(?:a|abbr|address|area|article|aside|audio|b|base|bdi|bdo|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|fieldset|figcaption|figure|footer|form|h[1-6]|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|label|legend|li|link|main|map|mark|menu|meta|meter|nav|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|ruby|s|samp|script|search|section|select|slot|small|source|span|strong|style|sub|summary|sup|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|u|ul|var|video|wbr|svg|path|g|circle|rect|line|polyline|polygon|text|defs|use|symbol)[\s>/!]/i
 
 function escapeLine(line: string): string {
   let result = ''
@@ -316,7 +316,7 @@ export default defineConfig({
     },
     preConfig: (md) => {
       const defaultParse = md.parse.bind(md)
-      md.parse = (src: string, env: any) => {
+      md.parse = (src: string, env: Record<string, unknown>) => {
         return defaultParse(escapeVueSyntax(src), env)
       }
     },
@@ -329,6 +329,38 @@ export default defineConfig({
         tokens[idx].attrSet('v-pre', '')
         return defaultCodeInline(tokens, idx, options, env, self)
       }
+
+      // Rewrite README.md links to directory index (README→index rewrite),
+      // and convert relative links pointing outside docs/ to GitHub URLs.
+      md.core.ruler.push('rewrite-links', (state) => {
+        for (const token of state.tokens) {
+          if (!token.children) continue
+          for (const child of token.children) {
+            if (child.type !== 'link_open') continue
+            const href = child.attrGet('href')
+            if (!href || href.startsWith('http') || href.startsWith('#') || href.startsWith('mailto:')) continue
+
+            if (/README\.md(#.*)?$/.test(href)) {
+              child.attrSet('href', href.replace(/README\.md(#.*)?$/, (_: string, anchor: string) => anchor || './'))
+            }
+
+            if (/\.\.\/(\.\.\/)*[^.][^/]*/.test(href)) {
+              const docPath = state.env?.relativePath || ''
+              const docDir = docPath.split('/').slice(0, -1)
+              const parts = href.split('#')
+              const linkPath = parts[0]
+              const anchor = parts[1] ? '#' + parts[1] : ''
+              const segments = linkPath.split('/')
+              let depth = 0
+              for (const s of segments) { if (s === '..') depth++; else break }
+              if (depth > docDir.length) {
+                const remainder = segments.slice(depth).join('/')
+                child.attrSet('href', 'https://github.com/fullsend-ai/fullsend/tree/main/' + remainder + anchor)
+              }
+            }
+          }
+        }
+      })
 
       const defaultFence = md.renderer.rules.fence!.bind(md.renderer.rules)
       md.renderer.rules.fence = (tokens, idx, options, env, self) => {

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -352,7 +352,8 @@ export default defineConfig({
             for (const s of segments) { if (s === '..') depth++; else break }
             if (depth > docDir.length) {
               const remainder = segments.slice(depth).join('/')
-              child.attrSet('href', 'https://github.com/fullsend-ai/fullsend/tree/main/' + remainder + anchor)
+              const prefix = /\.[a-zA-Z0-9]+$/.test(remainder) && !remainder.endsWith('/') ? 'blob' : 'tree'
+              child.attrSet('href', `https://github.com/fullsend-ai/fullsend/${prefix}/main/${remainder}${anchor}`)
               continue
             }
 


### PR DESCRIPTION
## Summary

- Adds a markdown-it core rule that rewrites `README.md` links to directory index paths — VitePress `rewrites` only affects routing/file output, not link resolution in markdown content
- Converts relative links that escape the `docs/` directory (e.g. `../../internal/scaffold/...`) into GitHub source URLs (`https://github.com/fullsend-ai/fullsend/tree/main/...`)
- Fixes 37 broken source-code links and all `README.md` 404s without modifying any doc content
- Fixes eslint warnings (unnecessary regex escape, `any` type)

## Context

After the VitePress migration (#2721), links like `[Default Agents](../../agents/README.md)` resolved to `README.html` which doesn't exist (VitePress outputs `index.html`). Links to source files like `../../internal/scaffold/fullsend-repo/harness/` also 404'd since they're outside the docs directory.

## Test plan

- [x] `npm run build && cd website && npm run build` passes locally
- [x] Default Agents link resolves to `/docs/agents/` (not 404)
- [x] Source code links resolve to `github.com/fullsend-ai/fullsend/tree/main/...`
- [x] Zero `README.html` references in built output
- [ ] CI build passes