### PR TITLE
feat(e2e): expand org pool from 6 to 12

### DIFF
--- a/e2e/admin/testutil.go
+++ b/e2e/admin/testutil.go
@@ -56,6 +56,12 @@ var orgPool = []string{
 	"halfsend-04",
 	"halfsend-05",
 	"halfsend-06",
+	"halfsend-07",
+	"halfsend-08",
+	"halfsend-09",
+	"halfsend-10",
+	"halfsend-11",
+	"halfsend-12",
 }
 
 // acquireOrg scans the pool for an unlocked org and acquires its lock.


### PR DESCRIPTION
## Summary

- Adds `halfsend-07` through `halfsend-12` to the e2e org pool, doubling capacity from 6 to 12 concurrent runs
- With only 6 orgs, concurrent PR e2e runs were exhausting the pool and timing out after 10 minutes waiting for a lock

## Prerequisites before merging

Each new org must be provisioned using the setup script:

```bash
export MINT_PROJECT=it-gcp-konflux-dev-fullsend
export MINT_FUNCTION=fullsend-mint

for n in 07 08 09 10 11 12; do
  hack/setup-new-e2e-org.sh "$n"
done
```

This creates the org, adds `botsend` as owner, creates `test-repo`, installs the GitHub Apps, and checks mint enrollment.

## Test plan

- [ ] Provision halfsend-07 through halfsend-12 with `hack/setup-new-e2e-org.sh`
- [ ] Enroll each in the token mint
- [ ] E2E tests pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)