### PR TITLE
docs: revert hardcoded getting-started link to README.md

### DIFF
--- a/docs/guides/getting-started/org-mode.md
+++ b/docs/guides/getting-started/org-mode.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Per-Org Mode
 
-> **Planned deprecation.** Per-org installation mode will be deprecated in favor of per-repo installation ([ADR 0044](../../ADRs/0044-deprecate-per-org-installation-mode.md)). New installations should use the [per-repo Getting Started guides](../getting-started/). Existing per-org installations continue to work and are fully supported during the transition.
+> **Planned deprecation.** Per-org installation mode will be deprecated in favor of per-repo installation ([ADR 0044](../../ADRs/0044-deprecate-per-org-installation-mode.md)). New installations should use the [per-repo Getting Started guides](README.md). Existing per-org installations continue to work and are fully supported during the transition.
 
 The goal of this document is that you install Fullsend for your whole
 GitHub organization, so different repositories share inference and infrastructure.


### PR DESCRIPTION
## Summary

- Reverts the hardcoded `../getting-started/` link in the org-mode deprecation notice back to the canonical `README.md` reference
- The hardcode was a workaround introduced in #2698 because VitePress didn't resolve `README.md` links

## Depends on

- #2765 — adds a markdown-it rewrite rule that automatically resolves `README.md` links to `./`, making this hardcode unnecessary

## Test plan

- [ ] Merge #2765 first
- [ ] Verify the org-mode deprecation notice link resolves correctly on the docs site