### PR TITLE
feat(config): add agent registration schema (ADR 0058 Phase 1)

### DIFF
--- a/docs/plans/adr-0045-forge-portable-harness-phase1.md
+++ b/docs/plans/adr-0045-forge-portable-harness-phase1.md
@@ -19,7 +19,7 @@ ADR-0038 makes harness *resources* (agents, skills, policies) URL-addressable. A
 **ADR-0038 implementation status** (as of this plan):
 | Phase | Status | Key artifacts |
 |-------|--------|---------------|
-| Phase 1 (MVP) | Shipped | `internal/fetch/`, `internal/harness/url.go`, `internal/resolve/`, CLI `--offline` |
+| Phase 1 (MVP) | Shipped | `internal/fetch/`, `internal/urlutil/` (formerly `internal/harness/url.go`), `internal/resolve/`, CLI `--offline` |
 | Phase 2 (Transitive deps) | Shipped | `internal/skill/`, recursive resolver, `--max-depth`/`--max-resources` |
 | Phase 3 (Lock files) | Shipped | `internal/lock/`, `fullsend lock` CLI (PR #2082) |
 | Phase 4 (Runtime fetch) | Not started | — |

--- a/docs/plans/agent-registration.md
+++ b/docs/plans/agent-registration.md
@@ -52,7 +52,7 @@ type PerRepoConfig struct {
 }
 ```
 
-Add a `AgentEntry.AgentName()` helper that returns `Name` if set,
+Add a `AgentEntry.DerivedName()` helper that returns `Name` if set,
 otherwise derives it from the `Source` filename.
 
 ### 1b. Validation

--- a/docs/plans/universal-harness-access-phase1.md
+++ b/docs/plans/universal-harness-access-phase1.md
@@ -26,7 +26,7 @@ PRs 1, 2, 4, and 6 have no dependencies and can be developed/merged in parallel.
 
 **Scope:** Pure utility functions with no callers. Zero risk to existing behavior.
 
-**Create `internal/harness/url.go`:**
+**Create `internal/harness/url.go`** (canonical implementations now in `internal/urlutil/urlutil.go`)**:**
 - `IsURL(s string) bool` — true for valid HTTPS URLs. Rejects empty host, userinfo, non-HTTPS schemes. Uses `net/url.Parse` with additional guards.
 - `IsAbsPath(s string) bool` — delegates to `filepath.IsAbs`.
 - `IsRelPath(s string) bool` — `!IsURL(s) && !IsAbsPath(s)`.

--- a/docs/plans/universal-harness-access.md
+++ b/docs/plans/universal-harness-access.md
@@ -555,7 +555,7 @@ func (h *Harness) Validate(orgAllowlist []string) error {
 
 ### 2. URL Detection and Classification
 
-**File:** `internal/harness/url.go`
+**File:** `internal/harness/url.go` (canonical implementations now in `internal/urlutil/urlutil.go`)
 
 ```go
 package harness

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,12 +2,74 @@ package config
 
 import (
 	"fmt"
+	"path"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
 
+	"github.com/fullsend-ai/fullsend/internal/urlutil"
 	"gopkg.in/yaml.v3"
 )
+
+// validConfigAgentName requires an alphanumeric first character, stricter
+// than harness.validAgentName which also allows leading underscores/hyphens.
+// Config names may be used as YAML keys or filesystem identifiers downstream.
+var validConfigAgentName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+// AgentEntry represents a registered agent source in config.
+// It supports both string shorthand (just the source URL/path) and
+// object form (with an explicit name override).
+type AgentEntry struct {
+	Name   string `yaml:"name,omitempty"`
+	Source string `yaml:"source"`
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler so that a plain string
+// is treated as a source-only entry, while a mapping decodes normally.
+// Old-format entries (role/name/slug identity tuples from pre-ADR-0058
+// config) are detected and rejected with a clear error message.
+func (a *AgentEntry) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		a.Source = value.Value
+		return nil
+	}
+	if value.Kind == yaml.MappingNode {
+		// Detect old-format entries (have "role" key but no "source" key).
+		hasRole := false
+		hasSource := false
+		for i := 0; i < len(value.Content)-1; i += 2 {
+			if value.Content[i].Value == "role" {
+				hasRole = true
+			}
+			if value.Content[i].Value == "source" {
+				hasSource = true
+			}
+		}
+		if hasRole && !hasSource {
+			return fmt.Errorf("agents entry uses legacy role/name/slug format (removed by ADR 0045 Phase 4); use source URL or path instead")
+		}
+
+		type plain AgentEntry
+		return value.Decode((*plain)(a))
+	}
+	return fmt.Errorf("agents entry must be a string or mapping, got %v", value.Kind)
+}
+
+// DerivedName returns the explicit Name if set, otherwise derives one
+// from the Source filename (e.g. "triage.yaml" → "triage").
+func (a AgentEntry) DerivedName() string {
+	if a.Name != "" {
+		return a.Name
+	}
+	src := a.Source
+	// Strip fragment (e.g. #sha256=...) before extracting filename.
+	if idx := strings.LastIndex(src, "#"); idx >= 0 {
+		src = src[:idx]
+	}
+	base := path.Base(src)
+	return strings.TrimSuffix(base, path.Ext(base))
+}
 
 const (
 	// DefaultUpstreamRepo is the canonical fullsend repository for layered workflow calls.
@@ -79,6 +141,7 @@ type OrgConfig struct {
 	Inference              InferenceConfig       `yaml:"inference,omitempty"`
 	Defaults               RepoDefaults          `yaml:"defaults"`
 	Repos                  map[string]RepoConfig `yaml:"repos"`
+	Agents                 []AgentEntry          `yaml:"agents,omitempty"`
 	AllowedRemoteResources []string              `yaml:"allowed_remote_resources,omitempty"`
 	CreateIssues           *CreateIssuesConfig   `yaml:"create_issues,omitempty"`
 }
@@ -107,6 +170,40 @@ func PerRepoDefaultRoles() []string {
 	return []string{"triage", "coder", "review", "fix", "retro", "prioritize"}
 }
 
+// DefaultAllowedRemoteResources returns the standard allowlist prefixes
+// for base composition and agent registration URLs.
+func DefaultAllowedRemoteResources() []string {
+	return []string{
+		"https://raw.githubusercontent.com/fullsend-ai/fullsend/",
+		"https://raw.githubusercontent.com/fullsend-ai/agents/",
+	}
+}
+
+// DefaultAgentEntries computes default agent URL entries for the given
+// harness names at a specific commit SHA. Each entry is a pinned
+// raw.githubusercontent.com URL with an integrity hash.
+type AgentEntryBuilder func(harnessName, commitSHA string) (string, error)
+
+// DefaultAgentEntries returns agent entries for the given harness names,
+// using builder to compute each URL. When builder is nil, it returns
+// nil (for callers that don't have access to the scaffold package).
+// Called by install/scaffold in Phase 2 (ADR 0058); defined here in
+// Phase 1 so the type and validation are co-located.
+func DefaultAgentEntries(harnessNames []string, commitSHA string, builder AgentEntryBuilder) ([]AgentEntry, error) {
+	if builder == nil || commitSHA == "" {
+		return nil, nil
+	}
+	entries := make([]AgentEntry, 0, len(harnessNames))
+	for _, name := range harnessNames {
+		urlWithHash, err := builder(name, commitSHA)
+		if err != nil {
+			return nil, fmt.Errorf("building agent URL for %s: %w", name, err)
+		}
+		entries = append(entries, AgentEntry{Source: urlWithHash})
+	}
+	return entries, nil
+}
+
 // NewOrgConfig creates a new OrgConfig with sensible defaults.
 func NewOrgConfig(allRepos, enabledRepos, roles []string, inferenceProvider, org string) *OrgConfig {
 	repos := make(map[string]RepoConfig, len(allRepos))
@@ -126,12 +223,8 @@ func NewOrgConfig(allRepos, enabledRepos, roles []string, inferenceProvider, org
 			MaxImplementationRetries: 2,
 			AutoMerge:                false,
 		},
-		Repos: repos,
-		// Default allowlist for base: composition in harness wrappers (ADR-0045 Phase 2).
-		AllowedRemoteResources: []string{
-			"https://raw.githubusercontent.com/fullsend-ai/fullsend/",
-			"https://raw.githubusercontent.com/fullsend-ai/agents/",
-		},
+		Repos:                  repos,
+		AllowedRemoteResources: DefaultAllowedRemoteResources(),
 	}
 	if inferenceProvider != "" {
 		cfg.Inference = InferenceConfig{Provider: inferenceProvider}
@@ -205,8 +298,63 @@ func (c *OrgConfig) Validate() error {
 	if err := validateStatusNotifications(c.Defaults.StatusNotifications); err != nil {
 		return err
 	}
+	if err := validateAgentEntries(c.Agents, c.AllowedRemoteResources); err != nil {
+		return err
+	}
 	if err := validateCreateIssues(c.CreateIssues); err != nil {
 		return err
+	}
+	return nil
+}
+
+// validateAgentEntries checks agent entries for structural correctness.
+// Uses urlutil.IsURL, urlutil.ParseIntegrityHash, and
+// urlutil.MatchingAllowedPrefixInList for consistency with runtime
+// resolution (case-insensitive scheme, percent-decoding, dot-segment
+// cleaning).
+func validateAgentEntries(agents []AgentEntry, allowlist []string) error {
+	seen := make(map[string]bool, len(agents))
+	for i, entry := range agents {
+		if entry.Source == "" {
+			return fmt.Errorf("agents[%d]: source must not be empty", i)
+		}
+
+		name := entry.DerivedName()
+		if !validConfigAgentName.MatchString(name) {
+			return fmt.Errorf("agents[%d] (%s): derived name is invalid, must start with alphanumeric and contain only [a-zA-Z0-9_-] (source: %q)", i, name, entry.Source)
+		}
+		lowerName := strings.ToLower(name)
+		if seen[lowerName] {
+			return fmt.Errorf("agents[%d] (%s): duplicate agent name (case-insensitive)", i, name)
+		}
+		seen[lowerName] = true
+
+		if urlutil.IsURL(entry.Source) {
+			cleanURL, _, hasHash := urlutil.ParseIntegrityHash(entry.Source)
+			if !hasHash {
+				return fmt.Errorf("agents[%d] (%s): URL source must include a valid #sha256=<64-hex-char> integrity fragment", i, name)
+			}
+			if urlutil.MatchingAllowedPrefixInList(cleanURL, allowlist) == "" {
+				return fmt.Errorf("agents[%d] (%s): URL %q is not covered by allowed_remote_resources", i, name, cleanURL)
+			}
+		} else if strings.HasPrefix(strings.ToLower(entry.Source), "http://") {
+			return fmt.Errorf("agents[%d] (%s): URL scheme must be https, got http", i, name)
+		} else {
+			if strings.Contains(entry.Source, "://") {
+				return fmt.Errorf("agents[%d] (%s): unsupported URL scheme, only https is allowed", i, name)
+			}
+			if strings.HasPrefix(entry.Source, "/") {
+				return fmt.Errorf("agents[%d] (%s): absolute paths are not allowed", i, name)
+			}
+			if strings.ContainsRune(entry.Source, '\\') {
+				return fmt.Errorf("agents[%d] (%s): local path must not contain backslashes", i, name)
+			}
+			for _, seg := range strings.Split(entry.Source, "/") {
+				if seg == ".." {
+					return fmt.Errorf("agents[%d] (%s): local path must not contain path traversal (..)", i, name)
+				}
+			}
+		}
 	}
 	return nil
 }
@@ -257,10 +405,12 @@ func (c *OrgConfig) DefaultRoles() []string {
 // PerRepoConfig holds configuration for per-repo installation mode.
 // Stored in .fullsend/config.yaml within the target repository.
 type PerRepoConfig struct {
-	Version      string              `yaml:"version"`
-	KillSwitch   bool                `yaml:"kill_switch,omitempty"`
-	Roles        []string            `yaml:"roles,omitempty"`
-	CreateIssues *CreateIssuesConfig `yaml:"create_issues,omitempty"`
+	Version                string              `yaml:"version"`
+	KillSwitch             bool                `yaml:"kill_switch,omitempty"`
+	Roles                  []string            `yaml:"roles,omitempty"`
+	Agents                 []AgentEntry        `yaml:"agents,omitempty"`
+	AllowedRemoteResources []string            `yaml:"allowed_remote_resources,omitempty"`
+	CreateIssues           *CreateIssuesConfig `yaml:"create_issues,omitempty"`
 }
 
 const perRepoConfigHeader = `# fullsend per-repo configuration
@@ -276,8 +426,9 @@ func NewPerRepoConfig(roles []string, targetRepo string) *PerRepoConfig {
 		roles = DefaultAgentRoles()
 	}
 	cfg := &PerRepoConfig{
-		Version: "1",
-		Roles:   roles,
+		Version:                "1",
+		Roles:                  roles,
+		AllowedRemoteResources: DefaultAllowedRemoteResources(),
 	}
 	if targetRepo != "" {
 		cfg.CreateIssues = &CreateIssuesConfig{
@@ -322,6 +473,9 @@ func (c *PerRepoConfig) Validate() error {
 			return fmt.Errorf("duplicate role %q in roles", role)
 		}
 		seen[role] = true
+	}
+	if err := validateAgentEntries(c.Agents, c.AllowedRemoteResources); err != nil {
+		return err
 	}
 	if err := validateCreateIssues(c.CreateIssues); err != nil {
 		return err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,11 +1,13 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/fullsend-ai/fullsend/internal/mintcore"
 )
@@ -264,7 +266,7 @@ repos:
 	assert.False(t, cfg.Repos["repo-y"].Enabled)
 }
 
-func TestParseOrgConfig_IgnoresLegacyAgentsBlock(t *testing.T) {
+func TestParseOrgConfig_RejectsLegacyAgentsBlock(t *testing.T) {
 	yamlData := `
 version: "1"
 dispatch:
@@ -279,9 +281,9 @@ agents:
     slug: my-app-slug
 repos: {}
 `
-	cfg, err := ParseOrgConfig([]byte(yamlData))
-	require.NoError(t, err)
-	assert.Equal(t, "1", cfg.Version)
+	_, err := ParseOrgConfig([]byte(yamlData))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "legacy role/name/slug format")
 }
 
 func TestNewOrgConfig_WithInferenceProvider(t *testing.T) {
@@ -1062,4 +1064,615 @@ func TestNewPerRepoConfig_CreateIssuesDefaults(t *testing.T) {
 	cfg := NewPerRepoConfig(nil, "my-org/my-repo")
 	require.NotNil(t, cfg.CreateIssues)
 	assert.Equal(t, []string{"my-org/my-repo", "fullsend-ai/fullsend"}, cfg.CreateIssues.AllowTargets.Repos)
+}
+
+// --- AgentEntry tests ---
+
+func TestAgentEntry_UnmarshalYAML_StringShorthand(t *testing.T) {
+	yamlData := `
+agents:
+  - https://raw.githubusercontent.com/fullsend-ai/agents/abc123/harness/triage.yaml#sha256=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+`
+	var out struct {
+		Agents []AgentEntry `yaml:"agents"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(yamlData), &out))
+	require.Len(t, out.Agents, 1)
+	assert.Empty(t, out.Agents[0].Name)
+	assert.Contains(t, out.Agents[0].Source, "triage.yaml")
+}
+
+func TestAgentEntry_UnmarshalYAML_ObjectForm(t *testing.T) {
+	yamlData := `
+agents:
+  - name: lint
+    source: harness/my-linter.yaml
+`
+	var out struct {
+		Agents []AgentEntry `yaml:"agents"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(yamlData), &out))
+	require.Len(t, out.Agents, 1)
+	assert.Equal(t, "lint", out.Agents[0].Name)
+	assert.Equal(t, "harness/my-linter.yaml", out.Agents[0].Source)
+}
+
+func TestAgentEntry_UnmarshalYAML_MixedForms(t *testing.T) {
+	yamlData := `
+agents:
+  - https://example.com/harness/triage.yaml#sha256=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+  - name: lint
+    source: harness/my-linter.yaml
+`
+	var out struct {
+		Agents []AgentEntry `yaml:"agents"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(yamlData), &out))
+	require.Len(t, out.Agents, 2)
+	assert.Empty(t, out.Agents[0].Name)
+	assert.Equal(t, "lint", out.Agents[1].Name)
+}
+
+func TestAgentEntry_UnmarshalYAML_InvalidNodeType(t *testing.T) {
+	yamlData := `
+agents:
+  - [not, a, string, or, mapping]
+`
+	var out struct {
+		Agents []AgentEntry `yaml:"agents"`
+	}
+	err := yaml.Unmarshal([]byte(yamlData), &out)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a string or mapping")
+}
+
+func TestAgentEntry_DerivedName_ExplicitName(t *testing.T) {
+	e := AgentEntry{Name: "custom", Source: "harness/triage.yaml"}
+	assert.Equal(t, "custom", e.DerivedName())
+}
+
+func TestAgentEntry_DerivedName_DerivedFromFilename(t *testing.T) {
+	e := AgentEntry{Source: "harness/triage.yaml"}
+	assert.Equal(t, "triage", e.DerivedName())
+}
+
+func TestAgentEntry_DerivedName_DerivedFromURL(t *testing.T) {
+	e := AgentEntry{Source: "https://raw.githubusercontent.com/fullsend-ai/agents/abc123/harness/triage.yaml#sha256=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"}
+	assert.Equal(t, "triage", e.DerivedName())
+}
+
+func TestAgentEntry_DerivedName_DerivedFromLocalPath(t *testing.T) {
+	e := AgentEntry{Source: "my-linter.yaml"}
+	assert.Equal(t, "my-linter", e.DerivedName())
+}
+
+func TestAgentEntry_MarshalRoundTrip(t *testing.T) {
+	original := []AgentEntry{
+		{Source: "https://example.com/harness/triage.yaml#sha256=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"},
+		{Name: "lint", Source: "harness/my-linter.yaml"},
+	}
+	data, err := yaml.Marshal(struct {
+		Agents []AgentEntry `yaml:"agents"`
+	}{Agents: original})
+	require.NoError(t, err)
+
+	var parsed struct {
+		Agents []AgentEntry `yaml:"agents"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &parsed))
+	require.Len(t, parsed.Agents, 2)
+	assert.Equal(t, original[0].Source, parsed.Agents[0].Source)
+	assert.Equal(t, original[1].Name, parsed.Agents[1].Name)
+	assert.Equal(t, original[1].Source, parsed.Agents[1].Source)
+}
+
+// --- Agent entry validation tests ---
+
+func TestValidateAgentEntries_Valid(t *testing.T) {
+	allowlist := []string{"https://raw.githubusercontent.com/fullsend-ai/agents/"}
+	agents := []AgentEntry{
+		{Source: "https://raw.githubusercontent.com/fullsend-ai/agents/abc123/harness/triage.yaml#sha256=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"},
+		{Name: "lint", Source: "harness/my-linter.yaml"},
+	}
+	cfg := &OrgConfig{
+		Version:                "1",
+		Dispatch:               DispatchConfig{Platform: "github-actions"},
+		Defaults:               RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:                 agents,
+		AllowedRemoteResources: allowlist,
+	}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestValidateAgentEntries_DuplicateName(t *testing.T) {
+	agents := []AgentEntry{
+		{Source: "harness/triage.yaml"},
+		{Source: "other/triage.yaml"},
+	}
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:   agents,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate agent name")
+}
+
+func TestValidateAgentEntries_DuplicateNameCaseInsensitive(t *testing.T) {
+	agents := []AgentEntry{
+		{Name: "Triage", Source: "harness/a.yaml"},
+		{Name: "triage", Source: "harness/b.yaml"},
+	}
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:   agents,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate agent name")
+}
+
+func TestValidateAgentEntries_MissingHash(t *testing.T) {
+	allowlist := []string{"https://raw.githubusercontent.com/fullsend-ai/agents/"}
+	agents := []AgentEntry{
+		{Source: "https://raw.githubusercontent.com/fullsend-ai/agents/abc123/harness/triage.yaml"},
+	}
+	cfg := &OrgConfig{
+		Version:                "1",
+		Dispatch:               DispatchConfig{Platform: "github-actions"},
+		Defaults:               RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:                 agents,
+		AllowedRemoteResources: allowlist,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "#sha256=")
+}
+
+func TestValidateAgentEntries_NonHTTPS(t *testing.T) {
+	agents := []AgentEntry{
+		{Source: "http://example.com/harness/triage.yaml#sha256=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"},
+	}
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:   agents,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "https")
+}
+
+func TestValidateAgentEntries_URLNotInAllowlist(t *testing.T) {
+	allowlist := []string{"https://raw.githubusercontent.com/fullsend-ai/fullsend/"}
+	agents := []AgentEntry{
+		{Source: "https://raw.githubusercontent.com/other-org/repo/abc123/harness/triage.yaml#sha256=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"},
+	}
+	cfg := &OrgConfig{
+		Version:                "1",
+		Dispatch:               DispatchConfig{Platform: "github-actions"},
+		Defaults:               RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:                 agents,
+		AllowedRemoteResources: allowlist,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not covered by allowed_remote_resources")
+}
+
+func TestValidateAgentEntries_PathTraversal(t *testing.T) {
+	agents := []AgentEntry{
+		{Source: "../../../etc/passwd"},
+	}
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:   agents,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "path traversal")
+}
+
+func TestValidateAgentEntries_EmptySource(t *testing.T) {
+	agents := []AgentEntry{
+		{Name: "empty"},
+	}
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:   agents,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "source must not be empty")
+}
+
+func TestValidateAgentEntries_LocalPathAcceptedWithoutHash(t *testing.T) {
+	agents := []AgentEntry{
+		{Source: "harness/my-agent.yaml"},
+	}
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:   agents,
+	}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestValidateAgentEntries_InvalidHashLength(t *testing.T) {
+	allowlist := []string{"https://raw.githubusercontent.com/fullsend-ai/agents/"}
+	agents := []AgentEntry{
+		{Source: "https://raw.githubusercontent.com/fullsend-ai/agents/abc/harness/triage.yaml#sha256=tooshort"},
+	}
+	cfg := &OrgConfig{
+		Version:                "1",
+		Dispatch:               DispatchConfig{Platform: "github-actions"},
+		Defaults:               RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:                 agents,
+		AllowedRemoteResources: allowlist,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "integrity fragment")
+}
+
+func TestValidateAgentEntries_InvalidHashChars(t *testing.T) {
+	allowlist := []string{"https://raw.githubusercontent.com/fullsend-ai/agents/"}
+	agents := []AgentEntry{
+		{Source: "https://raw.githubusercontent.com/fullsend-ai/agents/abc/harness/triage.yaml#sha256=zzzzzz1234567890abcdef1234567890abcdef1234567890abcdef1234567890"},
+	}
+	cfg := &OrgConfig{
+		Version:                "1",
+		Dispatch:               DispatchConfig{Platform: "github-actions"},
+		Defaults:               RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:                 agents,
+		AllowedRemoteResources: allowlist,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "integrity fragment")
+}
+
+func TestValidateAgentEntries_EmptyDerivedName(t *testing.T) {
+	agents := []AgentEntry{
+		{Source: ".yaml"},
+	}
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:   agents,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "is invalid")
+}
+
+func TestValidateAgentEntries_MixedCaseHTTP_Rejected(t *testing.T) {
+	agents := []AgentEntry{
+		{Source: "HTTP://example.com/harness/triage.yaml"},
+	}
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:   agents,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "https")
+}
+
+func TestValidateAgentEntries_UnsupportedScheme_Rejected(t *testing.T) {
+	agents := []AgentEntry{
+		{Source: "ftp://example.com/harness/triage.yaml"},
+	}
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:   agents,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported URL scheme")
+}
+
+func TestValidateAgentEntries_BackslashPath_Rejected(t *testing.T) {
+	agents := []AgentEntry{
+		{Name: "triage", Source: "harness\\triage.yaml"},
+	}
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:   agents,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "backslash")
+}
+
+func TestValidateAgentEntries_AbsolutePath_Rejected(t *testing.T) {
+	agents := []AgentEntry{
+		{Source: "/etc/agents/triage.yaml"},
+	}
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:   agents,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute paths")
+}
+
+func TestValidateAgentEntries_DegenerateName_Rejected(t *testing.T) {
+	agents := []AgentEntry{
+		{Source: "#sha256=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"},
+	}
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Agents:   agents,
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "is invalid")
+}
+
+// --- OrgConfig agents field tests ---
+
+func TestOrgConfig_ParseYAML_WithAgents(t *testing.T) {
+	yamlData := `
+version: "1"
+dispatch:
+  platform: github-actions
+defaults:
+  roles:
+    - fullsend
+  max_implementation_retries: 2
+agents:
+  - https://raw.githubusercontent.com/fullsend-ai/agents/abc123/harness/triage.yaml#sha256=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+  - name: lint
+    source: harness/my-linter.yaml
+repos: {}
+allowed_remote_resources:
+  - https://raw.githubusercontent.com/fullsend-ai/agents/
+`
+	cfg, err := ParseOrgConfig([]byte(yamlData))
+	require.NoError(t, err)
+	require.Len(t, cfg.Agents, 2)
+	assert.Contains(t, cfg.Agents[0].Source, "triage.yaml")
+	assert.Equal(t, "lint", cfg.Agents[1].Name)
+	assert.Equal(t, "harness/my-linter.yaml", cfg.Agents[1].Source)
+}
+
+func TestOrgConfig_ParseYAML_WithoutAgents(t *testing.T) {
+	yamlData := `
+version: "1"
+dispatch:
+  platform: github-actions
+defaults:
+  roles:
+    - fullsend
+  max_implementation_retries: 2
+repos: {}
+`
+	cfg, err := ParseOrgConfig([]byte(yamlData))
+	require.NoError(t, err)
+	assert.Empty(t, cfg.Agents)
+}
+
+func TestOrgConfig_Marshal_WithAgents(t *testing.T) {
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Repos:    map[string]RepoConfig{},
+		Agents: []AgentEntry{
+			{Source: "https://example.com/triage.yaml#sha256=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"},
+			{Name: "lint", Source: "harness/lint.yaml"},
+		},
+	}
+	data, err := cfg.Marshal()
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "agents:")
+	assert.Contains(t, string(data), "triage.yaml")
+	assert.Contains(t, string(data), "lint")
+}
+
+func TestOrgConfig_Marshal_WithoutAgents_OmitsKey(t *testing.T) {
+	cfg := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Repos:    map[string]RepoConfig{},
+	}
+	data, err := cfg.Marshal()
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "agents:")
+}
+
+// --- PerRepoConfig agents and allowlist tests ---
+
+func TestPerRepoConfig_ParseYAML_WithAgentsAndAllowlist(t *testing.T) {
+	yamlData := `
+version: "1"
+roles:
+  - fullsend
+  - triage
+agents:
+  - https://raw.githubusercontent.com/fullsend-ai/agents/abc123/harness/triage.yaml#sha256=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+  - name: lint
+    source: harness/lint.yaml
+allowed_remote_resources:
+  - https://raw.githubusercontent.com/fullsend-ai/agents/
+`
+	cfg, err := ParsePerRepoConfig([]byte(yamlData))
+	require.NoError(t, err)
+	require.Len(t, cfg.Agents, 2)
+	assert.Contains(t, cfg.Agents[0].Source, "triage.yaml")
+	assert.Equal(t, "lint", cfg.Agents[1].Name)
+	assert.Equal(t, []string{"https://raw.githubusercontent.com/fullsend-ai/agents/"}, cfg.AllowedRemoteResources)
+}
+
+func TestPerRepoConfig_Validate_WithAgents(t *testing.T) {
+	cfg := &PerRepoConfig{
+		Version: "1",
+		Roles:   []string{"fullsend"},
+		Agents: []AgentEntry{
+			{Source: "harness/my-agent.yaml"},
+		},
+	}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestPerRepoConfig_Validate_AgentDuplicate(t *testing.T) {
+	cfg := &PerRepoConfig{
+		Version: "1",
+		Roles:   []string{"fullsend"},
+		Agents: []AgentEntry{
+			{Source: "harness/triage.yaml"},
+			{Source: "other/triage.yaml"},
+		},
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate agent name")
+}
+
+func TestNewPerRepoConfig_AllowedRemoteResources(t *testing.T) {
+	cfg := NewPerRepoConfig(nil, "")
+	assert.Equal(t, DefaultAllowedRemoteResources(), cfg.AllowedRemoteResources)
+}
+
+func TestPerRepoConfig_Marshal_WithAgents(t *testing.T) {
+	cfg := &PerRepoConfig{
+		Version: "1",
+		Roles:   []string{"fullsend"},
+		Agents: []AgentEntry{
+			{Source: "harness/my-agent.yaml"},
+		},
+		AllowedRemoteResources: []string{"https://example.com/"},
+	}
+	data, err := cfg.Marshal()
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "agents:")
+	assert.Contains(t, string(data), "my-agent.yaml")
+	assert.Contains(t, string(data), "allowed_remote_resources:")
+}
+
+// --- DefaultAgentEntries tests ---
+
+func TestDefaultAgentEntries_WithBuilder(t *testing.T) {
+	builder := func(name, sha string) (string, error) {
+		return "https://example.com/" + sha + "/harness/" + name + ".yaml#sha256=0000000000000000000000000000000000000000000000000000000000000000", nil
+	}
+	entries, err := DefaultAgentEntries([]string{"triage", "code"}, "abc123", builder)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Contains(t, entries[0].Source, "triage.yaml")
+	assert.Contains(t, entries[1].Source, "code.yaml")
+	assert.Equal(t, "triage", entries[0].DerivedName())
+	assert.Equal(t, "code", entries[1].DerivedName())
+}
+
+func TestDefaultAgentEntries_NilBuilder(t *testing.T) {
+	entries, err := DefaultAgentEntries([]string{"triage"}, "abc123", nil)
+	require.NoError(t, err)
+	assert.Nil(t, entries)
+}
+
+func TestDefaultAgentEntries_BuilderError(t *testing.T) {
+	builder := func(name, sha string) (string, error) {
+		return "", fmt.Errorf("build failed for %s", name)
+	}
+	_, err := DefaultAgentEntries([]string{"triage"}, "abc123", builder)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "build failed for triage")
+}
+
+func TestDefaultAgentEntries_EmptySHA(t *testing.T) {
+	builder := func(name, sha string) (string, error) {
+		return "", nil
+	}
+	entries, err := DefaultAgentEntries([]string{"triage"}, "", builder)
+	require.NoError(t, err)
+	assert.Nil(t, entries)
+}
+
+// --- DefaultAllowedRemoteResources tests ---
+
+func TestDefaultAllowedRemoteResources(t *testing.T) {
+	resources := DefaultAllowedRemoteResources()
+	assert.Len(t, resources, 2)
+	assert.Contains(t, resources, "https://raw.githubusercontent.com/fullsend-ai/fullsend/")
+	assert.Contains(t, resources, "https://raw.githubusercontent.com/fullsend-ai/agents/")
+}
+
+func TestNewOrgConfig_UsesDefaultAllowedRemoteResources(t *testing.T) {
+	cfg := NewOrgConfig(nil, nil, nil, "", "")
+	assert.Equal(t, DefaultAllowedRemoteResources(), cfg.AllowedRemoteResources)
+}
+
+func TestPerRepoConfig_RoundTrip_WithAgents(t *testing.T) {
+	original := &PerRepoConfig{
+		Version: "1",
+		Roles:   []string{"fullsend", "triage"},
+		Agents: []AgentEntry{
+			{Source: "https://example.com/harness/triage.yaml#sha256=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"},
+			{Name: "lint", Source: "harness/lint.yaml"},
+		},
+		AllowedRemoteResources: []string{"https://example.com/"},
+	}
+	data, err := original.Marshal()
+	require.NoError(t, err)
+
+	headerEnd := strings.Index(string(data), "version:")
+	require.True(t, headerEnd > 0)
+
+	parsed, err := ParsePerRepoConfig(data[headerEnd:])
+	require.NoError(t, err)
+	require.Len(t, parsed.Agents, 2)
+	assert.Equal(t, original.Agents[0].Source, parsed.Agents[0].Source)
+	assert.Equal(t, original.Agents[1].Name, parsed.Agents[1].Name)
+	assert.Equal(t, original.AllowedRemoteResources, parsed.AllowedRemoteResources)
+}
+
+func TestOrgConfig_RoundTrip_WithAgents(t *testing.T) {
+	original := &OrgConfig{
+		Version:  "1",
+		Dispatch: DispatchConfig{Platform: "github-actions"},
+		Defaults: RepoDefaults{Roles: []string{"fullsend"}, MaxImplementationRetries: 2},
+		Repos:    map[string]RepoConfig{},
+		Agents: []AgentEntry{
+			{Source: "https://example.com/harness/triage.yaml#sha256=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"},
+			{Name: "lint", Source: "harness/lint.yaml"},
+		},
+		AllowedRemoteResources: []string{"https://example.com/"},
+	}
+	data, err := original.Marshal()
+	require.NoError(t, err)
+
+	headerEnd := strings.Index(string(data), "version:")
+	require.True(t, headerEnd > 0)
+
+	parsed, err := ParseOrgConfig(data[headerEnd:])
+	require.NoError(t, err)
+	require.Len(t, parsed.Agents, 2)
+	assert.Equal(t, original.Agents[0].Source, parsed.Agents[0].Source)
+	assert.Equal(t, original.Agents[1].Name, parsed.Agents[1].Name)
+	assert.Equal(t, original.AllowedRemoteResources, parsed.AllowedRemoteResources)
 }

--- a/internal/harness/compose.go
+++ b/internal/harness/compose.go
@@ -52,8 +52,10 @@ type ComposeOpts struct {
 	// If empty, ResolveForge is a no-op.
 	ForgePlatform string
 
-	// OrgAllowlist is the org-level allowed_remote_resources from config.yaml.
-	// Base URLs must match a prefix in this list.
+	// OrgAllowlist is the allowed_remote_resources from config.yaml (org-level
+	// or per-repo-level). Base URLs and agent source URLs must match a prefix
+	// in this list. Callers should merge org and per-repo allowlists when both
+	// are available.
 	OrgAllowlist []string
 
 	// ForgeClient enables full-directory skill fetches from URL bases.

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -2,9 +2,7 @@ package harness
 
 import (
 	"fmt"
-	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -12,6 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/fullsend-ai/fullsend/internal/forge"
+	"github.com/fullsend-ai/fullsend/internal/urlutil"
 )
 
 var (
@@ -683,13 +682,13 @@ func (h *Harness) ValidateAllowedRemoteResources(orgAllowlist []string) error {
 		if strings.Contains(strings.ToLower(entry), "%25") {
 			return fmt.Errorf("allowed_remote_resources[%d]: %q contains double-encoded sequence", i, entry)
 		}
-		normEntry, entryOK := normalizeURLPath(strings.ToLower(entry))
+		normEntry, entryOK := urlutil.NormalizeURLPath(strings.ToLower(entry))
 		if !entryOK {
 			return fmt.Errorf("allowed_remote_resources[%d]: %q cannot be normalized", i, entry)
 		}
 		covered := false
 		for _, orgEntry := range orgAllowlist {
-			normOrg, orgOK := normalizeURLPath(strings.ToLower(orgEntry))
+			normOrg, orgOK := urlutil.NormalizeURLPath(strings.ToLower(orgEntry))
 			if !orgOK {
 				continue
 			}
@@ -829,12 +828,12 @@ func (h *Harness) MatchingAllowedPrefix(rawURL string) string {
 	if strings.Contains(lower, "%25") {
 		return ""
 	}
-	normalized, ok := normalizeURLPath(lower)
+	normalized, ok := urlutil.NormalizeURLPath(lower)
 	if !ok {
 		return ""
 	}
 	for _, prefix := range h.AllowedRemoteResources {
-		normPrefix, prefixOK := normalizeURLPath(strings.ToLower(prefix))
+		normPrefix, prefixOK := urlutil.NormalizeURLPath(strings.ToLower(prefix))
 		if !prefixOK {
 			continue
 		}
@@ -848,47 +847,5 @@ func (h *Harness) MatchingAllowedPrefix(rawURL string) string {
 // MatchingAllowedPrefixInList checks if a URL matches any prefix in the given allowlist.
 // Returns the matching prefix or "" if none match. Standalone version of MatchingAllowedPrefix.
 func MatchingAllowedPrefixInList(rawURL string, allowlist []string) string {
-	lower := strings.ToLower(rawURL)
-	if strings.Contains(lower, "%25") {
-		return ""
-	}
-	normalized, ok := normalizeURLPath(lower)
-	if !ok {
-		return ""
-	}
-	for _, prefix := range allowlist {
-		normPrefix, prefixOK := normalizeURLPath(strings.ToLower(prefix))
-		if !prefixOK {
-			continue
-		}
-		if strings.HasPrefix(normalized, normPrefix) {
-			return prefix
-		}
-	}
-	return ""
-}
-
-// normalizeURLPath parses a URL, percent-decodes and cleans its path, and
-// returns the reconstructed URL string. Returns false if parsing fails.
-func normalizeURLPath(rawURL string) (string, bool) {
-	parsed, err := url.Parse(rawURL)
-	if err != nil {
-		return "", false
-	}
-	unescaped, err := url.PathUnescape(parsed.Path)
-	if err != nil {
-		return "", false
-	}
-	if strings.ContainsRune(unescaped, '\\') {
-		return "", false
-	}
-	rawPath := parsed.Path
-	parsed.Path = path.Clean(unescaped)
-	parsed.RawPath = ""
-	if parsed.Path == "." {
-		parsed.Path = "/"
-	} else if strings.HasSuffix(rawPath, "/") && !strings.HasSuffix(parsed.Path, "/") {
-		parsed.Path += "/"
-	}
-	return parsed.String(), true
+	return urlutil.MatchingAllowedPrefixInList(rawURL, allowlist)
 }

--- a/internal/harness/url.go
+++ b/internal/harness/url.go
@@ -1,31 +1,14 @@
 package harness
 
 import (
-	"net/url"
 	"path/filepath"
-	"strings"
+
+	"github.com/fullsend-ai/fullsend/internal/urlutil"
 )
 
 // IsURL returns true if s is a valid HTTPS URL suitable for remote resource references.
 func IsURL(s string) bool {
-	if s == "" {
-		return false
-	}
-	u, err := url.Parse(s)
-	if err != nil || u.Scheme != "https" {
-		return false
-	}
-	if u.Host == "" || u.User != nil {
-		return false
-	}
-	if u.Hostname() == "" {
-		return false
-	}
-	// Belt-and-suspenders: reject userinfo that url.Parse may not catch in all edge cases
-	if strings.Contains(u.Host, "@") {
-		return false
-	}
-	return true
+	return urlutil.IsURL(s)
 }
 
 // IsAbsPath returns true if s is an absolute file path.
@@ -42,22 +25,5 @@ func IsRelPath(s string) bool {
 // Returns the URL without the fragment, the hash value, and whether a valid hash was found.
 // The hash is normalized to lowercase; both "sha256=ABC..." and "sha256=abc..." are accepted.
 func ParseIntegrityHash(rawURL string) (cleanURL, hash string, hasHash bool) {
-	idx := strings.LastIndex(rawURL, "#")
-	if idx == -1 {
-		return rawURL, "", false
-	}
-	fragment := rawURL[idx+1:]
-	if !strings.HasPrefix(fragment, "sha256=") {
-		return rawURL, "", false
-	}
-	hash = strings.ToLower(strings.TrimPrefix(fragment, "sha256="))
-	if len(hash) != 64 {
-		return rawURL, "", false
-	}
-	for _, c := range hash {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
-			return rawURL, "", false
-		}
-	}
-	return rawURL[:idx], hash, true
+	return urlutil.ParseIntegrityHash(rawURL)
 }

--- a/internal/urlutil/urlutil.go
+++ b/internal/urlutil/urlutil.go
@@ -1,0 +1,105 @@
+// Package urlutil provides URL validation and integrity-hash utilities
+// shared by config (agent entry validation) and harness (remote resource
+// resolution) packages. It lives at the leaf of the import graph to
+// avoid the config → harness circular dependency.
+package urlutil
+
+import (
+	"net/url"
+	"path"
+	"strings"
+)
+
+// IsURL returns true if s is a valid HTTPS URL suitable for remote resource references.
+func IsURL(s string) bool {
+	if s == "" {
+		return false
+	}
+	u, err := url.Parse(s)
+	if err != nil || u.Scheme != "https" {
+		return false
+	}
+	if u.Host == "" || u.User != nil {
+		return false
+	}
+	if u.Hostname() == "" {
+		return false
+	}
+	if strings.Contains(u.Host, "@") {
+		return false
+	}
+	return true
+}
+
+// ParseIntegrityHash extracts the SHA256 hash from a URL fragment (#sha256=...).
+// Returns the URL without the fragment, the hash value, and whether a valid hash was found.
+// The hash is normalized to lowercase; both "sha256=ABC..." and "sha256=abc..." are accepted.
+func ParseIntegrityHash(rawURL string) (cleanURL, hash string, hasHash bool) {
+	idx := strings.LastIndex(rawURL, "#")
+	if idx == -1 {
+		return rawURL, "", false
+	}
+	fragment := rawURL[idx+1:]
+	if !strings.HasPrefix(fragment, "sha256=") {
+		return rawURL, "", false
+	}
+	hash = strings.ToLower(strings.TrimPrefix(fragment, "sha256="))
+	if len(hash) != 64 {
+		return rawURL, "", false
+	}
+	for _, c := range hash {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return rawURL, "", false
+		}
+	}
+	return rawURL[:idx], hash, true
+}
+
+// MatchingAllowedPrefixInList checks if a URL matches any prefix in the given allowlist.
+// Returns the matching prefix or "" if none match. Performs case-insensitive
+// comparison with percent-decoding and dot-segment cleaning.
+func MatchingAllowedPrefixInList(rawURL string, allowlist []string) string {
+	lower := strings.ToLower(rawURL)
+	if strings.Contains(lower, "%25") {
+		return ""
+	}
+	normalized, ok := NormalizeURLPath(lower)
+	if !ok {
+		return ""
+	}
+	for _, prefix := range allowlist {
+		normPrefix, prefixOK := NormalizeURLPath(strings.ToLower(prefix))
+		if !prefixOK {
+			continue
+		}
+		if strings.HasPrefix(normalized, normPrefix) {
+			return prefix
+		}
+	}
+	return ""
+}
+
+// NormalizeURLPath parses a URL, percent-decodes and cleans its path, and
+// returns the reconstructed URL string. Returns false if parsing fails.
+func NormalizeURLPath(rawURL string) (string, bool) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", false
+	}
+	unescaped, err := url.PathUnescape(parsed.Path)
+	if err != nil {
+		return "", false
+	}
+	if strings.ContainsRune(unescaped, '\\') {
+		return "", false
+	}
+	rawPath := parsed.Path
+	parsed.Path = path.Clean(unescaped)
+	parsed.RawPath = ""
+	if parsed.Path == "." {
+		parsed.Path = "/"
+	} else if strings.HasSuffix(rawPath, "/") && !strings.HasSuffix(parsed.Path, "/") {
+		parsed.Path += "/"
+	}
+	return parsed.String(), true
+}

--- a/internal/urlutil/urlutil_test.go
+++ b/internal/urlutil/urlutil_test.go
@@ -1,0 +1,192 @@
+package urlutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"valid https", "https://example.com/path/file.md", true},
+		{"valid https with port", "https://example.com:8443/path", true},
+		{"valid https with query", "https://example.com/path?q=1", true},
+		{"valid https with fragment", "https://example.com/path#sha256=abc", true},
+		{"http rejected", "http://example.com/path", false},
+		{"file scheme rejected", "file:///etc/passwd", false},
+		{"ftp rejected", "ftp://example.com/file", false},
+		{"empty string", "", false},
+		{"relative path", "agents/code.md", false},
+		{"absolute path", "/opt/agents/code.md", false},
+		{"empty host", "https:///path", false},
+		{"scheme only", "https://", false},
+		{"userinfo", "https://user:pass@example.com/path", false},
+		{"userinfo user only", "https://user@example.com/path", false},
+		{"plain text", "not a url at all", false},
+		{"just a word", "https", false},
+		{"at sign in host", "https://user@host.com/path", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsURL(tt.input))
+		})
+	}
+}
+
+func TestParseIntegrityHash(t *testing.T) {
+	validHash := "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+	tests := []struct {
+		name        string
+		input       string
+		wantURL     string
+		wantHash    string
+		wantHasHash bool
+	}{
+		{
+			name:        "valid hash",
+			input:       "https://example.com/file.md#sha256=" + validHash,
+			wantURL:     "https://example.com/file.md",
+			wantHash:    validHash,
+			wantHasHash: true,
+		},
+		{
+			name:        "valid hash with query params",
+			input:       "https://example.com/file.md?v=1#sha256=" + validHash,
+			wantURL:     "https://example.com/file.md?v=1",
+			wantHash:    validHash,
+			wantHasHash: true,
+		},
+		{
+			name:        "no fragment",
+			input:       "https://example.com/file.md",
+			wantURL:     "https://example.com/file.md",
+			wantHash:    "",
+			wantHasHash: false,
+		},
+		{
+			name:        "non-sha256 fragment",
+			input:       "https://example.com/file.md#section1",
+			wantURL:     "https://example.com/file.md#section1",
+			wantHash:    "",
+			wantHasHash: false,
+		},
+		{
+			name:        "wrong prefix",
+			input:       "https://example.com/file.md#md5=abc123",
+			wantURL:     "https://example.com/file.md#md5=abc123",
+			wantHash:    "",
+			wantHasHash: false,
+		},
+		{
+			name:        "hash too short",
+			input:       "https://example.com/file.md#sha256=" + validHash[:63],
+			wantURL:     "https://example.com/file.md#sha256=" + validHash[:63],
+			wantHash:    "",
+			wantHasHash: false,
+		},
+		{
+			name:        "hash too long",
+			input:       "https://example.com/file.md#sha256=" + validHash + "a",
+			wantURL:     "https://example.com/file.md#sha256=" + validHash + "a",
+			wantHash:    "",
+			wantHasHash: false,
+		},
+		{
+			name:        "uppercase hex normalized",
+			input:       "https://example.com/file.md#sha256=ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+			wantURL:     "https://example.com/file.md",
+			wantHash:    "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+			wantHasHash: true,
+		},
+		{
+			name:        "empty hash value",
+			input:       "https://example.com/file.md#sha256=",
+			wantURL:     "https://example.com/file.md#sha256=",
+			wantHash:    "",
+			wantHasHash: false,
+		},
+		{
+			name:        "invalid hex chars",
+			input:       "https://example.com/file.md#sha256=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+			wantURL:     "https://example.com/file.md#sha256=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+			wantHash:    "",
+			wantHasHash: false,
+		},
+		{
+			name:        "relative path unchanged",
+			input:       "agents/code.md",
+			wantURL:     "agents/code.md",
+			wantHash:    "",
+			wantHasHash: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, gotHash, gotHasHash := ParseIntegrityHash(tt.input)
+			assert.Equal(t, tt.wantURL, gotURL)
+			assert.Equal(t, tt.wantHash, gotHash)
+			assert.Equal(t, tt.wantHasHash, gotHasHash)
+		})
+	}
+}
+
+func TestMatchingAllowedPrefixInList(t *testing.T) {
+	allowlist := []string{
+		"https://example.com/skills/",
+		"https://cdn.example.com/policies/",
+	}
+
+	tests := []struct {
+		name      string
+		url       string
+		allowlist []string
+		want      string
+	}{
+		{"matching first prefix", "https://example.com/skills/summarize.md", allowlist, "https://example.com/skills/"},
+		{"matching second prefix", "https://cdn.example.com/policies/readonly.yaml", allowlist, "https://cdn.example.com/policies/"},
+		{"no match", "https://evil.com/skills/summarize.md", allowlist, ""},
+		{"path traversal rejected", "https://example.com/skills/../evil/payload", allowlist, ""},
+		{"case insensitive match", "https://Example.Com/Skills/test.md", []string{"https://example.com/skills/"}, "https://example.com/skills/"},
+		{"percent-encoded traversal rejected", "https://example.com/skills/%2e%2e/evil", allowlist, ""},
+		{"double encoding rejected", "https://example.com/skills/%252e%252e/evil", allowlist, ""},
+		{"empty allowlist", "https://example.com/skills/test.md", nil, ""},
+		{"empty URL", "", allowlist, ""},
+		{"invalid prefix skipped", "https://example.com/skills/test.md", []string{"://bad", "https://example.com/skills/"}, "https://example.com/skills/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, MatchingAllowedPrefixInList(tt.url, tt.allowlist))
+		})
+	}
+}
+
+func TestNormalizeURLPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		want   string
+		wantOK bool
+	}{
+		{"simple path", "https://example.com/path/file.md", "https://example.com/path/file.md", true},
+		{"dot segment cleaned", "https://example.com/a/../b/file.md", "https://example.com/b/file.md", true},
+		{"trailing slash preserved", "https://example.com/path/", "https://example.com/path/", true},
+		{"percent encoded path", "https://example.com/path%20with%20spaces/file.md", "https://example.com/path%20with%20spaces/file.md", true},
+		{"backslash rejected", "https://example.com/path\\file.md", "", false},
+		{"dot only path", "https://example.com/.", "https://example.com/", true},
+		{"relative path", "agents/code.md", "agents/code.md", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := NormalizeURLPath(tt.input)
+			assert.Equal(t, tt.wantOK, ok)
+			if ok {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of [ADR 0058](docs/ADRs/0058-agent-registration.md) — config schema for agent registration.

- Adds `AgentEntry` type with custom YAML unmarshaler supporting string shorthand (`source-url`) and object form (`{name, source}`)
- Adds `Agents` and `AllowedRemoteResources` fields to both `OrgConfig` and `PerRepoConfig`
- Validates URL entries require `#sha256=` integrity fragment, HTTPS scheme, and allowlist prefix
- Validates local path entries reject `..` traversal
- Validates agent names (derived from filename) are unique
- Rejects legacy `role/name/slug` agent entries with clear error (previously silently ignored)
- Seeds `DefaultAllowedRemoteResources()` in `NewPerRepoConfig`
- Adds `DefaultAgentEntries()` builder for install-time default URL computation
- 40+ new tests covering parse/marshal round-trip, validation rules, name derivation, and defaults

This is the foundation PR — [Phase 2 (CLI)](docs/plans/agent-registration.md#phase-2-fullsend-agent-cli-subcommand) and [Phase 3 (runtime resolution)](docs/plans/agent-registration.md#phase-3-runtime-agent-resolution-in-fullsend-run) can begin in parallel after this merges.

## Test plan

- [x] All existing `internal/config` tests pass (including updated legacy agents test)
- [x] All existing `internal/harness` tests pass
- [x] Full `go build ./...` succeeds
- [x] New tests cover: string shorthand parsing, object form parsing, mixed forms, AgentName derivation (explicit, filename, URL), marshal round-trip, duplicate name rejection, missing hash rejection, non-HTTPS rejection, allowlist enforcement, path traversal rejection, empty source rejection, invalid hash length/chars, per-repo agents/allowlist, DefaultAgentEntries builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)