### PR TITLE
feat(agents): add action-hints footer to review, triage, and fix comments

### DIFF
--- a/internal/scaffold/fullsend-repo/agents/triage.md
+++ b/internal/scaffold/fullsend-repo/agents/triage.md
@@ -313,3 +313,11 @@ Information is sufficient for a developer to investigate and fix.
 - Do not present unverified assumptions with certainty. Convey uncertainty when appropriate.
 - Write in second person ("you") addressing the reporter. Do not use first person ("I") — the comment is from the triage system, not an individual.
 - If you include `label_actions`, the pipeline appends your label reason to the comment automatically — do not include label justifications in the `comment` field yourself.
+- **Action hints footer (sufficient action only):** When `action` is `sufficient`, append the following footer to the end of the `comment` field. Omit it for all other actions (`insufficient`, `duplicate`, `prerequisites`, `question`).
+
+  ```markdown
+  ---
+  **Next steps:**
+  - `/fs-code` — agent creates a PR to implement this issue
+  - `/fs-code <your instruction>` — agent implements with your specific guidance
+  ```

--- a/internal/scaffold/fullsend-repo/scripts/process-fix-result-test.py
+++ b/internal/scaffold/fullsend-repo/scripts/process-fix-result-test.py
@@ -165,6 +165,19 @@ class TestBuildSummaryBody(unittest.TestCase):
         self.assertIn("**typo in docs**:", body)
         self.assertNotIn("(`", body)
 
+    def test_action_hints_footer_present(self):
+        data = {
+            "summary": "Fixed.",
+            "tests_passed": True,
+            "actions": [
+                {"type": "fix", "finding": "bug", "description": "Fixed"},
+            ],
+        }
+        body = build_summary_body(data)
+        self.assertIn("**Next steps:**", body)
+        self.assertIn("/fs-review", body)
+        self.assertIn("/fs-fix", body)
+
 
 post_summary = mod.post_summary
 MAX_COMMENT_LENGTH = mod.MAX_COMMENT_LENGTH

--- a/internal/scaffold/fullsend-repo/scripts/process-fix-result.py
+++ b/internal/scaffold/fullsend-repo/scripts/process-fix-result.py
@@ -89,6 +89,14 @@ def build_summary_body(data):
         sections.append(dp_text)
 
     sections.append(
+        "\n---\n"
+        "**Next steps:**\n"
+        "- `/fs-review` — request a re-review of the changes\n"
+        "- `/fs-fix <your instruction>` — run another fix pass with specific guidance\n"
+        "- Push commits directly — review re-runs automatically on push"
+    )
+
+    sections.append(
         '\n<sub>Updated by <a href="https://github.com/fullsend-ai/fullsend">'
         "fullsend</a> fix agent</sub>"
     )

--- a/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
@@ -725,8 +725,21 @@ where `[open]` = `<` + `!--` and `[close]` = `--` + `>`.
   section. If there are no findings at all, set the body to
   the hidden SHA comment followed by a newline and "Looks good to me"
   — omit the `## Review` header and `### Findings` section entirely.
-- **No footer.** Do not repeat the outcome or include boilerplate
-  about pushes clearing the review.
+- **No general footer.** Do not repeat the outcome or include
+  boilerplate about pushes clearing the review. **Exception:** for
+  `request-changes` outcomes only, append an action-hints footer
+  after the findings:
+
+  ```markdown
+  ---
+  **Next steps:**
+  - `/fs-fix` — agent addresses review findings automatically
+  - `/fs-fix <your instruction>` — agent fixes with your specific guidance
+  - Push commits directly — review re-runs automatically on push
+  - `/fs-fix-stop` — disable automatic fix runs for this PR
+  ```
+
+  Omit this footer for `approve`, `comment`, and `reject` outcomes.
 
 If `PRIOR_REVIEW_PROVENANCE` starts with `unverifiable-`, include an
 info-level finding in the review output:


### PR DESCRIPTION
## Summary

- Add "Next steps" footer to review comments on `request-changes` outcomes, showing `/fs-fix`, `/fs-fix <instruction>`, push, and `/fs-fix-stop`
- Add "Next steps" footer to triage comments on `sufficient` action, showing `/fs-code` and `/fs-code <instruction>`
- Add "Next steps" footer to fix agent summary comments, showing `/fs-review`, `/fs-fix <instruction>`, and push
- Add test for fix agent footer presence

Closes #1789

## Test plan

- [x] `process-fix-result-test.py` passes (27 tests)
- [ ] Deploy to staging, trigger a review with `request-changes` outcome — verify footer appears
- [ ] Trigger a triage with `sufficient` action — verify footer appears
- [ ] Trigger a fix agent run — verify footer appears
- [ ] Verify footer does NOT appear on `approve`, `comment`, `reject`, `insufficient`, `duplicate`, `prerequisites`, `question` outcomes

🤖 Generated with [Claude Code](https://claude.com/claude-code)