### PR TITLE
fix(github): detect primary rate limits returned as 403

### DIFF
--- a/e2e/admin/lock_test.go
+++ b/e2e/admin/lock_test.go
@@ -5,10 +5,12 @@ package admin
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/fullsend-ai/fullsend/internal/forge"
+	gh "github.com/fullsend-ai/fullsend/internal/forge/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -134,4 +136,48 @@ func TestAcquireOrg_PropagatesErrors(t *testing.T) {
 	// should fall through to the timeout path.
 	_, err := acquireOrgWithClient(ctx, fake, "", "run-4", pool, 1*time.Second, t.Logf)
 	require.Error(t, err)
+}
+
+func TestAcquireOrg_RateLimitSkipsRemainingOrgs(t *testing.T) {
+	fake := forge.NewFakeClient()
+	ctx := context.Background()
+
+	pool := []string{"test-org-1", "test-org-2", "test-org-3"}
+
+	// Inject a rate-limit APIError. Every CreateRepo call will hit this.
+	fake.Errors = map[string]error{
+		"CreateRepo": &gh.APIError{
+			StatusCode: 403,
+			Message:    "API rate limit exceeded for user ID 12345",
+		},
+	}
+
+	// Track how many CreateRepo calls are made per polling round.
+	// With rate-limit detection, the first pass should try org-1,
+	// see the rate limit, and skip orgs 2 and 3 (they share the
+	// same user-level quota). Use a short timeout so we don't block.
+	var logs []string
+	logf := func(format string, args ...any) {
+		msg := fmt.Sprintf(format, args...)
+		logs = append(logs, msg)
+		t.Log(msg)
+	}
+
+	_, err := acquireOrg(ctx, fake, "", "run-5", pool, 2*time.Second, logf)
+	require.Error(t, err)
+
+	// Count how many orgs were attempted before the first "skipping
+	// remaining" message. Without the fix, all 3 would be attempted.
+	// With the fix, only 1 should be attempted before breaking out.
+	firstPassAttempts := 0
+	for _, msg := range logs {
+		if strings.Contains(msg, "skipping remaining") {
+			break
+		}
+		if strings.Contains(msg, "[org-pool] Trying to acquire") {
+			firstPassAttempts++
+		}
+	}
+	assert.Equal(t, 1, firstPassAttempts,
+		"should only attempt 1 org before detecting rate limit and skipping the rest")
 }

--- a/e2e/admin/lock_test.go
+++ b/e2e/admin/lock_test.go
@@ -163,7 +163,7 @@ func TestAcquireOrg_RateLimitSkipsRemainingOrgs(t *testing.T) {
 		t.Log(msg)
 	}
 
-	_, err := acquireOrg(ctx, fake, "", "run-5", pool, 2*time.Second, logf)
+	_, err := acquireOrgWithClient(ctx, fake, "", "run-5", pool, 2*time.Second, logf)
 	require.Error(t, err)
 
 	// Count how many orgs were attempted before the first "skipping

--- a/e2e/admin/testutil.go
+++ b/e2e/admin/testutil.go
@@ -191,6 +191,10 @@ func acquireOrgFromClient(ctx context.Context, client forge.Client, token, runID
 		acquired, err := tryCreateLock(ctx, client, org, runID, logf)
 		if err != nil {
 			logf("[org-pool] Error trying %s: %v", org, err)
+			if gh.IsRateLimitError(err) {
+				logf("[org-pool] Hit rate limit, skipping remaining orgs this round")
+				break
+			}
 			var apiErr *gh.APIError
 			if token != "" && errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnprocessableEntity {
 				if reclaimed := tryReclaimStaleLock(ctx, client, token, org, runID, logf); reclaimed {
@@ -224,6 +228,10 @@ func acquireOrgFromClient(ctx context.Context, client forge.Client, token, runID
 		for _, org := range shuffled {
 			acquired, err := tryCreateLock(ctx, client, org, runID, logf)
 			if err != nil {
+				if gh.IsRateLimitError(err) {
+					logf("[org-pool] Hit rate limit, skipping remaining orgs this round")
+					break
+				}
 				var apiErr *gh.APIError
 				if token != "" && errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnprocessableEntity {
 					if reclaimed := tryReclaimStaleLock(ctx, client, token, org, runID, logf); reclaimed {

--- a/e2e/admin/testutil.go
+++ b/e2e/admin/testutil.go
@@ -88,9 +88,15 @@ func acquireOrg(ctx context.Context, cfg envConfig, runID string, pool []string,
 		acquired, err := tryCreateLock(ctx, client, org, runID, logf)
 		if err != nil {
 			logf("[org-pool] Error trying %s: %v", org, err)
+			// Rate limits are per-user, not per-org — trying more orgs
+			// just burns quota and delays recovery. Break immediately.
+			if gh.IsRateLimitError(err) {
+				logf("[org-pool] Hit rate limit, skipping remaining orgs this round")
+				break
+			}
 			// Only attempt stale lock recovery for 422 errors (repo
-			// likely exists). Rate limits, auth failures, and network
-			// errors would just waste more API quota.
+			// likely exists). Auth failures and network errors would
+			// just waste more API quota.
 			var apiErr *gh.APIError
 			if token != "" && errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnprocessableEntity {
 				logf("[org-pool] 422 on %s — will check for stale lock", org)
@@ -139,6 +145,10 @@ func acquireOrg(ctx context.Context, cfg envConfig, runID string, pool []string,
 			acquired, err := tryCreateLock(ctx, client, org, runID, logf)
 			if err != nil {
 				logf("[org-pool] Error trying %s: %v", org, err)
+				if gh.IsRateLimitError(err) {
+					logf("[org-pool] Hit rate limit, skipping remaining orgs this round")
+					break
+				}
 				var apiErr *gh.APIError
 				if token != "" && errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnprocessableEntity {
 					logf("[org-pool] 422 on %s — will check for stale lock", org)

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -100,6 +100,24 @@ func (e *APIError) Unwrap() error {
 	return nil
 }
 
+// IsRateLimitError reports whether err is a GitHub rate-limit error
+// (primary 429, primary-as-403, or secondary 403). It unwraps the
+// error chain, so wrapped errors are detected too.
+func IsRateLimitError(err error) bool {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	if apiErr.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	if apiErr.StatusCode == http.StatusForbidden {
+		lower := strings.ToLower(apiErr.Message)
+		return strings.Contains(lower, "rate limit")
+	}
+	return false
+}
+
 const maxRetries = 5
 
 // do performs an HTTP request against the GitHub API with retry on rate limits.
@@ -175,9 +193,9 @@ func (c *LiveClient) do(ctx context.Context, method, path string, body any) (*ht
 }
 
 // isRetryable returns true for responses that should trigger a retry.
-// GitHub uses 429 for primary rate limits and 403 for secondary rate limits.
-// Secondary rate limits may include a Retry-After header, or may only be
-// identifiable by the response body containing "secondary rate limit".
+// GitHub uses 429 for primary rate limits and 403 for both primary and
+// secondary rate limits. Rate-limit 403s may include a Retry-After header,
+// or may only be identifiable by the response body containing "rate limit".
 // Server errors (500, 502, 503, 504) are also retried as transient failures.
 func isRetryable(resp *http.Response) (bool, []byte) {
 	if resp.StatusCode == http.StatusTooManyRequests {
@@ -194,12 +212,14 @@ func isRetryable(resp *http.Response) (bool, []byte) {
 			io.Copy(io.Discard, resp.Body)
 			return true, nil
 		}
-		// Check body for secondary rate limit without Retry-After header.
+		// Check body for rate limit indicators without Retry-After header.
+		// GitHub returns primary rate limits as 403 with "API rate limit
+		// exceeded" and secondary rate limits with "secondary rate limit".
 		data, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<16)) // 64KB max
 		if readErr != nil {
 			return false, nil
 		}
-		if strings.Contains(strings.ToLower(string(data)), "secondary rate limit") {
+		if strings.Contains(strings.ToLower(string(data)), "rate limit") {
 			return true, nil
 		}
 		// Not a rate limit — return the body so the caller can still use it.

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1869,6 +1870,83 @@ func TestIsTransientStatus(t *testing.T) {
 	for _, code := range nonTransient {
 		assert.False(t, isTransientStatus(code), "expected %d to not be transient", code)
 	}
+}
+
+func TestIsRetryable_PrimaryRateLimitAs403(t *testing.T) {
+	// GitHub sometimes returns primary rate limits as 403 with body
+	// containing "API rate limit exceeded" instead of 429. This must
+	// be detected as retryable.
+	body := `{"message":"API rate limit exceeded for user ID 12345."}`
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+	retryable, _ := isRetryable(resp)
+	assert.True(t, retryable, "403 with 'API rate limit exceeded' should be retryable")
+}
+
+func TestIsRateLimitError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "primary rate limit as 403",
+			err:      &APIError{StatusCode: 403, Message: "API rate limit exceeded for user ID 12345"},
+			expected: true,
+		},
+		{
+			name:     "secondary rate limit as 403",
+			err:      &APIError{StatusCode: 403, Message: "You have exceeded a secondary rate limit"},
+			expected: true,
+		},
+		{
+			name:     "429 too many requests",
+			err:      &APIError{StatusCode: 429, Message: "rate limit exceeded"},
+			expected: true,
+		},
+		{
+			name:     "403 not rate limit",
+			err:      &APIError{StatusCode: 403, Message: "Resource not accessible by integration"},
+			expected: false,
+		},
+		{
+			name:     "wrapped rate limit",
+			err:      fmt.Errorf("create repo: %w", &APIError{StatusCode: 403, Message: "API rate limit exceeded"}),
+			expected: true,
+		},
+		{
+			name:     "non-API error",
+			err:      fmt.Errorf("network error"),
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsRateLimitError(tt.err))
+		})
+	}
+}
+
+func TestIsRetryable_403NotRateLimit(t *testing.T) {
+	// A 403 that is NOT a rate limit (e.g. insufficient permissions)
+	// should not be retryable.
+	body := `{"message":"Resource not accessible by integration"}`
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+	retryable, returnedBody := isRetryable(resp)
+	assert.False(t, retryable, "403 without rate limit text should not be retryable")
+	assert.NotNil(t, returnedBody, "body should be returned for non-rate-limit 403")
 }
 
 func TestIsRetryable_ServerErrors(t *testing.T) {


### PR DESCRIPTION
## Summary

- Broadens `isRetryable()` to match `"rate limit"` in 403 response bodies (not just `"secondary rate limit"`), so `do()` applies the 60s+ backoff on primary rate limits that GitHub returns as 403 instead of 429.
- Adds `IsRateLimitError()` helper to detect rate-limit errors through wrapped error chains.
- Uses `IsRateLimitError()` in `acquireOrg()` to break out of the inner org loop on rate-limit errors — trying more orgs under the same per-user quota just burns API calls and prevents recovery.

## Context

[CI failure on #2766](https://github.com/fullsend-ai/fullsend/actions/runs/28399471367/job/84146727727?pr=2766) — the e2e test hit a primary rate limit returned as HTTP 403 with body `"API rate limit exceeded for user ID ..."`. Because `isRetryable()` only checked for `"secondary rate limit"`, `do()` never retried. Then `acquireOrg()` blasted through all 12 orgs in rapid succession (~20ms apart), each hitting the same user-level limit, repeating every 30 seconds for 10 minutes. The rapid-fire attempts prevented the rate limit from ever recovering.

Independent of #2764 (retry count + jitter) — that PR improves retry behavior for errors that `do()` *does* retry; this PR fixes the case where `do()` wasn't retrying at all.

## Test plan

- [x] `TestIsRetryable_PrimaryRateLimitAs403` — verifies 403 with "API rate limit exceeded" is retryable
- [x] `TestIsRetryable_403NotRateLimit` — verifies non-rate-limit 403s are still non-retryable
- [x] `TestIsRateLimitError` — verifies detection through wrapped errors, 429, primary-as-403, secondary-as-403
- [x] `TestAcquireOrg_RateLimitSkipsRemainingOrgs` — verifies only 1 org is attempted before breaking out on rate limit
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)