### PR TITLE
fix(#2298): remove retro/prioritize→fullsend role mapping in dispatch

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -371,7 +371,7 @@ jobs:
           if [[ -n "$ROLES" ]] && ! echo "$ROLES" | grep -Fqx "$STAGE_ROLE"; then
             # Backward compat: "fullsend" in roles implies retro + prioritize
             if [[ "$STAGE" =~ ^(retro|prioritize)$ ]] && echo "$ROLES" | grep -Fqx "fullsend"; then
-              :
+              echo "::notice::Stage '$STAGE' allowed via 'fullsend' role — if customizing roles, add '$STAGE' explicitly"
             else
               echo "::notice::Stage '$STAGE' skipped — role '$STAGE_ROLE' not in configured roles"
               echo "skipped=true" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -366,13 +366,17 @@ jobs:
           STAGE_ROLE="$STAGE"
           case "$STAGE" in
             code|fix) STAGE_ROLE="coder" ;;
-            retro|prioritize) STAGE_ROLE="fullsend" ;;
           esac
           ROLES=$(yq '.roles[]' .fullsend/config.yaml 2>/dev/null || echo "")
           if [[ -n "$ROLES" ]] && ! echo "$ROLES" | grep -Fqx "$STAGE_ROLE"; then
-            echo "::notice::Stage '$STAGE' skipped — role '$STAGE_ROLE' not in configured roles"
-            echo "skipped=true" >> "${GITHUB_OUTPUT}"
-            exit 0
+            # Backward compat: "fullsend" in roles implies retro + prioritize
+            if [[ "$STAGE" =~ ^(retro|prioritize)$ ]] && echo "$ROLES" | grep -Fqx "fullsend"; then
+              :
+            else
+              echo "::notice::Stage '$STAGE' skipped — role '$STAGE_ROLE' not in configured roles"
+              echo "skipped=true" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
           fi
 
       - name: Block fork PRs for fix stage

--- a/docs/guides/getting-started/configuring-github.md
+++ b/docs/guides/getting-started/configuring-github.md
@@ -15,17 +15,21 @@ The goal of this document is that you configure Fullsend for your GitHub reposit
 
 ## Installing GitHub Applications
 
-In order to use Fullsend install the following applications to your organization
+Install the following agent applications to your organization
 and provide them permissions to the repository you want to install Fullsend to.
 
 | Role | Installation URL |
 |------|-----------------|
-| fullsend | <https://github.com/apps/fullsend-ai-fullsend/installations/new> |
 | triage | <https://github.com/apps/fullsend-ai-triage/installations/new> |
 | coder | <https://github.com/apps/fullsend-ai-coder/installations/new> |
 | review | <https://github.com/apps/fullsend-ai-review/installations/new> |
 | retro | <https://github.com/apps/fullsend-ai-retro/installations/new> |
 | prioritize | <https://github.com/apps/fullsend-ai-prioritize/installations/new> |
+
+> **Note:** The `fullsend` dispatch app (`fullsend-ai-fullsend`) is only
+> required for [organization-mode](org-mode.md) installations. Per-repo
+> mode uses the repository's own shim workflow for dispatch and does not
+> need the `fullsend` app.
 
 > **Note:** Installing a subset of GitHub Apps does **not** automatically
 > limit which agents are active. You must also pass the `--agents` flag

--- a/docs/guides/getting-started/org-mode.md
+++ b/docs/guides/getting-started/org-mode.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Per-Org Mode
 
-> **Planned deprecation.** Per-org installation mode will be deprecated in favor of per-repo installation ([ADR 0044](../../ADRs/0044-deprecate-per-org-installation-mode.md)). New installations should use the [per-repo Getting Started guides](../getting-started/). Existing per-org installations continue to work and are fully supported during the transition.
+> **Planned deprecation.** Per-org installation mode will be deprecated in favor of per-repo installation ([ADR 0044](../../ADRs/0044-deprecate-per-org-installation-mode.md)). New installations should use the [per-repo Getting Started guides](README.md). Existing per-org installations continue to work and are fully supported during the transition.
 
 The goal of this document is that you install Fullsend for your whole
 GitHub organization, so different repositories share inference and infrastructure.
@@ -56,6 +56,11 @@ If you previously ran the [Configuring GitHub](configuring-github.md) guide the 
 installed are configured just for a single repository. Change the permissions so they can access
 all repositories or `.fullsend` (not created yet) and any other repository you want to enable
 Fullsend for.
+
+Organization mode also requires the `fullsend` dispatch app, which handles
+cross-repo event routing. Install it at
+<https://github.com/apps/fullsend-ai-fullsend/installations/new> and grant it
+access to `.fullsend` and any enrolled repositories.
 
 ## Configure GitHub
 

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -347,14 +347,18 @@ jobs:
           STAGE_ROLE="$STAGE"
           case "$STAGE" in
             code|fix) STAGE_ROLE="coder" ;;
-            retro|prioritize) STAGE_ROLE="fullsend" ;;
           esac
 
           ROLES=$(yq '.defaults.roles[]' config.yaml 2>/dev/null || echo "")
           if [[ -n "$ROLES" ]] && ! echo "$ROLES" | grep -Fqx "$STAGE_ROLE"; then
-            echo "::notice::Stage '$STAGE' skipped — role '$STAGE_ROLE' not in defaults.roles"
-            echo "skipped=true" >> "${GITHUB_OUTPUT}"
-            exit 0
+            # Backward compat: "fullsend" in roles implies retro + prioritize
+            if [[ "$STAGE" =~ ^(retro|prioritize)$ ]] && echo "$ROLES" | grep -Fqx "fullsend"; then
+              :
+            else
+              echo "::notice::Stage '$STAGE' skipped — role '$STAGE_ROLE' not in defaults.roles"
+              echo "skipped=true" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
           fi
 
       - name: Block fork PRs for fix stage

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -353,7 +353,7 @@ jobs:
           if [[ -n "$ROLES" ]] && ! echo "$ROLES" | grep -Fqx "$STAGE_ROLE"; then
             # Backward compat: "fullsend" in roles implies retro + prioritize
             if [[ "$STAGE" =~ ^(retro|prioritize)$ ]] && echo "$ROLES" | grep -Fqx "fullsend"; then
-              :
+              echo "::notice::Stage '$STAGE' allowed via 'fullsend' role — if customizing roles, add '$STAGE' explicitly"
             else
               echo "::notice::Stage '$STAGE' skipped — role '$STAGE_ROLE' not in defaults.roles"
               echo "skipped=true" >> "${GITHUB_OUTPUT}"

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -438,3 +438,53 @@ func TestReusableDispatchWorkflowContent(t *testing.T) {
 	assert.Regexp(t, `(?s)/fs-review\)\s*\n\s+if \[\[ "\$\{ISSUE_IS_PR\}"`, s)
 	assert.Regexp(t, `(?s)ready-for-review"\s*\]\];\s*then\s*\n\s+if \[\[ "\$\{ISSUE_IS_PR\}"`, s)
 }
+
+// TestRoleCheckCaseBranches validates the role-check step's case mapping and
+// backward-compat logic in both dispatch workflows (#2298).
+func TestRoleCheckCaseBranches(t *testing.T) {
+	type workflowCase struct {
+		name    string
+		content func(t *testing.T) []byte
+	}
+
+	cases := []workflowCase{
+		{
+			"reusable-dispatch.yml",
+			loadRepoFile(".github/workflows/reusable-dispatch.yml"),
+		},
+		{
+			"scaffold/dispatch.yml",
+			loadScaffoldFile(".github/workflows/dispatch.yml"),
+		},
+	}
+
+	for _, wc := range cases {
+		t.Run(wc.name, func(t *testing.T) {
+			s := string(wc.content(t))
+
+			// code|fix must map to coder
+			assert.Contains(t, s, `code|fix) STAGE_ROLE="coder"`,
+				"code|fix should map to coder role")
+
+			// retro and prioritize must NOT be remapped to fullsend
+			assert.NotContains(t, s, `retro|prioritize) STAGE_ROLE="fullsend"`,
+				"retro/prioritize must not be remapped to fullsend (#2298)")
+
+			// backward compat: fullsend in roles implies retro + prioritize
+			assert.Regexp(t, `\^\(retro\|prioritize\)\$`, s,
+				"backward-compat regex should match retro and prioritize")
+			assert.Contains(t, s, `grep -Fqx "fullsend"`,
+				"backward-compat should check for fullsend in roles")
+
+			// compat path must emit a notice, not silently pass
+			assert.Regexp(t, `(?s)grep -Fqx "fullsend".*::notice::Stage`, s,
+				"backward-compat path must emit a ::notice:: annotation")
+
+			// stages that pass through unmapped must not be remapped
+			assert.NotRegexp(t, `triage\).*STAGE_ROLE=`, s,
+				"triage must not be remapped")
+			assert.NotRegexp(t, `review\).*STAGE_ROLE=`, s,
+				"review must not be remapped")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Remove the `retro|prioritize) STAGE_ROLE="fullsend"` mapping from the role-check step in both dispatch workflows (`reusable-dispatch.yml` and scaffold `dispatch.yml`)
- In per-repo mode, `PerRepoDefaultRoles()` includes `retro` and `prioritize` directly but excludes `fullsend`, so the remapping caused these stages to be silently skipped — and required the `fullsend-ai-fullsend` app to be installed even in per-repo mode
- Add backward-compat fallback: when `retro`/`prioritize` is not in the roles list but `fullsend` is, allow the stage with a `::notice::` annotation — preserves org-mode configs that used `fullsend` as an umbrella role
- Update docs: clarify that the `fullsend` dispatch app is only required for org-mode installations; per-repo mode no longer needs it
- Add `TestRoleCheckCaseBranches` to guard against regression

## Test plan

- [x] `make lint` passes
- [x] `make go-test` passes (new `TestRoleCheckCaseBranches` covers both workflows)
- [ ] Verify in a per-repo installation (e.g., `fullsend-playground/hello-pages`) that `/fs-retro` dispatches correctly with default roles
- [ ] Verify org-mode installations are unaffected (retro/prioritize still work with `fullsend` in `defaults.roles`)

Fixes fullsend-ai/fullsend#2298