### PR TITLE
fix: revert openshell to 0.0.63

### DIFF
--- a/.github/scripts/openshell-version.sh
+++ b/.github/scripts/openshell-version.sh
@@ -9,8 +9,8 @@
 #   source .github/scripts/openshell-version.sh
 
 # renovate: datasource=github-tags depName=NVIDIA/OpenShell
-OPENSHELL_VERSION=0.0.72
-OPENSHELL_SHA=8cb16de9eae4c44d7d31e1493747d8c10abb5963
+OPENSHELL_VERSION=0.0.63
+OPENSHELL_SHA=ec197a43ef349e36c3fff04e9aaea9599fb83b31
 
 export OPENSHELL_VERSION OPENSHELL_SHA
 


### PR DESCRIPTION
## Summary

- Reverts openshell from 0.0.72 back to 0.0.63 (undoing #2714 and #2753)
- Review agent sandbox creation started failing after the upgrade — sandboxes enter `Phase: Error` instead of becoming ready
- Two back-to-back failures on [konflux-ci/konflux-operator-tasks#276](https://github.com/konflux-ci/konflux-operator-tasks/pull/276): runs [28456139199](https://github.com/konflux-ci/konflux-operator-tasks/actions/runs/28456139199) and [28457074592](https://github.com/konflux-ci/konflux-operator-tasks/actions/runs/28457074592), both hitting the same `sandbox creation failed after 3 attempts` error
- Not 100% reproducible (other runs on the same repo succeeded), but the failures started after the v0 tag picked up the upgrade

## Context

The 0.0.63→0.0.71 jump spans 8 patch versions. Notable changes include a `sandbox_create` API refactor (positional args → config struct) in v0.0.71 and a GCE metadata emulator addition in v0.0.69. Either could affect sandbox init on our GCP backend.

Once we're back on stable ground, we could try stepping forward one version at a time to isolate the breaking change.

## Test plan

- [ ] Confirm review agent runs succeed on a repo that was previously failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)