### PR TITLE
fix(ci): trigger e2e tests on .github/scripts/ and action.yml changes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,7 @@ on:
       - 'Makefile'
       - '.github/scripts/**'
       - '.github/workflows/e2e.yml'
+      - 'action.yml'
       - '.github/actions/check-e2e-authorization/**'
       - 'scripts/check-e2e-authorization.sh'
   pull_request_target:
@@ -114,7 +115,7 @@ jobs:
               exit 0
             }
           fi
-          if echo "$FILES" | grep -qE '\.go$|^go\.(mod|sum)$|^e2e/|^internal/scaffold/fullsend-repo/|^internal/security/hooks/|^internal/dispatch/gcf/mintsrc/|^internal/sentencetoken/english\.json$|^Makefile$|^\.github/scripts/|^\.github/workflows/e2e\.yml$|^\.github/actions/check-e2e-authorization/|^scripts/check-e2e-authorization\.sh$'; then
+          if echo "$FILES" | grep -qE '\.go$|^go\.(mod|sum)$|^e2e/|^internal/scaffold/fullsend-repo/|^internal/security/hooks/|^internal/dispatch/gcf/mintsrc/|^internal/sentencetoken/english\.json$|^Makefile$|^\.github/scripts/|^\.github/workflows/e2e\.yml$|^action\.yml$|^\.github/actions/check-e2e-authorization/|^scripts/check-e2e-authorization\.sh$'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             echo "::notice::No e2e-relevant files changed — skipping tests"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,7 @@ on:
       - 'internal/dispatch/gcf/mintsrc/**'
       - 'internal/sentencetoken/english.json'
       - 'Makefile'
+      - '.github/scripts/**'
       - '.github/workflows/e2e.yml'
       - '.github/actions/check-e2e-authorization/**'
       - 'scripts/check-e2e-authorization.sh'
@@ -113,7 +114,7 @@ jobs:
               exit 0
             }
           fi
-          if echo "$FILES" | grep -qE '\.go$|^go\.(mod|sum)$|^e2e/|^internal/scaffold/fullsend-repo/|^internal/security/hooks/|^internal/dispatch/gcf/mintsrc/|^internal/sentencetoken/english\.json$|^Makefile$|^\.github/workflows/e2e\.yml$|^\.github/actions/check-e2e-authorization/|^scripts/check-e2e-authorization\.sh$'; then
+          if echo "$FILES" | grep -qE '\.go$|^go\.(mod|sum)$|^e2e/|^internal/scaffold/fullsend-repo/|^internal/security/hooks/|^internal/dispatch/gcf/mintsrc/|^internal/sentencetoken/english\.json$|^Makefile$|^\.github/scripts/|^\.github/workflows/e2e\.yml$|^\.github/actions/check-e2e-authorization/|^scripts/check-e2e-authorization\.sh$'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             echo "::notice::No e2e-relevant files changed — skipping tests"


### PR DESCRIPTION
## Summary

- Add `.github/scripts/**` to e2e trigger paths and relevance grep — helper scripts used by the composite action and workflows affect agent behavior
- Add `action.yml` to e2e trigger paths and relevance grep — this is the composite action entry point for all agent runs in CI; changes to sandbox creation, image pulling, or OpenShell configuration need e2e coverage

## Motivation

The OpenShell v0.0.73 supervisor crash (#2792) was fixed by pinning the supervisor image in `action.yml` (#2795), but that change would not have triggered e2e tests. If it had, we would have caught the regression before it broke all agent runs across both orgs for hours.

## Test plan

- [x] `paths:` trigger list and grep regex stay in sync (SYNC-WITH comment)
- [ ] PR changing only `action.yml` triggers e2e tests
- [ ] PR changing only `.github/scripts/foo.sh` triggers e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)