### PR TITLE
fix(ci): treat renovate bot as trusted for e2e/functional test gates

### DIFF
--- a/scripts/check-e2e-authorization-test.sh
+++ b/scripts/check-e2e-authorization-test.sh
@@ -142,6 +142,20 @@ run_case "trusted collaborator author" "true" "trusted_author" "false"
 write_pr "CONTRIBUTOR" '[]'
 run_case "contributor author denied" "false" "unauthorized" "false"
 
+# --- Trusted bot tests ---
+
+export PR_AUTHOR_ASSOCIATION="CONTRIBUTOR"
+export PR_AUTHOR_LOGIN="renovate-fullsend[bot]"
+echo "" >"${COLLAB_ROLE}"
+write_pr "NONE" '[]'
+run_case "renovate bot authorized as trusted bot" "true" "trusted_bot" "false"
+
+export PR_AUTHOR_LOGIN="some-other-bot[bot]"
+write_pr "NONE" '[]'
+run_case "unknown bot not authorized" "false" "unauthorized" "false"
+
+unset PR_AUTHOR_ASSOCIATION PR_AUTHOR_LOGIN
+
 write_pr "MEMBER" '[{"name":"ok-to-test"}]'
 run_case "trusted member ignores stale ok-to-test label" "true" "trusted_author" "false"
 

--- a/scripts/check-e2e-authorization.sh
+++ b/scripts/check-e2e-authorization.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # check-e2e-authorization.sh — Decide whether a PR may run e2e tests in CI.
 #
-# Authorized when the PR author is OWNER/MEMBER/COLLABORATOR, or when the
-# collaborator permission API confirms write+ access, or when a fresh
-# ok-to-test label was applied after the latest push.
+# Authorized when the PR author is OWNER/MEMBER/COLLABORATOR, when the author
+# is a trusted bot (e.g. renovate-fullsend[bot]), when the collaborator
+# permission API confirms write+ access, or when a fresh ok-to-test label was
+# applied after the latest push.
 #
 # The author_association field from the event payload can misreport org members
 # whose membership visibility is private (returns CONTRIBUTOR/NONE instead of
@@ -31,6 +32,7 @@ PR_NUMBER="${1:?PR number required}"
 REPOSITORY="${2:?repository (owner/repo) required}"
 
 TRUSTED_ASSOCIATIONS="OWNER MEMBER COLLABORATOR"
+TRUSTED_BOT_LOGINS="renovate-fullsend[bot]"
 OK_TO_TEST_LABEL="ok-to-test"
 
 write_error_output() {
@@ -51,6 +53,14 @@ is_trusted_author() {
   local assoc="$1"
   case " ${TRUSTED_ASSOCIATIONS} " in
     *" ${assoc} "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_trusted_bot() {
+  local login="${1:-}"
+  case " ${TRUSTED_BOT_LOGINS} " in
+    *" ${login} "*) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -89,6 +99,9 @@ fi
 if is_trusted_author "${author_association}"; then
   authorized=true
   reason="trusted_author"
+elif is_trusted_bot "${PR_AUTHOR_LOGIN:-}"; then
+  authorized=true
+  reason="trusted_bot"
 elif has_write_permission "${PR_AUTHOR_LOGIN:-}" 2>/dev/null; then
   # author_association was wrong (e.g. private org membership); collaborator
   # permission API confirms write+ access.


### PR DESCRIPTION
## Summary

- Adds `TRUSTED_BOT_LOGINS` list to `check-e2e-authorization.sh` with `renovate-fullsend[bot]` as the first entry
- The bot's `author_association` is `CONTRIBUTOR`, which meant its PRs were silently skipping e2e and functional tests unless someone manually added `ok-to-test`
- This is how the openshell 0.0.63→0.0.71 upgrade (#2714) merged without test coverage and caused sandbox creation failures downstream
- Adds test cases for both the trusted bot path and an unknown bot being denied

Companion to #2788 (adds `.github/scripts/` to e2e path triggers).

## Test plan

- [x] `bash scripts/check-e2e-authorization-test.sh` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)