### PR TITLE
fix: pin supervisor image to match openshell CLI version

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -163,8 +163,16 @@ jobs:
       - name: Configure OpenShell gateway
         if: steps.changes.outputs.relevant != 'false'
         run: |
+          source .github/scripts/openshell-version.sh
           mkdir -p "$HOME/.config/openshell"
           echo "OPENSHELL_BIND_ADDRESS=0.0.0.0" > "$HOME/.config/openshell/gateway.env"
+          cat > "$HOME/.config/openshell/gateway.toml" << EOF
+          [openshell]
+          version = 1
+
+          [openshell.gateway]
+          supervisor_image = "ghcr.io/nvidia/openshell/supervisor:${OPENSHELL_VERSION}"
+          EOF
 
       - name: Install OpenShell CLI
         if: steps.changes.outputs.relevant != 'false'

--- a/action.yml
+++ b/action.yml
@@ -269,9 +269,17 @@ runs:
     - name: Configure OpenShell gateway
       shell: bash
       run: |
+        source "$GITHUB_ACTION_PATH/.github/scripts/openshell-version.sh"
         mkdir -p $HOME/.config/openshell/
         cat > $HOME/.config/openshell/gateway.env << EOF
         OPENSHELL_BIND_ADDRESS=0.0.0.0
+        EOF
+        cat > $HOME/.config/openshell/gateway.toml << EOF
+        [openshell]
+        version = 1
+
+        [openshell.gateway]
+        supervisor_image = "ghcr.io/nvidia/openshell/supervisor:${OPENSHELL_VERSION}"
         EOF
 
     - name: Install OpenShell CLI


### PR DESCRIPTION
## Summary

- Pin the OpenShell supervisor image to `ghcr.io/nvidia/openshell/supervisor:${OPENSHELL_VERSION}` via `gateway.toml` so the in-container supervisor always matches the installed gateway/CLI version.
- Applies to both `action.yml` (production agent runs) and `functional-tests.yml` (e2e tests).

## Root Cause

OpenShell v0.0.73 was released at 15:31 UTC on June 30, re-pointing the `supervisor:latest` tag to a build containing [NVIDIA/OpenShell#2001](https://github.com/NVIDIA/OpenShell/pull/2001) (`fix(supervisor): drop sandbox child capability bounding set`). The `cap_drop_bound()` call fails with `EINVAL` in rootless Podman on GitHub Actions runners because `CAP_SETPCAP` is unavailable in user namespaces. The supervisor crashes immediately:

```
WARN openshell_supervisor_process::netns: Failed to delete network namespace
Error: × Invalid argument (os error 22)
```

The gateway defaults to `supervisor:latest` (not pinned to its own version), so every new runner after 15:31 UTC pulls the broken v0.0.73 supervisor regardless of what CLI version is installed. This is why reverting the CLI to 0.0.63 (PR #2787) did not fix sandbox creation.

## Fix

Write `$HOME/.config/openshell/gateway.toml` in the gateway configuration step, setting `supervisor_image` to the version-tagged image matching `OPENSHELL_VERSION` from `openshell-version.sh`. This eliminates the dependency on the `:latest` tag and ensures version lock between CLI ↔ supervisor.

## Test plan

- [ ] Verify sandbox creation succeeds in a fullsend-ai/.fullsend agent run after merge
- [ ] Verify `functional-tests.yml` e2e tests pass with the pinned supervisor

Fixes #2792