### PR TITLE
chore(deps): update OpenShell to 0.0.72

### DIFF
--- a/.github/scripts/openshell-version.sh
+++ b/.github/scripts/openshell-version.sh
@@ -9,8 +9,8 @@
 #   source .github/scripts/openshell-version.sh
 
 # renovate: datasource=github-tags depName=NVIDIA/OpenShell
-OPENSHELL_VERSION=0.0.63
-OPENSHELL_SHA=ec197a43ef349e36c3fff04e9aaea9599fb83b31
+OPENSHELL_VERSION=0.0.72
+OPENSHELL_SHA=8cb16de9eae4c44d7d31e1493747d8c10abb5963
 
 export OPENSHELL_VERSION OPENSHELL_SHA
 

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -11,7 +11,7 @@ Linux are supported with Podman as the container runtime.
 | Requirement | macOS | Linux |
 |-------------|-------|-------|
 | Container runtime | Podman Desktop with a running machine | Podman |
-| [OpenShell](https://github.com/NVIDIA/OpenShell) | 0.0.63 | 0.0.63 |
+| [OpenShell](https://github.com/NVIDIA/OpenShell) | 0.0.72 | 0.0.72 |
 | GCP project | [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled with [Claude models](https://console.cloud.google.com/vertex-ai/model-garden) enabled | Same |
 | GCP credentials | Service account key (see section below) | Same |
 | GitHub PAT | Classic PAT with `repo` scope (see section below) | Same |
@@ -51,7 +51,7 @@ to install it, here we use one similar to how we download it on Fullsend. Use th
 printed on your Fullsend workflow for better reproducibility.
 
 ```bash
-export OPENSHELL_VERSION=0.0.63
+export OPENSHELL_VERSION=0.0.72
 curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/v${OPENSHELL_VERSION}/install.sh | OPENSHELL_VERSION=v${OPENSHELL_VERSION} sh
 openshell --version
 ```


### PR DESCRIPTION
## Summary

- Bump pinned OpenShell version from 0.0.63 to 0.0.72 in `.github/scripts/openshell-version.sh`
- Update version references in `docs/guides/user/running-agents-locally.md`
- Pinning to 0.0.72 rather than 0.0.73 which introduces a breaking change

## Test plan

- [ ] Verify e2e tests pass with the new OpenShell version
- [ ] Confirm sandbox creation works with `supervisor:0.0.72` image

🤖 Generated with [Claude Code](https://claude.com/claude-code)