### PR TITLE
fix(#2783): refresh OIDC token before agent start

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -921,7 +921,12 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		if err != nil {
 			printer.StepWarn("OIDC token refresh disabled: " + err.Error())
 		} else {
-			printer.StepDone("OIDC token refresh enabled (WIF mode)")
+			// GHA OIDC tokens expire after 5 min; sandbox setup can exceed that.
+			if err := refreshOIDCToken(oidcCtx, sandboxName, oidcURL, oidcAuth); err != nil {
+				printer.StepWarn("Initial OIDC refresh failed (will retry): " + err.Error())
+			} else {
+				printer.StepDone("OIDC token refreshed, background refresh enabled (WIF mode)")
+			}
 			oidcWg.Add(1)
 			go func() {
 				defer oidcWg.Done()

--- a/internal/scaffold/fullsend-repo/scripts/prepare-sandbox-credentials.sh
+++ b/internal/scaffold/fullsend-repo/scripts/prepare-sandbox-credentials.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # endpoint, so this script pre-fetches the OIDC token and rewrites the config
 # to use a file-based credential source instead.
 #
-# Note: the OIDC token expires after ~10 min. The fullsend CLI refreshes it
+# Note: the OIDC token expires after ~5 min. The fullsend CLI refreshes it
 # automatically using FULLSEND_GCP_OIDC_URL and FULLSEND_GCP_OIDC_AUTH_FILE
 # exported below.
 #


### PR DESCRIPTION
## Summary

- Add an immediate `refreshOIDCToken()` call right before starting the periodic refresh goroutine. The pre-fetched OIDC token from `prepare-sandbox-credentials.sh` expires after 5 minutes (GHA OIDC token lifetime), but sandbox setup can exceed that window — causing `invalid_grant` on the agent's first inference call.
- Fix incorrect token lifetime comment in `prepare-sandbox-credentials.sh` (`~10 min` → `~5 min`).

## Test plan

- [x] Existing OIDC unit tests pass (`go test ./internal/cli/ -run OIDC`)
- [x] Lint passes (`make lint`)
- [ ] Verify in a WIF-enabled org with slow sandbox setup (>5 min) that the agent's first inference call succeeds

Closes #2783