### PR TITLE
fix(workflows): configure git identity for runner amends

### DIFF
--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -170,6 +170,8 @@ jobs:
           GIT_BOT_EMAIL="${BOT_USER_ID}+${BOT_LOGIN}@users.noreply.github.com"
           echo "Resolved bot identity: ${BOT_LOGIN} (${BOT_USER_ID})"
           echo "GIT_BOT_EMAIL=${GIT_BOT_EMAIL}" >> "${GITHUB_ENV}"
+          git config --global user.email "${GIT_BOT_EMAIL}"
+          git config --global user.name "${BOT_LOGIN}"
 
       - name: Setup agent environment
         if: steps.validate.outputs.skipped != 'true'

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -160,6 +160,8 @@ jobs:
           GIT_BOT_EMAIL="${BOT_USER_ID}+${BOT_LOGIN}@users.noreply.github.com"
           echo "Resolved bot identity: ${BOT_LOGIN} (${BOT_USER_ID})"
           echo "GIT_BOT_EMAIL=${GIT_BOT_EMAIL}" >> "${GITHUB_ENV}"
+          git config --global user.email "${GIT_BOT_EMAIL}"
+          git config --global user.name "${BOT_LOGIN}"
 
       - name: Block fork PRs
         env:


### PR DESCRIPTION
## Summary

Fixes fullsend-ai/fullsend#2910 — code/fix agent runs failed when pre-commit hooks auto-fixed files because `post-code.sh` amend operations ran on the runner without git identity configured.

## Changes

- Add `git config user.email/user.name` in `reusable-code.yml` after bot identity resolution
- Add `git config user.email/user.name` in `reusable-fix.yml` after bot identity resolution

## Root cause

The workflows resolved `BOT_LOGIN` and `GIT_BOT_EMAIL` but never called `git config` with them. The sandbox has identity via env vars (`GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_EMAIL`) from `code.yaml`, but `post-code.sh` executes outside the sandbox on the runner.

When pre-commit hooks auto-fixed files (line 323) or artifacts were stripped (line 198), `git commit --amend --no-edit` failed with "Committer identity unknown".

## Test plan

- [ ] Trigger code agent on issue that produces Go formatting issues
- [ ] Verify pre-commit hook auto-fix succeeds
- [ ] Verify amend completes with bot identity
- [ ] Check commit author/committer match bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)