### PR TITLE
docs(review): check runner prerequisites for write ops

### DIFF
--- a/internal/scaffold/fullsend-repo/skills/code-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/code-review/SKILL.md
@@ -88,6 +88,16 @@ dimension carry over to another — each requires its own scrutiny.
   (e.g., what happens if a critical sub-component fails — does the
   caller degrade gracefully or silently proceed?). Trace the full path
   from where the mechanism is set to where it is read.
+- Execution-context prerequisites: when a diff adds write-side shell
+  operations to runner-side scripts or workflows (for example
+  `post-code.sh`, `post-fix.sh`, reusable workflows, or workflow steps),
+  verify that prerequisites are configured in that same execution
+  context. For git write operations such as `git commit`, `git push`,
+  or `git tag`, check that git identity (`user.name`, `user.email`) and
+  any required auth/token state are established before the write. Do
+  not treat sandbox-only environment variables or setup as satisfying
+  runner-side prerequisites. Read-only git commands such as `git diff`,
+  `git log`, or `git status` do not trigger this rule.
 - Test adequacy: are the right behaviors tested?
 - Do the tests actually constrain the code's behavior, or do they
   merely assert it runs?

--- a/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/correctness.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/correctness.md
@@ -32,6 +32,15 @@ or inter-component contract in the diff:
 - Check failure paths: if the mechanism's component fails or is
   unavailable, does the caller handle it or silently proceed as if it
   succeeded?
+- Verify execution-context prerequisites for newly added write
+  operations in runner-side scripts or workflows. If a diff adds
+  commands such as `git commit`, `git push`, or `git tag` to
+  `post-code.sh`, `post-fix.sh`, reusable workflows, or GitHub Actions
+  steps, confirm that git identity (`user.name`, `user.email`) and any
+  required auth/token state are configured before the write in that same
+  runner context. Do not assume sandbox-provided environment variables
+  or setup apply to runner-side code. Read-only git commands such as
+  `git diff`, `git log`, or `git status` do not trigger this rule.
 
 **Consumer completeness:** If the diff adds new values to an enum,
 dispatch table, JSON schema enum, or case/switch structure, identify all


### PR DESCRIPTION
## Summary
- Add execution-context prerequisite guidance to the standalone code-review correctness checklist
- Teach the PR review correctness sub-agent to verify runner-side git write prerequisites
- Explicitly scope the rule to write operations so read-only git commands are not false positives

## Validation
- git diff --check
- make lint-md-links

Refs #2923