### PR TITLE
docs(#2923): add runner prerequisite review guidance

### DIFF
--- a/internal/scaffold/fullsend-repo/AGENTS.md
+++ b/internal/scaffold/fullsend-repo/AGENTS.md
@@ -57,3 +57,18 @@ Determine:
 
 Use these criteria as checkpoints. If a checkpoint fails, fix the root
 cause — do not weaken the check.
+
+## 6. Runner-side shell operations
+
+Post-scripts and GitHub Actions runner steps do not inherit every
+precondition from the sandbox. When adding or reviewing shell operations
+that run outside the sandbox, verify that required identity, auth,
+environment variables, permissions, and writable paths are configured in
+that same execution context.
+
+For git write operations in post-scripts or runner-side workflow steps
+(`git commit`, `git push`, `git tag`, `git merge`, etc.), configure and
+verify git identity (`user.name` and `user.email`) before the first write.
+Sandbox-only `GIT_AUTHOR_*` / `GIT_COMMITTER_*` settings are not enough
+for runner-side git commands. Read-only git operations such as `git diff`,
+`git status`, and `git log` do not need identity configuration.

--- a/internal/scaffold/fullsend-repo/skills/code-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/code-review/SKILL.md
@@ -88,6 +88,16 @@ dimension carry over to another — each requires its own scrutiny.
   (e.g., what happens if a critical sub-component fails — does the
   caller degrade gracefully or silently proceed?). Trace the full path
   from where the mechanism is set to where it is read.
+- Execution-context prerequisites: when a change adds or moves an
+  operation across contexts (sandbox vs. runner, workflow step vs.
+  post-script, local checkout vs. remote API), verify that the
+  prerequisites available in the source context also exist in the target
+  context. For post-scripts or runner-side workflow steps that add git
+  write operations (`git commit`, `git push`, `git tag`, `git merge`,
+  etc.), confirm runner-side git identity (`user.name` and `user.email`)
+  and credentials are configured before the write; sandbox-only
+  `GIT_AUTHOR_*` / `GIT_COMMITTER_*` settings do not satisfy runner
+  operations.
 - Test adequacy: are the right behaviors tested?
 - Do the tests actually constrain the code's behavior, or do they
   merely assert it runs?

--- a/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/correctness.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/correctness.md
@@ -29,6 +29,15 @@ or inter-component contract in the diff:
 - Verify format expectations match between components (e.g., does a
   consumer expect structured JSON while the producer has no output format
   instructions?).
+- Verify execution-context prerequisites. If the diff moves or adds an
+  operation in a different context (sandbox vs. runner, workflow step vs.
+  post-script, local checkout vs. remote API), confirm the required
+  identity, auth, environment variables, filesystem access, and
+  permissions are configured in that same context before the operation
+  runs. In post-scripts or runner-side workflows, new git write
+  operations such as `git commit`, `git push`, `git tag`, or
+  `git merge` must have runner-side git identity and credentials
+  configured; sandbox-only identity is not sufficient.
 - Check failure paths: if the mechanism's component fails or is
   unavailable, does the caller handle it or silently proceed as if it
   succeeded?


### PR DESCRIPTION
## Summary
- Add execution-context prerequisite checks to the correctness review sub-agent
- Add the same runner/post-script git write guidance to the code-review skill
- Document runner-side shell operation prerequisites in the scaffold AGENTS.md

Fixes #2923

## Tests
- `pre-commit run`
- `git diff --cached --check`