### PR TITLE
docs(review): require heading cross-reference checks

### DIFF
--- a/internal/scaffold/fullsend-repo/skills/code-implementation/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/code-implementation/SKILL.md
@@ -336,6 +336,14 @@ Before writing code, form a concrete plan:
    or changes a parameter sent to an external API, check the API documentation or
    test each code path that uses the function. Different operations
    (e.g., approve vs request-changes) often have different required fields.
+10. **Preserve markdown heading inbound links** — when renaming a markdown
+    heading, derive the old rendered anchor slug and search the full repository
+    for inbound links to it before committing. Search for the old slug (for
+    example `#old-heading-slug`) and, when useful, the old heading text. Update
+    all affected references, including files outside the initial edit scope, or
+    note why a remaining reference is intentionally historical. Mention the
+    cross-reference search in the commit message body or PR description so
+    reviewers know it was performed.
 
 When requirements are ambiguous, distinguish between "vague but actionable"
 (you can make a reasonable conservative interpretation) and "genuinely
@@ -590,6 +598,9 @@ Read every line. Check for:
 - Accidental artifacts: debug prints, commented-out code, TODO comments
 - Secret material: `.env`, `*.pem`, `*.key`, `credentials.json`
 - Protected-path files (see agent definition for the authoritative list)
+- Markdown heading renames include full-repo inbound anchor searches and any
+  stale `#old-heading-slug` references have been updated or intentionally left
+  with a note
 
 If you added more than necessary, revert the extras before staging.
 

--- a/internal/scaffold/fullsend-repo/skills/code-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/code-review/SKILL.md
@@ -196,6 +196,13 @@ readability or correctness.
   `OLD_NAME:` for YAML). Documentation files (`.md`, `.adoc`, `.rst`)
   often reference field names in prose without syntax suffixes and will
   be missed by syntax-specific patterns alone.
+- **Markdown heading inbound links:** When a PR renames a markdown heading,
+  treat the rendered anchor slug as a renamed identifier. Verify there is
+  evidence of a full-repository search for inbound links to the old anchor
+  (for example `#old-heading-slug`) and that references outside the touched
+  files were updated or intentionally left as historical references. If a
+  heading rename lacks that evidence, record at least a medium-severity
+  finding; a broken inbound link you can point to is direct evidence.
 
 #### Cross-repo contracts
 

--- a/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/docs-currency.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/sub-agents/docs-currency.md
@@ -36,3 +36,20 @@ Documentation files (`.md`, `.adoc`, `.rst`) frequently reference field
 names in prose without syntax-specific suffixes (e.g., "set the
 `repository` field"). Always include the bare-word pattern when scanning
 these file types — a syntax-specific pattern alone will miss them.
+
+## Markdown heading rename strategy
+
+Markdown heading renames change rendered anchor slugs and can break inbound
+links from files that are not otherwise touched by the PR. When the diff
+renames a markdown heading:
+
+1. Derive the old rendered anchor slug (for example,
+   `Old Heading` -> `#old-heading`).
+2. Search the full repository for inbound references to that old anchor slug,
+   including markdown links and prose references.
+3. Verify references outside the changed files were updated, or that any
+   remaining reference is intentionally historical.
+4. If the PR lacks evidence of a full-repository old-anchor search, flag a
+   medium-severity docs-currency finding even if you have not found a specific
+   broken link. If you do find a remaining broken link, cite that file and line
+   as direct evidence.


### PR DESCRIPTION
## Summary
- Add code-agent planning and self-review guidance for markdown heading renames
- Require full-repository searches for old rendered anchor slugs before committing heading renames
- Teach review/docs-currency guidance to flag missing old-anchor search evidence or direct broken inbound links

## Validation
- git diff --check
- make lint-md-links

## Not run
- scan-secrets: not installed in this local environment
- pre-commit: not installed in this local environment

Refs #2913