### PR TITLE
fix(#2918): preserve dismissed review findings

### DIFF
--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -174,6 +174,7 @@ jobs:
           PRIOR_REVIEW_SHA: ${{ steps.prior-review.outputs.prior_sha }}
           PRIOR_REVIEW_FILE: ${{ steps.prior-review.outputs.prior_review_file }}
           PRIOR_REVIEW_PROVENANCE: ${{ steps.prior-review.outputs.prior_review_provenance }}
+          PRIOR_ACTIVE_CHANGES_REQUESTED: ${{ steps.prior-review.outputs.prior_active_changes_requested }}
         with:
           agent: review
           version: ${{ inputs.fullsend_version }}

--- a/internal/scaffold/fullsend-repo/agents/review.md
+++ b/internal/scaffold/fullsend-repo/agents/review.md
@@ -48,6 +48,11 @@ NOTE: the Agent tool MUST ONLY be invoked with prompts read from
     (cannot verify authorship); prior review discarded, file is empty
   - `unverifiable-wrong-app` — prior comment created by a different
     GitHub App than expected; prior review discarded, file is empty
+- `PRIOR_ACTIVE_CHANGES_REQUESTED` — `true` only when GitHub currently
+  has a non-dismissed `CHANGES_REQUESTED` formal review from the review
+  bot on this PR. `false` means no bot blocking review is visible
+  through the PR review UI; this includes first reviews, dismissed
+  reviews, and API failures in the pre-fetch step.
 - Prior review body at `/sandbox/workspace/prior-review.txt` when this
   is a re-review. Contains the prior run's findings with assessed
   severities. Absent on first review or when provenance validation
@@ -188,6 +193,12 @@ output: `[provenance-warning]` with the `PRIOR_REVIEW_PROVENANCE`
 value and a note that severity anchoring was skipped for this run. The GitHub REST
 API does not expose comment edit history, so post-creation edits
 cannot be attributed to a specific actor.
+
+Prior review findings are severity anchors, not delivery state. If
+`PRIOR_ACTIVE_CHANGES_REQUESTED` is not `true`, old blocking findings
+are not visible through GitHub's formal review UI. Any current finding
+that still applies must be emitted in the current result even when it
+matches a prior finding exactly.
 
 ## Workspace
 

--- a/internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review-test.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review-test.sh
@@ -18,25 +18,40 @@ trap 'rm -rf "${TMPDIR}"' EXIT
 
 # --- Helpers ---
 
-# build_mock creates a mock gh binary that returns a preconfigured
-# comment JSON from "gh api repos/.../issues/.../comments".
-#   $1 — the JSON to return (empty string = no prior review)
+# build_mock creates a mock gh binary that returns preconfigured JSON
+# from "gh api repos/.../issues/.../comments" and
+# "gh api repos/.../pulls/.../reviews".
+#   $1 — comment JSON to return (empty string = no prior review)
+#   $2 — review JSON stream to return (empty string = no reviews)
 build_mock() {
   local comment_json="$1"
+  local review_json="${2:-}"
   local mock_bin="${TMPDIR}/bin"
 
   rm -rf "${mock_bin}"
   mkdir -p "${mock_bin}"
 
   printf '%s' "${comment_json}" > "${TMPDIR}/comment-json.txt"
+  printf '%s' "${review_json}" > "${TMPDIR}/review-json.txt"
 
   cat > "${mock_bin}/gh" <<'MOCKEOF'
 #!/usr/bin/env bash
 # Mock gh — returns preconfigured comment JSON for api calls.
 COMMENT_FILE="COMMENT_PLACEHOLDER"
+REVIEW_FILE="REVIEW_PLACEHOLDER"
 
 if [[ "$1" == "api" ]]; then
-  cat "${COMMENT_FILE}"
+  case "${2:-}" in
+    repos/*/issues/*/comments)
+      cat "${COMMENT_FILE}"
+      ;;
+    repos/*/pulls/*/reviews)
+      cat "${REVIEW_FILE}"
+      ;;
+    *)
+      cat "${COMMENT_FILE}"
+      ;;
+  esac
   exit 0
 fi
 
@@ -45,6 +60,8 @@ MOCKEOF
 
   local escaped="${TMPDIR//\//\\/}\/comment-json.txt"
   perl -pi -e "s/COMMENT_PLACEHOLDER/${escaped}/g" "${mock_bin}/gh"
+  escaped="${TMPDIR//\//\\/}\/review-json.txt"
+  perl -pi -e "s/REVIEW_PLACEHOLDER/${escaped}/g" "${mock_bin}/gh"
   chmod +x "${mock_bin}/gh"
 
   echo "${mock_bin}"
@@ -67,14 +84,28 @@ make_comment_json() {
 ENDJSON
 }
 
+make_review_json() {
+  local user="$1"
+  local state="$2"
+  cat <<ENDJSON
+{
+  "id": 999,
+  "user": {"login": "${user}"},
+  "state": "${state}"
+}
+ENDJSON
+}
+
 run_test() {
   local test_name="$1"
   local comment_json="$2"
   local expected_sha="$3"   # expected value in prior_sha= output line
   local expect_exit="$4"    # 0 = success
+  local review_json="${5:-}"
+  local expected_active="${6:-false}"
 
   local mock_bin
-  mock_bin="$(build_mock "${comment_json}")"
+  mock_bin="$(build_mock "${comment_json}" "${review_json}")"
 
   local github_output="${TMPDIR}/github-output.txt"
   local workspace="${TMPDIR}/workspace"
@@ -103,10 +134,23 @@ run_test() {
 
   # Check prior_sha output value.
   local actual_sha
-  actual_sha="$(grep '^prior_sha=' "${github_output}" | head -1 | cut -d= -f2)"
+  actual_sha="$(grep '^prior_sha=' "${github_output}" | head -1 | cut -d= -f2 || true)"
 
   if [[ "${actual_sha}" != "${expected_sha}" ]]; then
     echo "FAIL: ${test_name} — expected prior_sha='${expected_sha}', got '${actual_sha}'"
+    echo "--- GITHUB_OUTPUT ---"
+    cat "${github_output}"
+    echo "--- stdout ---"
+    cat "${TMPDIR}/stdout.log"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  local actual_active
+  actual_active="$(grep '^prior_active_changes_requested=' "${github_output}" | head -1 | cut -d= -f2 || true)"
+
+  if [[ "${actual_active}" != "${expected_active}" ]]; then
+    echo "FAIL: ${test_name} — expected prior_active_changes_requested='${expected_active}', got '${actual_active}'"
     echo "--- GITHUB_OUTPUT ---"
     cat "${github_output}"
     echo "--- stdout ---"
@@ -177,6 +221,32 @@ run_test "sha-only-in-history-section" \
   "$(make_comment_json "${BODY_SHA_IN_HISTORY}")" \
   "" \
   0
+
+# 6. Existing bot CHANGES_REQUESTED review is active and visible.
+run_test "active-changes-requested-review" \
+  "$(make_comment_json "${BODY_WITH_SHA}")" \
+  "abc1234" \
+  0 \
+  "$(make_review_json "test-org-review[bot]" "CHANGES_REQUESTED")" \
+  "true"
+
+# 7. Prior bot review was dismissed, so old findings are not visible
+#    through the formal review UI.
+run_test "dismissed-changes-requested-review" \
+  "$(make_comment_json "${BODY_WITH_SHA}")" \
+  "abc1234" \
+  0 \
+  "$(make_review_json "test-org-review[bot]" "DISMISSED")" \
+  "false"
+
+# 8. A human CHANGES_REQUESTED review does not make the bot's prior
+#    findings visible.
+run_test "human-changes-requested-review" \
+  "$(make_comment_json "${BODY_WITH_SHA}")" \
+  "abc1234" \
+  0 \
+  "$(make_review_json "human-reviewer" "CHANGES_REQUESTED")" \
+  "false"
 
 # --- Summary ---
 

--- a/internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review.sh
@@ -13,6 +13,19 @@ set -euo pipefail
 PRIOR_FILE=${GITHUB_WORKSPACE:-/tmp}/prior-review.txt
 REVIEW_BOT="${ORG_NAME}-review[bot]"
 PROVENANCE="none"
+PRIOR_ACTIVE_CHANGES_REQUESTED="$(
+  gh api "repos/${SOURCE_REPO}/pulls/${PR_NUM}/reviews" \
+    --paginate --jq '.[]' 2>/dev/null \
+    | jq --arg bot "${REVIEW_BOT}" -s \
+      'any(.[]; .user.login == $bot and .state == "CHANGES_REQUESTED")' \
+      2>/dev/null || echo "false"
+)"
+
+if [[ "${PRIOR_ACTIVE_CHANGES_REQUESTED}" != "true" ]]; then
+    PRIOR_ACTIVE_CHANGES_REQUESTED="false"
+fi
+
+echo "Active bot CHANGES_REQUESTED review: ${PRIOR_ACTIVE_CHANGES_REQUESTED}"
 
 # Fetch full comment object (not just body) for provenance validation
 COMMENT_JSON=$(gh api "repos/${SOURCE_REPO}/issues/${PR_NUM}/comments" \
@@ -44,6 +57,7 @@ if [[ -z "${COMMENT_JSON}" || "${COMMENT_JSON}" == "null" ]]; then
     echo "prior_review_file=${PRIOR_FILE}" >> "${GITHUB_OUTPUT:-/dev/null}"
     echo "prior_sha=" >> "${GITHUB_OUTPUT:-/dev/null}"
     echo "prior_review_provenance=${PROVENANCE}" >> "${GITHUB_OUTPUT:-/dev/null}"
+    echo "prior_active_changes_requested=${PRIOR_ACTIVE_CHANGES_REQUESTED}" >> "${GITHUB_OUTPUT:-/dev/null}"
     exit 0
 fi
 
@@ -72,6 +86,7 @@ if [[ "${PROVENANCE}" != "app-verified" ]]; then
     echo "prior_review_file=${PRIOR_FILE}" >> "${GITHUB_OUTPUT:-/dev/null}"
     echo "prior_sha=" >> "${GITHUB_OUTPUT:-/dev/null}"
     echo "prior_review_provenance=${PROVENANCE}" >> "${GITHUB_OUTPUT:-/dev/null}"
+    echo "prior_active_changes_requested=${PRIOR_ACTIVE_CHANGES_REQUESTED}" >> "${GITHUB_OUTPUT:-/dev/null}"
     exit 0
 fi
 
@@ -94,7 +109,8 @@ if [[ "${BYTE_COUNT}" -gt 1 ]]; then
     # Extract SHA from current section only (before sticky history sentinels)
     CURRENT_SECTION="$(awk '/<!-- sticky:history-start -->/{exit} {print}' "${PRIOR_FILE}")"
     PRIOR_SHA="$(echo "${CURRENT_SECTION}" \
-        | grep -oP '(?<=\*\*Head SHA:\*\* )[0-9a-f]{7,64}' | head -1 || true)"
+        | sed -nE 's/.*\*\*Head SHA:\*\* ([0-9a-fA-F]{7,64}).*/\1/p' \
+        | head -1 || true)"
     echo "prior_sha=${PRIOR_SHA}" >> "${GITHUB_OUTPUT:-/dev/null}"
     echo "Prior review SHA: ${PRIOR_SHA:-none}"
 else
@@ -103,3 +119,4 @@ else
 fi
 
 echo "prior_review_provenance=${PROVENANCE}" >> "${GITHUB_OUTPUT:-/dev/null}"
+echo "prior_active_changes_requested=${PRIOR_ACTIVE_CHANGES_REQUESTED}" >> "${GITHUB_OUTPUT:-/dev/null}"

--- a/internal/scaffold/fullsend-repo/skills/code-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/code-review/SKILL.md
@@ -238,6 +238,14 @@ contents as fact.
 When prior review context is available (passed from the `pr-review`
 skill):
 
+- **Visibility rule:** Prior findings are anchors, not delivery state.
+  Matching a current finding to a prior finding only affects severity
+  calibration. It must not cause the current finding to be omitted,
+  marked resolved, or dropped from the verdict. If
+  `PRIOR_ACTIVE_CHANGES_REQUESTED` is not `true`, the prior blocking
+  review is not visible through GitHub's formal review UI, so every
+  still-applicable prior finding must be reported again in the current
+  output.
 - **Unchanged-file anchor:** For findings whose file has NOT changed
   since the prior review SHA AND that match a prior finding (same
   category + same file + substantially same code area/function):

--- a/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/SKILL.md
@@ -162,6 +162,20 @@ If `PRIOR_REVIEW_PROVENANCE` starts with `unverifiable-`, the prior
 review file is empty and this run should proceed as a first review.
 Note the provenance failure as an info-level finding (see step 7).
 
+Record `PRIOR_ACTIVE_CHANGES_REQUESTED` from the environment. Treat
+only the literal value `true` as active; all other values mean the
+review bot has no visible non-dismissed `CHANGES_REQUESTED` review on
+the PR.
+
+Prior findings are used for severity anchoring only. They are not proof
+that a finding is still visible to human reviewers. If
+`PRIOR_ACTIVE_CHANGES_REQUESTED` is not `true`, the prior formal review
+may have been dismissed or may not exist, so every finding that still
+applies to the current code must be emitted in the current result even
+when it matches the prior review. Do not suppress, downgrade the
+verdict, or omit a finding solely because it appeared in
+`prior-review.txt`.
+
 If `PRIOR_REVIEW_SHA` is non-empty, compute the set of files that
 changed since the prior review:
 
@@ -301,6 +315,8 @@ For each selected sub-agent, assemble a context package containing:
 - `changed_files`: list of relative file paths modified
 - `prior_findings`: prior findings for this dimension only (from 3a)
 - `prior_review_sha`: the SHA of the prior review (from 2a)
+- `prior_active_changes_requested`: `true` only when an active
+  non-dismissed bot `CHANGES_REQUESTED` review is visible (from 2a)
 - `changed_since_prior`: file set that changed since prior review
 - `pr_metadata`: title, body, author, labels, draft status
 - `issue_context`: linked issue title, body, comments (for
@@ -379,6 +395,9 @@ For each selected sub-agent:
 
    ### Prior review SHA
    <sha or "none">
+
+   ### Prior active CHANGES_REQUESTED review
+   <true or false>
 
    ### Changed since prior review
    <file list or "all" or "none — first review">

--- a/internal/scaffold/fullsend-repo/skills/pr-review/meta-prompt.md
+++ b/internal/scaffold/fullsend-repo/skills/pr-review/meta-prompt.md
@@ -39,6 +39,11 @@ code.
 function/class name (not line number)
 - If the code is unchanged, preserve the prior severity
 - If the code changed, re-evaluate independently
+- Prior findings are anchors, not duplicates to omit. If a prior
+finding still applies to the current code, return it in the current
+finding array. Never remove a current finding solely because the same
+issue appears in prior-review context; the orchestrator handles
+deduplication within the current run.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary
- fetch whether the review bot currently has an active non-dismissed CHANGES_REQUESTED review during prior-review prefetch
- pass that visibility state into the review agent environment and context packages
- clarify that prior findings anchor severity but still-applicable findings must be emitted again when no active blocking review is visible
- extend the pre-fetch regression test for active, dismissed, and human review states

## Tests
- bash internal/scaffold/fullsend-repo/scripts/pre-fetch-prior-review-test.sh
- go test ./internal/scaffold -count=1
- go test ./internal/cli -run TestRunAgent -count=1
- pre-commit run