### PR TITLE
feat: add vouch system for first-time contributors

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/vouch-request.yml
+++ b/.github/DISCUSSION_TEMPLATE/vouch-request.yml
@@ -1,0 +1,45 @@
+title: "Vouch request: [your GitHub username]"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Vouch Request
+
+        Fullsend uses a vouch system for first-time contributors. Fill out this
+        form to request approval. A maintainer will review and comment `/vouch`
+        if approved.
+
+        **Write in your own words.** Do not have an AI generate this request.
+        Requests that read like LLM output will be denied.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What do you want to work on?
+      description: >
+        Describe the change you want to make. Link to an existing issue if
+        there is one.
+      placeholder: "I want to fix #123 which causes..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this change?
+      description: >
+        Explain your motivation and why this matters. Keep it concise.
+      placeholder: "This bug affects anyone who..."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I wrote this request myself (not AI-generated)
+          required: true
+        - label: I have read [CONTRIBUTING.md](https://github.com/fullsend-ai/fullsend/blob/main/CONTRIBUTING.md)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: First-time contributor? Get vouched first
+    url: https://github.com/fullsend-ai/fullsend/discussions/new?category=vouch-request
+    about: >
+      First-time contributors must be vouched before submitting PRs. Open a
+      Vouch Request discussion describing what you want to work on. A
+      maintainer will approve you with /vouch.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+<!-- 1-3 sentences: what this PR does and why -->
+
+## Related Issue
+<!-- Link to the issue this addresses: Fixes #NNN or Closes #NNN -->
+
+## Changes
+<!-- Bullet list of key changes -->
+
+## Testing
+- [ ] `make lint` passes (stage changes first, then run)
+- [ ] Tests added/updated for new or modified logic
+
+## Checklist
+- [ ] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
+- [ ] Commits are signed off (DCO) — human and human-directed agent sessions only
+- [ ] I wrote this contribution myself and can explain all changes in it

--- a/.github/workflows/vouch-check.yml
+++ b/.github/workflows/vouch-check.yml
@@ -1,0 +1,111 @@
+name: Vouch Check
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  vouch-gate:
+    if: github.repository_owner == 'fullsend-ai'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check if contributor is vouched
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const authorType = context.payload.pull_request.user.type;
+
+            // Skip bots (dependabot, renovate, fullsend agents, etc.).
+            if (authorType === 'Bot') {
+              console.log(`${author} is a bot. Skipping vouch check.`);
+              return;
+            }
+
+            // Check if author is a collaborator with write+ access.
+            // This covers org members, direct collaborators, and team members.
+            let trusted = false;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: author,
+              });
+              trusted = ['admin', 'maintain', 'write'].includes(data.role_name);
+            } catch (e) {
+              if (e.status !== 404) {
+                console.log(`Permission check error (status=${e.status}): ${e.message}`);
+              }
+            }
+
+            if (trusted) {
+              console.log(`${author} has write access. Skipping vouch check.`);
+              return;
+            }
+
+            // Read the VOUCHED.td file from the dedicated "vouched" branch.
+            // NOT the PR branch — the PR author could add themselves in their fork.
+            let vouched = false;
+            try {
+              const { data } = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: '.github/VOUCHED.td',
+                ref: 'vouched',
+              });
+              const content = Buffer.from(data.content, 'base64').toString('utf-8');
+              const usernames = content
+                .split('\n')
+                .map(line => line.trim())
+                .filter(line => line && !line.startsWith('#') && !line.startsWith('-'));
+              vouched = usernames.some(
+                name => name.toLowerCase() === author.toLowerCase()
+              );
+            } catch (e) {
+              console.log(`Could not read VOUCHED.td: ${e.message}`);
+            }
+
+            if (vouched) {
+              console.log(`${author} is in VOUCHED.td. Approved.`);
+              return;
+            }
+
+            // Not vouched — close the PR first, then comment.
+            // Close before commenting so enforcement succeeds even if the comment API fails.
+            console.log(`${author} is not vouched. Closing PR.`);
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              state: 'closed',
+            });
+
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: [
+                  `Thank you for your interest in contributing to fullsend, @${author}.`,
+                  '',
+                  'This project uses a **vouch system** for first-time contributors. Before submitting a pull request, you need to be vouched by a maintainer.',
+                  '',
+                  '**To get vouched:**',
+                  '1. Open a [Vouch Request](https://github.com/fullsend-ai/fullsend/discussions/new?category=vouch-request) discussion.',
+                  '2. Describe what you want to change and why.',
+                  '3. Write in your own words — do not have an AI generate the request.',
+                  '4. A maintainer will comment `/vouch` if approved.',
+                  '5. Once vouched, open a new PR (preferred) or reopen this one.',
+                  '',
+                  'See [CONTRIBUTING.md](https://github.com/fullsend-ai/fullsend/blob/main/CONTRIBUTING.md#first-time-contributors) for details.',
+                ].join('\n'),
+              });
+            } catch (e) {
+              console.log(`Warning: Could not post explanation comment: ${e.message}`);
+            }

--- a/.github/workflows/vouch-command.yml
+++ b/.github/workflows/vouch-command.yml
@@ -1,0 +1,218 @@
+name: Vouch Command
+
+on:
+  discussion_comment:
+    types: [created]
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  process-vouch:
+    permissions:
+      contents: write
+      discussions: write
+    if: >-
+      github.repository_owner == 'fullsend-ai' &&
+      github.event.comment.body == '/vouch' &&
+      github.event.discussion.category.slug == 'vouch-request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Process /vouch command
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const commenter = context.payload.comment.user.login;
+            const discussionAuthor = context.payload.discussion.user.login;
+            const discussionNumber = context.payload.discussion.number;
+
+            // --- Helpers ---
+
+            async function getDiscussionId() {
+              const query = `query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  discussion(number: $number) { id }
+                }
+              }`;
+              const { repository } = await github.graphql(query, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: discussionNumber,
+              });
+              return repository.discussion.id;
+            }
+
+            async function postDiscussionComment(body) {
+              try {
+                const discussionId = await getDiscussionId();
+                const mutation = `mutation($discussionId: ID!, $body: String!) {
+                  addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+                    comment { id }
+                  }
+                }`;
+                await github.graphql(mutation, { discussionId, body });
+              } catch (e) {
+                console.log(`Warning: Could not post discussion comment: ${e.message}`);
+              }
+            }
+
+            // --- Authorization ---
+
+            let isMaintainer = false;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: commenter,
+              });
+              isMaintainer = ['admin', 'maintain', 'write'].includes(data.role_name);
+            } catch (e) {
+              console.log(`Permission check failed: ${e.message}`);
+            }
+
+            if (!isMaintainer) {
+              console.log(`${commenter} does not have maintainer permissions. Ignoring.`);
+              return;
+            }
+
+            // --- Read VOUCHED.td ---
+
+            const filePath = '.github/VOUCHED.td';
+            const branch = 'vouched';
+
+            // Ensure the "vouched" branch exists. If not, create it as an
+            // orphan branch containing only VOUCHED.td — no history from main.
+            const headerContent = [
+              '# Vouched Contributors',
+              '#',
+              '# One GitHub username per line, no @ prefix.',
+              '# Prefix with - to denounce.',
+              '',
+            ].join('\n');
+
+            try {
+              await github.rest.repos.getBranch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch,
+              });
+            } catch (e) {
+              if (e.status === 404) {
+                console.log('Creating orphan "vouched" branch.');
+                const { data: blob } = await github.rest.git.createBlob({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  content: Buffer.from(headerContent).toString('base64'),
+                  encoding: 'base64',
+                });
+                const { data: tree } = await github.rest.git.createTree({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tree: [{ path: filePath, mode: '100644', type: 'blob', sha: blob.sha }],
+                });
+                const { data: commit } = await github.rest.git.createCommit({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  message: 'chore: initialize vouched branch',
+                  tree: tree.sha,
+                  parents: [],
+                });
+                await github.rest.git.createRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: 'refs/heads/vouched',
+                  sha: commit.sha,
+                });
+              } else {
+                throw e;
+              }
+            }
+
+            let currentContent = '';
+            let sha = '';
+            try {
+              const { data } = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: filePath,
+                ref: branch,
+              });
+              currentContent = Buffer.from(data.content, 'base64').toString('utf-8');
+              sha = data.sha;
+            } catch (e) {
+              console.log(`Could not read VOUCHED.td: ${e.message}`);
+              return;
+            }
+
+            // --- Parse .td format ---
+
+            function isVouched(content, username) {
+              return content
+                .split('\n')
+                .map(line => line.trim())
+                .filter(line => line && !line.startsWith('#') && !line.startsWith('-'))
+                .some(name => name.toLowerCase() === username.toLowerCase());
+            }
+
+            if (isVouched(currentContent, discussionAuthor)) {
+              console.log(`${discussionAuthor} is already vouched.`);
+              await postDiscussionComment(
+                `@${discussionAuthor} is already vouched. They can submit pull requests.`
+              );
+              return;
+            }
+
+            // --- Append username and commit ---
+
+            async function commitVouch(content, fileSha) {
+              const updatedContent = content.trimEnd() + '\n' + discussionAuthor + '\n';
+              const params = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: filePath,
+                message: `chore: vouch ${discussionAuthor} (by ${commenter})`,
+                content: Buffer.from(updatedContent).toString('base64'),
+                branch,
+              };
+              if (fileSha) params.sha = fileSha;
+              await github.rest.repos.createOrUpdateFileContents(params);
+            }
+
+            try {
+              await commitVouch(currentContent, sha);
+            } catch (e) {
+              if (e.status === 409) {
+                // Concurrent write — re-read and retry once.
+                console.log('409 conflict. Re-reading VOUCHED.td and retrying.');
+                const { data: fresh } = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: filePath,
+                  ref: branch,
+                });
+                const freshContent = Buffer.from(fresh.content, 'base64').toString('utf-8');
+                if (isVouched(freshContent, discussionAuthor)) {
+                  console.log(`${discussionAuthor} was vouched by a concurrent operation.`);
+                } else {
+                  await commitVouch(freshContent, fresh.sha);
+                }
+              } else {
+                throw e;
+              }
+            }
+
+            // --- Confirm ---
+
+            await postDiscussionComment([
+              `@${discussionAuthor} has been vouched by @${commenter}.`,
+              '',
+              'You can now submit pull requests to fullsend. Welcome aboard.',
+              '',
+              'Please read [CONTRIBUTING.md](https://github.com/fullsend-ai/fullsend/blob/main/CONTRIBUTING.md) before submitting.',
+            ].join('\n'));
+
+            console.log(`Vouched ${discussionAuthor} (approved by ${commenter}).`);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,17 @@ least-frequently-run agents.
 - **The repo is the coordinator.** No coordinator agent — branch protection, CODEOWNERS, and status checks are the coordination layer.
 - **Organization-specific content is cordoned.** Core problem docs are general; applied considerations live in `docs/problems/applied/`.
 
+## Vouch System
+
+- First-time external contributors must be vouched before their PRs are accepted. The `vouch-check` workflow auto-closes PRs from unvouched users.
+- Org members and collaborators with write access bypass the vouch gate automatically.
+- Maintainers vouch users by commenting `/vouch` on a Vouch Request discussion. The `vouch-command` workflow appends the username to `.github/VOUCHED.td` on the `vouched` branch.
+- Agent bot identities (`fullsend-ai-*[bot]`, `renovate-fullsend[bot]`, `github-actions[bot]`) are skipped automatically because they have `user.type: 'Bot'`.
+- The `vouched` branch is protected — only the `vouch-command` workflow (via `GITHUB_TOKEN`) can push to it. Do not push to, rebase, or target PRs at the `vouched` branch.
+- The vouch gate is separate from the e2e authorization gate. Vouch determines whether a PR stays open; e2e authorization determines whether tests run.
+- PRs from unvouched external contributors are automatically closed with a comment linking to the vouch process.
+- PRs should follow the PR template structure: Summary, Related Issue, Changes, Testing, Checklist.
+
 ## Terminology: tier conventions
 
 The term "tier" is used in multiple distinct contexts across this codebase. Always use a descriptive prefix to avoid ambiguity:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,18 @@
 
 Thank you for your interest in contributing! This document covers the social norms and processes we follow. For where to place your contribution (problem docs, ADRs, etc.), see the [README](README.md#how-to-contribute).
 
+## First-Time Contributors
+
+This project uses a **vouch system**. AI tools make it trivial to generate plausible-looking but low-quality contributions, so we require first-time contributors to be vouched by a maintainer before submitting pull requests.
+
+1. Open a [Vouch Request](https://github.com/fullsend-ai/fullsend/discussions/new?category=vouch-request) discussion.
+2. Describe what you want to change and why.
+3. Write in your own words — do not have an AI generate the request. Requests that read like LLM output will be denied.
+4. A maintainer will comment `/vouch` if approved.
+5. Once vouched, you can submit pull requests.
+
+**If you are not vouched, any pull request you open will be automatically closed.** Org members and collaborators with write access bypass this check.
+
 ## Commit messages
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/). See [COMMITS.md](COMMITS.md) for the full specification, type selection rules, and examples.


### PR DESCRIPTION
## Summary

Add a vouch system that gates PRs from unvouched first-time external contributors. Modeled after OpenShell (NVIDIA)'s approach — maintainers vouch users via `/vouch` on a GitHub Discussion before the contributor can open PRs.

## Changes

- **`vouch-check.yml`** — `pull_request_target` workflow that auto-closes PRs from unvouched users. Skips bots (`user.type === 'Bot'`) and org members/collaborators with write+ access (collaborator permission API). Closes before commenting for reliability.
- **`vouch-command.yml`** — `discussion_comment` workflow that processes `/vouch` commands from maintainers. Appends username to `VOUCHED.td` on the `vouched` branch with conflict retry. Creates the branch as an orphan (single file, no history from main) if it doesn't exist.
- **`vouch-request.yml`** — Discussion template with structured form: what/why textareas + anti-slop checkbox.
- **`config.yml`** — Issue chooser contact link directing first-time contributors to vouch process.
- **`pull_request_template.md`** — PR template with Summary, Changes, Testing, and attestation checklist.
- **`CONTRIBUTING.md`** — Added First-Time Contributors section with 5-step vouch process.
- **`AGENTS.md`** — Added Vouch System section documenting the gate, bypass rules, bot handling, and `vouched` branch protection.

## Manual Prerequisites

Before the workflows will work:

1. Enable Discussions on the repo (Settings > General > Features > Discussions)
2. Create "Vouch Request" discussion category (Discussions tab > Categories > New)
3. ~~Create `vouched` branch~~ **Done** — orphan branch created with `.github/VOUCHED.td` pre-seeded with 16 existing external contributors
4. ~~Protect the `vouched` branch~~ **Done** — force pushes and deletions blocked; no push restrictions (required for `GITHUB_TOKEN` via `createOrUpdateFileContents` to work)

## Testing
- [ ] `make lint` passes
- [ ] Workflow YAML validated (correct triggers, permissions, SHA-pinned actions)
- [ ] Bot bypass logic verified (`user.type === 'Bot'`)
- [ ] Collaborator permission API pattern matches existing `reusable-dispatch.yml` and `check-e2e-authorization.sh`
- [ ] Discussion template renders correctly
- [ ] Orphan branch creation verified on fork (blob → tree → parentless commit → ref, then `createOrUpdateFileContents` chains normally)