### PR TITLE
chore(e2e): delete per-repo var before starting

### DIFF
--- a/e2e/admin/admin_test.go
+++ b/e2e/admin/admin_test.go
@@ -266,9 +266,9 @@ func mergeEnrollmentPR(t *testing.T, env *e2eEnv) {
 		if enrollmentPR != nil {
 			break
 		}
-		t.Logf("Attempt %d: enrollment PR not yet visible", attempt+1)
+		t.Logf("Attempt %d: enrollment PR not yet visible for repository '%s/%s'", attempt+1, env.org, testRepo)
 	}
-	require.NotNil(t, enrollmentPR, "enrollment PR should exist for %s", testRepo)
+	require.NotNil(t, enrollmentPR, "enrollment PR should exist for %s/%s", env.org, testRepo)
 
 	t.Logf("Merging enrollment PR #%d: %s", enrollmentPR.Number, enrollmentPR.URL)
 

--- a/e2e/admin/cleanup.go
+++ b/e2e/admin/cleanup.go
@@ -92,6 +92,12 @@ func cleanupStaleResources(ctx context.Context, client forge.Client, token, org 
 		}
 	}
 
+	// 7. Delete stale FULLSEND_PER_REPO_INSTALL guard variable from test-repo.
+	// reconcile-repos.sh skips repos with this variable set to true.
+	if delErr := client.DeleteRepoVariable(ctx, org, testRepo, forge.PerRepoGuardVar); delErr != nil {
+		t.Logf("[cleanup] Warning: could not delete per-repo guard variable: %v", delErr)
+	}
+
 	t.Log("[cleanup] Stale resource scan complete")
 }
 

--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -831,6 +831,24 @@ func (f *FakeClient) GetRepoVariable(_ context.Context, owner, repo, name string
 	return "", false, nil
 }
 
+func (f *FakeClient) DeleteRepoVariable(_ context.Context, owner, repo, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if e := f.err("DeleteRepoVariable"); e != nil {
+		return e
+	}
+
+	key := owner + "/" + repo + "/" + name
+	if f.VariableValues != nil {
+		delete(f.VariableValues, key)
+	}
+	if f.VariablesExist != nil {
+		delete(f.VariablesExist, key)
+	}
+	return nil
+}
+
 func (f *FakeClient) GetWorkflow(_ context.Context, owner, repo, workflowFile string) (*Workflow, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/internal/forge/fake_test.go
+++ b/internal/forge/fake_test.go
@@ -503,6 +503,27 @@ func TestFakeClient_DeleteOrgVariable(t *testing.T) {
 	assert.Equal(t, "myorg/DISPATCH_URL", fc.DeletedOrgVariables[0])
 }
 
+func TestFakeClient_DeleteRepoVariable(t *testing.T) {
+	ctx := context.Background()
+	fc := &FakeClient{
+		VariableValues: map[string]string{
+			"myorg/myrepo/FULLSEND_PER_REPO_INSTALL": "true",
+		},
+		VariablesExist: map[string]bool{
+			"myorg/myrepo/FULLSEND_PER_REPO_INSTALL": true,
+		},
+	}
+
+	err := fc.DeleteRepoVariable(ctx, "myorg", "myrepo", "FULLSEND_PER_REPO_INSTALL")
+	require.NoError(t, err)
+
+	// Verify deletion from both maps
+	_, existsInValues := fc.VariableValues["myorg/myrepo/FULLSEND_PER_REPO_INSTALL"]
+	assert.False(t, existsInValues)
+	_, existsInExists := fc.VariablesExist["myorg/myrepo/FULLSEND_PER_REPO_INSTALL"]
+	assert.False(t, existsInExists)
+}
+
 func TestFakeClient_ErrorInjection(t *testing.T) {
 	ctx := context.Background()
 	injected := errors.New("injected error")
@@ -571,6 +592,9 @@ func TestFakeClient_ErrorInjection(t *testing.T) {
 		{"IsInstallationToken", func(fc *FakeClient) error { _, err := fc.IsInstallationToken(ctx); return err }},
 		{"DeleteOrgVariable", func(fc *FakeClient) error {
 			return fc.DeleteOrgVariable(ctx, "o", "n")
+		}},
+		{"DeleteRepoVariable", func(fc *FakeClient) error {
+			return fc.DeleteRepoVariable(ctx, "o", "r", "n")
 		}},
 		{"SetOrgVariableRepos", func(fc *FakeClient) error {
 			return fc.SetOrgVariableRepos(ctx, "o", "n", nil)

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -345,6 +345,7 @@ type Client interface {
 	CreateOrUpdateRepoVariable(ctx context.Context, owner, repo, name, value string) error
 	RepoVariableExists(ctx context.Context, owner, repo, name string) (bool, error)
 	GetRepoVariable(ctx context.Context, owner, repo, name string) (string, bool, error)
+	DeleteRepoVariable(ctx context.Context, owner, repo, name string) error
 
 	// Org-level secrets (for cross-repo dispatch tokens)
 	CreateOrgSecret(ctx context.Context, org, name, value string, selectedRepoIDs []int64) error

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -1819,6 +1819,21 @@ func (c *LiveClient) GetRepoVariable(ctx context.Context, owner, repo, name stri
 	return result.Value, true, nil
 }
 
+// DeleteRepoVariable deletes a repository Actions variable. It is idempotent:
+// a 404 (variable already gone) is not treated as an error.
+func (c *LiveClient) DeleteRepoVariable(ctx context.Context, owner, repo, name string) error {
+	resp, err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/repos/%s/%s/actions/variables/%s", owner, repo, name), nil)
+	if err != nil {
+		return fmt.Errorf("delete repo variable %s: %w", name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	return &APIError{StatusCode: resp.StatusCode, Message: "unexpected status deleting repo variable"}
+}
+
 // GetWorkflow returns a workflow definition by filename (e.g. repo-maintenance.yml).
 func (c *LiveClient) GetWorkflow(ctx context.Context, owner, repo, workflowFile string) (*forge.Workflow, error) {
 	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/actions/workflows/%s", owner, repo, workflowFile))

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -1747,6 +1747,47 @@ func TestDeleteOrgVariable(t *testing.T) {
 	})
 }
 
+func TestDeleteRepoVariable(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "DELETE", r.Method)
+			assert.Equal(t, "/repos/myorg/myrepo/actions/variables/FULLSEND_PER_REPO_INSTALL", r.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+
+		client := newTestClient(t, srv)
+		err := client.DeleteRepoVariable(context.Background(), "myorg", "myrepo", "FULLSEND_PER_REPO_INSTALL")
+		require.NoError(t, err)
+	})
+
+	t.Run("idempotent 404", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "DELETE", r.Method)
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]any{"message": "Not Found"})
+		}))
+		defer srv.Close()
+
+		client := newTestClient(t, srv)
+		err := client.DeleteRepoVariable(context.Background(), "myorg", "myrepo", "ALREADY_GONE")
+		require.NoError(t, err)
+	})
+
+	t.Run("unexpected status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "DELETE", r.Method)
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer srv.Close()
+
+		client := newTestClient(t, srv)
+		err := client.DeleteRepoVariable(context.Background(), "myorg", "myrepo", "VAR")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected status")
+	})
+}
+
 func TestListOrgRepos_Pagination(t *testing.T) {
 	page := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
Introduces code to remove the flag on the test-repo on e2e tests to allow repo-maintenance to enroll it.

## Related Issue
Fixes #2871

## Changes
- Clear `FULLSEND_PER_REPO_INSTALL` variable from test-repo before enrollment phase

## Testing
- [ ] `make lint` passes (stage changes first, then run)
- [ ] Tests added/updated for new or modified logic

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it