### PR TITLE
feat(forge): add ListRepoVariables, DeleteRepoVariable, DeleteRepoSecret

### DIFF
--- a/internal/forge/fake.go
+++ b/internal/forge/fake.go
@@ -200,7 +200,9 @@ type FakeClient struct {
 	DeletedRepos           []string // "owner/repo"
 	DeletedFiles           []FileRecord
 	CreatedSecrets         []SecretRecord
+	DeletedSecrets         []SecretRecord
 	Variables              []VariableRecord
+	DeletedVariables       []VariableRecord
 	DeletedOrgSecrets      []string // "org/name"
 	CreatedOrgSecrets      []OrgSecretRecord
 	CreatedOrgVariables    []OrgVariableRecord
@@ -770,6 +772,26 @@ func (f *FakeClient) CreateRepoSecret(_ context.Context, owner, repo, name, valu
 	return nil
 }
 
+func (f *FakeClient) DeleteRepoSecret(_ context.Context, owner, repo, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if e := f.err("DeleteRepoSecret"); e != nil {
+		return e
+	}
+
+	key := owner + "/" + repo + "/" + name
+	if f.Secrets != nil {
+		delete(f.Secrets, key)
+	}
+	f.DeletedSecrets = append(f.DeletedSecrets, SecretRecord{
+		Owner: owner,
+		Repo:  repo,
+		Name:  name,
+	})
+	return nil
+}
+
 func (f *FakeClient) RepoSecretExists(_ context.Context, owner, repo, name string) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -792,6 +814,15 @@ func (f *FakeClient) CreateOrUpdateRepoVariable(_ context.Context, owner, repo, 
 		return e
 	}
 
+	key := owner + "/" + repo + "/" + name
+	if f.VariableValues == nil {
+		f.VariableValues = make(map[string]string)
+	}
+	f.VariableValues[key] = value
+	if f.VariablesExist == nil {
+		f.VariablesExist = make(map[string]bool)
+	}
+	f.VariablesExist[key] = true
 	f.Variables = append(f.Variables, VariableRecord{
 		Owner: owner,
 		Repo:  repo,
@@ -831,6 +862,25 @@ func (f *FakeClient) GetRepoVariable(_ context.Context, owner, repo, name string
 	return "", false, nil
 }
 
+func (f *FakeClient) ListRepoVariables(_ context.Context, owner, repo string) (map[string]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if e := f.err("ListRepoVariables"); e != nil {
+		return nil, e
+	}
+
+	prefix := owner + "/" + repo + "/"
+	result := make(map[string]string)
+	for key, val := range f.VariableValues {
+		if strings.HasPrefix(key, prefix) {
+			name := strings.TrimPrefix(key, prefix)
+			result[name] = val
+		}
+	}
+	return result, nil
+}
+
 func (f *FakeClient) DeleteRepoVariable(_ context.Context, owner, repo, name string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -846,6 +896,11 @@ func (f *FakeClient) DeleteRepoVariable(_ context.Context, owner, repo, name str
 	if f.VariablesExist != nil {
 		delete(f.VariablesExist, key)
 	}
+	f.DeletedVariables = append(f.DeletedVariables, VariableRecord{
+		Owner: owner,
+		Repo:  repo,
+		Name:  name,
+	})
 	return nil
 }
 

--- a/internal/forge/fake_test.go
+++ b/internal/forge/fake_test.go
@@ -524,6 +524,82 @@ func TestFakeClient_DeleteRepoVariable(t *testing.T) {
 	assert.False(t, existsInExists)
 }
 
+func TestFakeClient_ListRepoVariables(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns matching variables", func(t *testing.T) {
+		fc := &FakeClient{
+			VariableValues: map[string]string{
+				"org/repo/FOO":       "bar",
+				"org/repo/BAZ":       "qux",
+				"org/other-repo/FOO": "other",
+			},
+		}
+
+		vars, err := fc.ListRepoVariables(ctx, "org", "repo")
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"FOO": "bar", "BAZ": "qux"}, vars)
+	})
+
+	t.Run("empty when no variables", func(t *testing.T) {
+		fc := &FakeClient{}
+		vars, err := fc.ListRepoVariables(ctx, "org", "repo")
+		require.NoError(t, err)
+		assert.Empty(t, vars)
+	})
+
+	t.Run("error injection", func(t *testing.T) {
+		fc := &FakeClient{Errors: map[string]error{"ListRepoVariables": errors.New("fail")}}
+		_, err := fc.ListRepoVariables(ctx, "org", "repo")
+		assert.Error(t, err)
+	})
+}
+
+func TestFakeClient_DeleteRepoSecret(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("deletes existing secret", func(t *testing.T) {
+		fc := &FakeClient{
+			Secrets: map[string]bool{
+				"org/repo/MY_SECRET": true,
+			},
+		}
+
+		err := fc.DeleteRepoSecret(ctx, "org", "repo", "MY_SECRET")
+		require.NoError(t, err)
+		assert.False(t, fc.Secrets["org/repo/MY_SECRET"])
+		require.Len(t, fc.DeletedSecrets, 1)
+		assert.Equal(t, "MY_SECRET", fc.DeletedSecrets[0].Name)
+	})
+
+	t.Run("idempotent when nil secrets map", func(t *testing.T) {
+		fc := &FakeClient{}
+		err := fc.DeleteRepoSecret(ctx, "org", "repo", "NONEXISTENT")
+		require.NoError(t, err)
+		require.Len(t, fc.DeletedSecrets, 1)
+	})
+
+	t.Run("error injection", func(t *testing.T) {
+		fc := &FakeClient{Errors: map[string]error{"DeleteRepoSecret": errors.New("fail")}}
+		err := fc.DeleteRepoSecret(ctx, "org", "repo", "SECRET")
+		assert.Error(t, err)
+	})
+}
+
+func TestFakeClient_CreateThenListVariables(t *testing.T) {
+	ctx := context.Background()
+	fc := &FakeClient{}
+
+	err := fc.CreateOrUpdateRepoVariable(ctx, "org", "repo", "FOO", "bar")
+	require.NoError(t, err)
+	err = fc.CreateOrUpdateRepoVariable(ctx, "org", "repo", "BAZ", "qux")
+	require.NoError(t, err)
+
+	vars, err := fc.ListRepoVariables(ctx, "org", "repo")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"FOO": "bar", "BAZ": "qux"}, vars)
+}
+
 func TestFakeClient_ErrorInjection(t *testing.T) {
 	ctx := context.Background()
 	injected := errors.New("injected error")
@@ -614,6 +690,13 @@ func TestFakeClient_ErrorInjection(t *testing.T) {
 			_, err := fc.GetFileContentAtRef(ctx, "o", "r", "p", "main")
 			return err
 		}},
+		{"DeleteRepoSecret", func(fc *FakeClient) error {
+			return fc.DeleteRepoSecret(ctx, "o", "r", "n")
+		}},
+		{"ListRepoVariables", func(fc *FakeClient) error {
+			_, err := fc.ListRepoVariables(ctx, "o", "r")
+			return err
+		}},
 	}
 
 	for _, m := range methods {
@@ -685,6 +768,8 @@ func TestFakeClient_ThreadSafety(t *testing.T) {
 			_ = fc.DeleteIssueComment(ctx, "o", "r", 1)
 			_, _ = fc.ListDirectoryContents(ctx, "o", "r", "p", "main", false)
 			_, _ = fc.GetFileContentAtRef(ctx, "o", "r", "p", "main")
+			_ = fc.DeleteRepoSecret(ctx, "o", "r", "n")
+			_, _ = fc.ListRepoVariables(ctx, "o", "r")
 		}(i)
 	}
 

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -342,9 +342,11 @@ type Client interface {
 	// Secrets and variables
 	CreateRepoSecret(ctx context.Context, owner, repo, name, value string) error
 	RepoSecretExists(ctx context.Context, owner, repo, name string) (bool, error)
+	DeleteRepoSecret(ctx context.Context, owner, repo, name string) error
 	CreateOrUpdateRepoVariable(ctx context.Context, owner, repo, name, value string) error
 	RepoVariableExists(ctx context.Context, owner, repo, name string) (bool, error)
 	GetRepoVariable(ctx context.Context, owner, repo, name string) (string, bool, error)
+	ListRepoVariables(ctx context.Context, owner, repo string) (map[string]string, error)
 	DeleteRepoVariable(ctx context.Context, owner, repo, name string) error
 
 	// Org-level secrets (for cross-repo dispatch tokens)

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -1834,6 +1834,61 @@ func (c *LiveClient) DeleteRepoVariable(ctx context.Context, owner, repo, name s
 	return &APIError{StatusCode: resp.StatusCode, Message: "unexpected status deleting repo variable"}
 }
 
+// ListRepoVariables returns all Actions variables for a repository as a
+// name-to-value map. Results are paginated; the method follows pagination
+// until all variables are fetched or the safety page cap is reached.
+func (c *LiveClient) ListRepoVariables(ctx context.Context, owner, repo string) (map[string]string, error) {
+	const maxPages = 100
+	result := make(map[string]string)
+	var totalCount, fetched int
+
+	for page := 1; page <= maxPages; page++ {
+		path := fmt.Sprintf("/repos/%s/%s/actions/variables?per_page=100&page=%d", owner, repo, page)
+		resp, err := c.get(ctx, path)
+		if err != nil {
+			return nil, fmt.Errorf("list repo variables page %d: %w", page, err)
+		}
+
+		var body struct {
+			TotalCount int `json:"total_count"`
+			Variables  []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"variables"`
+		}
+		if err := decodeJSON(resp, &body); err != nil {
+			return nil, fmt.Errorf("decode repo variables page %d: %w", page, err)
+		}
+
+		totalCount = body.TotalCount
+		for _, v := range body.Variables {
+			result[v.Name] = v.Value
+		}
+		fetched += len(body.Variables)
+
+		if fetched >= totalCount || len(body.Variables) == 0 {
+			return result, nil
+		}
+	}
+
+	return nil, fmt.Errorf("list repo variables: pagination exceeded %d pages (fetched %d of %d variables)", maxPages, len(result), totalCount)
+}
+
+// DeleteRepoSecret deletes a repository Actions secret. It is idempotent:
+// a 404 (secret already gone) is not treated as an error.
+func (c *LiveClient) DeleteRepoSecret(ctx context.Context, owner, repo, name string) error {
+	resp, err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/repos/%s/%s/actions/secrets/%s", owner, repo, name), nil)
+	if err != nil {
+		return fmt.Errorf("delete repo secret %s: %w", name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	return &APIError{StatusCode: resp.StatusCode, Message: "unexpected status deleting repo secret"}
+}
+
 // GetWorkflow returns a workflow definition by filename (e.g. repo-maintenance.yml).
 func (c *LiveClient) GetWorkflow(ctx context.Context, owner, repo, workflowFile string) (*forge.Workflow, error) {
 	resp, err := c.get(ctx, fmt.Sprintf("/repos/%s/%s/actions/workflows/%s", owner, repo, workflowFile))

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -2544,3 +2544,158 @@ func TestCommitFiles_BranchProtected(t *testing.T) {
 	assert.True(t, forge.IsBranchProtected(err))
 	assert.False(t, forge.IsNonFastForward(err), "should not match non-fast-forward")
 }
+
+func TestListRepoVariables_SinglePage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/repos/owner/repo/actions/variables", r.URL.Path)
+		assert.Equal(t, "100", r.URL.Query().Get("per_page"))
+
+		json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 2,
+			"variables": []map[string]string{
+				{"name": "FOO", "value": "bar"},
+				{"name": "BAZ", "value": "qux"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	vars, err := client.ListRepoVariables(context.Background(), "owner", "repo")
+	require.NoError(t, err)
+	require.Len(t, vars, 2)
+	assert.Equal(t, "bar", vars["FOO"])
+	assert.Equal(t, "qux", vars["BAZ"])
+}
+
+func TestListRepoVariables_Paginated(t *testing.T) {
+	page := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page++
+		switch page {
+		case 1:
+			// Return a full page with total_count indicating more pages
+			vars := make([]map[string]string, 100)
+			for i := range vars {
+				vars[i] = map[string]string{
+					"name":  fmt.Sprintf("VAR_%d", i),
+					"value": fmt.Sprintf("val_%d", i),
+				}
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 101,
+				"variables":   vars,
+			})
+		case 2:
+			// Second page: 1 variable
+			json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 101,
+				"variables": []map[string]string{
+					{"name": "VAR_100", "value": "val_100"},
+				},
+			})
+		default:
+			t.Errorf("unexpected page %d", page)
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	vars, err := client.ListRepoVariables(context.Background(), "owner", "repo")
+	require.NoError(t, err)
+	assert.Len(t, vars, 101)
+	assert.Equal(t, "val_0", vars["VAR_0"])
+	assert.Equal(t, "val_100", vars["VAR_100"])
+	assert.Equal(t, 2, page, "should have made exactly 2 requests")
+}
+
+func TestListRepoVariables_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 0,
+			"variables":   []map[string]string{},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	vars, err := client.ListRepoVariables(context.Background(), "owner", "repo")
+	require.NoError(t, err)
+	assert.Empty(t, vars)
+}
+
+func TestListRepoVariables_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]any{"message": "Internal Server Error"})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	_, err := client.ListRepoVariables(context.Background(), "owner", "repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list repo variables")
+}
+
+func TestListRepoVariables_PaginationTruncation(t *testing.T) {
+	page := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page++
+		// Always return 1 variable but claim there are 20000, so pagination never completes.
+		json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 20000,
+			"variables": []map[string]string{
+				{"name": fmt.Sprintf("VAR_%d", page), "value": "v"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	_, err := client.ListRepoVariables(context.Background(), "owner", "repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pagination exceeded")
+	assert.Equal(t, 100, page)
+}
+
+func TestDeleteRepoSecret(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "DELETE", r.Method)
+			assert.Equal(t, "/repos/owner/repo/actions/secrets/MY_SECRET", r.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+
+		client := newTestClient(t, srv)
+		err := client.DeleteRepoSecret(context.Background(), "owner", "repo", "MY_SECRET")
+		require.NoError(t, err)
+	})
+
+	t.Run("idempotent 404", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "DELETE", r.Method)
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]any{"message": "Not Found"})
+		}))
+		defer srv.Close()
+
+		client := newTestClient(t, srv)
+		err := client.DeleteRepoSecret(context.Background(), "owner", "repo", "ALREADY_GONE")
+		require.NoError(t, err)
+	})
+
+	t.Run("unexpected status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "DELETE", r.Method)
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer srv.Close()
+
+		client := newTestClient(t, srv)
+		err := client.DeleteRepoSecret(context.Background(), "owner", "repo", "SECRET")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected status")
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `ListRepoVariables`, `DeleteRepoVariable`, `DeleteRepoSecret` to the `forge.Client` interface
- GitHub implementation with paginated list and idempotent deletes
- FakeClient implementation with deletion tracking for test assertions
- Foundation for `fullsend repos status/sync/remove` commands (ADR 0057, PR 3 of 8)

## Test plan
- [ ] httptest-based tests for all three GitHub methods
- [ ] Pagination, empty results, idempotent deletes, error handling
- [ ] Coverage >85% on new code
- [ ] `go build ./...` passes — all interface implementations compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)