### PR TITLE
fix(#3036): resolve per-repo runner script paths in agent workflows

### DIFF
--- a/.github/actions/setup-gcp/action.yml
+++ b/.github/actions/setup-gcp/action.yml
@@ -8,6 +8,10 @@ inputs:
   gcp_project_id:
     description: 'GCP project ID — passed to google-github-actions/auth so the runner env has GOOGLE_CLOUD_PROJECT'
     required: false
+  scripts_dir:
+    description: 'Directory containing prepare-sandbox-credentials.sh (scripts for per-org, .fullsend/scripts for per-repo)'
+    required: false
+    default: 'scripts'
 
 runs:
   using: composite
@@ -34,4 +38,6 @@ runs:
 
     - name: Prepare sandbox credentials
       shell: bash
-      run: bash scripts/prepare-sandbox-credentials.sh
+      env:
+        SCRIPTS_DIR: ${{ inputs.scripts_dir }}
+      run: bash "${SCRIPTS_DIR}/prepare-sandbox-credentials.sh"

--- a/.github/actions/setup-gcp/action.yml
+++ b/.github/actions/setup-gcp/action.yml
@@ -8,10 +8,6 @@ inputs:
   gcp_project_id:
     description: 'GCP project ID — passed to google-github-actions/auth so the runner env has GOOGLE_CLOUD_PROJECT'
     required: false
-  scripts_dir:
-    description: 'Directory containing prepare-sandbox-credentials.sh (scripts for per-org, .fullsend/scripts for per-repo)'
-    required: false
-    default: 'scripts'
 
 runs:
   using: composite
@@ -38,6 +34,4 @@ runs:
 
     - name: Prepare sandbox credentials
       shell: bash
-      env:
-        SCRIPTS_DIR: ${{ inputs.scripts_dir }}
-      run: bash "${SCRIPTS_DIR}/prepare-sandbox-credentials.sh"
+      run: bash scripts/prepare-sandbox-credentials.sh

--- a/.github/actions/setup-gcp/action.yml
+++ b/.github/actions/setup-gcp/action.yml
@@ -8,6 +8,10 @@ inputs:
   gcp_project_id:
     description: 'GCP project ID — passed to google-github-actions/auth so the runner env has GOOGLE_CLOUD_PROJECT'
     required: false
+  fullsend-dir:
+    description: 'Path to fullsend config directory (empty for per-org workspace root layout)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -34,4 +38,6 @@ runs:
 
     - name: Prepare sandbox credentials
       shell: bash
-      run: bash scripts/prepare-sandbox-credentials.sh
+      env:
+        FULLSEND_DIR: ${{ inputs.fullsend-dir }}
+      run: bash "${FULLSEND_DIR:+$FULLSEND_DIR/}scripts/prepare-sandbox-credentials.sh"

--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -153,8 +153,8 @@ jobs:
           REPO_FULL_NAME: ${{ inputs.source_repo }}
           GITHUB_ISSUE_URL: ${{ fromJSON(inputs.event_payload).issue.html_url }}
           COMMENT_BODY: ${{ fromJSON(inputs.event_payload).comment.body }}
-          PRE_SCRIPT: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts/pre-code.sh' || 'scripts/pre-code.sh' }}
-        run: bash "${PRE_SCRIPT}"
+          FULLSEND_DIR: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
+        run: bash "${FULLSEND_DIR:+$FULLSEND_DIR/}scripts/pre-code.sh"
 
       - name: Setup GCP and prepare credentials
         if: steps.validate.outputs.skipped != 'true'
@@ -162,6 +162,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
       - name: Resolve bot identity
         if: steps.validate.outputs.skipped != 'true'

--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -162,7 +162,6 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
-          scripts_dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts' || 'scripts' }}
 
       - name: Resolve bot identity
         if: steps.validate.outputs.skipped != 'true'

--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -153,7 +153,8 @@ jobs:
           REPO_FULL_NAME: ${{ inputs.source_repo }}
           GITHUB_ISSUE_URL: ${{ fromJSON(inputs.event_payload).issue.html_url }}
           COMMENT_BODY: ${{ fromJSON(inputs.event_payload).comment.body }}
-        run: bash scripts/pre-code.sh
+          PRE_SCRIPT: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts/pre-code.sh' || 'scripts/pre-code.sh' }}
+        run: bash "${PRE_SCRIPT}"
 
       - name: Setup GCP and prepare credentials
         if: steps.validate.outputs.skipped != 'true'
@@ -161,6 +162,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          scripts_dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts' || 'scripts' }}
 
       - name: Resolve bot identity
         if: steps.validate.outputs.skipped != 'true'

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -366,13 +366,15 @@ jobs:
           TRIGGER_SOURCE: ${{ inputs.trigger_source }}
           FIX_ITERATION: ${{ steps.context.outputs.iteration }}
           HUMAN_INSTRUCTION: ${{ steps.context.outputs.instruction }}
-        run: bash scripts/pre-fix.sh
+          PRE_SCRIPT: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts/pre-fix.sh' || 'scripts/pre-fix.sh' }}
+        run: bash "${PRE_SCRIPT}"
 
       - name: Setup GCP and prepare credentials
         uses: ./.defaults/.github/actions/setup-gcp
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          scripts_dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts' || 'scripts' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -374,7 +374,6 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
-          scripts_dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts' || 'scripts' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -366,14 +366,15 @@ jobs:
           TRIGGER_SOURCE: ${{ inputs.trigger_source }}
           FIX_ITERATION: ${{ steps.context.outputs.iteration }}
           HUMAN_INSTRUCTION: ${{ steps.context.outputs.instruction }}
-          PRE_SCRIPT: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts/pre-fix.sh' || 'scripts/pre-fix.sh' }}
-        run: bash "${PRE_SCRIPT}"
+          FULLSEND_DIR: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
+        run: bash "${FULLSEND_DIR:+$FULLSEND_DIR/}scripts/pre-fix.sh"
 
       - name: Setup GCP and prepare credentials
         uses: ./.defaults/.github/actions/setup-gcp
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-prioritize.yml
+++ b/.github/workflows/reusable-prioritize.yml
@@ -135,7 +135,6 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
-          scripts_dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts' || 'scripts' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-prioritize.yml
+++ b/.github/workflows/reusable-prioritize.yml
@@ -135,6 +135,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          scripts_dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts' || 'scripts' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-prioritize.yml
+++ b/.github/workflows/reusable-prioritize.yml
@@ -135,6 +135,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-retro.yml
+++ b/.github/workflows/reusable-retro.yml
@@ -148,6 +148,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-retro.yml
+++ b/.github/workflows/reusable-retro.yml
@@ -148,7 +148,6 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
-          scripts_dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts' || 'scripts' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-retro.yml
+++ b/.github/workflows/reusable-retro.yml
@@ -148,6 +148,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          scripts_dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts' || 'scripts' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -153,13 +153,15 @@ jobs:
              || fromJSON(inputs.event_payload).issue.number }}
           ORG_NAME: ${{ github.repository_owner }}
           REVIEW_APP_CLIENT_ID: ${{ vars.FULLSEND_REVIEW_CLIENT_ID }}
-        run: bash scripts/pre-fetch-prior-review.sh
+          PRE_SCRIPT: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts/pre-fetch-prior-review.sh' || 'scripts/pre-fetch-prior-review.sh' }}
+        run: bash "${PRE_SCRIPT}"
 
       - name: Setup GCP and prepare credentials
         uses: ./.defaults/.github/actions/setup-gcp
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          scripts_dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts' || 'scripts' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -153,14 +153,15 @@ jobs:
              || fromJSON(inputs.event_payload).issue.number }}
           ORG_NAME: ${{ github.repository_owner }}
           REVIEW_APP_CLIENT_ID: ${{ vars.FULLSEND_REVIEW_CLIENT_ID }}
-          PRE_SCRIPT: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts/pre-fetch-prior-review.sh' || 'scripts/pre-fetch-prior-review.sh' }}
-        run: bash "${PRE_SCRIPT}"
+          FULLSEND_DIR: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
+        run: bash "${FULLSEND_DIR:+$FULLSEND_DIR/}scripts/pre-fetch-prior-review.sh"
 
       - name: Setup GCP and prepare credentials
         uses: ./.defaults/.github/actions/setup-gcp
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -161,7 +161,6 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
-          scripts_dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts' || 'scripts' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-triage.yml
+++ b/.github/workflows/reusable-triage.yml
@@ -149,6 +149,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-triage.yml
+++ b/.github/workflows/reusable-triage.yml
@@ -149,7 +149,6 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
-          scripts_dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts' || 'scripts' }}
 
       - name: Setup agent environment
         env:

--- a/.github/workflows/reusable-triage.yml
+++ b/.github/workflows/reusable-triage.yml
@@ -149,6 +149,7 @@ jobs:
         with:
           gcp_wif_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
           gcp_project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          scripts_dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend/scripts' || 'scripts' }}
 
       - name: Setup agent environment
         env:


### PR DESCRIPTION
## Summary

- Add a `fullsend-dir` input to the `setup-gcp` composite action and resolve `prepare-sandbox-credentials.sh` under `${FULLSEND_DIR}scripts/` (same prefix pattern as the agent action)
- Pass `fullsend-dir: ${{ inputs.install_mode == 'per-repo' && '.fullsend' || '' }}` from all six reusable agent workflows
- Fix inline runner-side pre-scripts in `reusable-code.yml`, `reusable-review.yml`, and `reusable-fix.yml` using the same `${FULLSEND_DIR:+$FULLSEND_DIR/}scripts/...` pattern

Fixes #3036
Fixes #3038

Supersedes #3037 (consolidated here).

## Background

After #3000, per-repo **Prepare workspace** copies scaffold content under `.fullsend/` (including `scripts/`). Several workflow steps still invoked `scripts/...` at the workspace root, causing exit 127 in per-repo agent runs. Per-org mode is unchanged.

## Test plan

- [x] `actionlint` passes on changed workflow files
- [ ] Behaviour CI on a per-repo pool repo confirms all six agent stages pass **Setup GCP** and inline pre-script steps
- [ ] Per-org agent runs still resolve `scripts/` at workspace root