### PR TITLE
ci(release): sync version tags to fullsend-ai/agents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,11 @@ jobs:
             git push origin v0
           fi
 
+      # Sync the version tag to fullsend-ai/agents. Runs for all tags
+      # including pre-releases — agents' own release.yml handles
+      # pre-release semantics. Intentionally coupled to the v0 step:
+      # if the v0 move fails, the release state is suspect and agents
+      # should not be tagged until the issue is investigated.
       - name: Generate agents repo token
         id: agents-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,29 @@ jobs:
           else
             git push origin v0
           fi
+
+      - name: Generate agents repo token
+        id: agents-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          repositories: agents
+
+      - name: Push tag to fullsend-ai/agents
+        env:
+          GH_TOKEN: ${{ steps.agents-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+
+          if gh api "repos/fullsend-ai/agents/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on fullsend-ai/agents, skipping"
+            exit 0
+          fi
+
+          AGENTS_SHA=$(gh api repos/fullsend-ai/agents/git/ref/heads/main --jq '.object.sha')
+          gh api repos/fullsend-ai/agents/git/refs \
+            -f ref="refs/tags/${TAG}" \
+            -f sha="${AGENTS_SHA}"
+          echo "Created tag ${TAG} on fullsend-ai/agents at ${AGENTS_SHA}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,9 +67,14 @@ jobs:
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
 
-          if gh api "repos/fullsend-ai/agents/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+          HTTP_CODE=$(gh api "repos/fullsend-ai/agents/git/ref/tags/${TAG}" \
+            --include 2>/dev/null | head -1 | awk '{print $2}') || true
+          if [[ "${HTTP_CODE}" == "200" ]]; then
             echo "Tag ${TAG} already exists on fullsend-ai/agents, skipping"
             exit 0
+          elif [[ "${HTTP_CODE}" != "404" ]]; then
+            echo "::error::Unexpected response (HTTP ${HTTP_CODE}) checking tag on fullsend-ai/agents"
+            exit 1
           fi
 
           AGENTS_SHA=$(gh api repos/fullsend-ai/agents/git/ref/heads/main --jq '.object.sha')

--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use when the user wants to tag a release, cut a release candidate, or ship a
   new version. Also use when asking about release process, versioning, or how
   GoReleaser is configured.
-allowed-tools: Read, Grep, Glob, AskUserQuestion, Bash(git tag:*), Bash(git log:*), Bash(git diff:*), Bash(git pull:*), Bash(git push:*), Bash(gh release:*), Bash(gh run:*), Bash(git checkout:*), Bash(git fetch:*), Bash(bash skills/cutting-releases/scripts/install-binary.sh:*)
+allowed-tools: Read, Grep, Glob, AskUserQuestion, Bash(git tag:*), Bash(git log:*), Bash(git diff:*), Bash(git pull:*), Bash(git push:*), Bash(gh release:*), Bash(gh run:*), Bash(gh api:*), Bash(gh pr:*), Bash(git checkout:*), Bash(git fetch:*), Bash(bash skills/cutting-releases/scripts/install-binary.sh:*)
 ---
 
 # Cutting Releases
@@ -135,3 +135,9 @@ installs the binary as `fullsend-<tag>` so multiple versions can coexist.
 - **The `v0` tag** is a moving tag consumed by downstream orgs for reusable
   workflows. It is automatically moved by the release workflow after
   GoReleaser completes (skipped for pre-release tags).
+- **The `fullsend-ai/agents` repo** is tagged with the same version
+  automatically. After GoReleaser completes, the release workflow
+  pushes the tag to agents using an org-owned GitHub App token
+  (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`). That tag push
+  triggers agents' own `release.yml`, which creates a GitHub Release
+  and moves its `v0` floating tag.

--- a/skills/cutting-releases/post-flight.md
+++ b/skills/cutting-releases/post-flight.md
@@ -30,6 +30,33 @@ gh release view <tag>
 Check that the title, changelog, and binary assets look correct.
 Verify the release is not marked as a draft.
 
+## B2. Verify agents repo release
+
+The release workflow pushes the same tag to `fullsend-ai/agents`,
+which triggers agents' own `release.yml` to create a GitHub Release
+and move the `v0` floating tag.
+
+Verify the agents release workflow succeeded:
+
+```
+gh run list --repo fullsend-ai/agents --workflow=release.yml --limit=1
+```
+
+Verify the tag and release exist:
+
+```
+gh release view <tag> --repo fullsend-ai/agents
+```
+
+For non-prerelease tags, verify the `v0` floating tag was moved:
+
+```
+gh api repos/fullsend-ai/agents/git/ref/tags/v0 --jq '.object.sha'
+```
+
+If the agents release workflow failed, investigate before continuing —
+downstream consumers may reference agents by tag.
+
 ## C. Skip fullsend-ai repos
 
 The `fullsend-ai/.fullsend` repo references reusable workflows via

--- a/skills/cutting-releases/pre-flight.md
+++ b/skills/cutting-releases/pre-flight.md
@@ -49,6 +49,23 @@ Classify each change as:
 - **Breaking** (removed/renamed inputs, outputs, jobs, new required
   secrets) — block the release until resolved.
 
+## A2. Check agents repo state
+
+The release workflow tags `fullsend-ai/agents` with the same version
+after GoReleaser succeeds. Verify agents is in a healthy state:
+
+```
+gh run list --repo fullsend-ai/agents --limit=5
+```
+
+Check for open PRs that should be merged before releasing:
+
+```
+gh pr list --repo fullsend-ai/agents --state=open --limit=5
+```
+
+If there are critical open PRs, resolve them before proceeding.
+
 ## B. Audit scaffold and template changes
 
 ```


### PR DESCRIPTION
## Summary

Closes #3083

- After GoReleaser completes, the release workflow now pushes the same semver tag to `fullsend-ai/agents` using an org-owned GitHub App token (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`)
- That tag push triggers agents' own `release.yml` (see fullsend-ai/agents#25) to create a GitHub Release and move the `v0` floating tag
- Pre-flight and post-flight checklists updated to verify agents repo state

## Prerequisites

The `fullsend-release` GitHub App must be:
1. Created in the `fullsend-ai` org with **Contents → Read and write** permission
2. Installed on `fullsend-ai/agents`
3. App ID stored as `RELEASE_APP_ID` variable on this repo
4. Private key stored as `RELEASE_APP_PRIVATE_KEY` secret on this repo

## Test plan

- [ ] Verify `RELEASE_APP_ID` variable and `RELEASE_APP_PRIVATE_KEY` secret are set
- [ ] Verify the GitHub App is installed on `fullsend-ai/agents`
- [ ] Merge companion PR in `fullsend-ai/agents` (adds `release.yml`)
- [ ] Cut a release and verify both repos get tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)