### PR TITLE
feat(runtime): render agent event stream live during execution

### DIFF
--- a/docs/superpowers/plans/2026-07-06-agent-event-stream-rendering.md
+++ b/docs/superpowers/plans/2026-07-06-agent-event-stream-rendering.md
@@ -1,0 +1,1515 @@
+# Agent Event Stream Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the full agent event stream (thinking, text, tool calls, tokens, errors) live during `fullsend run` execution, behind the `Runtime` interface so any runtime can plug in.
+
+**Architecture:** Three layers: normalized `AgentEvent` types (interface + concrete structs), a Claude-specific NDJSON parser that emits events via a callback, and a runtime-agnostic `EventRenderer` that renders structured colored output via `*ui.Printer`. The parser calls the handler synchronously -- no channels or goroutines.
+
+**Tech Stack:** Go, lipgloss (terminal styling), existing `internal/ui` and `internal/runtime` packages.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `internal/runtime/event.go` (new) | `AgentEvent` interface + concrete event structs |
+| `internal/runtime/event_test.go` (new) | Verify marker method compilation, event type assertions |
+| `internal/runtime/renderer.go` (new) | `EventRenderer` struct: consumes `AgentEvent`, renders via `*ui.Printer` |
+| `internal/runtime/renderer_test.go` (new) | Renderer unit tests: each event type, block transitions, CI annotations |
+| `internal/runtime/claude_progress.go` (modify) | Replace `progressParser` internals with `parseClaudeStream` + callback; keep `progressParser` as wrapper |
+| `internal/runtime/claude_progress_test.go` (modify) | Add `parseClaudeStream` tests for stream_event deltas; existing `progressParser` tests stay as integration tests |
+| `internal/runtime/runtime.go` (modify) | Add `OnEvent func(AgentEvent)` field to `RunParams` |
+| `internal/runtime/claude.go` (modify) | Wire `OnEvent` / default `EventRenderer` in `ClaudeRuntime.Run` |
+
+---
+
+### Task 1: Define normalized event types
+
+**Files:**
+- Create: `internal/runtime/event.go`
+- Create: `internal/runtime/event_test.go`
+
+- [ ] **Step 1: Write the event type definitions**
+
+Create `internal/runtime/event.go`:
+
+```go
+package runtime
+
+// AgentEvent is the normalized event interface for runtime-agnostic rendering.
+// Each concrete event type implements this with a no-op marker method.
+type AgentEvent interface {
+	agentEvent()
+}
+
+// InitEvent is emitted once at stream start with runtime metadata.
+type InitEvent struct {
+	Model   string
+	Version string
+}
+
+func (InitEvent) agentEvent() {}
+
+// ThinkingEvent carries an incremental thinking text delta.
+type ThinkingEvent struct {
+	Text string
+}
+
+func (ThinkingEvent) agentEvent() {}
+
+// TextEvent carries an incremental assistant text delta.
+type TextEvent struct {
+	Text string
+}
+
+func (TextEvent) agentEvent() {}
+
+// ToolUseEvent is emitted when a tool invocation completes.
+// Name is the tool name ("tool" for unknown/non-allowlisted tools).
+// Summary is a pre-computed one-line description safe for display.
+type ToolUseEvent struct {
+	Name    string
+	Summary string
+}
+
+func (ToolUseEvent) agentEvent() {}
+
+// TokensEvent carries incremental token usage counters.
+type TokensEvent struct {
+	InputTokens  int
+	OutputTokens int
+	CacheRead    int
+	CacheWrite   int
+}
+
+func (TokensEvent) agentEvent() {}
+
+// ResultEvent is emitted once at stream end with final metrics.
+type ResultEvent struct {
+	NumTurns                 int
+	TotalCostUSD             float64
+	IsError                  bool
+	ErrorMessage             string
+	Subtype                  string
+	InputTokens              int
+	OutputTokens             int
+	CacheCreationInputTokens int
+	CacheReadInputTokens     int
+}
+
+func (ResultEvent) agentEvent() {}
+
+// ErrorEvent is emitted when the runtime reports an error.
+type ErrorEvent struct {
+	ErrorType string
+	Message   string
+}
+
+func (ErrorEvent) agentEvent() {}
+
+// RetryEvent is emitted when the runtime retries an API call.
+type RetryEvent struct {
+	Attempt    int
+	MaxRetries int
+	DelayMs    int
+	Error      string
+}
+
+func (RetryEvent) agentEvent() {}
+```
+
+- [ ] **Step 2: Write a compilation test for the interface**
+
+Create `internal/runtime/event_test.go`:
+
+```go
+package runtime
+
+import "testing"
+
+func TestAgentEventInterfaceSatisfied(t *testing.T) {
+	// Compile-time verification that all concrete types satisfy AgentEvent.
+	var events []AgentEvent
+	events = append(events,
+		InitEvent{Model: "claude-opus-4-6", Version: "1.0.0"},
+		ThinkingEvent{Text: "thinking..."},
+		TextEvent{Text: "hello"},
+		ToolUseEvent{Name: "Read", Summary: "/src/main.go"},
+		TokensEvent{InputTokens: 100, OutputTokens: 50, CacheRead: 30, CacheWrite: 20},
+		ResultEvent{NumTurns: 5, TotalCostUSD: 0.42},
+		ErrorEvent{ErrorType: "overloaded", Message: "rate limited"},
+		RetryEvent{Attempt: 1, MaxRetries: 3, DelayMs: 1000, Error: "timeout"},
+	)
+	if len(events) != 8 {
+		t.Errorf("expected 8 event types, got %d", len(events))
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `cd /home/rbean/code/fullsend-2 && go test ./internal/runtime/ -run TestAgentEventInterfaceSatisfied -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/runtime/event.go internal/runtime/event_test.go
+git commit -S -s -m "$(cat <<'EOF'
+refactor(runtime): add normalized AgentEvent types for stream rendering
+
+Define the AgentEvent interface and concrete event structs (InitEvent,
+ThinkingEvent, TextEvent, ToolUseEvent, TokensEvent, ResultEvent,
+ErrorEvent, RetryEvent) that bridge runtime-specific NDJSON parsing
+and runtime-agnostic rendering.
+
+Part of #3170.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Add OnEvent callback to RunParams
+
+**Files:**
+- Modify: `internal/runtime/runtime.go`
+
+- [ ] **Step 1: Add the OnEvent field**
+
+In `internal/runtime/runtime.go`, add the `OnEvent` field to `RunParams` after the `OutputPath` field:
+
+```go
+// RunParams configures a single agent invocation inside the sandbox.
+type RunParams struct {
+	SandboxName   string
+	AgentBaseName string
+	Model         string
+	RepoDir       string
+	PluginDirs    []string
+	Debug         string
+	Timeout       time.Duration
+	OutputPath    string         // if set, tee stream-json stdout to this file
+	OnEvent       func(AgentEvent) // if non-nil, called with normalized events during Run
+}
+```
+
+- [ ] **Step 2: Run existing tests to verify nothing breaks**
+
+Run: `cd /home/rbean/code/fullsend-2 && go test ./internal/runtime/ -v`
+Expected: all existing tests PASS (adding an optional field breaks nothing)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/runtime/runtime.go
+git commit -S -s -m "$(cat <<'EOF'
+refactor(runtime): add OnEvent callback to RunParams
+
+Add an optional OnEvent func(AgentEvent) field to RunParams. When set,
+the runtime calls it with normalized events during execution. When nil,
+events are silently discarded (or the runtime uses a default renderer).
+
+Part of #3170.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Implement EventRenderer
+
+**Files:**
+- Create: `internal/runtime/renderer.go`
+- Create: `internal/runtime/renderer_test.go`
+
+- [ ] **Step 1: Write failing tests for the renderer**
+
+Create `internal/runtime/renderer_test.go`:
+
+```go
+package runtime
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+func newTestRenderer(buf *bytes.Buffer) (*EventRenderer, *RunMetrics) {
+	printer := ui.New(buf)
+	metrics := &RunMetrics{}
+	r := NewEventRenderer(printer, time.Now(), metrics)
+	return r, metrics
+}
+
+func TestRendererInitEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	r.Handle(InitEvent{Model: "claude-opus-4-6", Version: "1.2.3"})
+
+	output := buf.String()
+	if !strings.Contains(output, "claude-opus-4-6") {
+		t.Errorf("expected model in output, got: %s", output)
+	}
+}
+
+func TestRendererToolUseEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, metrics := newTestRenderer(&buf)
+
+	r.Handle(ToolUseEvent{Name: "Read", Summary: "/src/main.go"})
+
+	output := buf.String()
+	if !strings.Contains(output, "Read") {
+		t.Errorf("expected tool name in output, got: %s", output)
+	}
+	if !strings.Contains(output, "/src/main.go") {
+		t.Errorf("expected summary in output, got: %s", output)
+	}
+	if metrics.ToolCalls.Load() != 1 {
+		t.Errorf("expected 1 tool call, got %d", metrics.ToolCalls.Load())
+	}
+}
+
+func TestRendererToolUseEventCI(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+
+	var buf bytes.Buffer
+	// In CI mode the renderer writes ::notice:: to stderr.
+	// We capture stderr by creating the renderer with a separate writer.
+	oldStderr := os.Stderr
+	stderrR, stderrW, _ := os.Pipe()
+	os.Stderr = stderrW
+	defer func() { os.Stderr = oldStderr }()
+
+	r, _ := newTestRenderer(&buf)
+	r.Handle(ToolUseEvent{Name: "Bash", Summary: "make"})
+
+	stderrW.Close()
+	var stderrBuf bytes.Buffer
+	stderrBuf.ReadFrom(stderrR)
+
+	if !strings.Contains(stderrBuf.String(), "::notice::") {
+		t.Errorf("expected ::notice:: annotation in CI mode, got: %s", stderrBuf.String())
+	}
+}
+
+func TestRendererThinkingEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	r.Handle(ThinkingEvent{Text: "Let me consider"})
+
+	output := buf.String()
+	if !strings.Contains(output, "Let me consider") {
+		t.Errorf("expected thinking text in output, got: %s", output)
+	}
+}
+
+func TestRendererTextEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	r.Handle(TextEvent{Text: "Here is the answer"})
+
+	output := buf.String()
+	if !strings.Contains(output, "Here is the answer") {
+		t.Errorf("expected text in output, got: %s", output)
+	}
+}
+
+func TestRendererBlockTransition(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	// Thinking -> Tool should close thinking block first
+	r.Handle(ThinkingEvent{Text: "pondering"})
+	r.Handle(ToolUseEvent{Name: "Read", Summary: "/a.go"})
+
+	output := buf.String()
+	if !strings.Contains(output, "pondering") {
+		t.Errorf("expected thinking text, got: %s", output)
+	}
+	if !strings.Contains(output, "Read") {
+		t.Errorf("expected tool name after block transition, got: %s", output)
+	}
+}
+
+func TestRendererResultEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, metrics := newTestRenderer(&buf)
+
+	r.Handle(ResultEvent{
+		NumTurns:                 8,
+		TotalCostUSD:             0.42,
+		InputTokens:              12000,
+		OutputTokens:             3400,
+		CacheCreationInputTokens: 8000,
+		CacheReadInputTokens:     5000,
+	})
+
+	if metrics.NumTurns != 8 {
+		t.Errorf("expected 8 turns, got %d", metrics.NumTurns)
+	}
+	if metrics.TotalCostUSD != 0.42 {
+		t.Errorf("expected cost 0.42, got %f", metrics.TotalCostUSD)
+	}
+	if metrics.InputTokens != 12000 {
+		t.Errorf("expected 12000 input tokens, got %d", metrics.InputTokens)
+	}
+	if metrics.OutputTokens != 3400 {
+		t.Errorf("expected 3400 output tokens, got %d", metrics.OutputTokens)
+	}
+	if metrics.CacheCreationInputTokens != 8000 {
+		t.Errorf("expected 8000 cache creation tokens, got %d", metrics.CacheCreationInputTokens)
+	}
+	if metrics.CacheReadInputTokens != 5000 {
+		t.Errorf("expected 5000 cache read tokens, got %d", metrics.CacheReadInputTokens)
+	}
+}
+
+func TestRendererErrorEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	r.Handle(ErrorEvent{ErrorType: "overloaded_error", Message: "rate limited"})
+
+	output := buf.String()
+	if !strings.Contains(output, "overloaded_error") {
+		t.Errorf("expected error type in output, got: %s", output)
+	}
+	if !strings.Contains(output, "rate limited") {
+		t.Errorf("expected error message in output, got: %s", output)
+	}
+}
+
+func TestRendererRetryEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	r.Handle(RetryEvent{Attempt: 2, MaxRetries: 5, DelayMs: 1000, Error: "timeout"})
+
+	output := buf.String()
+	if !strings.Contains(output, "2") {
+		t.Errorf("expected attempt number in output, got: %s", output)
+	}
+	if !strings.Contains(output, "timeout") {
+		t.Errorf("expected error in output, got: %s", output)
+	}
+}
+
+func TestRendererTokensEventThrottled(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	// First tokens event should render (total crosses 0 -> 5k threshold)
+	r.Handle(TokensEvent{InputTokens: 4000, OutputTokens: 2000})
+	first := buf.String()
+
+	// Second event just below next 5k boundary should not add output
+	buf.Reset()
+	r.Handle(TokensEvent{InputTokens: 4000, OutputTokens: 2500})
+	second := buf.String()
+
+	if first == "" {
+		t.Error("expected first tokens event to render")
+	}
+	if second != "" {
+		t.Errorf("expected second tokens event to be throttled, got: %s", second)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/rbean/code/fullsend-2 && go test ./internal/runtime/ -run TestRenderer -v`
+Expected: FAIL with "undefined: NewEventRenderer"
+
+- [ ] **Step 3: Implement the renderer**
+
+Create `internal/runtime/renderer.go`:
+
+```go
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+// EventRenderer renders normalized AgentEvent values to a Printer.
+// It tracks block state (text/thinking) so transitions between event
+// types produce clean output boundaries.
+type EventRenderer struct {
+	printer        *ui.Printer
+	start          time.Time
+	metrics        *RunMetrics
+	isCI           bool
+	inText         bool
+	inThinking     bool
+	lastTokenTotal int
+}
+
+// NewEventRenderer creates a renderer that writes to the given printer
+// and populates metrics as events arrive.
+func NewEventRenderer(printer *ui.Printer, start time.Time, metrics *RunMetrics) *EventRenderer {
+	return &EventRenderer{
+		printer: printer,
+		start:   start,
+		metrics: metrics,
+		isCI:    os.Getenv("GITHUB_ACTIONS") == "true",
+	}
+}
+
+var (
+	thinkingStyle = lipgloss.NewStyle().Italic(true).Foreground(ui.ColorMuted)
+)
+
+// Handle dispatches a single AgentEvent to the appropriate rendering method.
+func (r *EventRenderer) Handle(evt AgentEvent) {
+	switch e := evt.(type) {
+	case InitEvent:
+		r.endBlock()
+		label := e.Model
+		if e.Version != "" {
+			label = fmt.Sprintf("%s (v%s)", e.Model, e.Version)
+		}
+		r.printer.Header("Agent: " + label)
+	case ThinkingEvent:
+		if !r.inThinking {
+			r.endBlock()
+			r.printer.Raw(thinkingStyle.Render("  \U0001f9e0 "))
+			r.inThinking = true
+		}
+		r.printer.Raw(thinkingStyle.Render(e.Text))
+	case TextEvent:
+		if !r.inText {
+			r.endBlock()
+			r.printer.Raw("  \U0001f4ac ")
+			r.inText = true
+		}
+		r.printer.Raw(e.Text)
+	case ToolUseEvent:
+		r.endBlock()
+		count := r.metrics.ToolCalls.Add(1)
+		elapsed := time.Since(r.start).Truncate(time.Second)
+		var msg string
+		if e.Summary != "" {
+			msg = fmt.Sprintf("%s: %s (%s, %d tools)", e.Name, e.Summary, elapsed, count)
+		} else {
+			msg = fmt.Sprintf("%s (%s, %d tools)", e.Name, elapsed, count)
+		}
+		msg = sanitizeOutput(msg)
+		if r.isCI {
+			fmt.Fprintf(os.Stderr, "::notice::%s\n", msg)
+		}
+		r.printer.Heartbeat(msg)
+	case TokensEvent:
+		total := e.InputTokens + e.OutputTokens + e.CacheRead + e.CacheWrite
+		if total-r.lastTokenTotal >= 5000 {
+			r.endBlock()
+			r.lastTokenTotal = total
+			r.printer.StepInfo(fmt.Sprintf(
+				"TOKENS in=%d out=%d cache_r=%d cache_w=%d total=%d",
+				e.InputTokens, e.OutputTokens, e.CacheRead, e.CacheWrite, total,
+			))
+		}
+	case ResultEvent:
+		r.endBlock()
+		r.metrics.NumTurns = e.NumTurns
+		r.metrics.TotalCostUSD = e.TotalCostUSD
+		r.metrics.InputTokens = e.InputTokens
+		r.metrics.OutputTokens = e.OutputTokens
+		r.metrics.CacheCreationInputTokens = e.CacheCreationInputTokens
+		r.metrics.CacheReadInputTokens = e.CacheReadInputTokens
+		label := "Result"
+		if e.Subtype != "" {
+			label = fmt.Sprintf("Result: %s", e.Subtype)
+		}
+		if e.IsError {
+			label = "Result: ERROR"
+			if e.Subtype != "" {
+				label = fmt.Sprintf("Result: ERROR (%s)", e.Subtype)
+			}
+		}
+		r.printer.Header(label)
+		r.printer.KeyValue("Turns", fmt.Sprintf("%d", e.NumTurns))
+		r.printer.KeyValue("Cost", fmt.Sprintf("$%.4f", e.TotalCostUSD))
+		r.printer.KeyValue("Tokens", fmt.Sprintf(
+			"in=%d out=%d cache_create=%d cache_read=%d",
+			e.InputTokens, e.OutputTokens,
+			e.CacheCreationInputTokens, e.CacheReadInputTokens,
+		))
+		if e.IsError && e.ErrorMessage != "" {
+			r.printer.StepFail(sanitizeOutput(e.ErrorMessage))
+		}
+	case ErrorEvent:
+		r.endBlock()
+		r.printer.StepFail(fmt.Sprintf("%s: %s",
+			sanitizeOutput(e.ErrorType), sanitizeOutput(e.Message)))
+	case RetryEvent:
+		r.endBlock()
+		r.printer.StepWarn(fmt.Sprintf("Retry %d/%d: %s (delay %dms)",
+			e.Attempt, e.MaxRetries, sanitizeOutput(e.Error), e.DelayMs))
+	}
+}
+
+// endBlock closes any open text or thinking block.
+func (r *EventRenderer) endBlock() {
+	if r.inText || r.inThinking {
+		r.printer.Raw("\n")
+		r.inText = false
+		r.inThinking = false
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/rbean/code/fullsend-2 && go test ./internal/runtime/ -run TestRenderer -v`
+Expected: all TestRenderer* tests PASS
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `cd /home/rbean/code/fullsend-2 && go test ./internal/runtime/ -v`
+Expected: all tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/runtime/renderer.go internal/runtime/renderer_test.go
+git commit -S -s -m "$(cat <<'EOF'
+refactor(runtime): add EventRenderer for structured agent output
+
+EventRenderer consumes normalized AgentEvent values and renders
+structured terminal output: thinking text (italic/dim), assistant text,
+tool summaries with elapsed time and count, token usage (throttled),
+result summaries, errors, and retry warnings. Tracks block state for
+clean transitions between event types.
+
+Part of #3170.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Refactor Claude stream parser to emit AgentEvent
+
+**Files:**
+- Modify: `internal/runtime/claude_progress.go`
+- Modify: `internal/runtime/claude_progress_test.go`
+
+- [ ] **Step 1: Write failing tests for parseClaudeStream**
+
+Add the following tests to `internal/runtime/claude_progress_test.go`:
+
+```go
+func collectEvents(t *testing.T, input string) []AgentEvent {
+	t.Helper()
+	var events []AgentEvent
+	err := parseClaudeStream(strings.NewReader(input), func(evt AgentEvent) {
+		events = append(events, evt)
+	})
+	if err != nil {
+		t.Fatalf("parseClaudeStream returned error: %v", err)
+	}
+	return events
+}
+
+func TestParseClaudeStreamInitEvent(t *testing.T) {
+	input := `{"type":"system","subtype":"init","model":"claude-opus-4-6","claude_code_version":"1.0.50"}`
+	events := collectEvents(t, input)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	init, ok := events[0].(InitEvent)
+	if !ok {
+		t.Fatalf("expected InitEvent, got %T", events[0])
+	}
+	if init.Model != "claude-opus-4-6" {
+		t.Errorf("expected model claude-opus-4-6, got %q", init.Model)
+	}
+	if init.Version != "1.0.50" {
+		t.Errorf("expected version 1.0.50, got %q", init.Version)
+	}
+}
+
+func TestParseClaudeStreamRetryEvent(t *testing.T) {
+	input := `{"type":"system","subtype":"api_retry","attempt":2,"max_retries":5,"retry_delay_ms":1000,"error":"overloaded"}`
+	events := collectEvents(t, input)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	retry, ok := events[0].(RetryEvent)
+	if !ok {
+		t.Fatalf("expected RetryEvent, got %T", events[0])
+	}
+	if retry.Attempt != 2 || retry.MaxRetries != 5 || retry.DelayMs != 1000 || retry.Error != "overloaded" {
+		t.Errorf("unexpected retry event: %+v", retry)
+	}
+}
+
+func TestParseClaudeStreamTextDeltas(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello "}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"world"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+
+	var texts []string
+	for _, e := range events {
+		if te, ok := e.(TextEvent); ok {
+			texts = append(texts, te.Text)
+		}
+	}
+	if len(texts) != 2 || texts[0] != "hello " || texts[1] != "world" {
+		t.Errorf("expected two text deltas [hello ] [world], got %v", texts)
+	}
+}
+
+func TestParseClaudeStreamThinkingDeltas(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+
+	var thinking []string
+	for _, e := range events {
+		if te, ok := e.(ThinkingEvent); ok {
+			thinking = append(thinking, te.Text)
+		}
+	}
+	if len(thinking) != 1 || thinking[0] != "hmm" {
+		t.Errorf("expected one thinking delta [hmm], got %v", thinking)
+	}
+}
+
+func TestParseClaudeStreamToolUse(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","name":"Read"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"file_path\""}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\"/src/main.go\"}"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+
+	var tools []ToolUseEvent
+	for _, e := range events {
+		if te, ok := e.(ToolUseEvent); ok {
+			tools = append(tools, te)
+		}
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool event, got %d", len(tools))
+	}
+	if tools[0].Name != "Read" {
+		t.Errorf("expected tool name Read, got %q", tools[0].Name)
+	}
+	if tools[0].Summary != "/src/main.go" {
+		t.Errorf("expected summary /src/main.go, got %q", tools[0].Summary)
+	}
+}
+
+func TestParseClaudeStreamUnknownTool(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","name":"EvilTool"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"secret\":\"password123\"}"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+
+	var tools []ToolUseEvent
+	for _, e := range events {
+		if te, ok := e.(ToolUseEvent); ok {
+			tools = append(tools, te)
+		}
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool event, got %d", len(tools))
+	}
+	if tools[0].Name != "tool" {
+		t.Errorf("expected masked tool name 'tool', got %q", tools[0].Name)
+	}
+	if tools[0].Summary != "" {
+		t.Errorf("expected empty summary for unknown tool, got %q", tools[0].Summary)
+	}
+}
+
+func TestParseClaudeStreamResultEvent(t *testing.T) {
+	input := `{"type":"result","num_turns":8,"total_cost_usd":0.42,"is_error":false,"subtype":"success","usage":{"input_tokens":12000,"output_tokens":3400,"cache_creation_input_tokens":8000,"cache_read_input_tokens":5000}}`
+	events := collectEvents(t, input)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	result, ok := events[0].(ResultEvent)
+	if !ok {
+		t.Fatalf("expected ResultEvent, got %T", events[0])
+	}
+	if result.NumTurns != 8 || result.TotalCostUSD != 0.42 {
+		t.Errorf("unexpected result: %+v", result)
+	}
+	if result.InputTokens != 12000 || result.OutputTokens != 3400 {
+		t.Errorf("unexpected token counts: %+v", result)
+	}
+}
+
+func TestParseClaudeStreamErrorEvent(t *testing.T) {
+	input := `{"type":"stream_event","event":{"type":"error","error":{"type":"overloaded_error","message":"rate limited"}}}`
+	events := collectEvents(t, input)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	errEvt, ok := events[0].(ErrorEvent)
+	if !ok {
+		t.Fatalf("expected ErrorEvent, got %T", events[0])
+	}
+	if errEvt.ErrorType != "overloaded_error" || errEvt.Message != "rate limited" {
+		t.Errorf("unexpected error event: %+v", errEvt)
+	}
+}
+
+func TestParseClaudeStreamAssistantFallback(t *testing.T) {
+	// When no stream_events have been seen, assistant messages should emit ToolUseEvent
+	lines := []string{
+		`{"type":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/src/main.go"}}]}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+
+	var tools []ToolUseEvent
+	for _, e := range events {
+		if te, ok := e.(ToolUseEvent); ok {
+			tools = append(tools, te)
+		}
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool event from assistant fallback, got %d", len(tools))
+	}
+	if tools[0].Name != "Read" || tools[0].Summary != "/src/main.go" {
+		t.Errorf("unexpected tool event: %+v", tools[0])
+	}
+}
+
+func TestParseClaudeStreamAssistantSuppressedWhenStreaming(t *testing.T) {
+	// When stream_events have been seen, assistant messages should NOT emit ToolUseEvent
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+		`{"type":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/src/main.go"}}]}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+
+	for _, e := range events {
+		if _, ok := e.(ToolUseEvent); ok {
+			t.Error("assistant message should not emit ToolUseEvent when stream_events are active")
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `cd /home/rbean/code/fullsend-2 && go test ./internal/runtime/ -run 'TestParseClaudeStream' -v`
+Expected: FAIL with "undefined: parseClaudeStream"
+
+- [ ] **Step 3: Implement parseClaudeStream**
+
+Replace the contents of `internal/runtime/claude_progress.go` with:
+
+```go
+package runtime
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+const (
+	maxPatternDisplay = 50
+	maxPathDisplay    = 200
+	tokenThreshold    = 5000
+)
+
+// streamEvent represents a single NDJSON event from Claude Code's stream-json output.
+type streamEvent struct {
+	Type string `json:"type"`
+}
+
+// systemEvent is Claude Code's initial "system"/"init" event, which carries the
+// resolved model name. The result event does not include the model.
+type systemEvent struct {
+	Type               string `json:"type"`
+	Subtype            string `json:"subtype"`
+	Model              string `json:"model"`
+	ClaudeCodeVersion  string `json:"claude_code_version"`
+	Attempt            int    `json:"attempt"`
+	MaxRetries         int    `json:"max_retries"`
+	RetryDelayMs       int    `json:"retry_delay_ms"`
+	Error              string `json:"error"`
+}
+
+// assistantMessage contains tool_use blocks from complete assistant messages.
+// Claude Code's stream-json nests the content array (and model) under "message";
+// older/flat shapes put content at the top level. We accept both.
+type assistantMessage struct {
+	Type    string          `json:"type"`
+	Content json.RawMessage `json:"content"`
+	Message struct {
+		Content json.RawMessage `json:"content"`
+		Model   string          `json:"model"`
+	} `json:"message"`
+}
+
+type contentItem struct {
+	Type  string          `json:"type"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
+}
+
+// allowedTools is the set of tool names we display in progress output.
+// Unknown tools emit no context to prevent information disclosure from
+// untrusted sandbox output.
+var allowedTools = map[string]bool{
+	"Bash":  true,
+	"Read":  true,
+	"Write": true,
+	"Edit":  true,
+	"Grep":  true,
+	"Glob":  true,
+	"Agent": true,
+}
+
+// resultEvent represents the final NDJSON event from Claude Code's stream-json
+// output, containing execution metrics.
+type resultEvent struct {
+	Type         string  `json:"type"`
+	Subtype      string  `json:"subtype"`
+	IsError      bool    `json:"is_error"`
+	Result       string  `json:"result"`
+	NumTurns     int     `json:"num_turns"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
+	Usage        struct {
+		InputTokens              int `json:"input_tokens"`
+		OutputTokens             int `json:"output_tokens"`
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+		CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	} `json:"usage"`
+}
+
+// streamEventWrapper wraps the nested event structure from stream-json.
+type streamEventWrapper struct {
+	Type  string          `json:"type"`
+	Event json.RawMessage `json:"event"`
+}
+
+type innerEvent struct {
+	Type         string          `json:"type"`
+	Index        int             `json:"index"`
+	ContentBlock json.RawMessage `json:"content_block"`
+	Delta        json.RawMessage `json:"delta"`
+	Message      json.RawMessage `json:"message"`
+	Usage        json.RawMessage `json:"usage"`
+	Error        json.RawMessage `json:"error"`
+}
+
+type contentBlock struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
+
+type delta struct {
+	Type        string `json:"type"`
+	Text        string `json:"text"`
+	Thinking    string `json:"thinking"`
+	PartialJSON string `json:"partial_json"`
+}
+
+type streamError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+type messageUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+}
+
+// parseClaudeStream reads NDJSON from Claude Code's stream-json output and
+// emits normalized AgentEvent values via the onEvent callback.
+func parseClaudeStream(r io.Reader, onEvent func(AgentEvent)) error {
+	br := bufio.NewReaderSize(r, 1024*1024)
+
+	var (
+		seenStreamEvent bool
+		// tool block accumulation state
+		currentToolName string
+		toolInputJSON   strings.Builder
+		// token tracking for throttled TokensEvent
+		totalInput      int
+		totalOutput     int
+		totalCacheRead  int
+		totalCacheWrite int
+		lastEmittedTotal int
+	)
+
+	emit := func(evt AgentEvent) {
+		if onEvent != nil {
+			onEvent(evt)
+		}
+	}
+
+	for {
+		line, isPrefix, err := br.ReadLine()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if isPrefix {
+			for isPrefix && err == nil {
+				_, isPrefix, err = br.ReadLine()
+			}
+			continue
+		}
+		if len(line) == 0 {
+			continue
+		}
+
+		var evt streamEvent
+		if jsonErr := json.Unmarshal(line, &evt); jsonErr != nil {
+			continue
+		}
+
+		switch evt.Type {
+		case "system":
+			var se systemEvent
+			if err := json.Unmarshal(line, &se); err != nil {
+				continue
+			}
+			switch se.Subtype {
+			case "init":
+				emit(InitEvent{Model: se.Model, Version: se.ClaudeCodeVersion})
+			case "api_retry":
+				emit(RetryEvent{
+					Attempt:    se.Attempt,
+					MaxRetries: se.MaxRetries,
+					DelayMs:    se.RetryDelayMs,
+					Error:      se.Error,
+				})
+			}
+
+		case "stream_event":
+			seenStreamEvent = true
+			var wrapper streamEventWrapper
+			if err := json.Unmarshal(line, &wrapper); err != nil {
+				continue
+			}
+			var inner innerEvent
+			if err := json.Unmarshal(wrapper.Event, &inner); err != nil {
+				continue
+			}
+
+			switch inner.Type {
+			case "content_block_start":
+				var cb contentBlock
+				if err := json.Unmarshal(inner.ContentBlock, &cb); err != nil {
+					continue
+				}
+				switch cb.Type {
+				case "tool_use", "server_tool_use":
+					currentToolName = cb.Name
+					toolInputJSON.Reset()
+				}
+
+			case "content_block_delta":
+				var d delta
+				if err := json.Unmarshal(inner.Delta, &d); err != nil {
+					continue
+				}
+				switch d.Type {
+				case "text_delta":
+					emit(TextEvent{Text: d.Text})
+				case "thinking_delta":
+					emit(ThinkingEvent{Text: d.Thinking})
+				case "input_json_delta":
+					toolInputJSON.WriteString(d.PartialJSON)
+				}
+
+			case "content_block_stop":
+				if currentToolName != "" {
+					name := currentToolName
+					var summary string
+					if !allowedTools[name] {
+						name = "tool"
+					} else {
+						summary = extractSafeContext(currentToolName, json.RawMessage(toolInputJSON.String()))
+					}
+					emit(ToolUseEvent{Name: name, Summary: summary})
+					currentToolName = ""
+					toolInputJSON.Reset()
+				}
+
+			case "message_start":
+				var msg struct {
+					Message struct {
+						Usage messageUsage `json:"usage"`
+					} `json:"message"`
+				}
+				if err := json.Unmarshal(wrapper.Event, &msg); err == nil {
+					totalInput = msg.Message.Usage.InputTokens
+					totalCacheRead = msg.Message.Usage.CacheReadInputTokens
+					totalCacheWrite = msg.Message.Usage.CacheCreationInputTokens
+				}
+
+			case "message_delta":
+				var md struct {
+					Usage struct {
+						OutputTokens int `json:"output_tokens"`
+					} `json:"usage"`
+				}
+				if err := json.Unmarshal(wrapper.Event, &md); err == nil && md.Usage.OutputTokens > 0 {
+					totalOutput = md.Usage.OutputTokens
+					total := totalInput + totalOutput + totalCacheRead + totalCacheWrite
+					if total-lastEmittedTotal >= tokenThreshold {
+						lastEmittedTotal = total
+						emit(TokensEvent{
+							InputTokens:  totalInput,
+							OutputTokens: totalOutput,
+							CacheRead:    totalCacheRead,
+							CacheWrite:   totalCacheWrite,
+						})
+					}
+				}
+
+			case "error":
+				var se streamError
+				if err := json.Unmarshal(inner.Error, &se); err == nil {
+					emit(ErrorEvent{ErrorType: se.Type, Message: se.Message})
+				}
+			}
+
+		case "result":
+			var re resultEvent
+			if err := json.Unmarshal(line, &re); err == nil {
+				emit(ResultEvent{
+					NumTurns:                 re.NumTurns,
+					TotalCostUSD:             re.TotalCostUSD,
+					IsError:                  re.IsError,
+					ErrorMessage:             re.Result,
+					Subtype:                  re.Subtype,
+					InputTokens:              re.Usage.InputTokens,
+					OutputTokens:             re.Usage.OutputTokens,
+					CacheCreationInputTokens: re.Usage.CacheCreationInputTokens,
+					CacheReadInputTokens:     re.Usage.CacheReadInputTokens,
+				})
+			}
+
+		case "assistant":
+			if seenStreamEvent {
+				// stream_event path is active; skip assistant fallback to
+				// avoid double-counting tool calls.
+				continue
+			}
+			var msg assistantMessage
+			if err := json.Unmarshal(line, &msg); err != nil {
+				continue
+			}
+			// Capture model from assistant message as fallback when system
+			// init event did not carry one.
+			if msg.Message.Model != "" {
+				emit(InitEvent{Model: msg.Message.Model})
+			}
+			content := msg.Message.Content
+			if len(content) == 0 {
+				content = msg.Content
+			}
+			var items []contentItem
+			if err := json.Unmarshal(content, &items); err != nil {
+				continue
+			}
+			for _, item := range items {
+				if item.Type != "tool_use" {
+					continue
+				}
+				name := item.Name
+				var summary string
+				if !allowedTools[name] {
+					name = "tool"
+				} else {
+					summary = extractSafeContext(item.Name, item.Input)
+				}
+				emit(ToolUseEvent{Name: name, Summary: summary})
+			}
+		}
+	}
+}
+
+// progressParser is the backward-compatible entry point. It creates an
+// EventRenderer and feeds it through parseClaudeStream.
+func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *RunMetrics) error {
+	renderer := NewEventRenderer(printer, start, metrics)
+
+	// Also capture the model from InitEvent for metrics, since the
+	// renderer does not set metrics.Model.
+	return parseClaudeStream(r, func(evt AgentEvent) {
+		if init, ok := evt.(InitEvent); ok && metrics.Model == "" {
+			metrics.Model = init.Model
+		}
+		// Fallback: capture model from assistant message if system init had none.
+		// The old parser did this; replicate by checking assistant messages.
+		renderer.Handle(evt)
+	})
+}
+
+// extractSafeContext returns a safe, non-secret string for progress display.
+func extractSafeContext(toolName string, input json.RawMessage) string {
+	if len(input) == 0 {
+		return ""
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(input, &fields); err != nil {
+		return ""
+	}
+
+	switch toolName {
+	case "Bash":
+		raw, ok := fields["command"]
+		if !ok {
+			return ""
+		}
+		var cmd string
+		if err := json.Unmarshal(raw, &cmd); err != nil {
+			return ""
+		}
+		return extractBinaryName(cmd)
+
+	case "Read", "Write", "Edit":
+		raw, ok := fields["file_path"]
+		if !ok {
+			return ""
+		}
+		var path string
+		if err := json.Unmarshal(raw, &path); err != nil {
+			return ""
+		}
+		if utf8.RuneCountInString(path) > maxPathDisplay {
+			runes := []rune(path)
+			return string(runes[:maxPathDisplay]) + "\u2026"
+		}
+		return path
+
+	case "Grep", "Glob":
+		raw, ok := fields["pattern"]
+		if !ok {
+			return ""
+		}
+		var pattern string
+		if err := json.Unmarshal(raw, &pattern); err != nil {
+			return ""
+		}
+		if utf8.RuneCountInString(pattern) > maxPatternDisplay {
+			runes := []rune(pattern)
+			return string(runes[:maxPatternDisplay]) + "\u2026"
+		}
+		return pattern
+	}
+
+	return ""
+}
+
+// extractBinaryName returns only the binary name from a shell command,
+// skipping leading KEY=VALUE environment variable assignments.
+func extractBinaryName(cmd string) string {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return ""
+	}
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return ""
+	}
+	// Skip leading KEY=VALUE env var assignments.
+	for _, f := range fields {
+		if !strings.Contains(f, "=") {
+			// Strip path prefix (e.g. /usr/bin/make -> make).
+			if idx := strings.LastIndex(f, "/"); idx >= 0 {
+				f = f[idx+1:]
+			}
+			return f
+		}
+	}
+	return ""
+}
+
+func emitToolProgress(printer *ui.Printer, toolName, context string, start time.Time, toolCount int32, isCI bool) {
+	elapsed := time.Since(start).Truncate(time.Second)
+
+	var msg string
+	if context != "" {
+		msg = fmt.Sprintf("%s: %s (%s, %d tools)", toolName, context, elapsed, toolCount)
+	} else {
+		msg = fmt.Sprintf("%s (%s, %d tools)", toolName, elapsed, toolCount)
+	}
+
+	msg = sanitizeOutput(msg)
+	if isCI {
+		fmt.Fprintf(os.Stderr, "::notice::%s\n", msg)
+	}
+	printer.Heartbeat(msg)
+}
+```
+
+Note: `emitToolProgress` and `parseAssistantToolUse` are no longer called by the main path but `emitToolProgress` is kept for now since removing it is a separate cleanup. Actually, let me check if anything else uses it.
+
+Actually, on reflection, `emitToolProgress` is only called by `parseAssistantToolUse` which is only called by the old `progressParser`. Since `progressParser` now delegates to `parseClaudeStream` + `EventRenderer`, both `emitToolProgress` and `parseAssistantToolUse` are dead code. Remove them in this step -- the `EventRenderer` handles the same rendering via `Handle(ToolUseEvent{...})`.
+
+- [ ] **Step 4: Run the new parseClaudeStream tests to verify they pass**
+
+Run: `cd /home/rbean/code/fullsend-2 && go test ./internal/runtime/ -run 'TestParseClaudeStream' -v`
+Expected: all PASS
+
+- [ ] **Step 5: Run ALL existing tests to verify backward compatibility**
+
+Run: `cd /home/rbean/code/fullsend-2 && go test ./internal/runtime/ -v`
+Expected: all tests PASS -- particularly `TestProgressParser*` tests which exercise the `progressParser` wrapper and should produce equivalent behavior.
+
+- [ ] **Step 6: Update existing tests for new behavior**
+
+The existing `TestProgressParserIgnoresStreamEvents` test verified that stream_events were ignored. With the new parser, stream_events ARE processed. Rename and update:
+
+```go
+func TestProgressParserStreamEventsProcessed(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","name":"Edit"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"file_path\":\"/src/main.go\"}"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+		`{"type":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/src/main.go"}}]}`,
+	}
+
+	input := strings.NewReader(strings.Join(lines, "\n"))
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	metrics := &RunMetrics{}
+
+	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+		t.Fatalf("progressParser returned error: %v", err)
+	}
+
+	// Tool counted once from stream_event, not again from assistant fallback
+	if metrics.ToolCalls.Load() != 1 {
+		t.Errorf("expected 1 tool call (from stream_event, assistant suppressed), got %d", metrics.ToolCalls.Load())
+	}
+}
+```
+
+The `TestProgressParserCapturesModelFromAssistantWhenSystemLacksIt` test should still pass unchanged: `parseClaudeStream` emits an `InitEvent` from the assistant message's `msg.Message.Model` field (see the assistant fallback path), and the `progressParser` wrapper captures it into `metrics.Model`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/runtime/claude_progress.go internal/runtime/claude_progress_test.go
+git commit -S -s -m "$(cat <<'EOF'
+refactor(runtime): replace progressParser with parseClaudeStream
+
+Refactor the Claude Code NDJSON parser to emit normalized AgentEvent
+values via a callback instead of calling printer.Heartbeat directly.
+The new parseClaudeStream function processes stream_event deltas
+(thinking, text, tool input JSON), system events (init, api_retry),
+result events, and errors. The old progressParser is kept as a thin
+wrapper that creates an EventRenderer.
+
+Supports assistant message fallback for older Claude Code versions that
+don't emit stream_event deltas.
+
+Part of #3170.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Wire OnEvent in ClaudeRuntime.Run
+
+**Files:**
+- Modify: `internal/runtime/claude.go`
+
+- [ ] **Step 1: Update ClaudeRuntime.Run to use OnEvent**
+
+In `internal/runtime/claude.go`, replace the `progressParser` call in `Run` with OnEvent-aware wiring:
+
+```go
+func (ClaudeRuntime) Run(ctx context.Context, params RunParams, printer *ui.Printer, start time.Time, metrics *RunMetrics) (int, error) {
+	cmd := buildRunCommand(params)
+	stdout, execCmd, cancel, err := sandbox.ExecStreamReader(ctx, params.SandboxName, cmd, params.Timeout, os.Stderr)
+	if err != nil {
+		return -1, err
+	}
+	defer cancel()
+
+	var r io.Reader = stdout
+	if params.OutputPath != "" {
+		f, ferr := os.Create(params.OutputPath)
+		if ferr != nil {
+			printer.StepWarn(fmt.Sprintf("Failed to create %s: ", params.OutputPath) + ferr.Error())
+		} else {
+			defer f.Close()
+			r = io.TeeReader(stdout, f)
+		}
+	}
+
+	handler := params.OnEvent
+	if handler == nil {
+		renderer := NewEventRenderer(printer, start, metrics)
+		handler = func(evt AgentEvent) {
+			if init, ok := evt.(InitEvent); ok && metrics.Model == "" {
+				metrics.Model = init.Model
+			}
+			renderer.Handle(evt)
+		}
+	}
+
+	if parseErr := parseClaudeStream(r, handler); parseErr != nil {
+		fmt.Fprintf(os.Stderr, "  progress parser: %v\n", sanitizeOutput(parseErr.Error()))
+		cancel()
+		io.Copy(io.Discard, r)
+	}
+
+	waitErr := execCmd.Wait()
+	exitCode := -1
+	if execCmd.ProcessState != nil {
+		exitCode = execCmd.ProcessState.ExitCode()
+	}
+
+	if waitErr != nil && execCmd.ProcessState == nil {
+		return exitCode, fmt.Errorf("openshell exec failed: %w", waitErr)
+	}
+
+	return exitCode, nil
+}
+```
+
+- [ ] **Step 2: Remove the old progressParser wrapper from claude_progress.go**
+
+Since `ClaudeRuntime.Run` now directly calls `parseClaudeStream` and handles the model extraction and renderer setup inline, the `progressParser` wrapper function can be removed. Also remove `emitToolProgress` and `parseAssistantToolUse` if they are now dead code.
+
+Check if anything else in the codebase calls `progressParser`:
+
+Run: `cd /home/rbean/code/fullsend-2 && grep -rn 'progressParser\|emitToolProgress\|parseAssistantToolUse' --include='*.go' | grep -v _test.go`
+
+If only `claude.go` and `claude_progress.go` reference these functions, and `claude.go` no longer calls `progressParser`, then remove `progressParser` and `emitToolProgress` from `claude_progress.go`.
+
+However, the existing tests call `progressParser` directly. Rather than rewriting all the existing tests, keep `progressParser` as an internal test helper or update the tests to call `parseClaudeStream` directly. The cleanest approach: keep `progressParser` in `claude_progress.go` as an unexported wrapper used by tests, since the tests verify backward-compatible behavior.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `cd /home/rbean/code/fullsend-2 && go test ./internal/runtime/ -v`
+Expected: all tests PASS
+
+- [ ] **Step 4: Run go vet**
+
+Run: `cd /home/rbean/code/fullsend-2 && go vet ./internal/runtime/`
+Expected: no issues
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runtime/claude.go internal/runtime/claude_progress.go
+git commit -S -s -m "$(cat <<'EOF'
+feat(runtime): render agent event stream live during execution
+
+Wire the OnEvent callback in ClaudeRuntime.Run. When OnEvent is nil
+(the default), creates an EventRenderer that renders thinking, text,
+tool summaries, token usage, errors, and result summaries to the
+terminal in real time. When OnEvent is set, the caller receives
+normalized AgentEvent values for custom handling.
+
+Closes #3170.
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Lint and final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Stage all changes and run lint**
+
+```bash
+cd /home/rbean/code/fullsend-2 && git add -A && make lint
+```
+
+Expected: no lint failures
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+cd /home/rbean/code/fullsend-2 && make go-test
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 3: Run go vet**
+
+```bash
+cd /home/rbean/code/fullsend-2 && make go-vet
+```
+
+Expected: no issues
+
+- [ ] **Step 4: Fix any issues found by lint/vet and amend or create a new commit**
+
+If lint or vet finds issues, fix them and commit:
+
+```bash
+git add -A
+git commit -S -s -m "$(cat <<'EOF'
+chore(runtime): fix lint/vet issues from event stream rendering
+
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-07-06-agent-event-stream-rendering-design.md
+++ b/docs/superpowers/specs/2026-07-06-agent-event-stream-rendering-design.md
@@ -164,33 +164,37 @@ The existing `extractSafeContext`, `extractBinaryName`, and `allowedTools`
 functions are reused to build `ToolUseEvent.Summary`. Unknown tools get
 name `"tool"` and empty summary.
 
-The old `progressParser` signature is preserved as a thin wrapper:
+`progressParser` is a thin wrapper that creates a renderer and metrics handler:
 
 ```go
-func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *RunMetrics) error {
-    renderer := NewEventRenderer(printer, start, metrics)
-    return parseClaudeStream(r, renderer.Handle)
+func progressParser(r io.Reader, printer *ui.Printer, metrics *RunMetrics) error {
+    renderer := NewEventRenderer(printer)
+    return parseClaudeStream(r, func(evt AgentEvent) {
+        // populate metrics from events
+        renderer.Handle(evt)
+    })
 }
 ```
 
-This maintains backward compatibility for any internal callers.
+Metrics population (model, tool count, result stats) is handled by the caller's
+wrapper — not the renderer — so custom `OnEvent` handlers also get correct metrics.
 
 ## EventRenderer
 
 File: `internal/runtime/renderer.go`
 
+`EventRenderer` is a pure rendering concern — it writes formatted output to the
+printer but does not populate `RunMetrics`.
+
 ```go
 type EventRenderer struct {
     printer    *ui.Printer
-    start      time.Time
-    metrics    *RunMetrics
     isCI       bool
     inText     bool
     inThinking bool
-    lastTokenTotal int
 }
 
-func NewEventRenderer(printer *ui.Printer, start time.Time, metrics *RunMetrics) *EventRenderer
+func NewEventRenderer(printer *ui.Printer) *EventRenderer
 func (r *EventRenderer) Handle(evt AgentEvent)
 ```
 
@@ -230,8 +234,14 @@ func (ClaudeRuntime) Run(ctx context.Context, params RunParams, printer *ui.Prin
 
     handler := params.OnEvent
     if handler == nil {
-        renderer := NewEventRenderer(printer, start, metrics)
+        renderer := NewEventRenderer(printer)
         handler = renderer.Handle
+    }
+    // Always wrap to capture metrics regardless of custom/default handler.
+    innerHandler := handler
+    handler = func(evt AgentEvent) {
+        // populate metrics from InitEvent, ResultEvent, ToolUseEvent
+        innerHandler(evt)
     }
 
     if parseErr := parseClaudeStream(r, handler); parseErr != nil {

--- a/docs/superpowers/specs/2026-07-06-agent-event-stream-rendering-design.md
+++ b/docs/superpowers/specs/2026-07-06-agent-event-stream-rendering-design.md
@@ -1,0 +1,304 @@
+# Agent Event Stream Rendering
+
+**Date:** 2026-07-06
+**Issue:** #3170
+**Status:** Draft
+
+## Problem
+
+When an agent runs via `fullsend run`, the agent's reasoning and tool usage are
+invisible until the run completes. The existing `progressParser` emits only tool
+name + safe context (e.g. `Read: path/to/file`) via `printer.Heartbeat()`. It
+ignores thinking text, assistant text, token usage, errors, retries, and
+stream-level deltas. In GHA workflow logs the agent step appears as a
+long-running black box with no incremental output.
+
+## Decision
+
+Implement full structured rendering of the agent event stream during execution,
+behind the `Runtime` interface so it works for any supported runtime. Claude Code
+exposes `--output-format stream-json`; opencode exposes `--format json` with
+ndjson events. A normalized event type set bridges runtime-specific parsing and
+runtime-agnostic rendering.
+
+## Architecture
+
+Three layers:
+
+1. **Normalized event types** (`internal/runtime/event.go`) -- a Go interface
+   `AgentEvent` with concrete structs for each event kind.
+2. **Runtime-specific parsers** -- each runtime reads its native ndjson format
+   and emits `AgentEvent` values via a callback.
+3. **EventRenderer** (`internal/runtime/renderer.go`) -- consumes `AgentEvent`
+   values and renders structured, colored terminal output via `*ui.Printer`.
+
+```
+sandbox stdout (ndjson)
+    |
+    v
+parseClaudeStream()  -- or parseOpenCodeStream() for opencode
+    |
+    | calls onEvent(AgentEvent) synchronously per event
+    v
+EventRenderer.Handle()
+    |
+    v
+ui.Printer  -->  stderr (terminal / GHA log)
+```
+
+The callback is synchronous: the parser blocks on the handler, which matches
+the existing pattern where `progressParser` blocks on `printer.Heartbeat`.
+No channels or extra goroutines.
+
+## Event Types
+
+File: `internal/runtime/event.go`
+
+```go
+// AgentEvent is the normalized event interface.
+type AgentEvent interface{ agentEvent() }
+
+type InitEvent struct {
+    Model   string
+    Version string // runtime version, optional
+}
+
+type ThinkingEvent struct {
+    Text string // incremental thinking delta
+}
+
+type TextEvent struct {
+    Text string // incremental assistant text delta
+}
+
+type ToolUseEvent struct {
+    Name    string // "Bash", "Read", "Write", etc. ("tool" for unknown)
+    Summary string // compact one-line summary
+}
+
+type TokensEvent struct {
+    InputTokens  int
+    OutputTokens int
+    CacheRead    int
+    CacheWrite   int
+}
+
+type ResultEvent struct {
+    NumTurns                 int
+    TotalCostUSD             float64
+    IsError                  bool
+    ErrorMessage             string
+    Subtype                  string // "success", "error_max_turns", etc.
+    InputTokens              int
+    OutputTokens             int
+    CacheCreationInputTokens int
+    CacheReadInputTokens     int
+}
+
+type ErrorEvent struct {
+    ErrorType string
+    Message   string
+}
+
+type RetryEvent struct {
+    Attempt    int
+    MaxRetries int
+    DelayMs    int
+    Error      string
+}
+```
+
+`ToolUseEvent` carries a pre-computed `Summary` rather than raw input params.
+The runtime-specific parser builds the summary using the existing
+`extractSafeContext` logic (expanded to match agentic-ci's `_format_tool`
+coverage). This keeps the renderer simple and avoids leaking raw tool arguments
+across the abstraction boundary.
+
+`ThinkingEvent` and `TextEvent` carry incremental deltas so the renderer prints
+text as it arrives, matching agentic-ci's streaming behavior.
+
+Each struct embeds a no-op `agentEvent()` marker method to satisfy the interface.
+
+## Callback Integration
+
+A new field on `RunParams`:
+
+```go
+type RunParams struct {
+    // ... existing fields unchanged ...
+    OnEvent func(AgentEvent) // if nil, events are silently discarded
+}
+```
+
+The runtime's `Run` method calls `params.OnEvent(evt)` as it parses each line.
+
+## Claude Stream Parser Refactor
+
+File: `internal/runtime/claude_progress.go`
+
+The existing `progressParser` is replaced by:
+
+```go
+func parseClaudeStream(r io.Reader, onEvent func(AgentEvent)) error
+```
+
+It processes all event types from the `stream-json` format:
+
+| stream-json event | Emitted AgentEvent |
+|---|---|
+| `system` / `init` | `InitEvent{Model, Version}` |
+| `system` / `api_retry` | `RetryEvent{Attempt, MaxRetries, DelayMs, Error}` |
+| `stream_event` / `content_block_start` (text) | sets internal state |
+| `stream_event` / `content_block_start` (thinking) | sets internal state |
+| `stream_event` / `content_block_start` (tool_use) | sets internal state, records tool name |
+| `stream_event` / `content_block_delta` (text_delta) | `TextEvent{Text}` |
+| `stream_event` / `content_block_delta` (thinking_delta) | `ThinkingEvent{Text}` |
+| `stream_event` / `content_block_delta` (input_json_delta) | accumulates tool input JSON |
+| `stream_event` / `content_block_stop` (tool block) | `ToolUseEvent{Name, Summary}` |
+| `stream_event` / `message_delta` | `TokensEvent` (throttled to every 5k tokens) |
+| `stream_event` / `error` | `ErrorEvent{ErrorType, Message}` |
+| `result` | `ResultEvent` with all metric fields |
+| `assistant` | if no `stream_event` has been seen yet, parse tool_use blocks and emit `ToolUseEvent` (supports older Claude Code versions that emit complete messages without streaming deltas) |
+
+The existing `extractSafeContext`, `extractBinaryName`, and `allowedTools`
+functions are reused to build `ToolUseEvent.Summary`. Unknown tools get
+name `"tool"` and empty summary.
+
+The old `progressParser` signature is preserved as a thin wrapper:
+
+```go
+func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *RunMetrics) error {
+    renderer := NewEventRenderer(printer, start, metrics)
+    return parseClaudeStream(r, renderer.Handle)
+}
+```
+
+This maintains backward compatibility for any internal callers.
+
+## EventRenderer
+
+File: `internal/runtime/renderer.go`
+
+```go
+type EventRenderer struct {
+    printer    *ui.Printer
+    start      time.Time
+    metrics    *RunMetrics
+    isCI       bool
+    inText     bool
+    inThinking bool
+    lastTokenTotal int
+}
+
+func NewEventRenderer(printer *ui.Printer, start time.Time, metrics *RunMetrics) *EventRenderer
+func (r *EventRenderer) Handle(evt AgentEvent)
+```
+
+`Handle` dispatches on event type:
+
+| Event | Rendering |
+|---|---|
+| `InitEvent` | `printer.Header` with model/version, `printer.KeyValue` for details |
+| `ThinkingEvent` | dim/italic prefix "Thinking" then incremental text via `printer.Raw` |
+| `TextEvent` | prefix "Claude" then incremental text via `printer.Raw` |
+| `ToolUseEvent` | wrench icon + name + summary via `printer.Heartbeat`, increments `metrics.ToolCalls` |
+| `TokensEvent` | token stats via `printer.StepInfo`, only when total crosses 5k boundary |
+| `ResultEvent` | populates `metrics.*` fields, renders summary via `printer.Header` + `printer.KeyValue` |
+| `ErrorEvent` | `printer.StepFail` with error type and message |
+| `RetryEvent` | `printer.StepWarn` with attempt count and error |
+
+Block state tracking: the renderer tracks `inText` / `inThinking`. When a new
+block starts (ThinkingEvent after text, ToolUseEvent after thinking, etc.), the
+renderer closes the previous block by emitting a newline and resetting style.
+This is the same state machine as agentic-ci's `_end_block()`.
+
+For CI (`GITHUB_ACTIONS=true`), tool use events also emit `::notice::`
+annotations to stderr, same as today.
+
+No new `Printer` methods are needed. `Raw()` handles incremental text output.
+The renderer uses `lipgloss` directly for italic/dim styling on thinking text,
+writing through `printer.Raw()`.
+
+## ClaudeRuntime.Run Wiring
+
+Minimal change to `claude.go`:
+
+```go
+func (ClaudeRuntime) Run(ctx context.Context, params RunParams, printer *ui.Printer,
+    start time.Time, metrics *RunMetrics) (int, error) {
+    // ... existing sandbox exec + TeeReader setup unchanged ...
+
+    handler := params.OnEvent
+    if handler == nil {
+        renderer := NewEventRenderer(printer, start, metrics)
+        handler = renderer.Handle
+    }
+
+    if parseErr := parseClaudeStream(r, handler); parseErr != nil {
+        // ... existing error handling unchanged ...
+    }
+    // ... existing wait logic unchanged ...
+}
+```
+
+When `fullsend run` in `run.go` sets up the call, it passes `OnEvent: nil` to
+get the default rendering. Custom handlers can be provided for testing or
+alternative output modes.
+
+## Information Disclosure
+
+The existing `allowedTools` safeguard carries over unchanged -- unknown tools
+get name `"tool"` and empty summary.
+
+Thinking and text events contain the model's own output inside the sandbox. This
+is the same content that ends up in the transcript JSONL artifact. Anyone who
+can see the GHA logs can already see the transcript artifact. If redaction is
+needed later, the `EventRenderer` is the natural place to add a filter.
+
+## Future: opencode Integration
+
+When opencode lands, it adds:
+
+```go
+func parseOpenCodeStream(r io.Reader, onEvent func(AgentEvent)) error
+```
+
+This maps opencode's ndjson events (`tool_use`, `text`, `thinking`,
+`step_start`, `step_finish`, `error`) to the same `AgentEvent` types. The
+`EventRenderer` works unchanged. The event types become the format-neutral
+bridge between runtime-specific parsing and runtime-agnostic rendering, which
+is the contract issue #1935 is asking for.
+
+## Testing Strategy
+
+- **Event types**: Unit tests that parse known Claude Code stream-json fixtures
+  and assert the sequence of `AgentEvent` values emitted. Fixtures derived from
+  real agent runs (sanitized).
+- **Renderer**: Unit tests that feed `AgentEvent` sequences to `EventRenderer`
+  and assert the output written to a `bytes.Buffer` via the Printer.
+- **Integration**: The existing `claude_progress_test.go` tests are updated to
+  verify the new parser produces equivalent output to the old one for the same
+  input fixtures.
+- **Block state machine**: Tests for edge cases -- thinking followed by text,
+  tool_use inside thinking, multiple consecutive tools, empty deltas.
+- **Sanitization**: Tests that `allowedTools` filtering and `sanitizeOutput`
+  are applied correctly to all rendered output.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `internal/runtime/event.go` | New: normalized event type definitions |
+| `internal/runtime/renderer.go` | New: `EventRenderer` struct and `Handle` method |
+| `internal/runtime/claude_progress.go` | Refactor: replace `progressParser` with `parseClaudeStream`, keep `progressParser` as wrapper |
+| `internal/runtime/runtime.go` | Add `OnEvent` field to `RunParams` |
+| `internal/runtime/claude.go` | Wire `OnEvent` / default `EventRenderer` in `Run` |
+| `internal/runtime/renderer_test.go` | New: renderer unit tests |
+| `internal/runtime/claude_progress_test.go` | Update: verify new parser against existing fixtures |
+
+## Related Issues
+
+- #663 -- Evaluate showboat for code agent work visibility (different approach)
+- #1591 -- `StepDebug` and `--verbose` flag (complementary: debug internals vs agent progress)
+- #1935 -- `TranscriptHandler` format-neutral contract (event types serve as that contract for live streaming)
+- #872 -- Surface failure reasons when logs inaccessible (partially addressed by live progress)

--- a/internal/runtime/claude.go
+++ b/internal/runtime/claude.go
@@ -105,7 +105,18 @@ func (ClaudeRuntime) Run(ctx context.Context, params RunParams, printer *ui.Prin
 		}
 	}
 
-	if parseErr := progressParser(r, printer, start, metrics); parseErr != nil {
+	handler := params.OnEvent
+	if handler == nil {
+		renderer := NewEventRenderer(printer, start, metrics)
+		handler = func(evt AgentEvent) {
+			if init, ok := evt.(InitEvent); ok && metrics.Model == "" {
+				metrics.Model = init.Model
+			}
+			renderer.Handle(evt)
+		}
+	}
+
+	if parseErr := parseClaudeStream(r, handler); parseErr != nil {
 		fmt.Fprintf(os.Stderr, "  progress parser: %v\n", sanitizeOutput(parseErr.Error()))
 		cancel()
 		io.Copy(io.Discard, r)

--- a/internal/runtime/claude.go
+++ b/internal/runtime/claude.go
@@ -107,13 +107,28 @@ func (ClaudeRuntime) Run(ctx context.Context, params RunParams, printer *ui.Prin
 
 	handler := params.OnEvent
 	if handler == nil {
-		renderer := NewEventRenderer(printer, start, metrics)
-		handler = func(evt AgentEvent) {
-			if init, ok := evt.(InitEvent); ok && metrics.Model == "" {
-				metrics.Model = init.Model
+		renderer := NewEventRenderer(printer)
+		handler = renderer.Handle
+	}
+	// Always wrap handler to capture metrics regardless of custom/default path.
+	innerHandler := handler
+	handler = func(evt AgentEvent) {
+		switch e := evt.(type) {
+		case InitEvent:
+			if metrics.Model == "" {
+				metrics.Model = e.Model
 			}
-			renderer.Handle(evt)
+		case ResultEvent:
+			metrics.NumTurns = e.NumTurns
+			metrics.TotalCostUSD = e.TotalCostUSD
+			metrics.InputTokens = e.InputTokens
+			metrics.OutputTokens = e.OutputTokens
+			metrics.CacheCreationInputTokens = e.CacheCreationInputTokens
+			metrics.CacheReadInputTokens = e.CacheReadInputTokens
+		case ToolUseEvent:
+			metrics.ToolCalls.Add(1)
 		}
+		innerHandler(evt)
 	}
 
 	if parseErr := parseClaudeStream(r, handler); parseErr != nil {

--- a/internal/runtime/claude_progress.go
+++ b/internal/runtime/claude_progress.go
@@ -3,9 +3,7 @@ package runtime
 import (
 	"bufio"
 	"encoding/json"
-	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -16,11 +14,42 @@ import (
 const (
 	maxPatternDisplay = 50
 	maxPathDisplay    = 200
+	tokenThreshold    = 5000
 )
 
 // streamEvent represents a single NDJSON event from Claude Code's stream-json output.
 type streamEvent struct {
 	Type string `json:"type"`
+}
+
+// streamEventWrapper wraps the nested event structure from stream-json.
+type streamEventWrapper struct {
+	Type  string          `json:"type"`
+	Event json.RawMessage `json:"event"`
+}
+
+type innerEvent struct {
+	Type         string          `json:"type"`
+	ContentBlock json.RawMessage `json:"content_block"`
+	Delta        json.RawMessage `json:"delta"`
+	Error        json.RawMessage `json:"error"`
+}
+
+type contentBlock struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
+
+type delta struct {
+	Type        string `json:"type"`
+	Text        string `json:"text"`
+	Thinking    string `json:"thinking"`
+	PartialJSON string `json:"partial_json"`
+}
+
+type streamError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
 }
 
 // assistantMessage contains tool_use blocks from complete assistant messages.
@@ -38,9 +67,14 @@ type assistantMessage struct {
 // systemEvent is Claude Code's initial "system"/"init" event, which carries the
 // resolved model name. The result event does not include the model.
 type systemEvent struct {
-	Type    string `json:"type"`
-	Subtype string `json:"subtype"`
-	Model   string `json:"model"`
+	Type              string `json:"type"`
+	Subtype           string `json:"subtype"`
+	Model             string `json:"model"`
+	ClaudeCodeVersion string `json:"claude_code_version"`
+	Attempt           int    `json:"attempt"`
+	MaxRetries        int    `json:"max_retries"`
+	RetryDelayMs      int    `json:"retry_delay_ms"`
+	Error             string `json:"error"`
 }
 
 type contentItem struct {
@@ -66,6 +100,9 @@ var allowedTools = map[string]bool{
 // output, containing execution metrics.
 type resultEvent struct {
 	Type         string  `json:"type"`
+	Subtype      string  `json:"subtype"`
+	IsError      bool    `json:"is_error"`
+	Result       string  `json:"result"`
 	NumTurns     int     `json:"num_turns"`
 	TotalCostUSD float64 `json:"total_cost_usd"`
 	Usage        struct {
@@ -76,13 +113,24 @@ type resultEvent struct {
 	} `json:"usage"`
 }
 
-// progressParser reads NDJSON from Claude Code's stream-json output and emits
-// progress updates via the printer. It extracts tool names and safe context
-// (binary name for Bash, file path for Read/Write/Edit) without logging
-// potentially sensitive arguments.
-func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *RunMetrics) error {
+// parseClaudeStream reads NDJSON from Claude Code's stream-json output and
+// emits normalized AgentEvent values via the onEvent callback. It processes
+// system events, stream_event deltas (thinking, text, tool input JSON),
+// result events, errors, and assistant message fallback.
+func parseClaudeStream(r io.Reader, onEvent func(AgentEvent)) error {
 	br := bufio.NewReaderSize(r, 1024*1024)
-	isCI := os.Getenv("GITHUB_ACTIONS") == "true"
+
+	var (
+		seenStreamEvent bool
+		currentToolName string
+		toolInputJSON   strings.Builder
+		// token tracking for throttled TokensEvent
+		totalInput       int
+		totalOutput      int
+		totalCacheRead   int
+		totalCacheWrite  int
+		lastEmittedTotal int
+	)
 
 	for {
 		line, isPrefix, err := br.ReadLine()
@@ -107,69 +155,202 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 			continue
 		}
 
-		if evt.Type == "system" {
+		switch evt.Type {
+		case "system":
 			var se systemEvent
-			if err := json.Unmarshal(line, &se); err == nil && se.Model != "" {
-				metrics.Model = se.Model
+			if err := json.Unmarshal(line, &se); err != nil {
+				continue
 			}
-		}
+			switch se.Subtype {
+			case "init":
+				onEvent(InitEvent{
+					Model:   se.Model,
+					Version: se.ClaudeCodeVersion,
+				})
+			case "api_retry":
+				onEvent(RetryEvent{
+					Attempt:    se.Attempt,
+					MaxRetries: se.MaxRetries,
+					DelayMs:    se.RetryDelayMs,
+					Error:      se.Error,
+				})
+			}
 
-		if evt.Type == "assistant" {
-			parseAssistantToolUse(line, printer, start, metrics, isCI)
-		}
+		case "stream_event":
+			seenStreamEvent = true
+			var wrapper streamEventWrapper
+			if err := json.Unmarshal(line, &wrapper); err != nil {
+				continue
+			}
+			var inner innerEvent
+			if err := json.Unmarshal(wrapper.Event, &inner); err != nil {
+				continue
+			}
 
-		if evt.Type == "result" {
+			switch inner.Type {
+			case "content_block_start":
+				var cb contentBlock
+				if err := json.Unmarshal(inner.ContentBlock, &cb); err != nil {
+					continue
+				}
+				if cb.Type == "tool_use" || cb.Type == "server_tool_use" {
+					currentToolName = cb.Name
+					toolInputJSON.Reset()
+				}
+
+			case "content_block_delta":
+				var d delta
+				if err := json.Unmarshal(inner.Delta, &d); err != nil {
+					continue
+				}
+				switch d.Type {
+				case "text_delta":
+					onEvent(TextEvent{Text: d.Text})
+				case "thinking_delta":
+					onEvent(ThinkingEvent{Text: d.Thinking})
+				case "input_json_delta":
+					toolInputJSON.WriteString(d.PartialJSON)
+				}
+
+			case "content_block_stop":
+				if currentToolName != "" {
+					toolName := currentToolName
+					var summary string
+					if !allowedTools[toolName] {
+						toolName = "tool"
+					} else {
+						summary = extractSafeContext(currentToolName, json.RawMessage(toolInputJSON.String()))
+					}
+					onEvent(ToolUseEvent{
+						Name:    toolName,
+						Summary: summary,
+					})
+					currentToolName = ""
+					toolInputJSON.Reset()
+				}
+
+			case "error":
+				var se streamError
+				if err := json.Unmarshal(inner.Error, &se); err != nil {
+					continue
+				}
+				onEvent(ErrorEvent{
+					ErrorType: se.Type,
+					Message:   se.Message,
+				})
+
+			case "message_start":
+				var msg struct {
+					Message struct {
+						Usage struct {
+							InputTokens              int `json:"input_tokens"`
+							CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+							CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+						} `json:"usage"`
+					} `json:"message"`
+				}
+				if err := json.Unmarshal(wrapper.Event, &msg); err == nil {
+					totalInput = msg.Message.Usage.InputTokens
+					totalCacheRead = msg.Message.Usage.CacheReadInputTokens
+					totalCacheWrite = msg.Message.Usage.CacheCreationInputTokens
+				}
+
+			case "message_delta":
+				var md struct {
+					Usage struct {
+						OutputTokens int `json:"output_tokens"`
+					} `json:"usage"`
+				}
+				if err := json.Unmarshal(wrapper.Event, &md); err == nil && md.Usage.OutputTokens > 0 {
+					totalOutput = md.Usage.OutputTokens
+					total := totalInput + totalOutput + totalCacheRead + totalCacheWrite
+					if total-lastEmittedTotal >= tokenThreshold {
+						lastEmittedTotal = total
+						onEvent(TokensEvent{
+							InputTokens:  totalInput,
+							OutputTokens: totalOutput,
+							CacheRead:    totalCacheRead,
+							CacheWrite:   totalCacheWrite,
+						})
+					}
+				}
+			}
+
+		case "result":
 			var re resultEvent
-			if err := json.Unmarshal(line, &re); err == nil {
-				metrics.NumTurns = re.NumTurns
-				metrics.TotalCostUSD = re.TotalCostUSD
-				metrics.InputTokens = re.Usage.InputTokens
-				metrics.OutputTokens = re.Usage.OutputTokens
-				metrics.CacheCreationInputTokens = re.Usage.CacheCreationInputTokens
-				metrics.CacheReadInputTokens = re.Usage.CacheReadInputTokens
+			if err := json.Unmarshal(line, &re); err != nil {
+				continue
+			}
+			onEvent(ResultEvent{
+				NumTurns:                 re.NumTurns,
+				TotalCostUSD:             re.TotalCostUSD,
+				IsError:                  re.IsError,
+				Subtype:                  re.Subtype,
+				InputTokens:              re.Usage.InputTokens,
+				OutputTokens:             re.Usage.OutputTokens,
+				CacheCreationInputTokens: re.Usage.CacheCreationInputTokens,
+				CacheReadInputTokens:     re.Usage.CacheReadInputTokens,
+			})
+
+		case "assistant":
+			if seenStreamEvent {
+				// When stream_events are active, the assistant message
+				// is a duplicate — skip it to avoid double-counting.
+				continue
+			}
+			var msg assistantMessage
+			if err := json.Unmarshal(line, &msg); err != nil {
+				continue
+			}
+
+			// Emit InitEvent from assistant message model as fallback.
+			if msg.Message.Model != "" {
+				onEvent(InitEvent{Model: msg.Message.Model})
+			}
+
+			// Real Claude Code output nests content under "message";
+			// fall back to the top-level "content" for older/flat shapes.
+			content := msg.Message.Content
+			if len(content) == 0 {
+				content = msg.Content
+			}
+
+			var items []contentItem
+			if err := json.Unmarshal(content, &items); err != nil {
+				continue
+			}
+
+			for _, item := range items {
+				if item.Type != "tool_use" {
+					continue
+				}
+				toolName := item.Name
+				var ctx string
+				if !allowedTools[toolName] {
+					toolName = "tool"
+				} else {
+					ctx = extractSafeContext(item.Name, item.Input)
+				}
+				onEvent(ToolUseEvent{
+					Name:    toolName,
+					Summary: ctx,
+				})
 			}
 		}
 	}
 }
 
-func parseAssistantToolUse(line []byte, printer *ui.Printer, start time.Time, metrics *RunMetrics, isCI bool) {
-	var msg assistantMessage
-	if err := json.Unmarshal(line, &msg); err != nil {
-		return
-	}
-
-	// Fall back to the assistant message's model when the system init event did
-	// not carry one, so gen_ai.request.model stays populated for all streams.
-	if metrics.Model == "" && msg.Message.Model != "" {
-		metrics.Model = msg.Message.Model
-	}
-
-	// Real Claude Code output nests content under "message"; fall back to the
-	// top-level "content" for older/flat shapes.
-	content := msg.Message.Content
-	if len(content) == 0 {
-		content = msg.Content
-	}
-
-	var items []contentItem
-	if err := json.Unmarshal(content, &items); err != nil {
-		return
-	}
-
-	for _, item := range items {
-		if item.Type != "tool_use" {
-			continue
+// progressParser reads NDJSON from Claude Code's stream-json output and emits
+// progress updates via the printer. It is a thin wrapper around parseClaudeStream
+// that creates an EventRenderer and populates RunMetrics.
+func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *RunMetrics) error {
+	renderer := NewEventRenderer(printer, start, metrics)
+	return parseClaudeStream(r, func(evt AgentEvent) {
+		if init, ok := evt.(InitEvent); ok && metrics.Model == "" {
+			metrics.Model = init.Model
 		}
-		toolName := item.Name
-		var ctx string
-		if !allowedTools[toolName] {
-			toolName = "tool"
-		} else {
-			ctx = extractSafeContext(item.Name, item.Input)
-		}
-		count := metrics.ToolCalls.Add(1)
-		emitToolProgress(printer, toolName, ctx, start, count, isCI)
-	}
+		renderer.Handle(evt)
+	})
 }
 
 // extractSafeContext returns a safe, non-secret string for progress display.
@@ -253,19 +434,3 @@ func extractBinaryName(cmd string) string {
 	return ""
 }
 
-func emitToolProgress(printer *ui.Printer, toolName, context string, start time.Time, toolCount int32, isCI bool) {
-	elapsed := time.Since(start).Truncate(time.Second)
-
-	var msg string
-	if context != "" {
-		msg = fmt.Sprintf("%s: %s (%s, %d tools)", toolName, context, elapsed, toolCount)
-	} else {
-		msg = fmt.Sprintf("%s (%s, %d tools)", toolName, elapsed, toolCount)
-	}
-
-	msg = sanitizeOutput(msg)
-	if isCI {
-		fmt.Fprintf(os.Stderr, "::notice::%s\n", msg)
-	}
-	printer.Heartbeat(msg)
-}

--- a/internal/runtime/claude_progress.go
+++ b/internal/runtime/claude_progress.go
@@ -86,7 +86,6 @@ type contentItem struct {
 	Input    json.RawMessage `json:"input"`
 }
 
-
 // resultEvent represents the final NDJSON event from Claude Code's stream-json
 // output, containing execution metrics.
 type resultEvent struct {
@@ -423,4 +422,3 @@ func collapseCommand(cmd string) string {
 	}
 	return collapsed
 }
-

--- a/internal/runtime/claude_progress.go
+++ b/internal/runtime/claude_progress.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	maxCommandDisplay = 120
 	maxPatternDisplay = 50
 	maxPathDisplay    = 200
 	tokenThreshold    = 5000
@@ -78,23 +79,13 @@ type systemEvent struct {
 }
 
 type contentItem struct {
-	Type  string          `json:"type"`
-	Name  string          `json:"name"`
-	Input json.RawMessage `json:"input"`
+	Type     string          `json:"type"`
+	Name     string          `json:"name"`
+	Text     string          `json:"text"`
+	Thinking string          `json:"thinking"`
+	Input    json.RawMessage `json:"input"`
 }
 
-// allowedTools is the set of tool names we display in progress output.
-// Unknown tools emit no context to prevent information disclosure from
-// untrusted sandbox output.
-var allowedTools = map[string]bool{
-	"Bash":  true,
-	"Read":  true,
-	"Write": true,
-	"Edit":  true,
-	"Grep":  true,
-	"Glob":  true,
-	"Agent": true,
-}
 
 // resultEvent represents the final NDJSON event from Claude Code's stream-json
 // output, containing execution metrics.
@@ -214,16 +205,9 @@ func parseClaudeStream(r io.Reader, onEvent func(AgentEvent)) error {
 
 			case "content_block_stop":
 				if currentToolName != "" {
-					toolName := currentToolName
-					var summary string
-					if !allowedTools[toolName] {
-						toolName = "tool"
-					} else {
-						summary = extractSafeContext(currentToolName, json.RawMessage(toolInputJSON.String()))
-					}
 					onEvent(ToolUseEvent{
-						Name:    toolName,
-						Summary: summary,
+						Name:    currentToolName,
+						Summary: extractSafeContext(currentToolName, json.RawMessage(toolInputJSON.String())),
 					})
 					currentToolName = ""
 					toolInputJSON.Reset()
@@ -322,20 +306,21 @@ func parseClaudeStream(r io.Reader, onEvent func(AgentEvent)) error {
 			}
 
 			for _, item := range items {
-				if item.Type != "tool_use" {
-					continue
+				switch item.Type {
+				case "thinking":
+					if item.Thinking != "" {
+						onEvent(ThinkingEvent{Text: item.Thinking})
+					}
+				case "text":
+					if item.Text != "" {
+						onEvent(TextEvent{Text: item.Text})
+					}
+				case "tool_use":
+					onEvent(ToolUseEvent{
+						Name:    item.Name,
+						Summary: extractSafeContext(item.Name, item.Input),
+					})
 				}
-				toolName := item.Name
-				var ctx string
-				if !allowedTools[toolName] {
-					toolName = "tool"
-				} else {
-					ctx = extractSafeContext(item.Name, item.Input)
-				}
-				onEvent(ToolUseEvent{
-					Name:    toolName,
-					Summary: ctx,
-				})
 			}
 		}
 	}
@@ -375,7 +360,7 @@ func extractSafeContext(toolName string, input json.RawMessage) string {
 		if err := json.Unmarshal(raw, &cmd); err != nil {
 			return ""
 		}
-		return extractBinaryName(cmd)
+		return collapseCommand(cmd)
 
 	case "Read", "Write", "Edit":
 		raw, ok := fields["file_path"]
@@ -391,6 +376,17 @@ func extractSafeContext(toolName string, input json.RawMessage) string {
 			return string(runes[:maxPathDisplay]) + "…"
 		}
 		return path
+
+	case "Agent":
+		raw, ok := fields["prompt"]
+		if !ok {
+			return ""
+		}
+		var prompt string
+		if err := json.Unmarshal(raw, &prompt); err != nil {
+			return ""
+		}
+		return collapseCommand(prompt)
 
 	case "Grep", "Glob":
 		raw, ok := fields["pattern"]
@@ -411,27 +407,20 @@ func extractSafeContext(toolName string, input json.RawMessage) string {
 	return ""
 }
 
-// extractBinaryName returns only the binary name from a shell command,
-// skipping leading KEY=VALUE environment variable assignments.
-func extractBinaryName(cmd string) string {
+// collapseCommand collapses a multi-line shell command to a single line
+// and truncates it for display.
+func collapseCommand(cmd string) string {
 	cmd = strings.TrimSpace(cmd)
 	if cmd == "" {
 		return ""
 	}
+	// Collapse newlines and runs of whitespace into single spaces.
 	fields := strings.Fields(cmd)
-	if len(fields) == 0 {
-		return ""
+	collapsed := strings.Join(fields, " ")
+	if utf8.RuneCountInString(collapsed) > maxCommandDisplay {
+		runes := []rune(collapsed)
+		return string(runes[:maxCommandDisplay]) + "…"
 	}
-	// Skip leading KEY=VALUE env var assignments.
-	for _, f := range fields {
-		if !strings.Contains(f, "=") {
-			// Strip path prefix (e.g. /usr/bin/make → make).
-			if idx := strings.LastIndex(f, "/"); idx >= 0 {
-				f = f[idx+1:]
-			}
-			return f
-		}
-	}
-	return ""
+	return collapsed
 }
 

--- a/internal/runtime/claude_progress.go
+++ b/internal/runtime/claude_progress.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/fullsend-ai/fullsend/internal/security"
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
@@ -338,8 +339,24 @@ func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *
 	})
 }
 
+// progressRedactor scrubs secrets from tool context strings before display.
+var progressRedactor = security.NewSecretRedactor()
+
 // extractSafeContext returns a safe, non-secret string for progress display.
+// The result is run through SecretRedactor to scrub tokens, keys, and
+// credentials before anything reaches the terminal or CI annotations.
 func extractSafeContext(toolName string, input json.RawMessage) string {
+	raw := extractRawContext(toolName, input)
+	if raw == "" {
+		return ""
+	}
+	if result := progressRedactor.Scan(raw); result.Sanitized != "" {
+		return result.Sanitized
+	}
+	return raw
+}
+
+func extractRawContext(toolName string, input json.RawMessage) string {
 	if len(input) == 0 {
 		return ""
 	}

--- a/internal/runtime/claude_progress.go
+++ b/internal/runtime/claude_progress.go
@@ -285,6 +285,7 @@ func parseClaudeStream(r io.Reader, onEvent func(AgentEvent)) error {
 				NumTurns:                 re.NumTurns,
 				TotalCostUSD:             re.TotalCostUSD,
 				IsError:                  re.IsError,
+				ErrorMessage:             re.Result,
 				Subtype:                  re.Subtype,
 				InputTokens:              re.Usage.InputTokens,
 				OutputTokens:             re.Usage.OutputTokens,

--- a/internal/runtime/claude_progress.go
+++ b/internal/runtime/claude_progress.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"strings"
-	"time"
 	"unicode/utf8"
 
 	"github.com/fullsend-ai/fullsend/internal/security"
@@ -16,6 +15,7 @@ const (
 	maxCommandDisplay = 120
 	maxPatternDisplay = 50
 	maxPathDisplay    = 200
+	maxToolInputSize  = 1 << 20 // 1MB cap for accumulated tool input JSON
 	tokenThreshold    = 5000
 )
 
@@ -200,7 +200,9 @@ func parseClaudeStream(r io.Reader, onEvent func(AgentEvent)) error {
 				case "thinking_delta":
 					onEvent(ThinkingEvent{Text: d.Thinking})
 				case "input_json_delta":
-					toolInputJSON.WriteString(d.PartialJSON)
+					if toolInputJSON.Len() < maxToolInputSize {
+						toolInputJSON.WriteString(d.PartialJSON)
+					}
 				}
 
 			case "content_block_stop":
@@ -235,6 +237,7 @@ func parseClaudeStream(r io.Reader, onEvent func(AgentEvent)) error {
 				}
 				if err := json.Unmarshal(wrapper.Event, &msg); err == nil {
 					totalInput = msg.Message.Usage.InputTokens
+					totalOutput = 0
 					totalCacheRead = msg.Message.Usage.CacheReadInputTokens
 					totalCacheWrite = msg.Message.Usage.CacheCreationInputTokens
 				}
@@ -329,11 +332,23 @@ func parseClaudeStream(r io.Reader, onEvent func(AgentEvent)) error {
 // progressParser reads NDJSON from Claude Code's stream-json output and emits
 // progress updates via the printer. It is a thin wrapper around parseClaudeStream
 // that creates an EventRenderer and populates RunMetrics.
-func progressParser(r io.Reader, printer *ui.Printer, start time.Time, metrics *RunMetrics) error {
-	renderer := NewEventRenderer(printer, start, metrics)
+func progressParser(r io.Reader, printer *ui.Printer, metrics *RunMetrics) error {
+	renderer := NewEventRenderer(printer)
 	return parseClaudeStream(r, func(evt AgentEvent) {
-		if init, ok := evt.(InitEvent); ok && metrics.Model == "" {
-			metrics.Model = init.Model
+		switch e := evt.(type) {
+		case InitEvent:
+			if metrics.Model == "" {
+				metrics.Model = e.Model
+			}
+		case ResultEvent:
+			metrics.NumTurns = e.NumTurns
+			metrics.TotalCostUSD = e.TotalCostUSD
+			metrics.InputTokens = e.InputTokens
+			metrics.OutputTokens = e.OutputTokens
+			metrics.CacheCreationInputTokens = e.CacheCreationInputTokens
+			metrics.CacheReadInputTokens = e.CacheReadInputTokens
+		case ToolUseEvent:
+			metrics.ToolCalls.Add(1)
 		}
 		renderer.Handle(evt)
 	})

--- a/internal/runtime/claude_progress_test.go
+++ b/internal/runtime/claude_progress_test.go
@@ -169,10 +169,11 @@ func TestProgressParser(t *testing.T) {
 	}
 }
 
-func TestProgressParserIgnoresStreamEvents(t *testing.T) {
+func TestProgressParserStreamEventsProcessed(t *testing.T) {
 	lines := []string{
-		`{"type":"stream_event","event":{"type":"content_block_start","content_block":{"type":"tool_use","name":"Edit"}}}`,
-		`{"type":"stream_event","event":{"type":"content_block_stop"}}`,
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","name":"Edit"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"file_path\":\"/src/main.go\"}"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
 		`{"type":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/src/main.go"}}]}`,
 	}
 
@@ -185,8 +186,9 @@ func TestProgressParserIgnoresStreamEvents(t *testing.T) {
 		t.Fatalf("progressParser returned error: %v", err)
 	}
 
+	// Tool counted once from stream_event, not again from assistant fallback
 	if metrics.ToolCalls.Load() != 1 {
-		t.Errorf("expected 1 tool call (stream_event ignored), got %d", metrics.ToolCalls.Load())
+		t.Errorf("expected 1 tool call (from stream_event, assistant suppressed), got %d", metrics.ToolCalls.Load())
 	}
 }
 
@@ -583,5 +585,248 @@ func TestHeartbeatConcurrency(t *testing.T) {
 	output := buf.String()
 	if !strings.Contains(output, "main goroutine") {
 		t.Errorf("expected main goroutine output, got: %s", output)
+	}
+}
+
+// --- parseClaudeStream tests ---
+
+func collectEvents(t *testing.T, input string) []AgentEvent {
+	t.Helper()
+	var events []AgentEvent
+	err := parseClaudeStream(strings.NewReader(input), func(evt AgentEvent) {
+		events = append(events, evt)
+	})
+	if err != nil {
+		t.Fatalf("parseClaudeStream returned error: %v", err)
+	}
+	return events
+}
+
+func TestParseClaudeStreamInitEvent(t *testing.T) {
+	input := `{"type":"system","subtype":"init","model":"claude-opus-4-6","claude_code_version":"1.0.50"}`
+	events := collectEvents(t, input)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	init, ok := events[0].(InitEvent)
+	if !ok {
+		t.Fatalf("expected InitEvent, got %T", events[0])
+	}
+	if init.Model != "claude-opus-4-6" {
+		t.Errorf("expected model claude-opus-4-6, got %q", init.Model)
+	}
+	if init.Version != "1.0.50" {
+		t.Errorf("expected version 1.0.50, got %q", init.Version)
+	}
+}
+
+func TestParseClaudeStreamRetryEvent(t *testing.T) {
+	input := `{"type":"system","subtype":"api_retry","attempt":2,"max_retries":5,"retry_delay_ms":1000,"error":"overloaded"}`
+	events := collectEvents(t, input)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	retry, ok := events[0].(RetryEvent)
+	if !ok {
+		t.Fatalf("expected RetryEvent, got %T", events[0])
+	}
+	if retry.Attempt != 2 || retry.MaxRetries != 5 || retry.DelayMs != 1000 || retry.Error != "overloaded" {
+		t.Errorf("unexpected retry event: %+v", retry)
+	}
+}
+
+func TestParseClaudeStreamTextDeltas(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello "}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"world"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+	var texts []string
+	for _, e := range events {
+		if te, ok := e.(TextEvent); ok {
+			texts = append(texts, te.Text)
+		}
+	}
+	if len(texts) != 2 || texts[0] != "hello " || texts[1] != "world" {
+		t.Errorf("expected two text deltas [hello ] [world], got %v", texts)
+	}
+}
+
+func TestParseClaudeStreamThinkingDeltas(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+	var thinking []string
+	for _, e := range events {
+		if te, ok := e.(ThinkingEvent); ok {
+			thinking = append(thinking, te.Text)
+		}
+	}
+	if len(thinking) != 1 || thinking[0] != "hmm" {
+		t.Errorf("expected one thinking delta [hmm], got %v", thinking)
+	}
+}
+
+func TestParseClaudeStreamToolUse(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","name":"Read"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"file_path\""}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\"/src/main.go\"}"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+	var tools []ToolUseEvent
+	for _, e := range events {
+		if te, ok := e.(ToolUseEvent); ok {
+			tools = append(tools, te)
+		}
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool event, got %d", len(tools))
+	}
+	if tools[0].Name != "Read" {
+		t.Errorf("expected tool name Read, got %q", tools[0].Name)
+	}
+	if tools[0].Summary != "/src/main.go" {
+		t.Errorf("expected summary /src/main.go, got %q", tools[0].Summary)
+	}
+}
+
+func TestParseClaudeStreamUnknownTool(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","name":"EvilTool"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"secret\":\"password123\"}"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+	var tools []ToolUseEvent
+	for _, e := range events {
+		if te, ok := e.(ToolUseEvent); ok {
+			tools = append(tools, te)
+		}
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool event, got %d", len(tools))
+	}
+	if tools[0].Name != "tool" {
+		t.Errorf("expected masked tool name 'tool', got %q", tools[0].Name)
+	}
+	if tools[0].Summary != "" {
+		t.Errorf("expected empty summary for unknown tool, got %q", tools[0].Summary)
+	}
+}
+
+func TestParseClaudeStreamResultEvent(t *testing.T) {
+	input := `{"type":"result","num_turns":8,"total_cost_usd":0.42,"is_error":false,"subtype":"success","usage":{"input_tokens":12000,"output_tokens":3400,"cache_creation_input_tokens":8000,"cache_read_input_tokens":5000}}`
+	events := collectEvents(t, input)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	result, ok := events[0].(ResultEvent)
+	if !ok {
+		t.Fatalf("expected ResultEvent, got %T", events[0])
+	}
+	if result.NumTurns != 8 || result.TotalCostUSD != 0.42 {
+		t.Errorf("unexpected result: %+v", result)
+	}
+	if result.InputTokens != 12000 || result.OutputTokens != 3400 {
+		t.Errorf("unexpected token counts: %+v", result)
+	}
+}
+
+func TestParseClaudeStreamErrorEvent(t *testing.T) {
+	input := `{"type":"stream_event","event":{"type":"error","error":{"type":"overloaded_error","message":"rate limited"}}}`
+	events := collectEvents(t, input)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	errEvt, ok := events[0].(ErrorEvent)
+	if !ok {
+		t.Fatalf("expected ErrorEvent, got %T", events[0])
+	}
+	if errEvt.ErrorType != "overloaded_error" || errEvt.Message != "rate limited" {
+		t.Errorf("unexpected error event: %+v", errEvt)
+	}
+}
+
+func TestParseClaudeStreamAssistantFallback(t *testing.T) {
+	lines := []string{
+		`{"type":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/src/main.go"}}]}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+	var tools []ToolUseEvent
+	for _, e := range events {
+		if te, ok := e.(ToolUseEvent); ok {
+			tools = append(tools, te)
+		}
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool event from assistant fallback, got %d", len(tools))
+	}
+	if tools[0].Name != "Read" || tools[0].Summary != "/src/main.go" {
+		t.Errorf("unexpected tool event: %+v", tools[0])
+	}
+}
+
+func TestParseClaudeStreamTokensEvent(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"message_start","message":{"usage":{"input_tokens":4000,"cache_read_input_tokens":500,"cache_creation_input_tokens":200}}}}`,
+		`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":1000}}}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+
+	var tokens []TokensEvent
+	for _, e := range events {
+		if te, ok := e.(TokensEvent); ok {
+			tokens = append(tokens, te)
+		}
+	}
+	// Total = 4000 + 1000 + 500 + 200 = 5700, crosses 5k threshold
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 tokens event, got %d", len(tokens))
+	}
+	if tokens[0].InputTokens != 4000 || tokens[0].OutputTokens != 1000 {
+		t.Errorf("unexpected token counts: %+v", tokens[0])
+	}
+	if tokens[0].CacheRead != 500 || tokens[0].CacheWrite != 200 {
+		t.Errorf("unexpected cache counts: %+v", tokens[0])
+	}
+}
+
+func TestParseClaudeStreamTokensEventThrottled(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"message_start","message":{"usage":{"input_tokens":4000}}}}`,
+		`{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":200}}}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+
+	var tokens []TokensEvent
+	for _, e := range events {
+		if te, ok := e.(TokensEvent); ok {
+			tokens = append(tokens, te)
+		}
+	}
+	// Total = 4200, below 5k threshold
+	if len(tokens) != 0 {
+		t.Fatalf("expected 0 tokens events (below threshold), got %d", len(tokens))
+	}
+}
+
+func TestParseClaudeStreamAssistantSuppressedWhenStreaming(t *testing.T) {
+	lines := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+		`{"type":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/src/main.go"}}]}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+	for _, e := range events {
+		if _, ok := e.(ToolUseEvent); ok {
+			t.Error("assistant message should not emit ToolUseEvent when stream_events are active")
+		}
 	}
 }

--- a/internal/runtime/claude_progress_test.go
+++ b/internal/runtime/claude_progress_test.go
@@ -754,6 +754,28 @@ func TestParseClaudeStreamErrorEvent(t *testing.T) {
 	}
 }
 
+func TestParseClaudeStreamResultEventWithError(t *testing.T) {
+	input := `{"type":"result","num_turns":3,"total_cost_usd":0.10,"is_error":true,"subtype":"error_max_turns","result":"Max turns reached","usage":{"input_tokens":5000,"output_tokens":1000}}`
+	events := collectEvents(t, input)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	result, ok := events[0].(ResultEvent)
+	if !ok {
+		t.Fatalf("expected ResultEvent, got %T", events[0])
+	}
+	if !result.IsError {
+		t.Error("expected IsError to be true")
+	}
+	if result.ErrorMessage != "Max turns reached" {
+		t.Errorf("expected error message 'Max turns reached', got %q", result.ErrorMessage)
+	}
+	if result.Subtype != "error_max_turns" {
+		t.Errorf("expected subtype error_max_turns, got %q", result.Subtype)
+	}
+}
+
 func TestParseClaudeStreamAssistantFallback(t *testing.T) {
 	lines := []string{
 		`{"type":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/src/main.go"}}]}`,

--- a/internal/runtime/claude_progress_test.go
+++ b/internal/runtime/claude_progress_test.go
@@ -147,10 +147,9 @@ func TestProgressParser(t *testing.T) {
 	input := strings.NewReader(strings.Join(lines, "\n"))
 	var buf bytes.Buffer
 	printer := ui.New(&buf)
-	start := time.Now()
 	metrics := &RunMetrics{}
 
-	if err := progressParser(input, printer, start, metrics); err != nil {
+	if err := progressParser(input, printer, metrics); err != nil {
 		t.Fatalf("progressParser returned error: %v", err)
 	}
 
@@ -180,7 +179,7 @@ func TestProgressParserStreamEventsProcessed(t *testing.T) {
 	printer := ui.New(&buf)
 	metrics := &RunMetrics{}
 
-	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+	if err := progressParser(input, printer, metrics); err != nil {
 		t.Fatalf("progressParser returned error: %v", err)
 	}
 
@@ -202,7 +201,7 @@ func TestProgressParserMalformedJSON(t *testing.T) {
 	printer := ui.New(&buf)
 	metrics := &RunMetrics{}
 
-	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+	if err := progressParser(input, printer, metrics); err != nil {
 		t.Fatalf("progressParser returned error: %v", err)
 	}
 
@@ -222,7 +221,7 @@ func TestProgressParserUnknownToolShowsNameNoContext(t *testing.T) {
 	printer := ui.New(&buf)
 	metrics := &RunMetrics{}
 
-	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+	if err := progressParser(input, printer, metrics); err != nil {
 		t.Fatalf("progressParser returned error: %v", err)
 	}
 
@@ -251,7 +250,7 @@ func TestProgressParserReaderError(t *testing.T) {
 	printer := ui.New(&buf)
 	metrics := &RunMetrics{}
 
-	err := progressParser(pr, printer, time.Now(), metrics)
+	err := progressParser(pr, printer, metrics)
 
 	if err == nil {
 		t.Error("expected error from broken reader, got nil")
@@ -271,7 +270,7 @@ func TestProgressParserOversizedLineSkipped(t *testing.T) {
 	printer := ui.New(&buf)
 	metrics := &RunMetrics{}
 
-	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+	if err := progressParser(input, printer, metrics); err != nil {
 		t.Fatalf("progressParser returned error: %v", err)
 	}
 
@@ -424,7 +423,7 @@ func TestSanitizeStreamText(t *testing.T) {
 
 func TestRendererSanitizesThinkingAndText(t *testing.T) {
 	var buf bytes.Buffer
-	r, _ := newTestRenderer(&buf)
+	r := newTestRenderer(&buf)
 
 	// Thinking with ANSI escape should be stripped
 	r.Handle(ThinkingEvent{Text: "\x1b[31minjected\x1b[0m"})
@@ -439,7 +438,7 @@ func TestRendererSanitizesThinkingAndText(t *testing.T) {
 	}
 
 	buf.Reset()
-	r2, _ := newTestRenderer(&buf)
+	r2 := newTestRenderer(&buf)
 
 	// Text with GHA command injection
 	r2.Handle(TextEvent{Text: "hello\n::error::pwned"})
@@ -463,7 +462,7 @@ func TestProgressParserCapturesResultMetrics(t *testing.T) {
 	printer := ui.New(&buf)
 	metrics := &RunMetrics{}
 
-	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+	if err := progressParser(input, printer, metrics); err != nil {
 		t.Fatalf("progressParser returned error: %v", err)
 	}
 
@@ -509,7 +508,7 @@ func TestProgressParserCountsToolCallsFromNestedMessage(t *testing.T) {
 	printer := ui.New(&buf)
 	metrics := &RunMetrics{}
 
-	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+	if err := progressParser(input, printer, metrics); err != nil {
 		t.Fatalf("progressParser returned error: %v", err)
 	}
 
@@ -533,7 +532,7 @@ func TestProgressParserCapturesModelFromAssistantWhenSystemLacksIt(t *testing.T)
 	printer := ui.New(&buf)
 	metrics := &RunMetrics{}
 
-	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+	if err := progressParser(input, printer, metrics); err != nil {
 		t.Fatalf("progressParser returned error: %v", err)
 	}
 
@@ -555,7 +554,7 @@ func TestProgressParserCapturesModelFromSystemEvent(t *testing.T) {
 	printer := ui.New(&buf)
 	metrics := &RunMetrics{}
 
-	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+	if err := progressParser(input, printer, metrics); err != nil {
 		t.Fatalf("progressParser returned error: %v", err)
 	}
 
@@ -574,7 +573,7 @@ func TestProgressParserNoResultEvent(t *testing.T) {
 	printer := ui.New(&buf)
 	metrics := &RunMetrics{}
 
-	if err := progressParser(input, printer, time.Now(), metrics); err != nil {
+	if err := progressParser(input, printer, metrics); err != nil {
 		t.Fatalf("progressParser returned error: %v", err)
 	}
 

--- a/internal/runtime/claude_progress_test.go
+++ b/internal/runtime/claude_progress_test.go
@@ -53,16 +53,16 @@ func TestExtractSafeContext(t *testing.T) {
 			want:     "make test",
 		},
 		{
-			name:     "bash with args",
+			name:     "bash with short arg (no redaction)",
 			toolName: "Bash",
-			input:    map[string]interface{}{"command": "curl -H 'Bearer token123' https://api.example.com"},
-			want:     "curl -H 'Bearer token123' https://api.example.com",
+			input:    map[string]interface{}{"command": "curl -H 'Bearer short' https://api.example.com"},
+			want:     "curl -H 'Bearer short' https://api.example.com",
 		},
 		{
-			name:     "bash with env var prefix",
+			name:     "bash with github token redacted",
 			toolName: "Bash",
-			input:    map[string]interface{}{"command": "API_KEY=secret123 curl https://api.example.com"},
-			want:     "API_KEY=secret123 curl https://api.example.com",
+			input:    map[string]interface{}{"command": "curl -H 'Authorization: Bearer ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' https://api.github.com"},
+			want:     "curl -H 'Authorization: Bearer *** https://api.github.com",
 		},
 		{
 			name:     "read file",
@@ -382,6 +382,72 @@ func TestSanitizeOutput(t *testing.T) {
 				t.Errorf("sanitizeOutput(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSanitizeStreamText(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "preserves newlines",
+			input: "line one\nline two\nline three",
+			want:  "line one\nline two\nline three",
+		},
+		{
+			name:  "strips ANSI but preserves newlines",
+			input: "\x1b[31mred\x1b[0m\nclean",
+			want:  "red\nclean",
+		},
+		{
+			name:  "breaks GHA commands across newlines",
+			input: "text\n::error::pwned",
+			want:  "text\n: :error: :pwned",
+		},
+		{
+			name:  "strips control chars except newline",
+			input: "hello\x00\tworld\nok",
+			want:  "hello  world\nok",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeStreamText(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeStreamText(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRendererSanitizesThinkingAndText(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	// Thinking with ANSI escape should be stripped
+	r.Handle(ThinkingEvent{Text: "\x1b[31minjected\x1b[0m"})
+	r.Handle(ToolUseEvent{Name: "Read", Summary: "/a.go"}) // force block transition
+
+	output := buf.String()
+	if strings.Contains(output, "\x1b[") {
+		t.Errorf("ANSI escape leaked through thinking event: %q", output)
+	}
+	if !strings.Contains(output, "injected") {
+		t.Errorf("expected sanitized thinking text, got: %s", output)
+	}
+
+	buf.Reset()
+	r2, _ := newTestRenderer(&buf)
+
+	// Text with GHA command injection
+	r2.Handle(TextEvent{Text: "hello\n::error::pwned"})
+	r2.Handle(ToolUseEvent{Name: "Read", Summary: "/b.go"})
+
+	output = buf.String()
+	if strings.Contains(output, "::error::") {
+		t.Errorf("GHA workflow command leaked through text event: %q", output)
 	}
 }
 

--- a/internal/runtime/claude_progress_test.go
+++ b/internal/runtime/claude_progress_test.go
@@ -13,30 +13,28 @@ import (
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
-func TestExtractBinaryName(t *testing.T) {
+func TestCollapseCommand(t *testing.T) {
 	tests := []struct {
 		cmd  string
 		want string
 	}{
-		{"make test", "make"},
-		{"git commit -s -m 'msg'", "git"},
-		{"/usr/bin/make lint", "make"},
-		{"  go test ./...", "go"},
+		{"make test", "make test"},
+		{"git commit -s -m 'msg'", "git commit -s -m 'msg'"},
+		{"/usr/bin/make lint", "/usr/bin/make lint"},
+		{"  go test ./...", "go test ./..."},
 		{"", ""},
-		{"gh pr create --title 'x'", "gh"},
-		{"curl -H 'Authorization: Bearer SECRET' https://api.example.com", "curl"},
-		// KEY=VALUE env var prefixes are skipped.
-		{"SECRET=val make test", "make"},
-		{"FOO=bar BAZ=qux /usr/bin/go test", "go"},
-		// All tokens are KEY=VALUE — return empty.
-		{"FOO=bar BAZ=qux", ""},
+		{"gh pr create --title 'x'", "gh pr create --title 'x'"},
+		// Multi-line commands are collapsed.
+		{"echo hello\necho world", "echo hello echo world"},
 		// Whitespace-only input.
 		{"   \t  ", ""},
+		// Long commands are truncated.
+		{"echo " + strings.Repeat("x", 200), "echo " + strings.Repeat("x", 115) + "…"},
 	}
 	for _, tt := range tests {
-		got := extractBinaryName(tt.cmd)
+		got := collapseCommand(tt.cmd)
 		if got != tt.want {
-			t.Errorf("extractBinaryName(%q) = %q, want %q", tt.cmd, got, tt.want)
+			t.Errorf("collapseCommand(%q) = %q, want %q", tt.cmd, got, tt.want)
 		}
 	}
 }
@@ -52,19 +50,19 @@ func TestExtractSafeContext(t *testing.T) {
 			name:     "bash command",
 			toolName: "Bash",
 			input:    map[string]interface{}{"command": "make test"},
-			want:     "make",
+			want:     "make test",
 		},
 		{
-			name:     "bash with secret in args",
+			name:     "bash with args",
 			toolName: "Bash",
 			input:    map[string]interface{}{"command": "curl -H 'Bearer token123' https://api.example.com"},
-			want:     "curl",
+			want:     "curl -H 'Bearer token123' https://api.example.com",
 		},
 		{
 			name:     "bash with env var prefix",
 			toolName: "Bash",
 			input:    map[string]interface{}{"command": "API_KEY=secret123 curl https://api.example.com"},
-			want:     "curl",
+			want:     "API_KEY=secret123 curl https://api.example.com",
 		},
 		{
 			name:     "read file",
@@ -115,9 +113,9 @@ func TestExtractSafeContext(t *testing.T) {
 			want:     "**/*.go",
 		},
 		{
-			name:     "unknown tool returns empty",
-			toolName: "Agent",
-			input:    map[string]interface{}{"prompt": "do something"},
+			name:     "unrecognized tool returns empty",
+			toolName: "Skill",
+			input:    map[string]interface{}{"skill_name": "issue-labels"},
 			want:     "",
 		},
 		{
@@ -213,9 +211,9 @@ func TestProgressParserMalformedJSON(t *testing.T) {
 	}
 }
 
-func TestProgressParserUnknownToolAllowlisted(t *testing.T) {
+func TestProgressParserUnknownToolShowsNameNoContext(t *testing.T) {
 	lines := []string{
-		`{"type":"assistant","content":[{"type":"tool_use","name":"EvilTool","input":{"secret":"should-not-appear"}}]}`,
+		`{"type":"assistant","content":[{"type":"tool_use","name":"CustomTool","input":{"secret":"should-not-appear"}}]}`,
 		`{"type":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/src/main.go"}}]}`,
 	}
 
@@ -233,32 +231,11 @@ func TestProgressParserUnknownToolAllowlisted(t *testing.T) {
 	}
 
 	output := buf.String()
-	if strings.Contains(output, "EvilTool") {
-		t.Errorf("unknown tool name should not appear in output, got: %s", output)
+	if !strings.Contains(output, "CustomTool") {
+		t.Errorf("expected tool name in output, got: %s", output)
 	}
-	if !strings.Contains(output, "tool") {
-		t.Errorf("expected generic 'tool' label for unknown tool, got: %s", output)
-	}
-}
-
-func TestProgressParserUnknownToolAssistantNoContext(t *testing.T) {
-	lines := []string{
-		`{"type":"assistant","content":[{"type":"tool_use","name":"CustomTool","input":{"secret":"should-not-appear"}}]}`,
-	}
-
-	input := strings.NewReader(strings.Join(lines, "\n"))
-	var buf bytes.Buffer
-	printer := ui.New(&buf)
-	metrics := &RunMetrics{}
-
-	_ = progressParser(input, printer, time.Now(), metrics)
-
-	output := buf.String()
 	if strings.Contains(output, "should-not-appear") {
-		t.Errorf("non-allowlisted tool should not extract context, got: %s", output)
-	}
-	if strings.Contains(output, "CustomTool") {
-		t.Errorf("non-allowlisted tool name should not appear, got: %s", output)
+		t.Errorf("unknown tool should not extract context, got: %s", output)
 	}
 }
 
@@ -697,10 +674,10 @@ func TestParseClaudeStreamToolUse(t *testing.T) {
 	}
 }
 
-func TestParseClaudeStreamUnknownTool(t *testing.T) {
+func TestParseClaudeStreamUnknownToolShowsNameNoContext(t *testing.T) {
 	lines := []string{
-		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","name":"EvilTool"}}}`,
-		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"secret\":\"password123\"}"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","name":"Skill"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"skill_name\":\"issue-labels\"}"}}}`,
 		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
 	}
 	events := collectEvents(t, strings.Join(lines, "\n"))
@@ -713,11 +690,11 @@ func TestParseClaudeStreamUnknownTool(t *testing.T) {
 	if len(tools) != 1 {
 		t.Fatalf("expected 1 tool event, got %d", len(tools))
 	}
-	if tools[0].Name != "tool" {
-		t.Errorf("expected masked tool name 'tool', got %q", tools[0].Name)
+	if tools[0].Name != "Skill" {
+		t.Errorf("expected real tool name 'Skill', got %q", tools[0].Name)
 	}
 	if tools[0].Summary != "" {
-		t.Errorf("expected empty summary for unknown tool, got %q", tools[0].Summary)
+		t.Errorf("expected empty summary for unrecognized tool, got %q", tools[0].Summary)
 	}
 }
 
@@ -792,6 +769,38 @@ func TestParseClaudeStreamAssistantFallback(t *testing.T) {
 	}
 	if tools[0].Name != "Read" || tools[0].Summary != "/src/main.go" {
 		t.Errorf("unexpected tool event: %+v", tools[0])
+	}
+}
+
+func TestParseClaudeStreamAssistantFallbackTextAndThinking(t *testing.T) {
+	lines := []string{
+		`{"type":"assistant","message":{"model":"claude-opus-4-6","content":[{"type":"thinking","thinking":"Let me analyze this."}]}}`,
+		`{"type":"assistant","message":{"model":"claude-opus-4-6","content":[{"type":"text","text":"I'll read the file now."}]}}`,
+		`{"type":"assistant","message":{"model":"claude-opus-4-6","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/a.go"}}]}}`,
+	}
+	events := collectEvents(t, strings.Join(lines, "\n"))
+
+	var thinking []ThinkingEvent
+	var texts []TextEvent
+	var tools []ToolUseEvent
+	for _, e := range events {
+		switch ev := e.(type) {
+		case ThinkingEvent:
+			thinking = append(thinking, ev)
+		case TextEvent:
+			texts = append(texts, ev)
+		case ToolUseEvent:
+			tools = append(tools, ev)
+		}
+	}
+	if len(thinking) != 1 || thinking[0].Text != "Let me analyze this." {
+		t.Errorf("expected 1 thinking event with correct text, got %v", thinking)
+	}
+	if len(texts) != 1 || texts[0].Text != "I'll read the file now." {
+		t.Errorf("expected 1 text event with correct text, got %v", texts)
+	}
+	if len(tools) != 1 {
+		t.Errorf("expected 1 tool event, got %d", len(tools))
 	}
 }
 

--- a/internal/runtime/event.go
+++ b/internal/runtime/event.go
@@ -1,0 +1,82 @@
+package runtime
+
+// AgentEvent is the normalized event interface for runtime-agnostic rendering.
+// Each concrete event type implements this with a no-op marker method.
+type AgentEvent interface {
+	agentEvent()
+}
+
+// InitEvent is emitted once at stream start with runtime metadata.
+type InitEvent struct {
+	Model   string
+	Version string
+}
+
+func (InitEvent) agentEvent() {}
+
+// ThinkingEvent carries an incremental thinking text delta.
+type ThinkingEvent struct {
+	Text string
+}
+
+func (ThinkingEvent) agentEvent() {}
+
+// TextEvent carries an incremental assistant text delta.
+type TextEvent struct {
+	Text string
+}
+
+func (TextEvent) agentEvent() {}
+
+// ToolUseEvent is emitted when a tool invocation completes.
+// Name is the tool name ("tool" for unknown/non-allowlisted tools).
+// Summary is a pre-computed one-line description safe for display.
+type ToolUseEvent struct {
+	Name    string
+	Summary string
+}
+
+func (ToolUseEvent) agentEvent() {}
+
+// TokensEvent carries incremental token usage counters.
+type TokensEvent struct {
+	InputTokens  int
+	OutputTokens int
+	CacheRead    int
+	CacheWrite   int
+}
+
+func (TokensEvent) agentEvent() {}
+
+// ResultEvent is emitted once at stream end with final metrics.
+type ResultEvent struct {
+	NumTurns                 int
+	TotalCostUSD             float64
+	IsError                  bool
+	ErrorMessage             string
+	Subtype                  string
+	InputTokens              int
+	OutputTokens             int
+	CacheCreationInputTokens int
+	CacheReadInputTokens     int
+}
+
+func (ResultEvent) agentEvent() {}
+
+// ErrorEvent is emitted when the runtime reports an error.
+type ErrorEvent struct {
+	ErrorType string
+	Message   string
+}
+
+func (ErrorEvent) agentEvent() {}
+
+// RetryEvent is emitted when the runtime retries an API call.
+type RetryEvent struct {
+	Attempt    int
+	MaxRetries int
+	DelayMs    int
+	Error      string
+}
+
+func (RetryEvent) agentEvent() {}

--- a/internal/runtime/event.go
+++ b/internal/runtime/event.go
@@ -29,8 +29,9 @@ type TextEvent struct {
 func (TextEvent) agentEvent() {}
 
 // ToolUseEvent is emitted when a tool invocation completes.
-// Name is the tool name ("tool" for unknown/non-allowlisted tools).
-// Summary is a pre-computed one-line description safe for display.
+// Name is the raw tool name from the runtime stream.
+// Summary is a one-line context string from extractSafeContext; it is
+// empty for tools not recognized by that function.
 type ToolUseEvent struct {
 	Name    string
 	Summary string

--- a/internal/runtime/event_test.go
+++ b/internal/runtime/event_test.go
@@ -1,0 +1,21 @@
+package runtime
+
+import "testing"
+
+func TestAgentEventInterfaceSatisfied(t *testing.T) {
+	// Compile-time verification that all concrete types satisfy AgentEvent.
+	var events []AgentEvent
+	events = append(events,
+		InitEvent{Model: "claude-opus-4-6", Version: "1.0.0"},
+		ThinkingEvent{Text: "thinking..."},
+		TextEvent{Text: "hello"},
+		ToolUseEvent{Name: "Read", Summary: "/src/main.go"},
+		TokensEvent{InputTokens: 100, OutputTokens: 50, CacheRead: 30, CacheWrite: 20},
+		ResultEvent{NumTurns: 5, TotalCostUSD: 0.42},
+		ErrorEvent{ErrorType: "overloaded", Message: "rate limited"},
+		RetryEvent{Attempt: 1, MaxRetries: 3, DelayMs: 1000, Error: "timeout"},
+	)
+	if len(events) != 8 {
+		t.Errorf("expected 8 event types, got %d", len(events))
+	}
+}

--- a/internal/runtime/renderer.go
+++ b/internal/runtime/renderer.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/fullsend-ai/fullsend/internal/ui"
@@ -14,19 +13,16 @@ import (
 // types produce clean output boundaries.
 type EventRenderer struct {
 	printer    *ui.Printer
-	metrics    *RunMetrics
 	isCI       bool
 	inText     bool
 	inThinking bool
 	seenInit   bool
 }
 
-// NewEventRenderer creates a renderer that writes to the given printer
-// and populates metrics as events arrive.
-func NewEventRenderer(printer *ui.Printer, start time.Time, metrics *RunMetrics) *EventRenderer {
+// NewEventRenderer creates a renderer that writes to the given printer.
+func NewEventRenderer(printer *ui.Printer) *EventRenderer {
 	return &EventRenderer{
 		printer: printer,
-		metrics: metrics,
 		isCI:    os.Getenv("GITHUB_ACTIONS") == "true",
 	}
 }
@@ -66,7 +62,6 @@ func (r *EventRenderer) Handle(evt AgentEvent) {
 		r.printer.Raw(sanitizeStreamText(e.Text))
 	case ToolUseEvent:
 		r.endBlock()
-		r.metrics.ToolCalls.Add(1)
 		var msg string
 		if e.Summary != "" {
 			msg = fmt.Sprintf("%s: %s", e.Name, e.Summary)
@@ -87,12 +82,6 @@ func (r *EventRenderer) Handle(evt AgentEvent) {
 		))
 	case ResultEvent:
 		r.endBlock()
-		r.metrics.NumTurns = e.NumTurns
-		r.metrics.TotalCostUSD = e.TotalCostUSD
-		r.metrics.InputTokens = e.InputTokens
-		r.metrics.OutputTokens = e.OutputTokens
-		r.metrics.CacheCreationInputTokens = e.CacheCreationInputTokens
-		r.metrics.CacheReadInputTokens = e.CacheReadInputTokens
 		subtype := sanitizeOutput(e.Subtype)
 		label := "Result"
 		if subtype != "" {

--- a/internal/runtime/renderer.go
+++ b/internal/runtime/renderer.go
@@ -16,10 +16,9 @@ type EventRenderer struct {
 	printer        *ui.Printer
 	start          time.Time
 	metrics        *RunMetrics
-	isCI           bool
-	inText         bool
-	inThinking     bool
-	lastTokenTotal int
+	isCI       bool
+	inText     bool
+	inThinking bool
 }
 
 // NewEventRenderer creates a renderer that writes to the given printer
@@ -77,15 +76,12 @@ func (r *EventRenderer) Handle(evt AgentEvent) {
 		}
 		r.printer.Heartbeat(msg)
 	case TokensEvent:
+		r.endBlock()
 		total := e.InputTokens + e.OutputTokens + e.CacheRead + e.CacheWrite
-		if total-r.lastTokenTotal >= 5000 {
-			r.endBlock()
-			r.lastTokenTotal = total
-			r.printer.StepInfo(fmt.Sprintf(
-				"TOKENS in=%d out=%d cache_r=%d cache_w=%d total=%d",
-				e.InputTokens, e.OutputTokens, e.CacheRead, e.CacheWrite, total,
-			))
-		}
+		r.printer.StepInfo(fmt.Sprintf(
+			"TOKENS in=%d out=%d cache_r=%d cache_w=%d total=%d",
+			e.InputTokens, e.OutputTokens, e.CacheRead, e.CacheWrite, total,
+		))
 	case ResultEvent:
 		r.endBlock()
 		r.metrics.NumTurns = e.NumTurns

--- a/internal/runtime/renderer.go
+++ b/internal/runtime/renderer.go
@@ -44,9 +44,10 @@ func (r *EventRenderer) Handle(evt AgentEvent) {
 		}
 		r.seenInit = true
 		r.endBlock()
-		label := e.Model
+		model := sanitizeOutput(e.Model)
+		label := model
 		if e.Version != "" {
-			label = fmt.Sprintf("%s (v%s)", e.Model, e.Version)
+			label = fmt.Sprintf("%s (v%s)", model, sanitizeOutput(e.Version))
 		}
 		r.printer.Header("Agent: " + label)
 	case ThinkingEvent:
@@ -55,14 +56,14 @@ func (r *EventRenderer) Handle(evt AgentEvent) {
 			r.printer.Raw(thinkingStyle.Render("  \U0001f9e0 "))
 			r.inThinking = true
 		}
-		r.printer.Raw(thinkingStyle.Render(e.Text))
+		r.printer.Raw(thinkingStyle.Render(sanitizeStreamText(e.Text)))
 	case TextEvent:
 		if !r.inText {
 			r.endBlock()
 			r.printer.Raw("  \U0001f4ac ")
 			r.inText = true
 		}
-		r.printer.Raw(e.Text)
+		r.printer.Raw(sanitizeStreamText(e.Text))
 	case ToolUseEvent:
 		r.endBlock()
 		r.metrics.ToolCalls.Add(1)
@@ -92,14 +93,15 @@ func (r *EventRenderer) Handle(evt AgentEvent) {
 		r.metrics.OutputTokens = e.OutputTokens
 		r.metrics.CacheCreationInputTokens = e.CacheCreationInputTokens
 		r.metrics.CacheReadInputTokens = e.CacheReadInputTokens
+		subtype := sanitizeOutput(e.Subtype)
 		label := "Result"
-		if e.Subtype != "" {
-			label = fmt.Sprintf("Result: %s", e.Subtype)
+		if subtype != "" {
+			label = fmt.Sprintf("Result: %s", subtype)
 		}
 		if e.IsError {
 			label = "Result: ERROR"
-			if e.Subtype != "" {
-				label = fmt.Sprintf("Result: ERROR (%s)", e.Subtype)
+			if subtype != "" {
+				label = fmt.Sprintf("Result: ERROR (%s)", subtype)
 			}
 		}
 		r.printer.Header(label)

--- a/internal/runtime/renderer.go
+++ b/internal/runtime/renderer.go
@@ -13,12 +13,12 @@ import (
 // It tracks block state (text/thinking) so transitions between event
 // types produce clean output boundaries.
 type EventRenderer struct {
-	printer        *ui.Printer
-	start          time.Time
-	metrics        *RunMetrics
+	printer *ui.Printer
+	metrics *RunMetrics
 	isCI       bool
 	inText     bool
 	inThinking bool
+	seenInit   bool
 }
 
 // NewEventRenderer creates a renderer that writes to the given printer
@@ -26,7 +26,6 @@ type EventRenderer struct {
 func NewEventRenderer(printer *ui.Printer, start time.Time, metrics *RunMetrics) *EventRenderer {
 	return &EventRenderer{
 		printer: printer,
-		start:   start,
 		metrics: metrics,
 		isCI:    os.Getenv("GITHUB_ACTIONS") == "true",
 	}
@@ -40,6 +39,10 @@ var (
 func (r *EventRenderer) Handle(evt AgentEvent) {
 	switch e := evt.(type) {
 	case InitEvent:
+		if r.seenInit {
+			return
+		}
+		r.seenInit = true
 		r.endBlock()
 		label := e.Model
 		if e.Version != "" {
@@ -62,19 +65,18 @@ func (r *EventRenderer) Handle(evt AgentEvent) {
 		r.printer.Raw(e.Text)
 	case ToolUseEvent:
 		r.endBlock()
-		count := r.metrics.ToolCalls.Add(1)
-		elapsed := time.Since(r.start).Truncate(time.Second)
+		r.metrics.ToolCalls.Add(1)
 		var msg string
 		if e.Summary != "" {
-			msg = fmt.Sprintf("%s: %s (%s, %d tools)", e.Name, e.Summary, elapsed, count)
+			msg = fmt.Sprintf("%s: %s", e.Name, e.Summary)
 		} else {
-			msg = fmt.Sprintf("%s (%s, %d tools)", e.Name, elapsed, count)
+			msg = e.Name
 		}
 		msg = sanitizeOutput(msg)
 		if r.isCI {
 			fmt.Fprintf(os.Stderr, "::notice::%s\n", msg)
 		}
-		r.printer.Heartbeat(msg)
+		r.printer.ToolProgress(msg)
 	case TokensEvent:
 		r.endBlock()
 		total := e.InputTokens + e.OutputTokens + e.CacheRead + e.CacheWrite

--- a/internal/runtime/renderer.go
+++ b/internal/runtime/renderer.go
@@ -1,0 +1,136 @@
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+// EventRenderer renders normalized AgentEvent values to a Printer.
+// It tracks block state (text/thinking) so transitions between event
+// types produce clean output boundaries.
+type EventRenderer struct {
+	printer        *ui.Printer
+	start          time.Time
+	metrics        *RunMetrics
+	isCI           bool
+	inText         bool
+	inThinking     bool
+	lastTokenTotal int
+}
+
+// NewEventRenderer creates a renderer that writes to the given printer
+// and populates metrics as events arrive.
+func NewEventRenderer(printer *ui.Printer, start time.Time, metrics *RunMetrics) *EventRenderer {
+	return &EventRenderer{
+		printer: printer,
+		start:   start,
+		metrics: metrics,
+		isCI:    os.Getenv("GITHUB_ACTIONS") == "true",
+	}
+}
+
+var (
+	thinkingStyle = lipgloss.NewStyle().Italic(true).Foreground(ui.ColorMuted)
+)
+
+// Handle dispatches a single AgentEvent to the appropriate rendering method.
+func (r *EventRenderer) Handle(evt AgentEvent) {
+	switch e := evt.(type) {
+	case InitEvent:
+		r.endBlock()
+		label := e.Model
+		if e.Version != "" {
+			label = fmt.Sprintf("%s (v%s)", e.Model, e.Version)
+		}
+		r.printer.Header("Agent: " + label)
+	case ThinkingEvent:
+		if !r.inThinking {
+			r.endBlock()
+			r.printer.Raw(thinkingStyle.Render("  \U0001f9e0 "))
+			r.inThinking = true
+		}
+		r.printer.Raw(thinkingStyle.Render(e.Text))
+	case TextEvent:
+		if !r.inText {
+			r.endBlock()
+			r.printer.Raw("  \U0001f4ac ")
+			r.inText = true
+		}
+		r.printer.Raw(e.Text)
+	case ToolUseEvent:
+		r.endBlock()
+		count := r.metrics.ToolCalls.Add(1)
+		elapsed := time.Since(r.start).Truncate(time.Second)
+		var msg string
+		if e.Summary != "" {
+			msg = fmt.Sprintf("%s: %s (%s, %d tools)", e.Name, e.Summary, elapsed, count)
+		} else {
+			msg = fmt.Sprintf("%s (%s, %d tools)", e.Name, elapsed, count)
+		}
+		msg = sanitizeOutput(msg)
+		if r.isCI {
+			fmt.Fprintf(os.Stderr, "::notice::%s\n", msg)
+		}
+		r.printer.Heartbeat(msg)
+	case TokensEvent:
+		total := e.InputTokens + e.OutputTokens + e.CacheRead + e.CacheWrite
+		if total-r.lastTokenTotal >= 5000 {
+			r.endBlock()
+			r.lastTokenTotal = total
+			r.printer.StepInfo(fmt.Sprintf(
+				"TOKENS in=%d out=%d cache_r=%d cache_w=%d total=%d",
+				e.InputTokens, e.OutputTokens, e.CacheRead, e.CacheWrite, total,
+			))
+		}
+	case ResultEvent:
+		r.endBlock()
+		r.metrics.NumTurns = e.NumTurns
+		r.metrics.TotalCostUSD = e.TotalCostUSD
+		r.metrics.InputTokens = e.InputTokens
+		r.metrics.OutputTokens = e.OutputTokens
+		r.metrics.CacheCreationInputTokens = e.CacheCreationInputTokens
+		r.metrics.CacheReadInputTokens = e.CacheReadInputTokens
+		label := "Result"
+		if e.Subtype != "" {
+			label = fmt.Sprintf("Result: %s", e.Subtype)
+		}
+		if e.IsError {
+			label = "Result: ERROR"
+			if e.Subtype != "" {
+				label = fmt.Sprintf("Result: ERROR (%s)", e.Subtype)
+			}
+		}
+		r.printer.Header(label)
+		r.printer.KeyValue("Turns", fmt.Sprintf("%d", e.NumTurns))
+		r.printer.KeyValue("Cost", fmt.Sprintf("$%.4f", e.TotalCostUSD))
+		r.printer.KeyValue("Tokens", fmt.Sprintf(
+			"in=%d out=%d cache_create=%d cache_read=%d",
+			e.InputTokens, e.OutputTokens,
+			e.CacheCreationInputTokens, e.CacheReadInputTokens,
+		))
+		if e.IsError && e.ErrorMessage != "" {
+			r.printer.StepFail(sanitizeOutput(e.ErrorMessage))
+		}
+	case ErrorEvent:
+		r.endBlock()
+		r.printer.StepFail(fmt.Sprintf("%s: %s",
+			sanitizeOutput(e.ErrorType), sanitizeOutput(e.Message)))
+	case RetryEvent:
+		r.endBlock()
+		r.printer.StepWarn(fmt.Sprintf("Retry %d/%d: %s (delay %dms)",
+			e.Attempt, e.MaxRetries, sanitizeOutput(e.Error), e.DelayMs))
+	}
+}
+
+// endBlock closes any open text or thinking block.
+func (r *EventRenderer) endBlock() {
+	if r.inText || r.inThinking {
+		r.printer.Raw("\n")
+		r.inText = false
+		r.inThinking = false
+	}
+}

--- a/internal/runtime/renderer.go
+++ b/internal/runtime/renderer.go
@@ -13,8 +13,8 @@ import (
 // It tracks block state (text/thinking) so transitions between event
 // types produce clean output boundaries.
 type EventRenderer struct {
-	printer *ui.Printer
-	metrics *RunMetrics
+	printer    *ui.Printer
+	metrics    *RunMetrics
 	isCI       bool
 	inText     bool
 	inThinking bool

--- a/internal/runtime/renderer_test.go
+++ b/internal/runtime/renderer_test.go
@@ -29,6 +29,20 @@ func TestRendererInitEvent(t *testing.T) {
 	}
 }
 
+func TestRendererDuplicateInitEventSuppressed(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	r.Handle(InitEvent{Model: "claude-opus-4-6", Version: "1.2.3"})
+	r.Handle(InitEvent{Model: "claude-opus-4-6"})
+	r.Handle(InitEvent{Model: "claude-opus-4-6"})
+
+	output := buf.String()
+	if count := strings.Count(output, "claude-opus-4-6"); count != 1 {
+		t.Errorf("expected init header exactly once, got %d times in: %s", count, output)
+	}
+}
+
 func TestRendererToolUseEvent(t *testing.T) {
 	var buf bytes.Buffer
 	r, metrics := newTestRenderer(&buf)

--- a/internal/runtime/renderer_test.go
+++ b/internal/runtime/renderer_test.go
@@ -5,21 +5,18 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/fullsend-ai/fullsend/internal/ui"
 )
 
-func newTestRenderer(buf *bytes.Buffer) (*EventRenderer, *RunMetrics) {
+func newTestRenderer(buf *bytes.Buffer) *EventRenderer {
 	printer := ui.New(buf)
-	metrics := &RunMetrics{}
-	r := NewEventRenderer(printer, time.Now(), metrics)
-	return r, metrics
+	return NewEventRenderer(printer)
 }
 
 func TestRendererInitEvent(t *testing.T) {
 	var buf bytes.Buffer
-	r, _ := newTestRenderer(&buf)
+	r := newTestRenderer(&buf)
 
 	r.Handle(InitEvent{Model: "claude-opus-4-6", Version: "1.2.3"})
 
@@ -31,7 +28,7 @@ func TestRendererInitEvent(t *testing.T) {
 
 func TestRendererDuplicateInitEventSuppressed(t *testing.T) {
 	var buf bytes.Buffer
-	r, _ := newTestRenderer(&buf)
+	r := newTestRenderer(&buf)
 
 	r.Handle(InitEvent{Model: "claude-opus-4-6", Version: "1.2.3"})
 	r.Handle(InitEvent{Model: "claude-opus-4-6"})
@@ -45,7 +42,7 @@ func TestRendererDuplicateInitEventSuppressed(t *testing.T) {
 
 func TestRendererToolUseEvent(t *testing.T) {
 	var buf bytes.Buffer
-	r, metrics := newTestRenderer(&buf)
+	r := newTestRenderer(&buf)
 
 	r.Handle(ToolUseEvent{Name: "Read", Summary: "/src/main.go"})
 
@@ -55,9 +52,6 @@ func TestRendererToolUseEvent(t *testing.T) {
 	}
 	if !strings.Contains(output, "/src/main.go") {
 		t.Errorf("expected summary in output, got: %s", output)
-	}
-	if metrics.ToolCalls.Load() != 1 {
-		t.Errorf("expected 1 tool call, got %d", metrics.ToolCalls.Load())
 	}
 }
 
@@ -72,7 +66,7 @@ func TestRendererToolUseEventCI(t *testing.T) {
 	os.Stderr = stderrW
 	defer func() { os.Stderr = oldStderr }()
 
-	r, _ := newTestRenderer(&buf)
+	r := newTestRenderer(&buf)
 	r.Handle(ToolUseEvent{Name: "Bash", Summary: "make"})
 
 	stderrW.Close()
@@ -86,7 +80,7 @@ func TestRendererToolUseEventCI(t *testing.T) {
 
 func TestRendererThinkingEvent(t *testing.T) {
 	var buf bytes.Buffer
-	r, _ := newTestRenderer(&buf)
+	r := newTestRenderer(&buf)
 
 	r.Handle(ThinkingEvent{Text: "Let me consider"})
 
@@ -98,7 +92,7 @@ func TestRendererThinkingEvent(t *testing.T) {
 
 func TestRendererTextEvent(t *testing.T) {
 	var buf bytes.Buffer
-	r, _ := newTestRenderer(&buf)
+	r := newTestRenderer(&buf)
 
 	r.Handle(TextEvent{Text: "Here is the answer"})
 
@@ -110,7 +104,7 @@ func TestRendererTextEvent(t *testing.T) {
 
 func TestRendererBlockTransition(t *testing.T) {
 	var buf bytes.Buffer
-	r, _ := newTestRenderer(&buf)
+	r := newTestRenderer(&buf)
 
 	// Thinking -> Tool should close thinking block first
 	r.Handle(ThinkingEvent{Text: "pondering"})
@@ -127,7 +121,7 @@ func TestRendererBlockTransition(t *testing.T) {
 
 func TestRendererResultEvent(t *testing.T) {
 	var buf bytes.Buffer
-	r, metrics := newTestRenderer(&buf)
+	r := newTestRenderer(&buf)
 
 	r.Handle(ResultEvent{
 		NumTurns:                 8,
@@ -138,29 +132,21 @@ func TestRendererResultEvent(t *testing.T) {
 		CacheReadInputTokens:     5000,
 	})
 
-	if metrics.NumTurns != 8 {
-		t.Errorf("expected 8 turns, got %d", metrics.NumTurns)
+	output := buf.String()
+	if !strings.Contains(output, "Result") {
+		t.Errorf("expected Result header, got: %s", output)
 	}
-	if metrics.TotalCostUSD != 0.42 {
-		t.Errorf("expected cost 0.42, got %f", metrics.TotalCostUSD)
+	if !strings.Contains(output, "8") {
+		t.Errorf("expected turns in output, got: %s", output)
 	}
-	if metrics.InputTokens != 12000 {
-		t.Errorf("expected 12000 input tokens, got %d", metrics.InputTokens)
-	}
-	if metrics.OutputTokens != 3400 {
-		t.Errorf("expected 3400 output tokens, got %d", metrics.OutputTokens)
-	}
-	if metrics.CacheCreationInputTokens != 8000 {
-		t.Errorf("expected 8000 cache creation tokens, got %d", metrics.CacheCreationInputTokens)
-	}
-	if metrics.CacheReadInputTokens != 5000 {
-		t.Errorf("expected 5000 cache read tokens, got %d", metrics.CacheReadInputTokens)
+	if !strings.Contains(output, "$0.4200") {
+		t.Errorf("expected cost in output, got: %s", output)
 	}
 }
 
 func TestRendererResultEventWithError(t *testing.T) {
 	var buf bytes.Buffer
-	r, _ := newTestRenderer(&buf)
+	r := newTestRenderer(&buf)
 
 	r.Handle(ResultEvent{
 		NumTurns:     3,
@@ -181,7 +167,7 @@ func TestRendererResultEventWithError(t *testing.T) {
 
 func TestRendererErrorEvent(t *testing.T) {
 	var buf bytes.Buffer
-	r, _ := newTestRenderer(&buf)
+	r := newTestRenderer(&buf)
 
 	r.Handle(ErrorEvent{ErrorType: "overloaded_error", Message: "rate limited"})
 
@@ -196,7 +182,7 @@ func TestRendererErrorEvent(t *testing.T) {
 
 func TestRendererRetryEvent(t *testing.T) {
 	var buf bytes.Buffer
-	r, _ := newTestRenderer(&buf)
+	r := newTestRenderer(&buf)
 
 	r.Handle(RetryEvent{Attempt: 2, MaxRetries: 5, DelayMs: 1000, Error: "timeout"})
 
@@ -211,7 +197,7 @@ func TestRendererRetryEvent(t *testing.T) {
 
 func TestRendererTokensEvent(t *testing.T) {
 	var buf bytes.Buffer
-	r, _ := newTestRenderer(&buf)
+	r := newTestRenderer(&buf)
 
 	r.Handle(TokensEvent{InputTokens: 4000, OutputTokens: 2000, CacheRead: 500, CacheWrite: 200})
 

--- a/internal/runtime/renderer_test.go
+++ b/internal/runtime/renderer_test.go
@@ -1,0 +1,196 @@
+package runtime
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+func newTestRenderer(buf *bytes.Buffer) (*EventRenderer, *RunMetrics) {
+	printer := ui.New(buf)
+	metrics := &RunMetrics{}
+	r := NewEventRenderer(printer, time.Now(), metrics)
+	return r, metrics
+}
+
+func TestRendererInitEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	r.Handle(InitEvent{Model: "claude-opus-4-6", Version: "1.2.3"})
+
+	output := buf.String()
+	if !strings.Contains(output, "claude-opus-4-6") {
+		t.Errorf("expected model in output, got: %s", output)
+	}
+}
+
+func TestRendererToolUseEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, metrics := newTestRenderer(&buf)
+
+	r.Handle(ToolUseEvent{Name: "Read", Summary: "/src/main.go"})
+
+	output := buf.String()
+	if !strings.Contains(output, "Read") {
+		t.Errorf("expected tool name in output, got: %s", output)
+	}
+	if !strings.Contains(output, "/src/main.go") {
+		t.Errorf("expected summary in output, got: %s", output)
+	}
+	if metrics.ToolCalls.Load() != 1 {
+		t.Errorf("expected 1 tool call, got %d", metrics.ToolCalls.Load())
+	}
+}
+
+func TestRendererToolUseEventCI(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+
+	var buf bytes.Buffer
+	// In CI mode the renderer writes ::notice:: to stderr.
+	// We capture stderr by creating the renderer with a separate writer.
+	oldStderr := os.Stderr
+	stderrR, stderrW, _ := os.Pipe()
+	os.Stderr = stderrW
+	defer func() { os.Stderr = oldStderr }()
+
+	r, _ := newTestRenderer(&buf)
+	r.Handle(ToolUseEvent{Name: "Bash", Summary: "make"})
+
+	stderrW.Close()
+	var stderrBuf bytes.Buffer
+	stderrBuf.ReadFrom(stderrR)
+
+	if !strings.Contains(stderrBuf.String(), "::notice::") {
+		t.Errorf("expected ::notice:: annotation in CI mode, got: %s", stderrBuf.String())
+	}
+}
+
+func TestRendererThinkingEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	r.Handle(ThinkingEvent{Text: "Let me consider"})
+
+	output := buf.String()
+	if !strings.Contains(output, "Let me consider") {
+		t.Errorf("expected thinking text in output, got: %s", output)
+	}
+}
+
+func TestRendererTextEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	r.Handle(TextEvent{Text: "Here is the answer"})
+
+	output := buf.String()
+	if !strings.Contains(output, "Here is the answer") {
+		t.Errorf("expected text in output, got: %s", output)
+	}
+}
+
+func TestRendererBlockTransition(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	// Thinking -> Tool should close thinking block first
+	r.Handle(ThinkingEvent{Text: "pondering"})
+	r.Handle(ToolUseEvent{Name: "Read", Summary: "/a.go"})
+
+	output := buf.String()
+	if !strings.Contains(output, "pondering") {
+		t.Errorf("expected thinking text, got: %s", output)
+	}
+	if !strings.Contains(output, "Read") {
+		t.Errorf("expected tool name after block transition, got: %s", output)
+	}
+}
+
+func TestRendererResultEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, metrics := newTestRenderer(&buf)
+
+	r.Handle(ResultEvent{
+		NumTurns:                 8,
+		TotalCostUSD:             0.42,
+		InputTokens:              12000,
+		OutputTokens:             3400,
+		CacheCreationInputTokens: 8000,
+		CacheReadInputTokens:     5000,
+	})
+
+	if metrics.NumTurns != 8 {
+		t.Errorf("expected 8 turns, got %d", metrics.NumTurns)
+	}
+	if metrics.TotalCostUSD != 0.42 {
+		t.Errorf("expected cost 0.42, got %f", metrics.TotalCostUSD)
+	}
+	if metrics.InputTokens != 12000 {
+		t.Errorf("expected 12000 input tokens, got %d", metrics.InputTokens)
+	}
+	if metrics.OutputTokens != 3400 {
+		t.Errorf("expected 3400 output tokens, got %d", metrics.OutputTokens)
+	}
+	if metrics.CacheCreationInputTokens != 8000 {
+		t.Errorf("expected 8000 cache creation tokens, got %d", metrics.CacheCreationInputTokens)
+	}
+	if metrics.CacheReadInputTokens != 5000 {
+		t.Errorf("expected 5000 cache read tokens, got %d", metrics.CacheReadInputTokens)
+	}
+}
+
+func TestRendererErrorEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	r.Handle(ErrorEvent{ErrorType: "overloaded_error", Message: "rate limited"})
+
+	output := buf.String()
+	if !strings.Contains(output, "overloaded_error") {
+		t.Errorf("expected error type in output, got: %s", output)
+	}
+	if !strings.Contains(output, "rate limited") {
+		t.Errorf("expected error message in output, got: %s", output)
+	}
+}
+
+func TestRendererRetryEvent(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	r.Handle(RetryEvent{Attempt: 2, MaxRetries: 5, DelayMs: 1000, Error: "timeout"})
+
+	output := buf.String()
+	if !strings.Contains(output, "2") {
+		t.Errorf("expected attempt number in output, got: %s", output)
+	}
+	if !strings.Contains(output, "timeout") {
+		t.Errorf("expected error in output, got: %s", output)
+	}
+}
+
+func TestRendererTokensEventThrottled(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	// First tokens event should render (total crosses 0 -> 5k threshold)
+	r.Handle(TokensEvent{InputTokens: 4000, OutputTokens: 2000})
+	first := buf.String()
+
+	// Second event just below next 5k boundary should not add output
+	buf.Reset()
+	r.Handle(TokensEvent{InputTokens: 4000, OutputTokens: 2500})
+	second := buf.String()
+
+	if first == "" {
+		t.Error("expected first tokens event to render")
+	}
+	if second != "" {
+		t.Errorf("expected second tokens event to be throttled, got: %s", second)
+	}
+}

--- a/internal/runtime/renderer_test.go
+++ b/internal/runtime/renderer_test.go
@@ -144,6 +144,27 @@ func TestRendererResultEvent(t *testing.T) {
 	}
 }
 
+func TestRendererResultEventWithError(t *testing.T) {
+	var buf bytes.Buffer
+	r, _ := newTestRenderer(&buf)
+
+	r.Handle(ResultEvent{
+		NumTurns:     3,
+		TotalCostUSD: 0.10,
+		IsError:      true,
+		ErrorMessage: "Max turns reached",
+		Subtype:      "error_max_turns",
+	})
+
+	output := buf.String()
+	if !strings.Contains(output, "ERROR") {
+		t.Errorf("expected ERROR in result header, got: %s", output)
+	}
+	if !strings.Contains(output, "Max turns reached") {
+		t.Errorf("expected error message in output, got: %s", output)
+	}
+}
+
 func TestRendererErrorEvent(t *testing.T) {
 	var buf bytes.Buffer
 	r, _ := newTestRenderer(&buf)
@@ -174,23 +195,17 @@ func TestRendererRetryEvent(t *testing.T) {
 	}
 }
 
-func TestRendererTokensEventThrottled(t *testing.T) {
+func TestRendererTokensEvent(t *testing.T) {
 	var buf bytes.Buffer
 	r, _ := newTestRenderer(&buf)
 
-	// First tokens event should render (total crosses 0 -> 5k threshold)
-	r.Handle(TokensEvent{InputTokens: 4000, OutputTokens: 2000})
-	first := buf.String()
+	r.Handle(TokensEvent{InputTokens: 4000, OutputTokens: 2000, CacheRead: 500, CacheWrite: 200})
 
-	// Second event just below next 5k boundary should not add output
-	buf.Reset()
-	r.Handle(TokensEvent{InputTokens: 4000, OutputTokens: 2500})
-	second := buf.String()
-
-	if first == "" {
-		t.Error("expected first tokens event to render")
+	output := buf.String()
+	if !strings.Contains(output, "TOKENS") {
+		t.Errorf("expected TOKENS in output, got: %s", output)
 	}
-	if second != "" {
-		t.Errorf("expected second tokens event to be throttled, got: %s", second)
+	if !strings.Contains(output, "in=4000") {
+		t.Errorf("expected input token count, got: %s", output)
 	}
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -30,7 +30,8 @@ type RunParams struct {
 	PluginDirs    []string
 	Debug         string
 	Timeout       time.Duration
-	OutputPath    string // if set, tee stream-json stdout to this file
+	OutputPath    string           // if set, tee stream-json stdout to this file
+	OnEvent       func(AgentEvent) // if non-nil, called with normalized events during Run
 }
 
 // TranscriptError holds extracted error information from a runtime transcript.

--- a/internal/runtime/sanitize.go
+++ b/internal/runtime/sanitize.go
@@ -11,6 +11,17 @@ var ansiEscRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1
 // sanitizeOutput strips ANSI escape sequences, control characters, and GHA
 // workflow command markers from untrusted sandbox output.
 func sanitizeOutput(s string) string {
+	return sanitize(s, false)
+}
+
+// sanitizeStreamText is like sanitizeOutput but preserves newlines for
+// streaming text/thinking deltas. GHA command injection is still blocked
+// because "::" is broken into ": :".
+func sanitizeStreamText(s string) string {
+	return sanitize(s, true)
+}
+
+func sanitize(s string, preserveNewlines bool) string {
 	s = ansiEscRe.ReplaceAllString(s, "")
 	s = strings.ReplaceAll(s, "::", ": :")
 	for _, enc := range []string{"%0A", "%0a", "%0D", "%0d"} {
@@ -21,6 +32,8 @@ func sanitizeOutput(s string) string {
 	for _, r := range s {
 		if (r >= 0x20 && r < 0x7F) || r > 0x9F {
 			buf.WriteRune(r)
+		} else if preserveNewlines && r == '\n' {
+			buf.WriteByte('\n')
 		} else {
 			buf.WriteByte(' ')
 		}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -137,7 +137,15 @@ func (p *Printer) ErrorBox(title, detail string) {
 func (p *Printer) Heartbeat(text string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	styled := lipgloss.NewStyle().Foreground(ColorMuted).Render("⟳ " + text)
+	styled := lipgloss.NewStyle().Foreground(ColorMuted).Render("⏳ " + text)
+	fmt.Fprintf(p.w, "  %s\n", styled)
+}
+
+// ToolProgress prints a tool invocation progress line.
+func (p *Printer) ToolProgress(text string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	styled := lipgloss.NewStyle().Foreground(ColorInfo).Render("⚙ " + text)
 	fmt.Fprintf(p.w, "  %s\n", styled)
 }
 


### PR DESCRIPTION
## Summary

Renders the agent's event stream live during `fullsend run`, replacing the old progress output that only showed periodic heartbeats and tool names.

- Define normalized `AgentEvent` types (`InitEvent`, `ThinkingEvent`, `TextEvent`, `ToolUseEvent`, `TokensEvent`, `ResultEvent`, `ErrorEvent`, `RetryEvent`) that bridge runtime-specific NDJSON parsing and runtime-agnostic rendering
- Add `OnEvent` callback to `RunParams` for custom event handling
- Add `EventRenderer` that renders structured terminal output: thinking (🧠 italic/muted), text (💬), tool calls (⚙ blue), heartbeats (⏳ muted), token usage, errors, retries, and result summaries
- Refactor Claude Code NDJSON parser to emit normalized events via callback, with assistant message fallback for non-streaming output
- Wire it all up in `ClaudeRuntime.Run`

```
→ Agent: claude-opus-4-6 (v2.1.91)
  🧠 Let me start by reading the AGENTS.md file...
  💬 I'll read the project instructions and fetch the issue details.
  ⚙ Read: /sandbox/workspace/fullsend-2/AGENTS.md
  ⚙ Bash: gh pr list --repo fullsend-ai/fullsend --state open
  ⚙ Skill: issue-labels
  ⏳ Agent running (30s elapsed, 9m30s remaining)
→ Result: success
    Turns: 15
    Cost: $0.3592
    Tokens: in=12 out=4110 cache_create=28320 cache_read=158872
```

Closes #3170.

## Test plan

- [x] All runtime and UI tests pass (87 tests)
- [x] Verified with live triage run against appdumpster/test-repo#25

🤖 Generated with [Claude Code](https://claude.com/claude-code)