### PR TITLE
chore(make): auto-install pre-commit hooks on lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,12 @@ bootstrap:
 	@echo "    Make sure $(BOOTSTRAP_BIN_DIR) is on your PATH."
 
 ensure-hooks:
-	@if [ ! -f .git/hooks/pre-commit ]; then \
-		echo "==> Installing pre-commit hooks..."; \
-		pre-commit install; \
+	@if [ -z "$$CI" ] && [ -z "$$(git config --get core.hooksPath 2>/dev/null)" ]; then \
+		hooks_dir=$$(git rev-parse --git-path hooks 2>/dev/null); \
+		if [ -n "$$hooks_dir" ] && [ ! -f "$$hooks_dir/pre-commit" ]; then \
+			echo "==> Installing pre-commit hooks..."; \
+			pre-commit install; \
+		fi; \
 	fi
 
 lint: ensure-hooks

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help bootstrap lint lint-all check fmt \
+.PHONY: help bootstrap ensure-hooks lint lint-all check fmt \
        mindmap go-build go-test go-lint go-fmt go-vet go-tidy \
        lint-md-links script-test test \
        e2e-test behaviour-test lint-eval-cases functional-tests
@@ -71,10 +71,16 @@ bootstrap:
 	@echo "==> Bootstrap complete!"
 	@echo "    Make sure $(BOOTSTRAP_BIN_DIR) is on your PATH."
 
-lint:
+ensure-hooks:
+	@if [ ! -f .git/hooks/pre-commit ]; then \
+		echo "==> Installing pre-commit hooks..."; \
+		pre-commit install; \
+	fi
+
+lint: ensure-hooks
 	pre-commit run
 
-lint-all:
+lint-all: ensure-hooks
 	pre-commit run --all-files
 
 check:


### PR DESCRIPTION
## Summary

- Add `ensure-hooks` target that runs `pre-commit install` if `.git/hooks/pre-commit` is missing
- Make `lint` and `lint-all` depend on `ensure-hooks`

Fresh clones that skip `make bootstrap` now get hooks installed automatically on first `make lint` instead of silently skipping pre-commit checks and failing in CI.

## Test plan

- [x] Verified hooks install automatically on `make lint` in a clone without hooks
- [x] Verified no-op when hooks already installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)