### PR TITLE
feat(dispatch): extend NormalizedEvent v1 schema for GitLab support

### DIFF
--- a/docs/ADRs/0061-harness-cel-dispatch.md
+++ b/docs/ADRs/0061-harness-cel-dispatch.md
@@ -70,8 +70,10 @@ Adopt **Option C**.
   ([`docs/normative/normalized-event/v1/`](../normative/normalized-event/v1/),
   [ADR 0015](0015-normative-specifications-directory.md)). **v1 normative scope
   is GitHub Actions** (`gha-event` driver); other forges are documented as
-  future illustrations only. Examples and projection rules live in the normative
-  tree — not duplicated here.
+  future illustrations only. (Scope extended to GitLab cron-poll input by
+  [ADR 0067](0067-gitlab-cron-polling-event-dispatch.md) and to Jira poll input
+  by [ADR 0063](0063-polling-based-work-discovery.md).) Examples and projection
+  rules live in the normative tree — not duplicated here.
 - **Authorization:** `fullsend dispatch` enforces
   [ADR 0054](0054-require-authorization-on-all-agent-dispatch-paths.md) as a
   **platform-level gate** after the input driver normalizes the event and

--- a/docs/normative/normalized-event/v1/README.md
+++ b/docs/normative/normalized-event/v1/README.md
@@ -1,11 +1,10 @@
 # NormalizedEvent v1
 
-GitHub-oriented routing input for `fullsend dispatch` and harness CEL `trigger`
+Forge-neutral routing input for `fullsend dispatch` and harness CEL `trigger`
 expressions ([ADR 0061](../../../ADRs/0061-harness-cel-dispatch.md)).
 
-The field names and transition vocabulary are forge-neutral so future adapters
-can reuse them; **v1 normative scope is GitHub Actions only** (see
-[Scope](#scope-v1)).
+The field names and transition vocabulary are forge-neutral; **v1 normative
+scope covers GitHub, GitLab, and Jira** (see [Scope](#scope-v1)).
 
 ## Contract
 
@@ -19,16 +18,17 @@ can reuse them; **v1 normative scope is GitHub Actions only** (see
 
 ## Scope (v1)
 
-v1 adapters and examples target **GitHub** webhooks and **Jira poll** input:
+v1 adapters and examples target **GitHub** webhooks, **GitLab** cron-poll
+input, and **Jira poll** input:
 
-- `source.system` is `github`, `jira`, `manual`, or `schedule`.
-- `repo` is the target Fullsend repository (`owner/repo` GitHub slug) for all
-  systems — including Jira poll events (see [jira-poll-adapter.md](jira-poll-adapter.md)).
-- The `gha-event` input driver is the production GitHub adapter; `jira-poll` is
-  the production Jira poll adapter; `json` supports tests and replay.
-
-Other forges (e.g. GitLab) are **not** part of this normative version. See
-[Future forges](#future-forges) for illustrative notes only.
+- `source.system` is `github`, `gitlab`, `jira`, `manual`, or `schedule`.
+- `repo` is the target Fullsend repository (`owner/repo` for GitHub,
+  `group/subgroup/project` for GitLab) for all systems — including Jira poll
+  events (see [jira-poll-adapter.md](jira-poll-adapter.md)).
+- The `gha-event` input driver is the production GitHub adapter; `gitlab-poll`
+  is the production GitLab adapter ([ADR 0067](../../../ADRs/0067-gitlab-cron-polling-event-dispatch.md));
+  `jira-poll` is the production Jira poll adapter; `json` supports tests and
+  replay.
 
 ## Versioning
 
@@ -49,6 +49,7 @@ Input drivers map native forge events into this struct:
 | Driver | Source | v1 status |
 |--------|--------|-----------|
 | `gha-event` | `GITHUB_EVENT_PATH` + `gh` snapshot for labels and change-proposal metadata | Production |
+| `gitlab-poll` | GitLab CI event payload (cron-polled; [ADR 0067](../../../ADRs/0067-gitlab-cron-polling-event-dispatch.md)) | Production (poll) |
 | `jira-poll` | Jira issue search + changelog/comments since `lastCheck` ([jira-poll-adapter.md](jira-poll-adapter.md), [ADR 0063](../../../ADRs/0063-polling-based-work-discovery.md)) | Production (poll) |
 | `json` | stdin or `--input-file` | Tests, replay |
 
@@ -101,6 +102,7 @@ cross-field equality.
 | `edited` | Title/body/metadata edit without new commits |
 | `synchronized` | Head branch received new commits (GitHub `synchronize`) |
 | `updated` | Legacy umbrella; prefer `edited` or `synchronized` for new adapters |
+| `merged` | Change proposal merged into target branch |
 | `closed`, `marked_ready`, `label_changed`, `comment_added`, `review_submitted` | As named |
 
 ### Comment extraction
@@ -183,7 +185,7 @@ contract):
 | Execution ref field | Source in `NormalizedEvent` |
 |---------------------|----------------------------|
 | `source_repo` | `repo` |
-| `event_type` | `source.raw_type` (GitHub Actions event name; see note below) |
+| `event_type` | `source.raw_type` (native event name from the source forge; see notes below) |
 | `event_action` | `source.raw_action` when present |
 | `event_payload.issue` | `entity` when `entity.kind == "work_item"`: `{number: entity.id, html_url: entity.url}` |
 | `event_payload.pull_request` | See below |
@@ -251,22 +253,23 @@ No execution-ref field requires information outside this schema when adapters
 have populated `state.change_proposal` for change-proposal workloads, except
 `project_number` (prioritize env) and `run-url` (runtime).
 
-## Future forges
+**GitLab event projection:** the table above uses GitHub-oriented examples, but
+the same projection logic applies to GitLab events. `source.raw_type` carries
+the GitLab object type (e.g. `merge_request`, `note`), and
+`event_payload.pull_request` uses the same GitHub-shaped structure for backward
+compatibility — the GitLab adapter maps MR fields into this shape so downstream
+workflows do not need forge-specific handling.
 
-The v1 schema intentionally omits forge systems beyond GitHub. A future
-`normalized-event/v2/` (or v1.x extension) may add adapters for other forges.
-**The following is illustrative only — not normative for v1.**
+## GitLab adapter notes
 
-Example: **GitLab** ([gitlab-implementation.md](../../../problems/gitlab-implementation.md)):
+GitLab is a normative v1 source system ([gitlab-implementation.md](../../../problems/gitlab-implementation.md)):
 
-| Concern | Illustrative mapping (future) |
-|---------|-------------------------------|
+| Concern | Mapping |
+|---------|---------|
 | Input driver | `gitlab-poll` from GitLab CI event payload (cron-polled or `merge_request_event`; see [ADR 0067](../../../ADRs/0067-gitlab-cron-polling-event-dispatch.md)) |
-| `source.system` | `gitlab` (new enum value — not yet in the v1 schema; requires the Phase 0 schema change from the [implementation plan](../../../plans/gitlab-cron-polling-implementation.md)) |
-| `repo` slug | Nested group path (`group/subgroup/project`) — requires wider `repo_path` pattern (not yet in the v1 schema; requires the Phase 0 schema change) |
+| `source.system` | `gitlab` |
+| `repo` slug | Nested group path (`group/subgroup/project`) — `repo_path` pattern supports multi-segment paths |
 | MR events | `merge_request_event` → `entity.kind: change_proposal` |
+| MR merge | `merge_request_event` (state=merged) → `transition.kind: merged` (primary path for retro-stage dispatch; GitLab merge and close are distinct events) |
 | Notes | `note` → `transition.kind: comment_added` |
 | Role mapping | Guest→`read`, Reporter→`triage`, Developer→`write`, Maintainer→`maintain`, Owner→`admin` |
-
-Implementers must not assume these GitLab mappings until a future normative
-version publishes them.

--- a/docs/normative/normalized-event/v1/examples/gitlab-mr-merged.json
+++ b/docs/normative/normalized-event/v1/examples/gitlab-mr-merged.json
@@ -1,0 +1,35 @@
+{
+  "repo": "acme-group/platform/backend",
+  "entity": {
+    "kind": "change_proposal",
+    "id": 42,
+    "url": "https://gitlab.com/acme-group/platform/backend/-/merge_requests/42"
+  },
+  "transition": {
+    "kind": "merged"
+  },
+  "actor": {
+    "id": "maintainer-user",
+    "kind": "human",
+    "role": "maintain",
+    "is_entity_author": false
+  },
+  "state": {
+    "labels": ["fullsend-review"],
+    "change_proposal": {
+      "id": 42,
+      "head_repo": "acme-group/platform/backend",
+      "base_repo": "acme-group/platform/backend",
+      "head_ref": "feature/add-logging",
+      "base_ref": "main",
+      "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+      "author_id": "dev-user",
+      "is_fork": false
+    }
+  },
+  "source": {
+    "system": "gitlab",
+    "raw_type": "merge_request",
+    "raw_action": "merged"
+  }
+}

--- a/docs/normative/normalized-event/v1/examples/gitlab-mr-opened.json
+++ b/docs/normative/normalized-event/v1/examples/gitlab-mr-opened.json
@@ -1,0 +1,35 @@
+{
+  "repo": "acme-group/platform/backend",
+  "entity": {
+    "kind": "change_proposal",
+    "id": 42,
+    "url": "https://gitlab.com/acme-group/platform/backend/-/merge_requests/42"
+  },
+  "transition": {
+    "kind": "opened"
+  },
+  "actor": {
+    "id": "dev-user",
+    "kind": "human",
+    "role": "write",
+    "is_entity_author": true
+  },
+  "state": {
+    "labels": [],
+    "change_proposal": {
+      "id": 42,
+      "head_repo": "acme-group/platform/backend",
+      "base_repo": "acme-group/platform/backend",
+      "head_ref": "feature/add-logging",
+      "base_ref": "main",
+      "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "author_id": "dev-user",
+      "is_fork": false
+    }
+  },
+  "source": {
+    "system": "gitlab",
+    "raw_type": "merge_request",
+    "raw_action": "opened"
+  }
+}

--- a/docs/normative/normalized-event/v1/examples/invalid-path-traversal.json
+++ b/docs/normative/normalized-event/v1/examples/invalid-path-traversal.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "INVALID — this fixture demonstrates a repo path containing '..' that adapters MUST reject. The JSON Schema repo_path pattern permits this syntactically; rejection is an adapter-level responsibility.",
+  "repo": "acme-group/../secrets",
+  "entity": {
+    "kind": "change_proposal",
+    "id": 1,
+    "url": "https://gitlab.com/acme-group/../secrets/-/merge_requests/1"
+  },
+  "transition": {
+    "kind": "opened"
+  },
+  "actor": {
+    "id": "attacker",
+    "kind": "human",
+    "role": "external",
+    "is_entity_author": true
+  },
+  "state": {
+    "labels": []
+  },
+  "source": {
+    "system": "gitlab",
+    "raw_type": "merge_request",
+    "raw_action": "opened"
+  }
+}

--- a/docs/normative/normalized-event/v1/normalized-event.schema.json
+++ b/docs/normative/normalized-event/v1/normalized-event.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://fullsend.ai/normative/normalized-event/v1/normalized-event.schema.json",
   "title": "NormalizedEvent",
-  "description": "Forge-neutral routing input for fullsend dispatch and harness CEL trigger evaluation (ADR 0061). v1 targets GitHub Actions webhooks and Jira poll input (ADR 0063); other forges remain future work.",
+  "description": "Forge-neutral routing input for fullsend dispatch and harness CEL trigger evaluation (ADR 0061). v1 targets GitHub Actions webhooks, GitLab cron-poll input (ADR 0067), and Jira poll input (ADR 0063).",
   "type": "object",
   "additionalProperties": false,
   "required": ["repo", "entity", "transition", "actor", "state", "source"],
@@ -88,10 +88,10 @@
   "$defs": {
     "repo_path": {
       "type": "string",
-      "pattern": "^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$",
+      "pattern": "^[a-zA-Z0-9._-]+(/[a-zA-Z0-9._-]+)+$",
       "minLength": 3,
       "maxLength": 512,
-      "description": "GitHub repository slug (owner/repo)."
+      "description": "Repository path (owner/repo for GitHub, group/subgroup/project for GitLab). Adapters MUST reject path segments containing '..' (path traversal) independently of this pattern."
     },
     "entity": {
       "type": "object",
@@ -156,6 +156,7 @@
             "synchronized",
             "updated",
             "closed",
+            "merged",
             "marked_ready",
             "label_changed",
             "comment_added",
@@ -359,8 +360,8 @@
       "properties": {
         "system": {
           "type": "string",
-          "enum": ["github", "jira", "manual", "schedule"],
-          "description": "Event provenance. v1 adapters emit github (webhooks), jira (poll input), manual, or schedule."
+          "enum": ["github", "gitlab", "jira", "manual", "schedule"],
+          "description": "Event provenance. v1 adapters emit github (webhooks), gitlab (cron-poll input), jira (poll input), manual, or schedule."
         },
         "raw_type": {
           "type": "string",

--- a/docs/plans/gitlab-cron-polling-implementation.md
+++ b/docs/plans/gitlab-cron-polling-implementation.md
@@ -137,7 +137,7 @@ func extractHost(remoteURL string) string {
 ### NormalizedEvent schema updates
 
 Three schema changes are required before the `gitlab-poll` input driver can
-emit valid `NormalizedEvent` values:
+emit valid `NormalizedEvent` values. **Status: completed** (PR #3191).
 
 1. **`source.system` enum**: Add `"gitlab"` to the allowed values. The v1
    versioning policy permits adding new enum values as a non-breaking change.


### PR DESCRIPTION
## Summary

Extend the NormalizedEvent v1 schema to support GitLab as a normative source system, implementing Phase 0 of the GitLab cron-polling implementation plan.

## Related Issue

Closes #3309

## Changes

- Add `gitlab` to `source.system` enum (non-breaking v1 change)
- Add `merged` to `transition.kind` enum (non-breaking v1 change)
- Relax `repo_path` pattern for GitLab nested group paths (non-breaking relaxation)
- Update README and schema descriptions for GitLab as normative v1 source
- Add `gitlab-poll` to the Adapters table
- Add `merged` to transition kind vocabulary
- Add GitLab event projection guidance
- Add cross-reference annotation to ADR 0061
- Replace illustrative "Future forges" section with normative "GitLab adapter notes"
- Add `gitlab-mr-opened.json` and `gitlab-mr-merged.json` example fixtures
- Add `invalid-path-traversal.json` contract test fixture
- Document adapter-level path traversal rejection for `repo_path`
- Mark Phase 0 schema changes as completed in the implementation plan

## Testing

- All example fixtures validated against the JSON schema
- Pre-commit hooks pass (JSON validation, link checks, ADR lints)
- No Go code changes — schema is documentation-only until Phase 2

## Checklist

- [x] Non-breaking v1 changes per versioning policy
- [x] Authorized by ADR 0067 and implementation plan
- [x] Schema descriptions updated
- [x] README scope, adapters, vocabulary updated
- [x] Example fixtures added
- [x] ADR cross-reference annotation added