### PR TITLE
feat(jira): add `fullsend jira enroll` command for Jira project enrollment

### DIFF
--- a/internal/cli/jira.go
+++ b/internal/cli/jira.go
@@ -1,0 +1,378 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
+	gh "github.com/fullsend-ai/fullsend/internal/forge/github"
+	"github.com/fullsend-ai/fullsend/internal/jira"
+	"github.com/fullsend-ai/fullsend/internal/scaffold"
+	"github.com/fullsend-ai/fullsend/internal/ui"
+)
+
+var jiraProjectKeyPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]{0,9}$`)
+
+func newJiraCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "jira",
+		Short: "Manage Jira project integration",
+		Long:  "Commands for connecting Jira projects to fullsend agent pipelines.",
+	}
+	cmd.AddCommand(newJiraEnrollCmd())
+	return cmd
+}
+
+type jiraEnrollConfig struct {
+	jiraHost            string
+	projectKey          string
+	jiraEmail           string
+	jiraAPIToken        string
+	githubPAT           string
+	linkedRepos         string
+	skipAutomationRules bool
+	skipWorkflows       bool
+	dryRun              bool
+}
+
+func newJiraEnrollCmd() *cobra.Command {
+	var cfg jiraEnrollConfig
+
+	cmd := &cobra.Command{
+		Use:   "enroll <owner/repo>",
+		Short: "Enroll a Jira project for fullsend triage",
+		Long: `Connects a Jira Cloud project to a GitHub repository's fullsend pipeline.
+
+This command:
+  1. Creates or updates .jira.yml in the GitHub repo
+  2. Creates Jira Automation rules for triage dispatch
+  3. Commits dispatch and triage workflow files
+  4. Sets Jira credential secrets on the GitHub repo
+
+Prerequisites:
+  - The GitHub repo must have fullsend installed (per-repo mode)
+  - Jira agent customization files must exist in .fullsend/customized/
+  - A Jira API token (https://id.atlassian.com/manage-profile/security/api-tokens)
+  - A GitHub fine-grained PAT with Contents: Read and write on the target repo`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			owner, repo, isRepo := parseTarget(args[0])
+			if !isRepo {
+				return fmt.Errorf("argument must be owner/repo (e.g., myorg/myrepo)")
+			}
+			return runJiraEnroll(cmd.Context(), owner, repo, cfg)
+		},
+	}
+
+	cmd.Flags().StringVar(&cfg.jiraHost, "jira-host", "", "Jira Cloud hostname (e.g., myorg.atlassian.net)")
+	cmd.Flags().StringVar(&cfg.projectKey, "project-key", "", "Jira project key (e.g., MYPROJ)")
+	cmd.Flags().StringVar(&cfg.jiraEmail, "jira-email", "", "Jira user email (env: JIRA_EMAIL)")
+	cmd.Flags().StringVar(&cfg.jiraAPIToken, "jira-api-token", "", "Jira API token (env: JIRA_API_TOKEN)")
+	cmd.Flags().StringVar(&cfg.githubPAT, "github-pat", "", "GitHub PAT for Jira webhook auth (env: FULLSEND_JIRA_GITHUB_PAT)")
+	cmd.Flags().StringVar(&cfg.linkedRepos, "linked-repos", "", "comma-separated org/repo values for cross-repo search")
+	cmd.Flags().BoolVar(&cfg.skipAutomationRules, "skip-automation-rules", false, "skip creating Jira Automation rules")
+	cmd.Flags().BoolVar(&cfg.skipWorkflows, "skip-workflows", false, "skip committing GitHub workflow files (use when workflows already exist in the repo)")
+	cmd.Flags().BoolVar(&cfg.dryRun, "dry-run", false, "preview changes without executing")
+
+	_ = cmd.MarkFlagRequired("jira-host")
+	_ = cmd.MarkFlagRequired("project-key")
+
+	return cmd
+}
+
+func runJiraEnroll(ctx context.Context, owner, repo string, cfg jiraEnrollConfig) error {
+	printer := ui.New(os.Stdout)
+	printer.Banner(version)
+
+	// --- Validate inputs ---
+
+	if !jiraProjectKeyPattern.MatchString(cfg.projectKey) {
+		return fmt.Errorf("invalid project key %q: must match %s", cfg.projectKey, jiraProjectKeyPattern.String())
+	}
+	if cfg.jiraHost == "" {
+		return fmt.Errorf("--jira-host is required")
+	}
+	if strings.HasPrefix(cfg.jiraHost, "https://") || strings.HasPrefix(cfg.jiraHost, "http://") {
+		return fmt.Errorf("--jira-host should be a hostname (e.g., myorg.atlassian.net), not a URL")
+	}
+
+	// --- Resolve credentials ---
+
+	jiraEmail := resolveEnvOrFlag(cfg.jiraEmail, "JIRA_EMAIL")
+	if jiraEmail == "" {
+		return fmt.Errorf("Jira email is required: use --jira-email or set JIRA_EMAIL")
+	}
+
+	jiraAPIToken := resolveEnvOrFlag(cfg.jiraAPIToken, "JIRA_API_TOKEN")
+	if jiraAPIToken == "" {
+		return fmt.Errorf("Jira API token is required: use --jira-api-token or set JIRA_API_TOKEN")
+	}
+
+	githubPAT := resolveEnvOrFlag(cfg.githubPAT, "FULLSEND_JIRA_GITHUB_PAT")
+	if githubPAT == "" && !cfg.skipAutomationRules {
+		return fmt.Errorf("GitHub PAT is required for automation rules: use --github-pat or set FULLSEND_JIRA_GITHUB_PAT")
+	}
+
+	ghToken, err := resolveToken()
+	if err != nil {
+		return fmt.Errorf("resolving GitHub token: %w", err)
+	}
+	ghClient := gh.New(ghToken)
+
+	printer.Header(fmt.Sprintf("Enrolling Jira project %s on %s → %s/%s", cfg.projectKey, cfg.jiraHost, owner, repo))
+
+	if cfg.dryRun {
+		printer.StepInfo("DRY RUN — no changes will be made")
+	}
+
+	// --- Validate Jira project ---
+
+	printer.StepStart("Validating Jira project")
+	jiraClient := jira.NewClient(jiraEmail, jiraAPIToken)
+
+	var projectID string
+	if !cfg.dryRun {
+		projectInfo, err := jiraClient.ValidateProject(ctx, cfg.jiraHost, cfg.projectKey)
+		if err != nil {
+			printer.StepFail("Jira project validation failed")
+			return err
+		}
+		projectID = projectInfo.ID
+	} else {
+		projectID = "<dry-run>"
+	}
+	printer.StepDone(fmt.Sprintf("Jira project %s is accessible (ID: %s)", cfg.projectKey, projectID))
+
+	// --- Get Cloud ID and Account ID ---
+
+	var cloudID, accountID string
+	if !cfg.skipAutomationRules {
+		printer.StepStart("Fetching Jira Cloud ID and account info")
+		if !cfg.dryRun {
+			cloudID, err = jiraClient.GetCloudID(ctx, cfg.jiraHost)
+			if err != nil {
+				printer.StepFail("Failed to get Cloud ID")
+				return err
+			}
+			accountID, err = jiraClient.GetCurrentUser(ctx, cfg.jiraHost)
+			if err != nil {
+				printer.StepFail("Failed to get account ID")
+				return err
+			}
+		} else {
+			cloudID = "<dry-run>"
+			accountID = "<dry-run>"
+		}
+		printer.StepDone(fmt.Sprintf("Cloud ID: %s", cloudID))
+	}
+
+	// --- Create/update .jira.yml ---
+
+	printer.StepStart("Updating .jira.yml")
+
+	var linkedRepos []string
+	if cfg.linkedRepos != "" {
+		linkedRepos = strings.Split(cfg.linkedRepos, ",")
+		for i := range linkedRepos {
+			linkedRepos[i] = strings.TrimSpace(linkedRepos[i])
+		}
+	}
+
+	jiraCfg, err := loadOrCreateJiraConfig(ctx, ghClient, owner, repo)
+	if err != nil {
+		printer.StepFail("Failed to load .jira.yml")
+		return err
+	}
+
+	project := jira.JiraProjectConfig{
+		ProjectKey:        cfg.projectKey,
+		Host:              cfg.jiraHost,
+		LinkedGitHubRepos: linkedRepos,
+	}
+
+	added := jiraCfg.AddProject(project)
+	if !added {
+		printer.StepDone(fmt.Sprintf("Project %s already enrolled in .jira.yml", cfg.projectKey))
+	} else if cfg.dryRun {
+		printer.StepDone(fmt.Sprintf("Would add %s to .jira.yml", cfg.projectKey))
+	} else {
+		data, err := jiraCfg.Marshal()
+		if err != nil {
+			return fmt.Errorf("marshaling .jira.yml: %w", err)
+		}
+		if err := ghClient.CreateOrUpdateFile(ctx, owner, repo, ".jira.yml",
+			"chore: enroll Jira project "+cfg.projectKey, data); err != nil {
+			printer.StepFail("Failed to write .jira.yml")
+			return fmt.Errorf("writing .jira.yml: %w", err)
+		}
+		printer.StepDone(fmt.Sprintf("Added %s to .jira.yml", cfg.projectKey))
+	}
+
+	// --- Create automation rules ---
+
+	rulesCreated := true
+	if !cfg.skipAutomationRules {
+		rc := jira.RuleContext{
+			Owner:     owner,
+			Repo:      repo,
+			GitHubPAT: githubPAT,
+			AccountID: accountID,
+			CloudID:   cloudID,
+			ProjectID: projectID,
+		}
+
+		rules := []jira.CreateRuleRequest{
+			jira.AutoTriageRule(rc),
+			jira.SlashCommandRule(rc, "/fs-triage"),
+		}
+
+		for _, rule := range rules {
+			name := rule.Rule.Name
+			printer.StepStart(fmt.Sprintf("Creating automation rule: %s", name))
+
+			if cfg.dryRun {
+				printer.StepDone(fmt.Sprintf("Would create rule: %s", name))
+				continue
+			}
+
+			exists, err := jiraClient.RuleExistsByName(ctx, cloudID, name)
+			if err != nil {
+				printer.StepInfo("Could not check existing rules (will attempt creation)")
+			} else if exists {
+				printer.StepDone(fmt.Sprintf("Rule already exists: %s", name))
+				continue
+			}
+
+			uuid, err := jiraClient.CreateAutomationRule(ctx, cloudID, rule)
+			if err != nil {
+				if strings.Contains(err.Error(), "HTTP 403") {
+					rulesCreated = false
+					break
+				}
+				printer.StepFail(fmt.Sprintf("Failed to create rule: %s", name))
+				return fmt.Errorf("creating automation rule %q: %w", name, err)
+			}
+			printer.StepDone(fmt.Sprintf("Created rule: %s (uuid: %s)", name, uuid))
+		}
+
+		if !rulesCreated && !cfg.dryRun {
+			printer.StepWarn("Automation API requires Jira site admin (https://jira.atlassian.com/browse/AUTO-2120)")
+			printer.StepInfo("Create these rules manually in the Jira UI:")
+			printer.StepInfo("Navigate to: Space settings > Automation > Create flow")
+			printer.Blank()
+			printer.Raw(jira.ManualRuleInstructions(owner, repo))
+			printer.Blank()
+		}
+	}
+
+	// --- Commit workflow files ---
+
+	if !cfg.skipWorkflows {
+		printer.StepStart("Committing workflow files")
+
+		dispatchYML, err := scaffold.JiraDispatchTemplate()
+		if err != nil {
+			return fmt.Errorf("reading jira-dispatch.yml template: %w", err)
+		}
+		triageYML, err := scaffold.JiraTriageTemplate()
+		if err != nil {
+			return fmt.Errorf("reading jira-triage.yml template: %w", err)
+		}
+
+		files := []forge.TreeFile{
+			{Path: ".github/workflows/jira-dispatch.yml", Content: dispatchYML, Mode: "100644"},
+			{Path: ".github/workflows/jira-triage.yml", Content: triageYML, Mode: "100644"},
+		}
+
+		if cfg.dryRun {
+			for _, f := range files {
+				printer.StepInfo(fmt.Sprintf("  Would write %s", f.Path))
+			}
+			printer.StepDone("Would commit workflow files")
+		} else {
+			committed, err := ghClient.CommitFiles(ctx, owner, repo,
+				"chore: add Jira triage workflows for "+cfg.projectKey, files)
+			if err != nil {
+				printer.StepFail("Failed to commit workflow files")
+				return fmt.Errorf("committing workflow files: %w", err)
+			}
+			if committed {
+				printer.StepDone("Committed workflow files")
+			} else {
+				printer.StepDone("Workflow files already up to date")
+			}
+		}
+	}
+
+	// --- Set GitHub secrets ---
+
+	printer.StepStart("Setting GitHub secrets")
+	secrets := map[string]string{
+		"JIRA_HOST":      cfg.jiraHost,
+		"JIRA_EMAIL":     jiraEmail,
+		"JIRA_API_TOKEN": jiraAPIToken,
+	}
+
+	for name, value := range secrets {
+		if cfg.dryRun {
+			printer.StepInfo(fmt.Sprintf("  Would set secret %s", name))
+		} else {
+			if err := ghClient.CreateRepoSecret(ctx, owner, repo, name, value); err != nil {
+				printer.StepFail(fmt.Sprintf("Failed to set secret %s", name))
+				return fmt.Errorf("setting secret %s: %w", name, err)
+			}
+		}
+	}
+	printer.StepDone("GitHub secrets configured")
+
+	// --- Summary ---
+
+	summary := []string{
+		fmt.Sprintf("Jira project: %s (%s)", cfg.projectKey, cfg.jiraHost),
+		fmt.Sprintf("GitHub repo: %s/%s", owner, repo),
+	}
+	if !cfg.skipAutomationRules {
+		if rulesCreated {
+			summary = append(summary, "Automation rules: created via API")
+		} else {
+			summary = append(summary, "Automation rules: manual setup required (see instructions above)")
+		}
+	}
+	if !cfg.skipWorkflows {
+		summary = append(summary, "Workflows: jira-dispatch.yml, jira-triage.yml")
+	}
+	summary = append(summary, "Secrets: JIRA_HOST, JIRA_EMAIL, JIRA_API_TOKEN")
+
+	if cfg.dryRun {
+		printer.Summary("Dry run complete", summary)
+	} else {
+		printer.Summary("Jira enrollment complete", summary)
+	}
+
+	return nil
+}
+
+// resolveEnvOrFlag returns the flag value if set, otherwise falls back
+// to the environment variable.
+func resolveEnvOrFlag(flagValue, envVar string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	return os.Getenv(envVar)
+}
+
+// loadOrCreateJiraConfig reads .jira.yml from the repo, or creates a
+// new empty config if the file does not exist.
+func loadOrCreateJiraConfig(ctx context.Context, client forge.Client, owner, repo string) (*jira.JiraConfig, error) {
+	data, err := client.GetFileContent(ctx, owner, repo, ".jira.yml")
+	if err != nil {
+		// File does not exist — start with empty config.
+		return jira.NewJiraConfig(), nil
+	}
+	return jira.ParseJiraConfig(data)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -41,6 +41,7 @@ func newRootCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newAdminCmd())
 	cmd.AddCommand(newGitHubCmd())
+	cmd.AddCommand(newJiraCmd())
 	cmd.AddCommand(newInferenceCmd())
 	cmd.AddCommand(newLockCmd())
 	cmd.AddCommand(newMintCmd())

--- a/internal/jira/client.go
+++ b/internal/jira/client.go
@@ -1,0 +1,222 @@
+package jira
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Client provides access to Jira Cloud and its Automation REST API.
+type Client struct {
+	httpClient *http.Client
+	email      string
+	apiToken   string
+}
+
+// NewClient creates a Jira API client authenticated with Basic auth.
+func NewClient(email, apiToken string) *Client {
+	return &Client{
+		httpClient: http.DefaultClient,
+		email:      email,
+		apiToken:   apiToken,
+	}
+}
+
+func (c *Client) basicAuth() string {
+	return base64.StdEncoding.EncodeToString([]byte(c.email + ":" + c.apiToken))
+}
+
+// GetCloudID fetches the Jira Cloud ID from the tenant info endpoint.
+// The host parameter is the Jira hostname (e.g., "myorg.atlassian.net").
+func (c *Client) GetCloudID(ctx context.Context, host string) (string, error) {
+	url := fmt.Sprintf("https://%s/_edge/tenant_info", host)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating tenant info request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching tenant info from %s: %w", host, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("tenant info returned HTTP %d for %s", resp.StatusCode, host)
+	}
+
+	var info TenantInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return "", fmt.Errorf("decoding tenant info: %w", err)
+	}
+	if info.CloudID == "" {
+		return "", fmt.Errorf("tenant info response missing cloudId for %s", host)
+	}
+	return info.CloudID, nil
+}
+
+// ProjectInfo holds the key fields returned by the Jira project API.
+type ProjectInfo struct {
+	ID  string `json:"id"`
+	Key string `json:"key"`
+}
+
+// ValidateProject checks that a Jira project exists and is accessible.
+// Returns the project's numeric ID (needed for Automation API URLs).
+func (c *Client) ValidateProject(ctx context.Context, host, projectKey string) (*ProjectInfo, error) {
+	url := fmt.Sprintf("https://%s/rest/api/3/project/%s", host, projectKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating project validation request: %w", err)
+	}
+	req.Header.Set("Authorization", "Basic "+c.basicAuth())
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("validating project %s: %w", projectKey, err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var info ProjectInfo
+		if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+			return nil, fmt.Errorf("decoding project response: %w", err)
+		}
+		if info.ID == "" {
+			return nil, fmt.Errorf("project response missing id for %s", projectKey)
+		}
+		return &info, nil
+	case http.StatusUnauthorized:
+		return nil, fmt.Errorf("authentication failed for %s — check JIRA_EMAIL and JIRA_API_TOKEN", host)
+	case http.StatusForbidden:
+		return nil, fmt.Errorf("no permission to access project %s on %s", projectKey, host)
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("project %s not found on %s", projectKey, host)
+	default:
+		return nil, fmt.Errorf("project validation returned HTTP %d for %s", resp.StatusCode, projectKey)
+	}
+}
+
+// AccountInfo holds the current user's Jira account details.
+type AccountInfo struct {
+	AccountID string `json:"accountId"`
+}
+
+// GetCurrentUser returns the account ID of the authenticated user.
+func (c *Client) GetCurrentUser(ctx context.Context, host string) (string, error) {
+	url := fmt.Sprintf("https://%s/rest/api/3/myself", host)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating myself request: %w", err)
+	}
+	req.Header.Set("Authorization", "Basic "+c.basicAuth())
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching current user: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("current user request returned HTTP %d", resp.StatusCode)
+	}
+
+	var info AccountInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return "", fmt.Errorf("decoding current user: %w", err)
+	}
+	if info.AccountID == "" {
+		return "", fmt.Errorf("current user response missing accountId")
+	}
+	return info.AccountID, nil
+}
+
+// automationBaseURL returns the Jira Automation public REST API base URL.
+func automationBaseURL(cloudID string) string {
+	return fmt.Sprintf("https://api.atlassian.com/automation/public/jira/%s/rest/v1", cloudID)
+}
+
+// CreateAutomationRule creates a Jira Automation rule and returns its UUID.
+func (c *Client) CreateAutomationRule(ctx context.Context, cloudID string, rule CreateRuleRequest) (string, error) {
+	body, err := json.Marshal(rule)
+	if err != nil {
+		return "", fmt.Errorf("marshaling automation rule: %w", err)
+	}
+
+	url := automationBaseURL(cloudID) + "/rule"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("creating automation rule request: %w", err)
+	}
+	req.Header.Set("Authorization", "Basic "+c.basicAuth())
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("creating automation rule: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("automation rule creation returned HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result CreateRuleResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decoding automation rule response: %w", err)
+	}
+	return result.RuleUUID, nil
+}
+
+// ListAutomationRules lists automation rules for the given cloud instance.
+// Used for idempotency checks — skip creation if a rule with the same
+// name already exists.
+func (c *Client) ListAutomationRules(ctx context.Context, cloudID string) ([]RuleSummary, error) {
+	url := automationBaseURL(cloudID) + "/rule/summary"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating list rules request: %w", err)
+	}
+	req.Header.Set("Authorization", "Basic "+c.basicAuth())
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("listing automation rules: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list automation rules returned HTTP %d", resp.StatusCode)
+	}
+
+	var rules []RuleSummary
+	if err := json.NewDecoder(resp.Body).Decode(&rules); err != nil {
+		return nil, fmt.Errorf("decoding automation rules list: %w", err)
+	}
+	return rules, nil
+}
+
+// RuleExistsByName checks whether an automation rule with the given
+// name already exists.
+func (c *Client) RuleExistsByName(ctx context.Context, cloudID, name string) (bool, error) {
+	rules, err := c.ListAutomationRules(ctx, cloudID)
+	if err != nil {
+		return false, err
+	}
+	for _, r := range rules {
+		if r.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/jira/client_test.go
+++ b/internal/jira/client_test.go
@@ -1,0 +1,554 @@
+package jira
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestClient creates a Client whose httpClient is wired to the given
+// test server, and whose methods are callable with host = srv address
+// (the helper patches https:// → http:// via a custom transport).
+func newTestClient(srv *httptest.Server) (*Client, string) {
+	c := NewClient("test@example.com", "test-token")
+	c.httpClient = srv.Client()
+	// Strip scheme — methods prepend "https://", but httptest uses http.
+	// We swap the transport so it hits the test server regardless.
+	c.httpClient.Transport = &rewriteTransport{base: srv.Client().Transport, srvURL: srv.URL}
+	host := strings.TrimPrefix(srv.URL, "http://")
+	return c, host
+}
+
+// rewriteTransport rewrites https:// requests to the test server URL.
+type rewriteTransport struct {
+	base   http.RoundTripper
+	srvURL string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	parts := strings.SplitN(t.srvURL, "://", 2)
+	req.URL.Host = parts[1]
+	return t.base.RoundTrip(req)
+}
+
+// --- GetCloudID ---
+
+func TestGetCloudID_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_edge/tenant_info" {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(TenantInfo{CloudID: "cloud-abc-123"})
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	cloudID, err := client.GetCloudID(context.Background(), host)
+	if err != nil {
+		t.Fatalf("GetCloudID: %v", err)
+	}
+	if cloudID != "cloud-abc-123" {
+		t.Errorf("cloudID = %q, want cloud-abc-123", cloudID)
+	}
+}
+
+func TestGetCloudID_EmptyCloudID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(TenantInfo{CloudID: ""})
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	_, err := client.GetCloudID(context.Background(), host)
+	if err == nil {
+		t.Error("expected error for empty cloudId")
+	}
+	if !strings.Contains(err.Error(), "missing cloudId") {
+		t.Errorf("error = %q, want 'missing cloudId'", err)
+	}
+}
+
+func TestGetCloudID_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	_, err := client.GetCloudID(context.Background(), host)
+	if err == nil {
+		t.Error("expected error for 500")
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("error = %q, want HTTP 500", err)
+	}
+}
+
+// --- ValidateProject ---
+
+func TestValidateProject_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/api/3/project/TESTPROJ" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		json.NewEncoder(w).Encode(ProjectInfo{ID: "12345", Key: "TESTPROJ"})
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	info, err := client.ValidateProject(context.Background(), host, "TESTPROJ")
+	if err != nil {
+		t.Fatalf("ValidateProject: %v", err)
+	}
+	if info.ID != "12345" {
+		t.Errorf("ID = %q, want 12345", info.ID)
+	}
+	if info.Key != "TESTPROJ" {
+		t.Errorf("Key = %q, want TESTPROJ", info.Key)
+	}
+}
+
+func TestValidateProject_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	_, err := client.ValidateProject(context.Background(), host, "MISSING")
+	if err == nil {
+		t.Error("expected error for missing project")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want 'not found'", err)
+	}
+}
+
+func TestValidateProject_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	_, err := client.ValidateProject(context.Background(), host, "PROJ")
+	if err == nil {
+		t.Error("expected error for 401")
+	}
+	if !strings.Contains(err.Error(), "authentication failed") {
+		t.Errorf("error = %q, want 'authentication failed'", err)
+	}
+}
+
+func TestValidateProject_Forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	_, err := client.ValidateProject(context.Background(), host, "PROJ")
+	if err == nil {
+		t.Error("expected error for 403")
+	}
+	if !strings.Contains(err.Error(), "no permission") {
+		t.Errorf("error = %q, want 'no permission'", err)
+	}
+}
+
+func TestValidateProject_MissingID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ProjectInfo{Key: "PROJ"})
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	_, err := client.ValidateProject(context.Background(), host, "PROJ")
+	if err == nil {
+		t.Error("expected error for missing ID")
+	}
+}
+
+// --- GetCurrentUser ---
+
+func TestGetCurrentUser_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/api/3/myself" {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(AccountInfo{AccountID: "user-abc-123"})
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	accountID, err := client.GetCurrentUser(context.Background(), host)
+	if err != nil {
+		t.Fatalf("GetCurrentUser: %v", err)
+	}
+	if accountID != "user-abc-123" {
+		t.Errorf("accountID = %q, want user-abc-123", accountID)
+	}
+}
+
+func TestGetCurrentUser_EmptyAccountID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(AccountInfo{})
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	_, err := client.GetCurrentUser(context.Background(), host)
+	if err == nil {
+		t.Error("expected error for empty accountId")
+	}
+}
+
+func TestGetCurrentUser_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	_, err := client.GetCurrentUser(context.Background(), host)
+	if err == nil {
+		t.Error("expected error for 500")
+	}
+}
+
+// --- CreateAutomationRule ---
+
+func TestCreateAutomationRule_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/rule") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") == "" {
+			t.Error("missing Authorization header")
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Content-Type = %q", r.Header.Get("Content-Type"))
+		}
+
+		var req CreateRuleRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if req.Rule.Name != "test rule" {
+			t.Errorf("rule name = %q", req.Rule.Name)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(CreateRuleResponse{RuleUUID: "uuid-789"})
+	}))
+	defer srv.Close()
+
+	client := NewClient("test@example.com", "token")
+	client.httpClient = srv.Client()
+	client.httpClient.Transport = &rewriteTransport{base: srv.Client().Transport, srvURL: srv.URL}
+
+	rule := CreateRuleRequest{
+		Rule: RulePayload{
+			Name:  "test rule",
+			State: "ENABLED",
+			Components: []RuleComponent{
+				{Component: "ACTION", Type: "jira.issue.edit", Value: json.RawMessage(`{"operations":[]}`)},
+			},
+		},
+		Connections: []RuleConnection{},
+	}
+
+	uuid, err := client.CreateAutomationRule(context.Background(), "cloud-123", rule)
+	if err != nil {
+		t.Fatalf("CreateAutomationRule: %v", err)
+	}
+	if uuid != "uuid-789" {
+		t.Errorf("uuid = %q, want uuid-789", uuid)
+	}
+}
+
+func TestCreateAutomationRule_Forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient("test@example.com", "token")
+	client.httpClient = srv.Client()
+	client.httpClient.Transport = &rewriteTransport{base: srv.Client().Transport, srvURL: srv.URL}
+
+	rule := CreateRuleRequest{Rule: RulePayload{Name: "test", Components: []RuleComponent{{}}}}
+	_, err := client.CreateAutomationRule(context.Background(), "cloud-123", rule)
+	if err == nil {
+		t.Error("expected error for 403")
+	}
+	if !strings.Contains(err.Error(), "HTTP 403") {
+		t.Errorf("error = %q, want HTTP 403", err)
+	}
+}
+
+// --- ListAutomationRules ---
+
+func TestListAutomationRules_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/rule/summary") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		rules := []RuleSummary{
+			{ID: 1, Name: "fullsend: auto-triage on issue creation", State: "ENABLED"},
+			{ID: 2, Name: "fullsend: /fs-triage command", State: "ENABLED"},
+			{ID: 3, Name: "other rule", State: "DISABLED"},
+		}
+		json.NewEncoder(w).Encode(rules)
+	}))
+	defer srv.Close()
+
+	client := NewClient("test@example.com", "token")
+	client.httpClient = srv.Client()
+	client.httpClient.Transport = &rewriteTransport{base: srv.Client().Transport, srvURL: srv.URL}
+
+	rules, err := client.ListAutomationRules(context.Background(), "cloud-123")
+	if err != nil {
+		t.Fatalf("ListAutomationRules: %v", err)
+	}
+	if len(rules) != 3 {
+		t.Errorf("rules len = %d, want 3", len(rules))
+	}
+	if rules[0].Name != "fullsend: auto-triage on issue creation" {
+		t.Errorf("rules[0].Name = %q", rules[0].Name)
+	}
+}
+
+func TestListAutomationRules_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := NewClient("test@example.com", "token")
+	client.httpClient = srv.Client()
+	client.httpClient.Transport = &rewriteTransport{base: srv.Client().Transport, srvURL: srv.URL}
+
+	_, err := client.ListAutomationRules(context.Background(), "cloud-123")
+	if err == nil {
+		t.Error("expected error for 500")
+	}
+}
+
+// --- RuleExistsByName ---
+
+func TestRuleExistsByName_Found(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rules := []RuleSummary{
+			{ID: 1, Name: "fullsend: auto-triage on issue creation"},
+		}
+		json.NewEncoder(w).Encode(rules)
+	}))
+	defer srv.Close()
+
+	client := NewClient("test@example.com", "token")
+	client.httpClient = srv.Client()
+	client.httpClient.Transport = &rewriteTransport{base: srv.Client().Transport, srvURL: srv.URL}
+
+	exists, err := client.RuleExistsByName(context.Background(), "cloud-123", "fullsend: auto-triage on issue creation")
+	if err != nil {
+		t.Fatalf("RuleExistsByName: %v", err)
+	}
+	if !exists {
+		t.Error("expected rule to exist")
+	}
+}
+
+func TestRuleExistsByName_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]RuleSummary{})
+	}))
+	defer srv.Close()
+
+	client := NewClient("test@example.com", "token")
+	client.httpClient = srv.Client()
+	client.httpClient.Transport = &rewriteTransport{base: srv.Client().Transport, srvURL: srv.URL}
+
+	exists, err := client.RuleExistsByName(context.Background(), "cloud-123", "nonexistent")
+	if err != nil {
+		t.Fatalf("RuleExistsByName: %v", err)
+	}
+	if exists {
+		t.Error("expected rule to not exist")
+	}
+}
+
+// --- BasicAuth ---
+
+func TestBasicAuth_Format(t *testing.T) {
+	client := NewClient("user@example.com", "my-token")
+	auth := client.basicAuth()
+	decoded, err := base64.StdEncoding.DecodeString(auth)
+	if err != nil {
+		t.Fatalf("decode base64: %v", err)
+	}
+	if string(decoded) != "user@example.com:my-token" {
+		t.Errorf("decoded auth = %q, want user@example.com:my-token", decoded)
+	}
+}
+
+// --- Malformed JSON responses ---
+
+func TestGetCloudID_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	_, err := client.GetCloudID(context.Background(), host)
+	if err == nil {
+		t.Error("expected error for malformed JSON")
+	}
+}
+
+func TestValidateProject_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{invalid`))
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	_, err := client.ValidateProject(context.Background(), host, "PROJ")
+	if err == nil {
+		t.Error("expected error for malformed JSON")
+	}
+}
+
+func TestGetCurrentUser_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{bad`))
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	_, err := client.GetCurrentUser(context.Background(), host)
+	if err == nil {
+		t.Error("expected error for malformed JSON")
+	}
+}
+
+func TestCreateAutomationRule_MalformedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`not-json`))
+	}))
+	defer srv.Close()
+
+	client := NewClient("test@example.com", "token")
+	client.httpClient = srv.Client()
+	client.httpClient.Transport = &rewriteTransport{base: srv.Client().Transport, srvURL: srv.URL}
+
+	rule := CreateRuleRequest{Rule: RulePayload{Name: "test", Components: []RuleComponent{{}}}}
+	_, err := client.CreateAutomationRule(context.Background(), "cloud-123", rule)
+	if err == nil {
+		t.Error("expected error for malformed JSON response")
+	}
+}
+
+func TestListAutomationRules_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`[{bad`))
+	}))
+	defer srv.Close()
+
+	client := NewClient("test@example.com", "token")
+	client.httpClient = srv.Client()
+	client.httpClient.Transport = &rewriteTransport{base: srv.Client().Transport, srvURL: srv.URL}
+
+	_, err := client.ListAutomationRules(context.Background(), "cloud-123")
+	if err == nil {
+		t.Error("expected error for malformed JSON")
+	}
+}
+
+// --- automationBaseURL ---
+
+func TestAutomationBaseURL(t *testing.T) {
+	url := automationBaseURL("cloud-123")
+	want := "https://api.atlassian.com/automation/public/jira/cloud-123/rest/v1"
+	if url != want {
+		t.Errorf("automationBaseURL = %q, want %q", url, want)
+	}
+}
+
+// --- RuleExistsByName error propagation ---
+
+func TestRuleExistsByName_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := NewClient("test@example.com", "token")
+	client.httpClient = srv.Client()
+	client.httpClient.Transport = &rewriteTransport{base: srv.Client().Transport, srvURL: srv.URL}
+
+	_, err := client.RuleExistsByName(context.Background(), "cloud-123", "anything")
+	if err == nil {
+		t.Error("expected error to propagate from ListAutomationRules")
+	}
+}
+
+// --- ValidateProject other status codes ---
+
+func TestValidateProject_UnexpectedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	client, host := newTestClient(srv)
+	_, err := client.ValidateProject(context.Background(), host, "PROJ")
+	if err == nil {
+		t.Error("expected error for 503")
+	}
+	if !strings.Contains(err.Error(), "HTTP 503") {
+		t.Errorf("error = %q, want HTTP 503", err)
+	}
+}
+
+// --- CreateAutomationRule verifies auth header ---
+
+func TestCreateAutomationRule_SetsAuthHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Basic ") {
+			t.Errorf("Authorization header = %q, want Basic prefix", auth)
+		}
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(CreateRuleResponse{RuleUUID: "test-uuid"})
+	}))
+	defer srv.Close()
+
+	client := NewClient("test@example.com", "token")
+	client.httpClient = srv.Client()
+	client.httpClient.Transport = &rewriteTransport{base: srv.Client().Transport, srvURL: srv.URL}
+
+	rule := CreateRuleRequest{Rule: RulePayload{Name: "test", Components: []RuleComponent{{}}}}
+	_, err := client.CreateAutomationRule(context.Background(), "cloud-123", rule)
+	if err != nil {
+		t.Fatalf("CreateAutomationRule: %v", err)
+	}
+}

--- a/internal/jira/config.go
+++ b/internal/jira/config.go
@@ -1,0 +1,68 @@
+package jira
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// JiraProjectConfig represents a single Jira project enrollment entry
+// in .jira.yml.
+type JiraProjectConfig struct {
+	ProjectKey        string   `yaml:"project_key"`
+	Host              string   `yaml:"host"`
+	LinkedGitHubRepos []string `yaml:"linked_github_repos"`
+}
+
+// JiraConfig represents the .jira.yml file at the root of an enrolled repo.
+type JiraConfig struct {
+	Version      int                 `yaml:"version"`
+	JiraProjects []JiraProjectConfig `yaml:"jira_projects"`
+}
+
+// ParseJiraConfig parses .jira.yml content into a JiraConfig.
+func ParseJiraConfig(data []byte) (*JiraConfig, error) {
+	var cfg JiraConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing .jira.yml: %w", err)
+	}
+	if cfg.Version == 0 {
+		cfg.Version = 1
+	}
+	return &cfg, nil
+}
+
+// Marshal serializes the config back to YAML with a header comment.
+func (c *JiraConfig) Marshal() ([]byte, error) {
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling .jira.yml: %w", err)
+	}
+	return data, nil
+}
+
+// HasProject checks whether a project with the given key and host is
+// already enrolled.
+func (c *JiraConfig) HasProject(projectKey, host string) bool {
+	for _, p := range c.JiraProjects {
+		if p.ProjectKey == projectKey && p.Host == host {
+			return true
+		}
+	}
+	return false
+}
+
+// AddProject adds a project to the config if it is not already enrolled.
+// Returns true if the project was added, false if it already existed.
+func (c *JiraConfig) AddProject(project JiraProjectConfig) bool {
+	if c.HasProject(project.ProjectKey, project.Host) {
+		return false
+	}
+	c.JiraProjects = append(c.JiraProjects, project)
+	return true
+}
+
+// NewJiraConfig returns an empty config with version set.
+func NewJiraConfig() *JiraConfig {
+	return &JiraConfig{Version: 1}
+}

--- a/internal/jira/config_test.go
+++ b/internal/jira/config_test.go
@@ -1,0 +1,137 @@
+package jira
+
+import (
+	"testing"
+)
+
+func TestParseJiraConfig(t *testing.T) {
+	input := []byte(`version: 1
+jira_projects:
+  - project_key: KFLUXINFRA
+    host: stage-redhat.atlassian.net
+    linked_github_repos:
+      - redhat-appstudio/infra-deployments
+`)
+	cfg, err := ParseJiraConfig(input)
+	if err != nil {
+		t.Fatalf("ParseJiraConfig: %v", err)
+	}
+	if cfg.Version != 1 {
+		t.Errorf("Version = %d, want 1", cfg.Version)
+	}
+	if len(cfg.JiraProjects) != 1 {
+		t.Fatalf("JiraProjects len = %d, want 1", len(cfg.JiraProjects))
+	}
+	p := cfg.JiraProjects[0]
+	if p.ProjectKey != "KFLUXINFRA" {
+		t.Errorf("ProjectKey = %q, want KFLUXINFRA", p.ProjectKey)
+	}
+	if p.Host != "stage-redhat.atlassian.net" {
+		t.Errorf("Host = %q, want stage-redhat.atlassian.net", p.Host)
+	}
+	if len(p.LinkedGitHubRepos) != 1 || p.LinkedGitHubRepos[0] != "redhat-appstudio/infra-deployments" {
+		t.Errorf("LinkedGitHubRepos = %v, want [redhat-appstudio/infra-deployments]", p.LinkedGitHubRepos)
+	}
+}
+
+func TestParseJiraConfig_DefaultVersion(t *testing.T) {
+	input := []byte(`jira_projects: []`)
+	cfg, err := ParseJiraConfig(input)
+	if err != nil {
+		t.Fatalf("ParseJiraConfig: %v", err)
+	}
+	if cfg.Version != 1 {
+		t.Errorf("Version = %d, want 1 (default)", cfg.Version)
+	}
+}
+
+func TestParseJiraConfig_InvalidYAML(t *testing.T) {
+	input := []byte(`{{{invalid`)
+	_, err := ParseJiraConfig(input)
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+func TestHasProject(t *testing.T) {
+	cfg := &JiraConfig{
+		Version: 1,
+		JiraProjects: []JiraProjectConfig{
+			{ProjectKey: "PROJ", Host: "example.atlassian.net"},
+		},
+	}
+
+	if !cfg.HasProject("PROJ", "example.atlassian.net") {
+		t.Error("HasProject should return true for enrolled project")
+	}
+	if cfg.HasProject("PROJ", "other.atlassian.net") {
+		t.Error("HasProject should return false for different host")
+	}
+	if cfg.HasProject("OTHER", "example.atlassian.net") {
+		t.Error("HasProject should return false for different key")
+	}
+}
+
+func TestAddProject_Idempotent(t *testing.T) {
+	cfg := NewJiraConfig()
+	p := JiraProjectConfig{
+		ProjectKey:        "PROJ",
+		Host:              "example.atlassian.net",
+		LinkedGitHubRepos: []string{"org/repo"},
+	}
+
+	added := cfg.AddProject(p)
+	if !added {
+		t.Error("first AddProject should return true")
+	}
+	if len(cfg.JiraProjects) != 1 {
+		t.Fatalf("JiraProjects len = %d, want 1", len(cfg.JiraProjects))
+	}
+
+	added = cfg.AddProject(p)
+	if added {
+		t.Error("second AddProject should return false (idempotent)")
+	}
+	if len(cfg.JiraProjects) != 1 {
+		t.Fatalf("JiraProjects len = %d, want 1 after duplicate add", len(cfg.JiraProjects))
+	}
+}
+
+func TestAddProject_DifferentProjects(t *testing.T) {
+	cfg := NewJiraConfig()
+	cfg.AddProject(JiraProjectConfig{ProjectKey: "PROJ1", Host: "a.atlassian.net"})
+	cfg.AddProject(JiraProjectConfig{ProjectKey: "PROJ2", Host: "a.atlassian.net"})
+	cfg.AddProject(JiraProjectConfig{ProjectKey: "PROJ1", Host: "b.atlassian.net"})
+
+	if len(cfg.JiraProjects) != 3 {
+		t.Errorf("JiraProjects len = %d, want 3", len(cfg.JiraProjects))
+	}
+}
+
+func TestMarshalRoundTrip(t *testing.T) {
+	cfg := NewJiraConfig()
+	cfg.AddProject(JiraProjectConfig{
+		ProjectKey:        "TEST",
+		Host:              "test.atlassian.net",
+		LinkedGitHubRepos: []string{"org/repo1", "org/repo2"},
+	})
+
+	data, err := cfg.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	cfg2, err := ParseJiraConfig(data)
+	if err != nil {
+		t.Fatalf("ParseJiraConfig after Marshal: %v", err)
+	}
+	if len(cfg2.JiraProjects) != 1 {
+		t.Fatalf("round-trip: JiraProjects len = %d, want 1", len(cfg2.JiraProjects))
+	}
+	if cfg2.JiraProjects[0].ProjectKey != "TEST" {
+		t.Errorf("round-trip: ProjectKey = %q, want TEST", cfg2.JiraProjects[0].ProjectKey)
+	}
+	if len(cfg2.JiraProjects[0].LinkedGitHubRepos) != 2 {
+		t.Errorf("round-trip: LinkedGitHubRepos len = %d, want 2", len(cfg2.JiraProjects[0].LinkedGitHubRepos))
+	}
+}

--- a/internal/jira/rules.go
+++ b/internal/jira/rules.go
@@ -1,0 +1,224 @@
+package jira
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Automation rule component types. These are internal Jira identifiers
+// discovered by reverse-engineering existing rules via the Jira
+// Automation REST API. Atlassian does not document these.
+const (
+	TriggerIssueCreated    = "jira.issue.event.trigger:created"
+	TriggerCommentAdded    = "jira.issue.event.trigger:commented"
+	ConditionCompareValues = "jira.comparator.condition"
+	ActionSendWebRequest   = "jira.issue.outgoing.webhook"
+)
+
+// Rule names used for idempotency checks.
+const (
+	RuleNameAutoTriage = "fullsend: auto-triage on issue creation"
+	RuleNameFsTriage   = "fullsend: /fs-triage command"
+)
+
+// RuleContext holds the identifiers needed to construct automation rules.
+type RuleContext struct {
+	Owner     string // GitHub repo owner
+	Repo      string // GitHub repo name
+	GitHubPAT string // GitHub PAT for webhook auth
+	AccountID string // Jira account ID of the rule author
+	CloudID   string // Jira Cloud ID
+	ProjectID string // Jira numeric project ID
+}
+
+// projectARI returns the Atlassian Resource Identifier for the project.
+func (rc RuleContext) projectARI() string {
+	return fmt.Sprintf("ari:cloud:jira:%s:project/%s", rc.CloudID, rc.ProjectID)
+}
+
+func webhookURL(owner, repo string) string {
+	return "https://api.github.com/repos/" + owner + "/" + repo + "/dispatches"
+}
+
+func webhookHeaders(githubPAT string) json.RawMessage {
+	now := time.Now().UnixMilli()
+	headers := []map[string]interface{}{
+		{"id": fmt.Sprintf("_header_%d", now), "name": "Authorization", "value": "Bearer " + githubPAT, "headerSecure": false},
+		{"id": fmt.Sprintf("_header_%d", now+1), "name": "Accept", "value": "application/vnd.github.v3+json", "headerSecure": false},
+		{"id": fmt.Sprintf("_header_%d", now+2), "name": "Content-Type", "value": "application/json", "headerSecure": false},
+	}
+	data, _ := json.Marshal(headers)
+	return data
+}
+
+func webhookAction(url, githubPAT, customBody string) RuleComponent {
+	actionValue, _ := json.Marshal(map[string]interface{}{
+		"url":                    url,
+		"urlSecure":              false,
+		"headers":                json.RawMessage(webhookHeaders(githubPAT)),
+		"sendIssue":              false,
+		"contentType":            "custom",
+		"customBody":             customBody,
+		"method":                 "POST",
+		"responseEnabled":        false,
+		"continueOnErrorEnabled": false,
+	})
+	return RuleComponent{
+		Component:     "ACTION",
+		Type:          ActionSendWebRequest,
+		Value:         json.RawMessage(actionValue),
+		SchemaVersion: 1,
+	}
+}
+
+// basePayload returns a RulePayload with the required fields populated.
+func basePayload(rc RuleContext, name string) RulePayload {
+	return RulePayload{
+		Name:  name,
+		State: "ENABLED",
+		Actor: &RuleActor{
+			Type:  "ACCOUNT_ID",
+			Actor: rc.AccountID,
+		},
+		AuthorAccountID:     rc.AccountID,
+		CanOtherRuleTrigger: false,
+		NotifyOnError:       "FIRSTERROR",
+		WriteAccessType:     "OWNER_ONLY",
+		RuleScopeARIs:       []string{rc.projectARI()},
+	}
+}
+
+// AutoTriageRule builds a Jira Automation rule that triggers on work
+// item creation and sends a webhook to the GitHub dispatch API.
+func AutoTriageRule(rc RuleContext) CreateRuleRequest {
+	url := webhookURL(rc.Owner, rc.Repo)
+
+	triggerValue, _ := json.Marshal(map[string]interface{}{
+		"eventKey":     "jira:issue_created",
+		"issueEvent":   "issue_created",
+		"eventFilters": []string{rc.projectARI()},
+	})
+
+	customBody := `{
+  "event_type": "jira-issue-created",
+  "client_payload": {
+    "issue_key": "{{issue.key}}",
+    "project_key": "{{issue.fields.project.key}}"
+  }
+}`
+
+	payload := basePayload(rc, RuleNameAutoTriage)
+	payload.Trigger = RuleComponent{
+		Component:     "TRIGGER",
+		Type:          TriggerIssueCreated,
+		Value:         json.RawMessage(triggerValue),
+		SchemaVersion: 1,
+	}
+	payload.Components = []RuleComponent{
+		webhookAction(url, rc.GitHubPAT, customBody),
+	}
+
+	return CreateRuleRequest{
+		Rule:        payload,
+		Connections: []RuleConnection{},
+	}
+}
+
+// SlashCommandRule builds a Jira Automation rule that triggers on
+// comments containing a slash command and sends a webhook to the
+// GitHub dispatch API.
+func SlashCommandRule(rc RuleContext, command string) CreateRuleRequest {
+	url := webhookURL(rc.Owner, rc.Repo)
+	ruleName := "fullsend: " + command + " command"
+
+	triggerValue, _ := json.Marshal(map[string]interface{}{
+		"eventTypes":   []string{},
+		"eventFilters": []string{rc.projectARI()},
+	})
+
+	conditionValue, _ := json.Marshal(map[string]interface{}{
+		"first":    "{{comment.body}}",
+		"second":   command,
+		"operator": "CONTAINS",
+	})
+
+	customBody := fmt.Sprintf(`{
+  "event_type": "jira-command",
+  "client_payload": {
+    "issue_key": "{{issue.key}}",
+    "project_key": "{{issue.fields.project.key}}",
+    "command": "%s"
+  }
+}`, command)
+
+	payload := basePayload(rc, ruleName)
+	payload.Trigger = RuleComponent{
+		Component:     "TRIGGER",
+		Type:          TriggerCommentAdded,
+		Value:         json.RawMessage(triggerValue),
+		SchemaVersion: 1,
+	}
+	payload.Components = []RuleComponent{
+		{
+			Component:     "CONDITION",
+			Type:          ConditionCompareValues,
+			Value:         json.RawMessage(conditionValue),
+			SchemaVersion: 1,
+		},
+		webhookAction(url, rc.GitHubPAT, customBody),
+	}
+
+	return CreateRuleRequest{
+		Rule:        payload,
+		Connections: []RuleConnection{},
+	}
+}
+
+// ManualRuleInstructions returns human-readable instructions for
+// creating automation rules manually in the Jira UI when the API
+// returns 403 (requires site admin — see AUTO-2120).
+func ManualRuleInstructions(owner, repo string) string {
+	url := webhookURL(owner, repo)
+	var b strings.Builder
+
+	b.WriteString("Rule 1: fullsend: auto-triage on issue creation\n")
+	b.WriteString("\n")
+	b.WriteString("  Trigger:   Work item created\n")
+	b.WriteString("  Action:    Send web request\n")
+	b.WriteString(fmt.Sprintf("    URL:     %s\n", url))
+	b.WriteString("    Method:  POST\n")
+	b.WriteString("    Headers:\n")
+	b.WriteString("      Authorization: Bearer <your-github-pat>\n")
+	b.WriteString("      Accept: application/vnd.github.v3+json\n")
+	b.WriteString("      Content-Type: application/json\n")
+	b.WriteString("    Body:\n")
+	b.WriteString("      {\n")
+	b.WriteString("        \"event_type\": \"jira-issue-created\",\n")
+	b.WriteString("        \"client_payload\": {\n")
+	b.WriteString("          \"issue_key\": \"{{issue.key}}\",\n")
+	b.WriteString("          \"project_key\": \"{{issue.fields.project.key}}\"\n")
+	b.WriteString("        }\n")
+	b.WriteString("      }\n")
+	b.WriteString("\n")
+	b.WriteString("Rule 2: fullsend: /fs-triage command\n")
+	b.WriteString("\n")
+	b.WriteString("  Trigger:   Comment added (all comments)\n")
+	b.WriteString("  Condition: {{comment.body}} contains /fs-triage\n")
+	b.WriteString("  Action:    Send web request\n")
+	b.WriteString(fmt.Sprintf("    URL:     %s\n", url))
+	b.WriteString("    Method:  POST\n")
+	b.WriteString("    Headers: (same as Rule 1)\n")
+	b.WriteString("    Body:\n")
+	b.WriteString("      {\n")
+	b.WriteString("        \"event_type\": \"jira-command\",\n")
+	b.WriteString("        \"client_payload\": {\n")
+	b.WriteString("          \"issue_key\": \"{{issue.key}}\",\n")
+	b.WriteString("          \"project_key\": \"{{issue.fields.project.key}}\",\n")
+	b.WriteString("          \"command\": \"/fs-triage\"\n")
+	b.WriteString("        }\n")
+	b.WriteString("      }\n")
+
+	return b.String()
+}

--- a/internal/jira/rules_test.go
+++ b/internal/jira/rules_test.go
@@ -1,0 +1,394 @@
+package jira
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+var testRC = RuleContext{
+	Owner:     "myorg",
+	Repo:      "myrepo",
+	GitHubPAT: "ghp_test123",
+	AccountID: "abc-123",
+	CloudID:   "cloud-456",
+	ProjectID: "11294",
+}
+
+func TestAutoTriageRule_Structure(t *testing.T) {
+	rule := AutoTriageRule(testRC)
+
+	if rule.Rule.Name != RuleNameAutoTriage {
+		t.Errorf("Name = %q, want %q", rule.Rule.Name, RuleNameAutoTriage)
+	}
+	if rule.Rule.State != "ENABLED" {
+		t.Errorf("State = %q, want ENABLED", rule.Rule.State)
+	}
+	if rule.Rule.NotifyOnError != "FIRSTERROR" {
+		t.Errorf("NotifyOnError = %q, want FIRSTERROR", rule.Rule.NotifyOnError)
+	}
+	if rule.Rule.WriteAccessType != "OWNER_ONLY" {
+		t.Errorf("WriteAccessType = %q, want OWNER_ONLY", rule.Rule.WriteAccessType)
+	}
+}
+
+func TestAutoTriageRule_Actor(t *testing.T) {
+	rule := AutoTriageRule(testRC)
+
+	if rule.Rule.Actor == nil {
+		t.Fatal("Actor is nil")
+	}
+	if rule.Rule.Actor.Type != "ACCOUNT_ID" {
+		t.Errorf("Actor.Type = %q, want ACCOUNT_ID", rule.Rule.Actor.Type)
+	}
+	if rule.Rule.Actor.Actor != "abc-123" {
+		t.Errorf("Actor.Actor = %q, want abc-123", rule.Rule.Actor.Actor)
+	}
+	if rule.Rule.AuthorAccountID != "abc-123" {
+		t.Errorf("AuthorAccountID = %q, want abc-123", rule.Rule.AuthorAccountID)
+	}
+}
+
+func TestAutoTriageRule_RuleScope(t *testing.T) {
+	rule := AutoTriageRule(testRC)
+
+	if len(rule.Rule.RuleScopeARIs) != 1 {
+		t.Fatalf("RuleScopeARIs len = %d, want 1", len(rule.Rule.RuleScopeARIs))
+	}
+	want := "ari:cloud:jira:cloud-456:project/11294"
+	if rule.Rule.RuleScopeARIs[0] != want {
+		t.Errorf("RuleScopeARIs[0] = %q, want %q", rule.Rule.RuleScopeARIs[0], want)
+	}
+}
+
+func TestAutoTriageRule_Connections(t *testing.T) {
+	rule := AutoTriageRule(testRC)
+
+	if rule.Connections == nil {
+		t.Fatal("Connections is nil, want empty slice")
+	}
+	if len(rule.Connections) != 0 {
+		t.Errorf("Connections len = %d, want 0", len(rule.Connections))
+	}
+}
+
+func TestAutoTriageRule_Trigger(t *testing.T) {
+	rule := AutoTriageRule(testRC)
+
+	tr := rule.Rule.Trigger
+	if tr.Component != "TRIGGER" {
+		t.Errorf("Trigger.Component = %q, want TRIGGER", tr.Component)
+	}
+	if tr.Type != TriggerIssueCreated {
+		t.Errorf("Trigger.Type = %q, want %q", tr.Type, TriggerIssueCreated)
+	}
+	if tr.SchemaVersion != 1 {
+		t.Errorf("Trigger.SchemaVersion = %d, want 1", tr.SchemaVersion)
+	}
+
+	var trigVal map[string]interface{}
+	if err := json.Unmarshal(tr.Value, &trigVal); err != nil {
+		t.Fatalf("unmarshal trigger value: %v", err)
+	}
+	if trigVal["eventKey"] != "jira:issue_created" {
+		t.Errorf("trigger eventKey = %v", trigVal["eventKey"])
+	}
+	if trigVal["issueEvent"] != "issue_created" {
+		t.Errorf("trigger issueEvent = %v", trigVal["issueEvent"])
+	}
+	filters, ok := trigVal["eventFilters"].([]interface{})
+	if !ok || len(filters) != 1 {
+		t.Fatalf("eventFilters = %v", trigVal["eventFilters"])
+	}
+	if filters[0] != "ari:cloud:jira:cloud-456:project/11294" {
+		t.Errorf("eventFilters[0] = %v", filters[0])
+	}
+}
+
+func TestAutoTriageRule_WebhookAction(t *testing.T) {
+	rule := AutoTriageRule(testRC)
+
+	if len(rule.Rule.Components) != 1 {
+		t.Fatalf("Components len = %d, want 1", len(rule.Rule.Components))
+	}
+	action := rule.Rule.Components[0]
+	if action.Component != "ACTION" {
+		t.Errorf("action.Component = %q, want ACTION", action.Component)
+	}
+	if action.Type != ActionSendWebRequest {
+		t.Errorf("action.Type = %q, want %q", action.Type, ActionSendWebRequest)
+	}
+	if action.SchemaVersion != 1 {
+		t.Errorf("action.SchemaVersion = %d, want 1", action.SchemaVersion)
+	}
+
+	var val map[string]interface{}
+	if err := json.Unmarshal(action.Value, &val); err != nil {
+		t.Fatalf("unmarshal action value: %v", err)
+	}
+	if val["url"] != "https://api.github.com/repos/myorg/myrepo/dispatches" {
+		t.Errorf("url = %v", val["url"])
+	}
+	if val["method"] != "POST" {
+		t.Errorf("method = %v", val["method"])
+	}
+	if val["contentType"] != "custom" {
+		t.Errorf("contentType = %v", val["contentType"])
+	}
+	if val["sendIssue"] != false {
+		t.Errorf("sendIssue = %v", val["sendIssue"])
+	}
+	body, _ := val["customBody"].(string)
+	if !strings.Contains(body, "jira-issue-created") {
+		t.Error("customBody missing event_type jira-issue-created")
+	}
+	if !strings.Contains(body, "{{issue.key}}") {
+		t.Error("customBody missing {{issue.key}}")
+	}
+	if !strings.Contains(body, "{{issue.fields.project.key}}") {
+		t.Error("customBody missing {{issue.fields.project.key}}")
+	}
+
+	headers, ok := val["headers"].([]interface{})
+	if !ok {
+		t.Fatal("headers is not an array")
+	}
+	if len(headers) != 3 {
+		t.Fatalf("headers len = %d, want 3", len(headers))
+	}
+	h0, _ := headers[0].(map[string]interface{})
+	if h0["name"] != "Authorization" {
+		t.Errorf("header[0].name = %v", h0["name"])
+	}
+	if !strings.HasPrefix(h0["value"].(string), "Bearer ghp_test123") {
+		t.Errorf("header[0].value = %v", h0["value"])
+	}
+}
+
+func TestSlashCommandRule_Structure(t *testing.T) {
+	rule := SlashCommandRule(testRC, "/fs-triage")
+
+	if rule.Rule.Name != "fullsend: /fs-triage command" {
+		t.Errorf("Name = %q", rule.Rule.Name)
+	}
+	if rule.Rule.State != "ENABLED" {
+		t.Errorf("State = %q", rule.Rule.State)
+	}
+	if rule.Rule.Actor == nil || rule.Rule.Actor.Actor != "abc-123" {
+		t.Error("Actor not set correctly")
+	}
+	if len(rule.Rule.RuleScopeARIs) != 1 {
+		t.Fatal("missing RuleScopeARIs")
+	}
+	if len(rule.Connections) != 0 {
+		t.Errorf("Connections should be empty, got %d", len(rule.Connections))
+	}
+}
+
+func TestSlashCommandRule_Trigger(t *testing.T) {
+	rule := SlashCommandRule(testRC, "/fs-triage")
+
+	tr := rule.Rule.Trigger
+	if tr.Type != TriggerCommentAdded {
+		t.Errorf("Trigger.Type = %q, want %q", tr.Type, TriggerCommentAdded)
+	}
+
+	var trigVal map[string]interface{}
+	if err := json.Unmarshal(tr.Value, &trigVal); err != nil {
+		t.Fatalf("unmarshal trigger value: %v", err)
+	}
+	filters, ok := trigVal["eventFilters"].([]interface{})
+	if !ok || len(filters) != 1 {
+		t.Fatalf("eventFilters = %v", trigVal["eventFilters"])
+	}
+}
+
+func TestSlashCommandRule_Condition(t *testing.T) {
+	rule := SlashCommandRule(testRC, "/fs-triage")
+
+	if len(rule.Rule.Components) != 2 {
+		t.Fatalf("Components len = %d, want 2", len(rule.Rule.Components))
+	}
+
+	cond := rule.Rule.Components[0]
+	if cond.Component != "CONDITION" {
+		t.Errorf("condition.Component = %q, want CONDITION", cond.Component)
+	}
+	if cond.Type != ConditionCompareValues {
+		t.Errorf("condition.Type = %q, want %q", cond.Type, ConditionCompareValues)
+	}
+
+	var condVal map[string]interface{}
+	if err := json.Unmarshal(cond.Value, &condVal); err != nil {
+		t.Fatalf("unmarshal condition value: %v", err)
+	}
+	if condVal["first"] != "{{comment.body}}" {
+		t.Errorf("first = %v", condVal["first"])
+	}
+	if condVal["second"] != "/fs-triage" {
+		t.Errorf("second = %v", condVal["second"])
+	}
+	if condVal["operator"] != "CONTAINS" {
+		t.Errorf("operator = %v", condVal["operator"])
+	}
+}
+
+func TestSlashCommandRule_Action(t *testing.T) {
+	rule := SlashCommandRule(testRC, "/fs-triage")
+
+	action := rule.Rule.Components[1]
+	if action.Component != "ACTION" {
+		t.Errorf("action.Component = %q, want ACTION", action.Component)
+	}
+	if action.Type != ActionSendWebRequest {
+		t.Errorf("action.Type = %q", action.Type)
+	}
+
+	var val map[string]interface{}
+	if err := json.Unmarshal(action.Value, &val); err != nil {
+		t.Fatalf("unmarshal action value: %v", err)
+	}
+	body, _ := val["customBody"].(string)
+	if !strings.Contains(body, "jira-command") {
+		t.Error("customBody missing jira-command")
+	}
+	if !strings.Contains(body, `"/fs-triage"`) {
+		t.Error("customBody missing /fs-triage command")
+	}
+}
+
+func TestSlashCommandRule_DifferentCommands(t *testing.T) {
+	for _, cmd := range []string{"/fs-triage", "/fs-prioritize", "/fs-code"} {
+		rule := SlashCommandRule(testRC, cmd)
+		if !strings.Contains(rule.Rule.Name, cmd) {
+			t.Errorf("rule name %q missing command %q", rule.Rule.Name, cmd)
+		}
+		var condVal map[string]interface{}
+		json.Unmarshal(rule.Rule.Components[0].Value, &condVal)
+		if condVal["second"] != cmd {
+			t.Errorf("condition second = %v, want %s", condVal["second"], cmd)
+		}
+	}
+}
+
+func TestWebhookURL(t *testing.T) {
+	url := webhookURL("org", "repo")
+	want := "https://api.github.com/repos/org/repo/dispatches"
+	if url != want {
+		t.Errorf("webhookURL = %q, want %q", url, want)
+	}
+}
+
+func TestRuleContext_ProjectARI(t *testing.T) {
+	rc := RuleContext{CloudID: "cloud-xyz", ProjectID: "99"}
+	ari := rc.projectARI()
+	want := "ari:cloud:jira:cloud-xyz:project/99"
+	if ari != want {
+		t.Errorf("projectARI = %q, want %q", ari, want)
+	}
+}
+
+func TestComponentTypeConstants(t *testing.T) {
+	tests := map[string]string{
+		"TriggerIssueCreated":    TriggerIssueCreated,
+		"TriggerCommentAdded":    TriggerCommentAdded,
+		"ConditionCompareValues": ConditionCompareValues,
+		"ActionSendWebRequest":   ActionSendWebRequest,
+	}
+	expected := map[string]string{
+		"TriggerIssueCreated":    "jira.issue.event.trigger:created",
+		"TriggerCommentAdded":    "jira.issue.event.trigger:commented",
+		"ConditionCompareValues": "jira.comparator.condition",
+		"ActionSendWebRequest":   "jira.issue.outgoing.webhook",
+	}
+	for name, got := range tests {
+		if got != expected[name] {
+			t.Errorf("%s = %q, want %q", name, got, expected[name])
+		}
+	}
+}
+
+func TestAutoTriageRule_FullJSON_IsValid(t *testing.T) {
+	rule := AutoTriageRule(testRC)
+	data, err := json.Marshal(rule)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var roundtrip CreateRuleRequest
+	if err := json.Unmarshal(data, &roundtrip); err != nil {
+		t.Fatalf("unmarshal roundtrip: %v", err)
+	}
+	if roundtrip.Rule.Name != RuleNameAutoTriage {
+		t.Errorf("roundtrip name = %q", roundtrip.Rule.Name)
+	}
+}
+
+func TestSlashCommandRule_FullJSON_IsValid(t *testing.T) {
+	rule := SlashCommandRule(testRC, "/fs-triage")
+	data, err := json.Marshal(rule)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var roundtrip CreateRuleRequest
+	if err := json.Unmarshal(data, &roundtrip); err != nil {
+		t.Fatalf("unmarshal roundtrip: %v", err)
+	}
+	if roundtrip.Rule.Name != "fullsend: /fs-triage command" {
+		t.Errorf("roundtrip name = %q", roundtrip.Rule.Name)
+	}
+	if len(roundtrip.Rule.Components) != 2 {
+		t.Errorf("roundtrip components len = %d", len(roundtrip.Rule.Components))
+	}
+}
+
+func TestManualRuleInstructions(t *testing.T) {
+	instructions := ManualRuleInstructions("myorg", "myrepo")
+
+	checks := []string{
+		"Rule 1: fullsend: auto-triage on issue creation",
+		"Rule 2: fullsend: /fs-triage command",
+		"https://api.github.com/repos/myorg/myrepo/dispatches",
+		"Work item created",
+		"Send web request",
+		"POST",
+		"jira-issue-created",
+		"jira-command",
+		"/fs-triage",
+		"{{issue.key}}",
+		"{{issue.fields.project.key}}",
+		"Comment added",
+		"{{comment.body}} contains /fs-triage",
+		"Bearer <your-github-pat>",
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(instructions, check) {
+			t.Errorf("instructions missing %q", check)
+		}
+	}
+}
+
+func TestManualRuleInstructions_DifferentRepo(t *testing.T) {
+	instructions := ManualRuleInstructions("acme", "widgets")
+	if !strings.Contains(instructions, "https://api.github.com/repos/acme/widgets/dispatches") {
+		t.Error("instructions should use the provided owner/repo")
+	}
+}
+
+func TestWebhookHeaders_HasThreeEntries(t *testing.T) {
+	headers := webhookHeaders("ghp_test")
+	var parsed []map[string]interface{}
+	if err := json.Unmarshal(headers, &parsed); err != nil {
+		t.Fatalf("unmarshal headers: %v", err)
+	}
+	if len(parsed) != 3 {
+		t.Fatalf("headers len = %d, want 3", len(parsed))
+	}
+	names := make([]string, len(parsed))
+	for i, h := range parsed {
+		names[i], _ = h["name"].(string)
+	}
+	if names[0] != "Authorization" || names[1] != "Accept" || names[2] != "Content-Type" {
+		t.Errorf("header names = %v", names)
+	}
+}

--- a/internal/jira/types.go
+++ b/internal/jira/types.go
@@ -1,0 +1,83 @@
+package jira
+
+import "encoding/json"
+
+// TenantInfo is the response from GET https://{host}/_edge/tenant_info.
+type TenantInfo struct {
+	CloudID string `json:"cloudId"`
+}
+
+// CreateRuleRequest is the top-level request body for creating a Jira
+// Automation rule.
+type CreateRuleRequest struct {
+	Rule        RulePayload      `json:"rule"`
+	Connections []RuleConnection `json:"connections,omitempty"`
+}
+
+// RuleActor identifies who the rule runs as.
+type RuleActor struct {
+	Type  string `json:"type"`
+	Actor string `json:"actor"`
+}
+
+// RulePayload describes a Jira Automation rule.
+type RulePayload struct {
+	Name                string          `json:"name"`
+	State               string          `json:"state"`
+	Description         string          `json:"description,omitempty"`
+	Actor               *RuleActor      `json:"actor,omitempty"`
+	AuthorAccountID     string          `json:"authorAccountId,omitempty"`
+	Trigger             RuleComponent   `json:"trigger"`
+	Components          []RuleComponent `json:"components"`
+	Labels              []string        `json:"labels,omitempty"`
+	NotifyOnError       string          `json:"notifyOnError,omitempty"`
+	WriteAccessType     string          `json:"writeAccessType,omitempty"`
+	RuleScopeARIs       []string        `json:"ruleScopeARIs,omitempty"`
+	CanOtherRuleTrigger bool            `json:"canOtherRuleTrigger"`
+}
+
+// RuleComponent represents a trigger, condition, or action in an
+// automation rule. The Type field is an internal Jira identifier
+// (e.g., "jira.issue.event.trigger:created") and Value is a
+// JSON-encoded configuration blob whose schema depends on Type.
+type RuleComponent struct {
+	Component         string          `json:"component"`
+	Type              string          `json:"type"`
+	Value             json.RawMessage `json:"value,omitempty"`
+	SchemaVersion     int             `json:"schemaVersion,omitempty"`
+	Children          []RuleComponent `json:"children,omitempty"`
+	Conditions        []RuleComponent `json:"conditions,omitempty"`
+	ConnectionID      *string         `json:"connectionId,omitempty"`
+	ParentID          *string         `json:"parentId,omitempty"`
+	ConditionParentID *string         `json:"conditionParentId,omitempty"`
+}
+
+// RuleConnection defines an external connection used by an automation
+// rule (e.g., for cross-product triggers).
+type RuleConnection struct {
+	ID                  string `json:"id"`
+	AccountID           string `json:"accountId,omitempty"`
+	ConnectionTargetKey string `json:"connectionTargetKey,omitempty"`
+	TargetConfigJSON    string `json:"targetConfigJson,omitempty"`
+	AuthType            string `json:"authType,omitempty"`
+}
+
+// CreateRuleResponse is returned by the Jira Automation API after
+// successfully creating a rule.
+type CreateRuleResponse struct {
+	RuleUUID string `json:"ruleUuid"`
+}
+
+// RuleSummary is a condensed view of a rule returned by the list
+// endpoint, used for idempotency checks.
+type RuleSummary struct {
+	ID    int    `json:"id"`
+	UUID  string `json:"uuid,omitempty"`
+	Name  string `json:"name"`
+	State string `json:"state"`
+}
+
+// ListRulesResponse wraps the response from the list rules endpoint.
+type ListRulesResponse struct {
+	Rules []RuleSummary `json:"rules,omitempty"`
+}

--- a/internal/scaffold/fullsend-repo/templates/jira-dispatch.yml
+++ b/internal/scaffold/fullsend-repo/templates/jira-dispatch.yml
@@ -1,0 +1,65 @@
+---
+name: Jira Dispatch
+
+on:
+  repository_dispatch:
+    types:
+      - jira-issue-created
+      - jira-command
+
+jobs:
+  route:
+    name: Route Jira Event
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Validate Jira enrollment
+        id: validate
+        env:
+          PROJECT_KEY: ${{ github.event.client_payload.project_key }}
+          ISSUE_KEY: ${{ github.event.client_payload.issue_key }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${PROJECT_KEY}" =~ ^[A-Z][A-Z0-9_]{0,9}$ ]]; then
+            echo "::error::Invalid project_key format: ${PROJECT_KEY}"
+            exit 1
+          fi
+          if [[ ! "${ISSUE_KEY}" =~ ^[A-Z][A-Z0-9_]{0,9}-[0-9]+$ ]]; then
+            echo "::error::Invalid issue_key format: ${ISSUE_KEY}"
+            exit 1
+          fi
+          CONFIG_FILE=".jira.yml"
+          if [[ ! -f "${CONFIG_FILE}" ]]; then
+            echo "::error::.jira.yml not found"
+            exit 1
+          fi
+          ENROLLED=$(PROJECT_KEY="${PROJECT_KEY}" python3 -c "
+          import os, yaml
+          key = os.environ['PROJECT_KEY']
+          with open('.jira.yml') as f:
+              cfg = yaml.safe_load(f)
+          projects = cfg.get('jira_projects', [])
+          keys = [p.get('project_key','') for p in projects]
+          print('true' if key in keys else 'false')
+          " 2>/dev/null || echo "false")
+          if [[ "${ENROLLED}" != "true" ]]; then
+            echo "::error::Jira project ${PROJECT_KEY} is not enrolled"
+            exit 1
+          fi
+          echo "project_key=${PROJECT_KEY}" >> "$GITHUB_OUTPUT"
+          echo "issue_key=${ISSUE_KEY}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Routing Jira event for ${PROJECT_KEY}: ${ISSUE_KEY}"
+
+      - name: Dispatch jira-triage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run jira-triage.yml \
+            --repo "${{ github.repository }}" \
+            -f issue_key="${{ steps.validate.outputs.issue_key }}" \
+            -f project_key="${{ steps.validate.outputs.project_key }}"

--- a/internal/scaffold/fullsend-repo/templates/jira-triage.yml
+++ b/internal/scaffold/fullsend-repo/templates/jira-triage.yml
@@ -1,0 +1,174 @@
+---
+name: Jira Triage
+
+permissions:
+  actions: write
+  contents: read
+  id-token: write
+  issues: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_key:
+        description: "Jira issue key (e.g., PROJ-123)"
+        required: true
+        type: string
+      project_key:
+        description: "Jira project key (e.g., PROJ)"
+        required: true
+        type: string
+
+concurrency:
+  group: fullsend-jira-triage-${{ inputs.project_key }}-${{ inputs.issue_key }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    name: Triage Jira Issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Checkout target repo
+        uses: actions/checkout@v6
+        with:
+          path: target-repo
+          persist-credentials: false
+
+      - name: Checkout upstream defaults
+        uses: actions/checkout@v6
+        with:
+          repository: fullsend-ai/fullsend
+          ref: v0
+          path: .defaults
+          sparse-checkout: |
+            .github/actions/
+            .github/scripts/
+            internal/scaffold/fullsend-repo/
+            action.yml
+
+      - name: Prepare workspace (upstream defaults + repo overrides)
+        run: |
+          set -euo pipefail
+          SRC=".defaults/internal/scaffold/fullsend-repo"
+          LAYERED_DIRS="agents skills schemas harness plugins policies scripts env"
+          for dir in ${LAYERED_DIRS}; do
+            if [[ -d "${SRC}/${dir}" ]]; then
+              mkdir -p "${dir}"
+              cp -r "${SRC}/${dir}/." "${dir}/"
+            fi
+          done
+          CUSTOM_BASE=".fullsend/customized"
+          for dir in ${LAYERED_DIRS}; do
+            if [[ -d "${CUSTOM_BASE}/${dir}" ]]; then
+              find "${CUSTOM_BASE}/${dir}" -type f ! -name '.gitkeep' -print0 \
+                | while IFS= read -r -d '' f; do
+                    rel="${f#"${CUSTOM_BASE}"/}"
+                    mkdir -p "$(dirname "${rel}")"
+                    cp "${f}" "${rel}"
+                  done
+            fi
+          done
+          mkdir -p .github/scripts
+          if [[ -f "${SRC}/.github/scripts/setup-agent-env.sh" ]]; then
+            cp "${SRC}/.github/scripts/setup-agent-env.sh" .github/scripts/setup-agent-env.sh
+          fi
+
+      - name: Validate Jira enrollment
+        id: validate
+        env:
+          PROJECT_KEY: ${{ inputs.project_key }}
+        run: |
+          set -euo pipefail
+          CONFIG_FILE=".jira.yml"
+          if [[ ! -f "${CONFIG_FILE}" ]]; then
+            echo "::error::.jira.yml not found"
+            exit 1
+          fi
+          ENROLLED=$(PROJECT_KEY="${PROJECT_KEY}" python3 -c "
+          import os, yaml
+          key = os.environ['PROJECT_KEY']
+          with open('.jira.yml') as f:
+              cfg = yaml.safe_load(f)
+          projects = cfg.get('jira_projects', [])
+          keys = [p.get('project_key','') for p in projects]
+          print('true' if key in keys else 'false')
+          " 2>/dev/null || echo "false")
+          if [[ "${ENROLLED}" != "true" ]]; then
+            echo "::error::Jira project ${PROJECT_KEY} is not enrolled"
+            exit 1
+          fi
+          echo "::notice::Jira project ${PROJECT_KEY} is enrolled"
+
+      - name: Extract Jira project config
+        id: jira-config
+        env:
+          PROJECT_KEY: ${{ inputs.project_key }}
+        run: |
+          set -euo pipefail
+          JIRA_HOST=$(PROJECT_KEY="${PROJECT_KEY}" python3 -c "
+          import os, yaml
+          key = os.environ['PROJECT_KEY']
+          with open('.jira.yml') as f:
+              cfg = yaml.safe_load(f)
+          projects = cfg.get('jira_projects', [])
+          for p in projects:
+              if p.get('project_key') == key:
+                  print(p.get('host', ''))
+                  break
+          ")
+          LINKED_REPOS=$(PROJECT_KEY="${PROJECT_KEY}" python3 -c "
+          import os, yaml
+          key = os.environ['PROJECT_KEY']
+          with open('.jira.yml') as f:
+              cfg = yaml.safe_load(f)
+          projects = cfg.get('jira_projects', [])
+          for p in projects:
+              if p.get('project_key') == key:
+                  print(' '.join(p.get('linked_github_repos', [])))
+                  break
+          ")
+          echo "jira_host=${JIRA_HOST}" >> "$GITHUB_OUTPUT"
+          echo "linked_repos=${LINKED_REPOS}" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.FULLSEND_GCP_WIF_PROVIDER }}
+          project_id: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+
+      - name: Prepare sandbox credentials
+        run: bash scripts/prepare-sandbox-credentials.sh
+
+      - name: Setup agent environment
+        env:
+          AGENT_PREFIX: TRIAGE_
+          TRIAGE_GH_TOKEN: ${{ github.token }}
+          TRIAGE_ISSUE_KEY: ${{ inputs.issue_key }}
+          TRIAGE_JIRA_HOST: ${{ steps.jira-config.outputs.jira_host }}
+          TRIAGE_LINKED_GITHUB_REPOS: ${{ steps.jira-config.outputs.linked_repos }}
+          TRIAGE_ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          TRIAGE_CLOUD_ML_REGION: ${{ vars.FULLSEND_GCP_REGION }}
+        run: bash .github/scripts/setup-agent-env.sh
+
+      - name: Run triage agent
+        uses: ./.defaults/
+        env:
+          TRIAGE_SOURCE: jira
+          GITHUB_ISSUE_URL: ""
+          LINKED_GITHUB_REPOS: ${{ steps.jira-config.outputs.linked_repos }}
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        with:
+          agent: triage
+          version: latest
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fullsend-triage-${{ inputs.issue_key }}
+          path: ${{ github.workspace }}/output

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -114,6 +114,16 @@ func PerRepoShimTemplate() ([]byte, error) {
 	return content.ReadFile("fullsend-repo/templates/shim-per-repo.yaml")
 }
 
+// JiraDispatchTemplate returns the Jira dispatch workflow template.
+func JiraDispatchTemplate() ([]byte, error) {
+	return content.ReadFile("fullsend-repo/templates/jira-dispatch.yml")
+}
+
+// JiraTriageTemplate returns the Jira triage workflow template.
+func JiraTriageTemplate() ([]byte, error) {
+	return content.ReadFile("fullsend-repo/templates/jira-triage.yml")
+}
+
 // CustomizedDirs returns the set of customized/ subdirectories
 // that should be scaffolded in a per-org .fullsend config repo.
 func CustomizedDirs() []string {


### PR DESCRIPTION
## Summary

Adds a new `fullsend jira enroll <owner/repo>` CLI command that automates connecting a Jira Cloud project to a GitHub repository's fullsend triage pipeline.

**Agents:** Uses the existing triage agent — no new agents are created. Jira source support is handled via the customization layer (`.fullsend/customized/`).

**Scope:** Triage only. Prioritize and code agents are deferred — prioritize lacks Jira-aware prompt/scripts, and code requires a repo-selection mechanism for the 1-Jira-project-to-N-repos pattern common in enterprise teams.

## What the command does

```
fullsend jira enroll <owner/repo> --jira-host <host> --project-key <KEY>
```

1. **Validates** the Jira project is accessible (`GET /rest/api/3/project/{key}`)
2. **Fetches** the Jira Cloud ID and current user account ID
3. **Creates/updates** `.jira.yml` enrollment config in the GitHub repo
4. **Creates Jira Automation rules** via the public Automation API (2 rules: auto-triage on issue creation + `/fs-triage` slash command)
5. **Commits** `jira-dispatch.yml` and `jira-triage.yml` workflow files to the repo
6. **Sets** `JIRA_HOST`, `JIRA_EMAIL`, `JIRA_API_TOKEN` as GitHub repo secrets

### Automation API limitation (AUTO-2120)

The [Jira Automation Rule Management API requires site admin](https://jira.atlassian.com/browse/AUTO-2120) for write operations, even though project admins can create rules via the Jira UI. When the API returns 403, the CLI gracefully falls back to printing pre-filled manual instructions with the exact rule configuration (webhook URLs, headers, payloads) so the user can create them in the Jira UI at **Space settings > Automation > Create flow**.

## Files changed

| File | Purpose |
|------|---------|
| `internal/jira/config.go` | `.jira.yml` parsing — `JiraConfig`, `AddProject` (idempotent), `HasProject` |
| `internal/jira/types.go` | Jira Automation REST API types (`CreateRuleRequest`, `RulePayload`, `RuleComponent`, `RuleActor`) |
| `internal/jira/client.go` | Jira API client — `GetCloudID`, `ValidateProject`, `GetCurrentUser`, `CreateAutomationRule`, `ListAutomationRules`, `RuleExistsByName` |
| `internal/jira/rules.go` | Automation rule builders — `AutoTriageRule`, `SlashCommandRule`, `ManualRuleInstructions`. Component types reverse-engineered from existing rules |
| `internal/jira/rules_test.go` | 20 tests covering rule structure, JSON roundtrip, parameterization |
| `internal/jira/client_test.go` | 22 tests with `httptest` mocks — success paths, error codes, malformed JSON |
| `internal/jira/config_test.go` | 7 tests — parsing, idempotency, round-trip |
| `internal/cli/jira.go` | `fullsend jira enroll` command — flags, credential resolution, execution flow, 403 fallback |
| `internal/cli/root.go` | Register `newJiraCmd()` |
| `internal/scaffold/scaffold.go` | `JiraDispatchTemplate()`, `JiraTriageTemplate()` helpers |
| `internal/scaffold/fullsend-repo/templates/jira-dispatch.yml` | Dispatch workflow — validates enrollment, routes to triage |
| `internal/scaffold/fullsend-repo/templates/jira-triage.yml` | Triage workflow — layers customizations, runs `fullsend run triage` with `TRIAGE_SOURCE=jira` |

## Design decisions

- **Follows `fullsend github` pattern** — `fullsend jira` is a parallel command group with the same cobra structure, `ui.Printer` output, and credential resolution cascade (flag → env → prompt)
- **Public Automation API** (`api.atlassian.com/automation/public/jira/{cloudId}/rest/v1/rule`) with Basic auth — confirmed by Atlassian support as the only supported auth method (OAuth is explicitly blocked)
- **Component types hardcoded** — `jira.issue.event.trigger:created`, `jira.issue.event.trigger:commented`, `jira.comparator.condition`, `jira.issue.outgoing.webhook` — discovered by reverse-engineering existing rules (Atlassian does not document these)
- **Idempotent** — `.jira.yml` skips existing projects, rule creation skips rules with matching names, `CreateOrUpdateFile` for config, `CreateRepoSecret` overwrites

## Test plan

- [x] `go test ./internal/jira/...` — 49 tests pass, 93.5% coverage
- [x] `go build ./cmd/fullsend/` — clean build
- [x] `fullsend jira enroll --help` — displays correct usage and flags
- [x] Input validation — rejects invalid project keys, URLs as hostnames, missing credentials
- [x] `--dry-run` — previews all steps without making changes
- [x] `--skip-workflows` — tested against live `stage-redhat.atlassian.net` with KFLUXINFRA project
- [x] 403 fallback — prints pre-filled manual instructions when Automation API returns 403
- [x] Pre-commit hooks — gofmt, go vet, actionlint, gitleaks, shellcheck, lychee all pass

## Out of scope (future work)

- Prioritize/code agent Jira support (needs Jira-aware prompts, pre/post scripts, repo-selection)
- `fullsend jira unenroll` / `fullsend jira status` subcommands
- Jira OAuth 2.0 / Forge app auth (currently static API token)
- Per-org Jira enrollment

🤖 Generated with [Claude Code](https://claude.com/claude-code)