### PR TITLE
docs(vision): frame autonomy as configurable per workflow

### DIFF
--- a/docs/vision.md
+++ b/docs/vision.md
@@ -35,7 +35,7 @@ The current bugfix workflow spans three phases. The remaining phases are planned
                 ***Feedback*** ◄─── Monitor ◄─────── Delivery
 ```
 
-**Current (bugfix workflow):** An issue reports a bug (***feedback***). An agent triages, implements a fix (***execution***), and validates it against tests and review (***verification***). Humans must set strategic intent and approve guardrails; the rest may be fully autonomous based on configuration.
+**Current (bugfix workflow):** An issue reports a bug (***feedback***). An agent triages, implements a fix (***execution***), and validates it against tests and review (***verification***). Humans must set strategic intent and approve guardrails; everything else may be fully autonomous based on configuration.
 
 **Planned:** Discovery (identifying what needs work from production signals and tech debt), refinement (scoping and decomposing work), prioritization (ordering the backlog), delivery (merge-to-production with graduated autonomy), and monitor (production observability feeding back into the loop).
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -2,12 +2,12 @@
 
 ## The goal
 
-A GitHub organization's repos operate with fully autonomous agents handling the routine software development lifecycle: issue triage, implementation, code review, testing, and merge-to-production. Humans participate at two points:
+Everything autonomous is the goal. A GitHub organization's repos operate with agents handling the full software development lifecycle: issue triage, implementation, code review, testing, and merge-to-production. Humans participate at two points:
 
 1. **Strategic intent** — defining what the system should do and become. Features, architecture, direction.
-2. **Guarded paths** — CODEOWNERS-enforced human approval for security-critical, API-changing, or architecturally significant code paths.
+2. **Guardrails** — CODEOWNERS-enforced human approval for security-critical, API-changing, or architecturally significant code paths.
 
-Everything else is autonomous.
+Getting there is incremental. Each phase and transition in the [agentic SDLC](#the-agentic-sdlc) can be configured — per workflow — as human-driven, agent-driven, or both. A bugfix workflow might run fully autonomously while a feature workflow keeps a human in the loop at refinement and review. Teams adopt at whatever pace builds confidence, shifting one phase at a time rather than flipping a giant switch.
 
 ## The agentic SDLC
 
@@ -35,7 +35,7 @@ The current bugfix workflow spans three phases. The remaining phases are planned
                 ***Feedback*** ◄─── Monitor ◄─────── Delivery
 ```
 
-**Current (bugfix workflow):** An issue reports a bug (***feedback***). An agent triages, implements a fix (***execution***), and validates it against tests and review (***verification***). Humans set strategic intent and approve guarded paths; everything else is autonomous.
+**Current (bugfix workflow):** An issue reports a bug (***feedback***). An agent triages, implements a fix (***execution***), and validates it against tests and review (***verification***). Humans must set strategic intent and approve guardrails; the rest may be fully autonomous based on configuration.
 
 **Planned:** Discovery (identifying what needs work from production signals and tech debt), refinement (scoping and decomposing work), prioritization (ordering the backlog), delivery (merge-to-production with graduated autonomy), and monitor (production observability feeding back into the loop).
 


### PR DESCRIPTION
## Summary

- Keeps "everything autonomous" as the lede
- Adds per-workflow configurability: each ASDLC phase can be human-driven, agent-driven, or both
- Frames adoption as incremental — teams shift one phase at a time as confidence grows

Incorporates feedback from Romain on the vision doc.

## Test plan

- [ ] Verify doc renders correctly on the website
- [ ] Review wording with Romain

🤖 Generated with [Claude Code](https://claude.com/claude-code)