### PR TITLE
feat(cutting-releases): add release highlights step

### DIFF
--- a/skills/cutting-releases/SKILL.md
+++ b/skills/cutting-releases/SKILL.md
@@ -114,7 +114,51 @@ gh run list --workflow=release.yml --limit=1
 Read [post-flight.md](post-flight.md) in this skill's directory and
 follow the post-flight verification procedure.
 
-### 9. Install the binary locally
+### 9. Write release highlights
+
+After post-flight confirms the release is published, write a short user-facing
+summary highlighting the changes that matter most to end users.
+
+1. **Gather the raw changelog.** Run `gh release view <tag> --json body -q .body`
+   to get the auto-generated release body.
+2. **Research the actual changes.** Do not rely on PR titles or one-line
+   summaries — they often undersell or misrepresent user impact. Launch an
+   `Agent` sub-agent to read the full body, diff, and comments of every merged
+   PR in the release (`gh pr view <number>`, `gh pr diff <number>`). The agent
+   should identify which changes affect user-visible behavior, CLI flags,
+   configuration, error messages, performance, or compatibility — and flag
+   anything that looks like a breaking change or notable upgrade, even if the
+   PR title doesn't say so.
+3. **Draft highlights.** Write one or more paragraphs of prose (not
+   bullet lists — use only one paragraph if only one is necessary)
+   focusing on *what changed for the user*, not internal refactors.
+   Bold the names of features or areas being discussed (e.g. **token mint**,
+   **`fullsend init`**). Use code fences where showing a command or config
+   snippet helps illustrate a change. Skip items that have no user-visible
+   effect. Full coverage of every change is a non-goal — clarity and impact
+   are the goals.
+4. **Present the draft to the user.** Use `AskUserQuestion` to show the
+   proposed highlights text and ask:
+
+   > Here are the draft release highlights I'd prepend to the release body.
+   > Edit freely or say "looks good" to proceed.
+
+5. **Prepend to the release.** Once confirmed (with any edits applied), fetch
+   the current release body, prepend the highlights separated by a horizontal
+   rule (`---`), and update the release:
+
+   ```
+   gh release edit <tag> --notes "$(cat <<'EOF'
+   <highlights>
+
+   ---
+
+   <existing body>
+   EOF
+   )"
+   ```
+
+### 10. Install the binary locally
 
 Use `AskUserQuestion` to ask where to install (default: `~/.local/bin/`),
 then run the install script using its repo-root-relative path:


### PR DESCRIPTION
## Summary

- Adds a new step 9 to the cutting-releases skill that writes user-facing release highlights
- Launches a sub-agent to research the full body, diff, and comments of every merged PR — not just titles
- Drafts prose paragraphs (not bullet lists) focused on end-user impact, with bold feature names and code fences
- Presents the draft for review/editing via AskUserQuestion before prepending to the release body
- Existing auto-generated changelog is preserved below a `---` separator

## Test plan

- [ ] Cut the next release using the skill and verify step 9 fires after post-flight
- [ ] Confirm the sub-agent reads PR diffs, not just titles
- [ ] Confirm the highlights text is prepended correctly via `gh release edit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)