### PR TITLE
fix(#3069): fall back to workspace scripts dir for script companions

### DIFF
--- a/internal/scaffold/fullsend-repo/scripts/post-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-code.sh
@@ -270,6 +270,32 @@ SCRIPT_DIR_POST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_SCRIPT="${SCRIPT_DIR_POST}/resolve-precommit-tools.py"
 INSTALL_SCRIPT="${SCRIPT_DIR_POST}/install-precommit-tools.sh"
 
+# Fallback: when this script is fetched as a single blob from a URL base,
+# BASH_SOURCE points to a temp dir with no siblings. The reusable workflow's
+# "Prepare workspace" step always materializes the full scripts/ directory
+# at ${GITHUB_WORKSPACE}/scripts/ (per-org) or ${GITHUB_WORKSPACE}/.fullsend/scripts/
+# (per-repo). Try those paths when the BASH_SOURCE-relative lookup misses.
+if [ ! -f "${RESOLVE_SCRIPT}" ] || [ ! -f "${INSTALL_SCRIPT}" ]; then
+  for _ws_candidate in "${GITHUB_WORKSPACE:-}/scripts" "${GITHUB_WORKSPACE:-}/.fullsend/scripts"; do
+    if [ -f "${_ws_candidate}/resolve-precommit-tools.py" ] \
+       && [ -f "${_ws_candidate}/install-precommit-tools.sh" ]; then
+      RESOLVE_SCRIPT="${_ws_candidate}/resolve-precommit-tools.py"
+      INSTALL_SCRIPT="${_ws_candidate}/install-precommit-tools.sh"
+      break
+    fi
+  done
+fi
+
+# Warn instead of silently skipping when the repo needs the auto-install but
+# the companions are missing everywhere (issue #3070) — a silent skip here
+# surfaces later as a confusing "Executable X not found" pre-commit failure.
+if [ -f .pre-commit-config.yaml ] \
+   && { [ ! -f "${RESOLVE_SCRIPT}" ] || [ ! -f "${INSTALL_SCRIPT}" ]; }; then
+  echo "::warning::Pre-commit tool auto-install skipped: companion scripts not found"
+  echo "::warning::Expected ${RESOLVE_SCRIPT} and ${INSTALL_SCRIPT}"
+  echo "::warning::Pre-commit hooks requiring system tools (e.g. lychee) may fail"
+fi
+
 if [ -f .pre-commit-config.yaml ] \
    && [ -f "${RESOLVE_SCRIPT}" ] \
    && [ -f "${INSTALL_SCRIPT}" ]; then

--- a/internal/scaffold/fullsend-repo/scripts/post-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/post-fix.sh
@@ -182,6 +182,32 @@ SCRIPT_DIR_POST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVE_SCRIPT="${SCRIPT_DIR_POST}/resolve-precommit-tools.py"
 INSTALL_SCRIPT="${SCRIPT_DIR_POST}/install-precommit-tools.sh"
 
+# Fallback: when this script is fetched as a single blob from a URL base,
+# BASH_SOURCE points to a temp dir with no siblings. The reusable workflow's
+# "Prepare workspace" step always materializes the full scripts/ directory
+# at ${GITHUB_WORKSPACE}/scripts/ (per-org) or ${GITHUB_WORKSPACE}/.fullsend/scripts/
+# (per-repo). Try those paths when the BASH_SOURCE-relative lookup misses.
+if [ ! -f "${RESOLVE_SCRIPT}" ] || [ ! -f "${INSTALL_SCRIPT}" ]; then
+  for _ws_candidate in "${GITHUB_WORKSPACE:-}/scripts" "${GITHUB_WORKSPACE:-}/.fullsend/scripts"; do
+    if [ -f "${_ws_candidate}/resolve-precommit-tools.py" ] \
+       && [ -f "${_ws_candidate}/install-precommit-tools.sh" ]; then
+      RESOLVE_SCRIPT="${_ws_candidate}/resolve-precommit-tools.py"
+      INSTALL_SCRIPT="${_ws_candidate}/install-precommit-tools.sh"
+      break
+    fi
+  done
+fi
+
+# Warn instead of silently skipping when the repo needs the auto-install but
+# the companions are missing everywhere (issue #3070) — a silent skip here
+# surfaces later as a confusing "Executable X not found" pre-commit failure.
+if [ -f .pre-commit-config.yaml ] \
+   && { [ ! -f "${RESOLVE_SCRIPT}" ] || [ ! -f "${INSTALL_SCRIPT}" ]; }; then
+  echo "::warning::Pre-commit tool auto-install skipped: companion scripts not found"
+  echo "::warning::Expected ${RESOLVE_SCRIPT} and ${INSTALL_SCRIPT}"
+  echo "::warning::Pre-commit hooks requiring system tools (e.g. lychee) may fail"
+fi
+
 if [ -f .pre-commit-config.yaml ] \
    && [ -f "${RESOLVE_SCRIPT}" ] \
    && [ -f "${INSTALL_SCRIPT}" ]; then
@@ -314,9 +340,18 @@ fi
 # ---------------------------------------------------------------------------
 export GH_TOKEN="${PUSH_TOKEN}"
 
-# Locate process-fix-result.py relative to this script.
+# Locate process-fix-result.py relative to this script, with workspace fallback.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROCESS_SCRIPT="${SCRIPT_DIR}/process-fix-result.py"
+
+if [ ! -f "${PROCESS_SCRIPT}" ]; then
+  for _ws_candidate in "${GITHUB_WORKSPACE:-}/scripts" "${GITHUB_WORKSPACE:-}/.fullsend/scripts"; do
+    if [ -f "${_ws_candidate}/process-fix-result.py" ]; then
+      PROCESS_SCRIPT="${_ws_candidate}/process-fix-result.py"
+      break
+    fi
+  done
+fi
 
 # Find fix-result.json in the output directory.
 # RUN_DIR is the original cwd (runDir = <outputBase>/<sandboxName>), saved

--- a/internal/scaffold/fullsend-repo/scripts/pre-code.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-code.sh
@@ -130,6 +130,32 @@ TARGET_REPO="${REPO_DIR:-${GITHUB_WORKSPACE:-}/target-repo}"
 RESOLVE_SCRIPT="${SCRIPT_DIR}/resolve-precommit-tools.py"
 INSTALL_SCRIPT="${SCRIPT_DIR}/install-precommit-tools.sh"
 
+# Fallback: when this script is fetched as a single blob from a URL base,
+# BASH_SOURCE points to a temp dir with no siblings. The reusable workflow's
+# "Prepare workspace" step always materializes the full scripts/ directory
+# at ${GITHUB_WORKSPACE}/scripts/ (per-org) or ${GITHUB_WORKSPACE}/.fullsend/scripts/
+# (per-repo). Try those paths when the BASH_SOURCE-relative lookup misses.
+if [ ! -f "${RESOLVE_SCRIPT}" ] || [ ! -f "${INSTALL_SCRIPT}" ]; then
+  for _ws_candidate in "${GITHUB_WORKSPACE:-}/scripts" "${GITHUB_WORKSPACE:-}/.fullsend/scripts"; do
+    if [ -f "${_ws_candidate}/resolve-precommit-tools.py" ] \
+       && [ -f "${_ws_candidate}/install-precommit-tools.sh" ]; then
+      RESOLVE_SCRIPT="${_ws_candidate}/resolve-precommit-tools.py"
+      INSTALL_SCRIPT="${_ws_candidate}/install-precommit-tools.sh"
+      break
+    fi
+  done
+fi
+
+# Warn instead of silently skipping when the repo needs the auto-install but
+# the companions are missing everywhere (issue #3070) — a silent skip here
+# surfaces later as a confusing "Executable X not found" pre-commit failure.
+if [ -f "${TARGET_REPO}/.pre-commit-config.yaml" ] \
+   && { [ ! -f "${RESOLVE_SCRIPT}" ] || [ ! -f "${INSTALL_SCRIPT}" ]; }; then
+  echo "::warning::Pre-commit tool auto-install skipped: companion scripts not found"
+  echo "::warning::Expected ${RESOLVE_SCRIPT} and ${INSTALL_SCRIPT}"
+  echo "::warning::Pre-commit hooks requiring system tools (e.g. lychee) may fail"
+fi
+
 if [ -f "${TARGET_REPO}/.pre-commit-config.yaml" ] \
    && [ -f "${RESOLVE_SCRIPT}" ] \
    && [ -f "${INSTALL_SCRIPT}" ]; then

--- a/internal/scaffold/fullsend-repo/scripts/pre-fix.sh
+++ b/internal/scaffold/fullsend-repo/scripts/pre-fix.sh
@@ -110,6 +110,32 @@ TARGET_REPO="${REPO_DIR:-${GITHUB_WORKSPACE:-}/target-repo}"
 RESOLVE_SCRIPT="${SCRIPT_DIR}/resolve-precommit-tools.py"
 INSTALL_SCRIPT="${SCRIPT_DIR}/install-precommit-tools.sh"
 
+# Fallback: when this script is fetched as a single blob from a URL base,
+# BASH_SOURCE points to a temp dir with no siblings. The reusable workflow's
+# "Prepare workspace" step always materializes the full scripts/ directory
+# at ${GITHUB_WORKSPACE}/scripts/ (per-org) or ${GITHUB_WORKSPACE}/.fullsend/scripts/
+# (per-repo). Try those paths when the BASH_SOURCE-relative lookup misses.
+if [ ! -f "${RESOLVE_SCRIPT}" ] || [ ! -f "${INSTALL_SCRIPT}" ]; then
+  for _ws_candidate in "${GITHUB_WORKSPACE:-}/scripts" "${GITHUB_WORKSPACE:-}/.fullsend/scripts"; do
+    if [ -f "${_ws_candidate}/resolve-precommit-tools.py" ] \
+       && [ -f "${_ws_candidate}/install-precommit-tools.sh" ]; then
+      RESOLVE_SCRIPT="${_ws_candidate}/resolve-precommit-tools.py"
+      INSTALL_SCRIPT="${_ws_candidate}/install-precommit-tools.sh"
+      break
+    fi
+  done
+fi
+
+# Warn instead of silently skipping when the repo needs the auto-install but
+# the companions are missing everywhere (issue #3070) — a silent skip here
+# surfaces later as a confusing "Executable X not found" pre-commit failure.
+if [ -f "${TARGET_REPO}/.pre-commit-config.yaml" ] \
+   && { [ ! -f "${RESOLVE_SCRIPT}" ] || [ ! -f "${INSTALL_SCRIPT}" ]; }; then
+  echo "::warning::Pre-commit tool auto-install skipped: companion scripts not found"
+  echo "::warning::Expected ${RESOLVE_SCRIPT} and ${INSTALL_SCRIPT}"
+  echo "::warning::Pre-commit hooks requiring system tools (e.g. lychee) may fail"
+fi
+
 if [ -f "${TARGET_REPO}/.pre-commit-config.yaml" ] \
    && [ -f "${RESOLVE_SCRIPT}" ] \
    && [ -f "${INSTALL_SCRIPT}" ]; then


### PR DESCRIPTION
## Summary
- Fixes pre-commit tool auto-install and fix-agent PR summaries silently failing once `pre-code.sh`/`pre-fix.sh`/`post-code.sh`/`post-fix.sh` are resolved from a URL base (e.g. `fullsend-ai/agents`) instead of the local scaffold checkout.
- Adds a workspace-directory fallback for companion-file lookup in the four scripts — no new CLI surface, no Go changes (per [review feedback](https://github.com/fullsend-ai/fullsend/pull/3393#issuecomment-4907084757), this replaces the earlier `fullsend postrun` subcommand approach).
- Warns instead of silently skipping when companions are missing everywhere, so the failure no longer surfaces only as a confusing `Executable X not found` at the pre-commit gate.

## Related Issue
Fixes #3069
Fixes #3070

## Root cause
The scripts locate their companions (`resolve-precommit-tools.py`, `install-precommit-tools.sh`, `process-fix-result.py`) next to `BASH_SOURCE[0]`. That worked while scripts lived in the local scaffold checkout, but the harness fetches URL-based scripts as single flat files into the content-addressed cache (`fetchBaseFile` in `internal/harness/compose.go`) with no sibling-file concept — so once `post-code.sh`/`post-fix.sh` moved to URL resolution, the sibling lookups silently missed and the whole install step was skipped.

The companions were never really "sibling files of an agent script": the reusable workflows' **"Prepare workspace"** step unconditionally materializes the full `scripts/` directory (with L1 org overrides applied) at a known workspace path on every job — `${GITHUB_WORKSPACE}/scripts/` (per-org) or `${GITHUB_WORKSPACE}/.fullsend/scripts/` (per-repo). Only the `BASH_SOURCE`-derived guess at where that copy lives was broken.

## Changes
`internal/scaffold/fullsend-repo/scripts/{pre-code,pre-fix,post-code,post-fix}.sh`:
- After the `BASH_SOURCE`-relative lookup, fall back to `${GITHUB_WORKSPACE}/scripts/` then `${GITHUB_WORKSPACE}/.fullsend/scripts/` (5 lookup sites: 4 pre-commit-install sections + `process-fix-result.py` in `post-fix.sh`). This is issue #3069's Option A, with one correction: `GITHUB_WORKSPACE` (absolute, always in the post-script env — `childScriptEnv` layers `runner_env` over the full process environment) instead of `FULLSEND_DIR`, whose per-repo value is the *relative* path `.fullsend` and would mis-resolve from the post-script's cwd (`runDir`).
- Emit `::warning::` when `.pre-commit-config.yaml` exists but the companions are missing after both lookups (#3070's proposed change).

Because the fallback executes the workspace copy, `resolve-precommit-tools.py` finds the L1-overridden `.pre-commit-tools.yaml` next to itself (`__file__`), so org registry overrides keep working from the cache path too.

## Testing
- [x] `bash -n` and `shellcheck` (via `make lint`) clean on all four scripts
- [x] Existing `pre-code-test.sh` / `post-code-test.sh` / `post-fix-test.sh` suites pass
- [x] Isolated smoke test of the fallback block in 5 scenarios: co-located siblings (no fallback taken), URL-cache + per-org (resolves `$GITHUB_WORKSPACE/scripts`), URL-cache + per-repo (resolves `$GITHUB_WORKSPACE/.fullsend/scripts`), companions missing everywhere (warning fires, graceful skip), `GITHUB_WORKSPACE` unset for local runs (safe via `:-`, no error)
- [ ] #3069 validation criteria 1–3 (live agent run auto-installing lychee from the cache path) require a post-merge workflow run

## Checklist
- [x] PR title follows Conventional Commits
- [x] Commits are signed off (DCO)
- [x] I wrote this contribution myself and can explain all changes in it

Note: this rework removes the sequencing dependency on a `fullsend` release — the companion `fullsend-ai/agents` PR no longer needs to wait for a new subcommand to ship, since `post-code.sh`/`post-fix.sh` fetched from `fullsend-ai/agents` will find the companions via the workspace fallback.