### PR TITLE
fix(#3396): propagate default allowlist to harness composition

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - 'eval/**'
       - 'internal/scaffold/**'
+      - 'internal/cli/run.go'
       - '.github/workflows/functional-tests.yml'
       - '.github/scripts/**'
   pull_request_target:
@@ -105,7 +106,7 @@ jobs:
               exit 0
             }
           fi
-          if echo "$FILES" | grep -qE '^eval/|^internal/scaffold/|^\.github/workflows/functional-tests\.yml$|^\.github/scripts/'; then
+          if echo "$FILES" | grep -qE '^eval/|^internal/scaffold/|^internal/cli/run\.go$|^\.github/workflows/functional-tests\.yml$|^\.github/scripts/'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             echo "::notice::No functional-test-relevant files changed — skipping tests"

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2691,6 +2691,11 @@ func resolveAgentSource(ctx context.Context, fullsendDir, agentName string, forg
 // but the caller must also propagate it so that downstream harness
 // composition (LoadWithBase → resolveBaseScripts) sees a consistent
 // allowlist. See #3396.
+//
+// This applies when OrgAllowlist is nil (no config.yaml, or config.yaml
+// omits allowed_remote_resources). An explicitly empty list ([]string{})
+// is left as-is to preserve deny-all semantics — orgs that want no remote
+// resources must write an explicit empty allowed_remote_resources: [].
 func propagateDefaultAllowlist(opts *harness.ComposeOpts) {
 	if opts.OrgAllowlist == nil {
 		opts.OrgAllowlist = config.DefaultAllowedRemoteResources()

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -271,6 +271,11 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 		composeOpts.SourceURL = fetchDeps[0].URL
 	}
 
+	// Propagate the default allowlist when no config.yaml provided one.
+	// tryAgentsRepoFallback defaults internally, but that local default
+	// wasn't reaching LoadWithBase → resolveBaseScripts. See #3396.
+	propagateDefaultAllowlist(&composeOpts)
+
 	// If the harness has a URL base and org config failed to load,
 	// load it strictly now so LoadWithBase gets a proper error path
 	// rather than an unhelpful "URL base requires allowed_remote_resources".
@@ -2678,6 +2683,18 @@ func resolveAgentSource(ctx context.Context, fullsendDir, agentName string, forg
 	}
 	printer.StepDone(fmt.Sprintf("Agent %s resolved from config (local path)", agent.Name))
 	return contained, nil, nil
+}
+
+// propagateDefaultAllowlist ensures composeOpts carries the default
+// allowed-remote-resources list when no org config supplied one.
+// tryAgentsRepoFallback applies this default internally for its own fetch,
+// but the caller must also propagate it so that downstream harness
+// composition (LoadWithBase → resolveBaseScripts) sees a consistent
+// allowlist. See #3396.
+func propagateDefaultAllowlist(opts *harness.ComposeOpts) {
+	if opts.OrgAllowlist == nil {
+		opts.OrgAllowlist = config.DefaultAllowedRemoteResources()
+	}
 }
 
 // tryAgentsRepoFallback attempts to resolve an agent from the default agents

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -269,12 +269,15 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	// field (ADR-0045 resource resolution for config-registered agents).
 	if len(fetchDeps) > 0 && fetchDeps[0].URL != "" {
 		composeOpts.SourceURL = fetchDeps[0].URL
-	}
 
-	// Propagate the default allowlist when no config.yaml provided one.
-	// tryAgentsRepoFallback defaults internally, but that local default
-	// wasn't reaching LoadWithBase → resolveBaseScripts. See #3396.
-	propagateDefaultAllowlist(&composeOpts)
+		// Propagate the default allowlist when the agents-repo fallback
+		// set SourceURL. tryAgentsRepoFallback defaults internally for
+		// its own fetch, but that local default wasn't reaching
+		// LoadWithBase → resolveBaseScripts. Scoped to the fallback
+		// path to preserve the deny-all contract for config-present
+		// harnesses with URL bases. See #3396.
+		propagateDefaultAllowlist(&composeOpts)
+	}
 
 	// If the harness has a URL base and org config failed to load,
 	// load it strictly now so LoadWithBase gets a proper error path

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3572,6 +3572,16 @@ post_script: scripts/post-triage.sh
 		SourceURL:     sourceURL,
 	}
 	propagateDefaultAllowlist(&opts)
+	assert.Equal(t, config.DefaultAllowedRemoteResources(), opts.OrgAllowlist,
+		"propagateDefaultAllowlist should set the default list")
+
+	// Verify the real default list covers the fallback URL shape.
+	// A future edit to DefaultAllowedRemoteResources() that drops the
+	// agents repo prefix would regress #3396 silently without this.
+	sampleURL := defaultAgentsRepoURLPrefix + strings.Repeat("a", 40) + "/scripts/pre-triage.sh"
+	assert.NotEmpty(t, harness.MatchingAllowedPrefixInList(sampleURL, config.DefaultAllowedRemoteResources()),
+		"DefaultAllowedRemoteResources must cover the agents repo fallback URL shape")
+
 	// Override allowlist to match test server (default points at github.com).
 	opts.OrgAllowlist = []string{srv.URL + "/"}
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3507,6 +3507,12 @@ func TestPropagateDefaultAllowlist(t *testing.T) {
 		propagateDefaultAllowlist(&opts)
 		assert.Equal(t, custom, opts.OrgAllowlist)
 	})
+
+	t.Run("explicit empty slice stays deny-all", func(t *testing.T) {
+		opts := harness.ComposeOpts{OrgAllowlist: []string{}}
+		propagateDefaultAllowlist(&opts)
+		assert.Empty(t, opts.OrgAllowlist, "explicit empty list must not be replaced with defaults")
+	})
 }
 
 func TestAgentsRepoFallback_LoadWithBase_NilAllowlist(t *testing.T) {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3493,3 +3493,90 @@ func TestRunAgent_StatusNotifierSetup(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "openshell")
 }
+
+func TestPropagateDefaultAllowlist(t *testing.T) {
+	t.Run("nil allowlist gets default", func(t *testing.T) {
+		opts := harness.ComposeOpts{}
+		propagateDefaultAllowlist(&opts)
+		assert.Equal(t, config.DefaultAllowedRemoteResources(), opts.OrgAllowlist)
+	})
+
+	t.Run("existing allowlist preserved", func(t *testing.T) {
+		custom := []string{"https://example.com/"}
+		opts := harness.ComposeOpts{OrgAllowlist: custom}
+		propagateDefaultAllowlist(&opts)
+		assert.Equal(t, custom, opts.OrgAllowlist)
+	})
+}
+
+func TestAgentsRepoFallback_LoadWithBase_NilAllowlist(t *testing.T) {
+	// Integration test for #3396: a URL-sourced harness (from agents-repo
+	// fallback) with pre_script/post_script must succeed when OrgAllowlist
+	// is populated via propagateDefaultAllowlist.
+	preScript := []byte("#!/bin/bash\necho pre")
+	postScript := []byte("#!/bin/bash\necho post")
+	fakeSHA := "abcdef1234567890abcdef1234567890abcdef12"
+
+	harnessContent := []byte(`role: triage
+slug: triage
+agent: agents/triage.md
+pre_script: scripts/pre-triage.sh
+post_script: scripts/post-triage.sh
+`)
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/"+fakeSHA+"/harness/triage.yaml":
+			_, _ = w.Write(harnessContent)
+		case r.URL.Path == "/"+fakeSHA+"/scripts/pre-triage.sh":
+			_, _ = w.Write(preScript)
+		case r.URL.Path == "/"+fakeSHA+"/scripts/post-triage.sh":
+			_, _ = w.Write(postScript)
+		case r.URL.Path == "/"+fakeSHA+"/agents/triage.md":
+			_, _ = w.Write([]byte("# triage agent"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	hostPort := strings.TrimPrefix(srv.URL, "https://")
+	hostname, port, _ := net.SplitHostPort(hostPort)
+	tlsCfg := srv.TLS.Clone()
+	tlsCfg.InsecureSkipVerify = true
+	policy := fetch.NewTestPolicy(tlsCfg, []string{hostname}, []string{port})
+
+	workDir := t.TempDir()
+	sourceURL := srv.URL + "/" + fakeSHA + "/harness/triage.yaml"
+
+	// Write harness locally (simulating the cache write from tryAgentsRepoFallback).
+	harnessDir := filepath.Join(workDir, "harness")
+	require.NoError(t, os.MkdirAll(harnessDir, 0o755))
+	harnessPath := filepath.Join(harnessDir, "triage.yaml")
+	require.NoError(t, os.WriteFile(harnessPath, harnessContent, 0o644))
+
+	// Without the fix: OrgAllowlist nil + SourceURL set → fails.
+	_, _, err := harness.LoadWithBase(context.Background(), harnessPath, harness.ComposeOpts{
+		WorkspaceRoot: workDir,
+		FetchPolicy:   policy,
+		SourceURL:     sourceURL,
+		// OrgAllowlist nil — reproduces the bug.
+	})
+	require.Error(t, err, "should fail with nil allowlist")
+	assert.Contains(t, err.Error(), "not in allowed_remote_resources")
+
+	// With the fix: propagateDefaultAllowlist sets the default → succeeds.
+	opts := harness.ComposeOpts{
+		WorkspaceRoot: workDir,
+		FetchPolicy:   policy,
+		SourceURL:     sourceURL,
+	}
+	propagateDefaultAllowlist(&opts)
+	// Override allowlist to match test server (default points at github.com).
+	opts.OrgAllowlist = []string{srv.URL + "/"}
+
+	h, _, err := harness.LoadWithBase(context.Background(), harnessPath, opts)
+	require.NoError(t, err, "should succeed with allowlist propagated")
+	assert.True(t, filepath.IsAbs(h.PreScript), "pre_script should be resolved to cache path")
+	assert.True(t, filepath.IsAbs(h.PostScript), "post_script should be resolved to cache path")
+}


### PR DESCRIPTION
## Summary

- Fix allowlist-default asymmetry introduced by PR #2947: `tryAgentsRepoFallback` defaulted `OrgAllowlist` internally for its own fetch but didn't propagate it into `composeOpts`, causing `LoadWithBase` → `resolveBaseScripts` → `fetchBaseFile` to reject pre_script/post_script URLs with "not in allowed_remote_resources"
- Add `propagateDefaultAllowlist()` in `runAgent` between `resolveAgentSource` and `LoadWithBase` to fill the default when no `config.yaml` supplied an allowlist
- Affects any install with no `config.yaml` (or one missing `allowed_remote_resources`) that relies on the agents-repo fallback — including fullsend's own CI

## Related Issue

Closes #3396

## Changes

- `internal/cli/run.go`: Add `propagateDefaultAllowlist()` and call it in `runAgent` after setting `SourceURL`
- `internal/cli/run_test.go`: Unit test for `propagateDefaultAllowlist` (nil → default, non-nil → preserved) and integration test confirming `LoadWithBase` succeeds with propagated allowlist but fails without

## Testing

- [x] Unit tests pass: `TestPropagateDefaultAllowlist`, `TestAgentsRepoFallback_LoadWithBase_NilAllowlist`
- [x] Integration test confirms the bug (nil allowlist → error) and the fix (propagated allowlist → success)
- [x] `go vet` clean
- [x] `make lint` clean
- [ ] CI `functional-tests` job should go green — the 4 triage eval cases that have been failing since PR #2947 merged

## Checklist

- [x] Tests added
- [x] Linter passes
- [x] Commit message follows COMMITS.md conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)