### PR TITLE
fix(skills): check open PRs for in-flight ADR numbers

### DIFF
--- a/skills/renumber-adr/SKILL.md
+++ b/skills/renumber-adr/SKILL.md
@@ -11,9 +11,9 @@ description: >-
 ## Overview
 
 When multiple PRs add ADRs concurrently, they may pick the same four-digit
-number. This skill detects collisions against the target branch and renumbers
-the ADR file, its internal title/heading, and every reference to it across the
-repository.
+number. This skill detects collisions against the target branch **and** against
+ADR numbers introduced by other open PRs, then renumbers the ADR file, its
+internal title/heading, and every reference to it across the repository.
 
 ## When to Use
 
@@ -55,14 +55,33 @@ For each new ADR file, extract its four-digit number from the filename
 (`NNNN-short-description.md`). Check whether any file with the same `NNNN`
 prefix exists on the target branch.
 
-If there are no collisions, report that all numbers are clear and stop.
+If there are no collisions with the target branch, continue to step 3 anyway —
+there may still be collisions with numbers claimed by other open PRs.
 
-### 3. Find the next available number
+### 3. Collect in-flight ADR numbers and check for collisions
 
-For each colliding ADR, determine the next available four-digit number.
-Consider both the target branch ADR files **and** other new ADR files in this
-branch (to avoid collisions among the branch's own ADRs). Pick the lowest
-unused number.
+Collect **all** taken ADR numbers from these three sources:
+
+1. **Target branch ADR files** (from step 2).
+2. **Other new ADR files in this branch** (to avoid collisions among the
+   branch's own ADRs).
+3. **ADR files introduced by other open PRs.** This is critical — multiple
+   PRs may be adding ADRs concurrently. Run the helper script to collect
+   every ADR number from open PRs targeting the same base branch:
+
+```bash
+bash skills/renumber-adr/scripts/inflight-adr-numbers.sh <target-branch>
+```
+
+   The script prints one four-digit number per line. If it produces no
+   output, there are no in-flight ADR numbers to worry about.
+
+Combine all three sets of taken numbers. For each new ADR in this branch,
+check whether its number appears in the combined set. If none of the new ADR
+numbers collide with any taken number, report that all numbers are clear and
+stop.
+
+For each colliding ADR, pick the lowest unused four-digit number.
 
 ### 4. Rename the file
 
@@ -127,5 +146,8 @@ After all renames and reference updates:
 - **Handle multiple ADRs.** If the branch adds several ADRs and more than one
   collides, renumber all of them before updating references (so cross-references
   among the new ADRs are correct).
+- **Check open PRs.** Always check ADR numbers introduced by other open PRs
+  targeting the same base branch. A number that is clear on the target branch
+  today may collide with another PR that merges first.
 - **Do not modify ADR content** beyond the number in the title and heading.
   Substantial ADR content is not rewritten once accepted; this skill only fixes numbering.

--- a/skills/renumber-adr/SKILL.md
+++ b/skills/renumber-adr/SKILL.md
@@ -70,11 +70,13 @@ Collect **all** taken ADR numbers from these three sources:
    every ADR number from open PRs targeting the same base branch:
 
 ```bash
-bash skills/renumber-adr/scripts/inflight-adr-numbers.sh <target-branch>
+bash skills/renumber-adr/scripts/inflight-adr-numbers.sh <target-branch> <current-pr-number>
 ```
 
-   The script prints one four-digit number per line. If it produces no
-   output, there are no in-flight ADR numbers to worry about.
+   Pass the current PR number so the script excludes it (avoiding
+   self-collision). The script prints one four-digit number per line.
+   If it produces no output, there are no in-flight ADR numbers to
+   worry about.
 
 Combine all three sets of taken numbers. For each new ADR in this branch,
 check whether its number appears in the combined set. If none of the new ADR

--- a/skills/renumber-adr/scripts/inflight-adr-numbers.sh
+++ b/skills/renumber-adr/scripts/inflight-adr-numbers.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# inflight-adr-numbers.sh — collect ADR numbers from open PRs targeting a branch.
+#
+# Usage: inflight-adr-numbers.sh [base-branch]
+#   base-branch  defaults to "main"
+#
+# Prints one four-digit ADR number per line, sorted and deduplicated.
+# Exit code is always 0 (no output means no in-flight ADR numbers found).
+
+set -euo pipefail
+
+base="${1:-main}"
+
+gh pr list --base "$base" --state open --json number --jq '.[].number' \
+  | while read -r pr; do
+      gh pr diff "$pr" --name-only 2>/dev/null
+    done \
+  | grep '^docs/ADRs/[0-9]\{4\}-' \
+  | sed 's|docs/ADRs/\([0-9]\{4\}\)-.*|\1|' \
+  | sort -u

--- a/skills/renumber-adr/scripts/inflight-adr-numbers.sh
+++ b/skills/renumber-adr/scripts/inflight-adr-numbers.sh
@@ -1,20 +1,29 @@
 #!/usr/bin/env bash
 # inflight-adr-numbers.sh — collect ADR numbers from open PRs targeting a branch.
 #
-# Usage: inflight-adr-numbers.sh [base-branch]
+# Usage: inflight-adr-numbers.sh [base-branch] [exclude-pr]
 #   base-branch  defaults to "main"
+#   exclude-pr   PR number to exclude (typically the current PR)
 #
 # Prints one four-digit ADR number per line, sorted and deduplicated.
 # Exit code is always 0 (no output means no in-flight ADR numbers found).
+#
+# Note: reports ADR numbers from all changed files (added, modified, deleted),
+# not just additions. This is intentionally conservative — the caller already
+# collects target-branch ADR numbers separately, so duplicates are harmless.
+#
+# Requires: gh CLI (authenticated).
 
 set -euo pipefail
 
 base="${1:-main}"
+exclude="${2:-}"
 
 gh pr list --base "$base" --state open --json number --jq '.[].number' \
   | while read -r pr; do
-      gh pr diff "$pr" --name-only 2>/dev/null
+      [ "$pr" = "$exclude" ] && continue
+      gh pr diff "$pr" --name-only 2>/dev/null || true
     done \
-  | grep '^docs/ADRs/[0-9]\{4\}-' \
+  | { grep '^docs/ADRs/[0-9]\{4\}-' || true; } \
   | sed 's|docs/ADRs/\([0-9]\{4\}\)-.*|\1|' \
   | sort -u


### PR DESCRIPTION
## Summary

- The renumber-adr skill now checks ADR numbers from all open PRs targeting the same base branch, not just the target branch itself. This prevents two PRs from independently picking the same number.
- Extracted the `gh pr list` + diff pipeline into a helper script (`skills/renumber-adr/scripts/inflight-adr-numbers.sh`) since the pipeline is non-trivial.
- Fixed step 2's early exit — it no longer stops if the target branch is clear, since open PRs may still claim the same number.

## Test plan

- [x] Ran `inflight-adr-numbers.sh main` — found 7 in-flight ADR numbers across open PRs (0024, 0038, 0044, 0057, 0065, 0066, 0068)
- [x] shellcheck passed via pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)