### PR TITLE
fix(config): always merge default allowed_remote_resources into loaded configs

### DIFF
--- a/docs/guides/user/customizing-agents.md
+++ b/docs/guides/user/customizing-agents.md
@@ -64,7 +64,9 @@ validation_loop:                     # script is required; these sub-fields are 
   feedback_mode: stderr          # "stderr", "stdout", or "exit_code" (optional)
 
 allowed_remote_resources:        # URL prefixes allowed for remote skills/agents/policies
-  - https://github.com/org/       # Resources must match a prefix to be fetched
+  - https://github.com/org/       # Omit field: first-party defaults apply automatically
+                                   # Non-empty list: your entries + first-party defaults appended
+                                   # Set to [] to deny all remote fetches (deny-all)
 allow_runtime_fetch: true         # Opt-in to runtime skill fetching (default: false)
 max_runtime_fetches: 10           # Max runtime fetch requests per run (1–1000, default: 10)
 

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/fullsend-ai/fullsend/internal/config"
 	"github.com/fullsend-ai/fullsend/internal/fetch"
 	"github.com/fullsend-ai/fullsend/internal/harness"
 	"github.com/fullsend-ai/fullsend/internal/lock"
@@ -173,7 +174,9 @@ func lockOneAgent(ctx context.Context, agentName, absFullsendDir, forgeFlag stri
 
 	orgConfigPath := filepath.Join(absFullsendDir, "config.yaml")
 	orgCfg := tryLoadOrgConfig(orgConfigPath, printer)
-	var orgAllowlist []string
+	// Fallback for absent config; EnsureDefaultAllowedRemoteResources
+	// handles the omitted-field case when a config is present.
+	orgAllowlist := config.DefaultAllowedRemoteResources()
 	if orgCfg != nil {
 		orgAllowlist = orgCfg.AllowedRemoteResources
 	}

--- a/internal/cli/orgconfig.go
+++ b/internal/cli/orgconfig.go
@@ -61,13 +61,16 @@ func tryLoadFullsendConfig(path string, printer *ui.Printer) *config.OrgConfig {
 			printer.StepWarn("Per-repo config malformed (remote resource allowlist unavailable): " + perRepoErr.Error())
 			return nil
 		}
-		return config.OrgConfigFromPerRepo(perRepo)
+		orgCfg := config.OrgConfigFromPerRepo(perRepo)
+		orgCfg.AllowedRemoteResources = config.EnsureDefaultAllowedRemoteResources(orgCfg.AllowedRemoteResources)
+		return orgCfg
 	}
 	cfg, parseErr := config.ParseOrgConfig(data)
 	if parseErr != nil {
 		printer.StepWarn("Org config malformed (remote resource allowlist unavailable): " + parseErr.Error())
 		return nil
 	}
+	cfg.AllowedRemoteResources = config.EnsureDefaultAllowedRemoteResources(cfg.AllowedRemoteResources)
 	return cfg
 }
 
@@ -97,13 +100,16 @@ func requireFullsendConfig(path string, printer *ui.Printer) (*config.OrgConfig,
 			printer.StepFail("Failed to parse per-repo config")
 			return nil, fmt.Errorf("parsing per-repo config: %w", perRepoErr)
 		}
-		return config.OrgConfigFromPerRepo(perRepo), nil
+		orgCfg := config.OrgConfigFromPerRepo(perRepo)
+		orgCfg.AllowedRemoteResources = config.EnsureDefaultAllowedRemoteResources(orgCfg.AllowedRemoteResources)
+		return orgCfg, nil
 	}
 	cfg, parseErr := config.ParseOrgConfig(data)
 	if parseErr != nil {
 		printer.StepFail("Failed to parse org config")
 		return nil, fmt.Errorf("parsing org config: %w", parseErr)
 	}
+	cfg.AllowedRemoteResources = config.EnsureDefaultAllowedRemoteResources(cfg.AllowedRemoteResources)
 	return cfg, nil
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -304,7 +304,9 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	// HasURLReferences will enforce its presence later if needed.
 	orgConfigPath := filepath.Join(absFullsendDir, "config.yaml")
 	orgCfg := tryLoadOrgConfig(orgConfigPath, printer)
-	var orgAllowlist []string
+	// Fallback for absent config; EnsureDefaultAllowedRemoteResources
+	// handles the omitted-field case when a config is present.
+	orgAllowlist := config.DefaultAllowedRemoteResources()
 	if orgCfg != nil {
 		orgAllowlist = orgCfg.AllowedRemoteResources
 	}
@@ -346,14 +348,6 @@ func runAgent(ctx context.Context, agentName, fullsendDir, outputBase, targetRep
 	// field (ADR-0045 resource resolution for config-registered agents).
 	if len(fetchDeps) > 0 && fetchDeps[0].URL != "" {
 		composeOpts.SourceURL = fetchDeps[0].URL
-
-		// Propagate the default allowlist when the agents-repo fallback
-		// set SourceURL. tryAgentsRepoFallback defaults internally for
-		// its own fetch, but that local default wasn't reaching
-		// LoadWithBase → resolveBaseScripts. Scoped to the fallback
-		// path to preserve the deny-all contract for config-present
-		// harnesses with URL bases. See #3396.
-		propagateDefaultAllowlist(&composeOpts)
 	}
 
 	// If the harness has a URL base and org config failed to load,
@@ -2829,23 +2823,6 @@ func resolveAgentSource(ctx context.Context, fullsendDir, agentName string, forg
 	return contained, nil, nil
 }
 
-// propagateDefaultAllowlist ensures composeOpts carries the default
-// allowed-remote-resources list when no org config supplied one.
-// tryAgentsRepoFallback applies this default internally for its own fetch,
-// but the caller must also propagate it so that downstream harness
-// composition (LoadWithBase → resolveBaseScripts) sees a consistent
-// allowlist. See #3396.
-//
-// This applies when OrgAllowlist is nil (no config.yaml, or config.yaml
-// omits allowed_remote_resources). An explicitly empty list ([]string{})
-// is left as-is to preserve deny-all semantics — orgs that want no remote
-// resources must write an explicit empty allowed_remote_resources: [].
-func propagateDefaultAllowlist(opts *harness.ComposeOpts) {
-	if opts.OrgAllowlist == nil {
-		opts.OrgAllowlist = config.DefaultAllowedRemoteResources()
-	}
-}
-
 // tryAgentsRepoFallback attempts to resolve an agent from the default agents
 // repository (fullsend-ai/agents) by fetching the latest harness from the
 // main branch. This is a transitional mechanism to support the extraction of
@@ -2868,9 +2845,6 @@ func tryAgentsRepoFallback(ctx context.Context, agentName string, forgeClient fo
 	}
 
 	allowlist := composeOpts.OrgAllowlist
-	if allowlist == nil {
-		allowlist = config.DefaultAllowedRemoteResources()
-	}
 
 	tagRef := "tags/" + config.DefaultUpstreamRef
 	tagSHA, err := forgeClient.GetRef(ctx, defaultAgentsRepoOwner, defaultAgentsRepoName, tagRef)

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -275,7 +275,12 @@ func TestTryLoadFullsendConfig_PerRepoFallback(t *testing.T) {
 	printer := ui.New(io.Discard)
 	cfg := tryLoadFullsendConfig(path, printer)
 	require.NotNil(t, cfg)
-	assert.Equal(t, []string{"https://example.com/"}, cfg.AllowedRemoteResources)
+	expected := []string{
+		"https://example.com/",
+		"https://raw.githubusercontent.com/fullsend-ai/fullsend/",
+		"https://raw.githubusercontent.com/fullsend-ai/agents/",
+	}
+	assert.Equal(t, expected, cfg.AllowedRemoteResources)
 	require.Len(t, cfg.Agents, 1)
 	assert.Equal(t, "lint", cfg.Agents[0].Name)
 	assert.Equal(t, []string{"triage"}, cfg.Defaults.Roles)
@@ -354,7 +359,12 @@ func TestRequireFullsendConfig_PerRepoFallback(t *testing.T) {
 	cfg, err := requireFullsendConfig(path, printer)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
-	assert.Equal(t, []string{"https://example.com/"}, cfg.AllowedRemoteResources)
+	expected := []string{
+		"https://example.com/",
+		"https://raw.githubusercontent.com/fullsend-ai/fullsend/",
+		"https://raw.githubusercontent.com/fullsend-ai/agents/",
+	}
+	assert.Equal(t, expected, cfg.AllowedRemoteResources)
 	assert.Equal(t, []string{"triage"}, cfg.Defaults.Roles)
 }
 
@@ -402,7 +412,53 @@ func TestTryLoadFullsendConfig_OrgConfig(t *testing.T) {
 	cfg := tryLoadFullsendConfig(path, printer)
 	require.NotNil(t, cfg)
 	assert.Equal(t, "github", cfg.Dispatch.Platform)
-	assert.Equal(t, []string{"https://example.com/"}, cfg.AllowedRemoteResources)
+	expected := []string{
+		"https://example.com/",
+		"https://raw.githubusercontent.com/fullsend-ai/fullsend/",
+		"https://raw.githubusercontent.com/fullsend-ai/agents/",
+	}
+	assert.Equal(t, expected, cfg.AllowedRemoteResources)
+}
+
+func TestTryLoadFullsendConfig_ExplicitEmptyAllowlist(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(
+		"version: \"1\"\ndispatch:\n  platform: github\nallowed_remote_resources: []\n",
+	), 0o644))
+
+	printer := ui.New(io.Discard)
+	cfg := tryLoadFullsendConfig(path, printer)
+	require.NotNil(t, cfg)
+	assert.Empty(t, cfg.AllowedRemoteResources, "explicit empty [] must preserve deny-all")
+}
+
+func TestTryLoadFullsendConfig_OmittedAllowlist(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(
+		"version: \"1\"\ndispatch:\n  platform: github\n",
+	), 0o644))
+
+	printer := ui.New(io.Discard)
+	cfg := tryLoadFullsendConfig(path, printer)
+	require.NotNil(t, cfg)
+	assert.Equal(t, config.DefaultAllowedRemoteResources(), cfg.AllowedRemoteResources,
+		"omitted field must get defaults")
+}
+
+func TestRequireFullsendConfig_ExplicitEmptyAllowlist(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(
+		"version: \"1\"\ndispatch:\n  platform: github\nallowed_remote_resources: []\n",
+	), 0o644))
+
+	printer := ui.New(io.Discard)
+	cfg, err := requireFullsendConfig(path, printer)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Empty(t, cfg.AllowedRemoteResources, "explicit empty [] must preserve deny-all")
 }
 
 func TestRequireFullsendConfig_PerRepoMalformed(t *testing.T) {
@@ -3648,31 +3704,20 @@ func TestIsOrgConfigData_HeaderlessOrgByStructure(t *testing.T) {
 	assert.True(t, isOrgConfigData(data))
 }
 
-func TestPropagateDefaultAllowlist(t *testing.T) {
-	t.Run("nil allowlist gets default", func(t *testing.T) {
-		opts := harness.ComposeOpts{}
-		propagateDefaultAllowlist(&opts)
-		assert.Equal(t, config.DefaultAllowedRemoteResources(), opts.OrgAllowlist)
-	})
-
-	t.Run("existing allowlist preserved", func(t *testing.T) {
-		custom := []string{"https://example.com/"}
-		opts := harness.ComposeOpts{OrgAllowlist: custom}
-		propagateDefaultAllowlist(&opts)
-		assert.Equal(t, custom, opts.OrgAllowlist)
-	})
-
-	t.Run("explicit empty slice stays deny-all", func(t *testing.T) {
-		opts := harness.ComposeOpts{OrgAllowlist: []string{}}
-		propagateDefaultAllowlist(&opts)
-		assert.Empty(t, opts.OrgAllowlist, "explicit empty list must not be replaced with defaults")
-	})
+func TestDefaultAllowlistCoversAgentsRepoFallback(t *testing.T) {
+	// Verify the default allowlist covers the agents repo fallback URL shape.
+	// A future edit to DefaultAllowedRemoteResources() that drops the
+	// agents repo prefix would regress #3396 silently without this.
+	sampleURL := defaultAgentsRepoURLPrefix + strings.Repeat("a", 40) + "/scripts/pre-triage.sh"
+	assert.NotEmpty(t, harness.MatchingAllowedPrefixInList(sampleURL, config.DefaultAllowedRemoteResources()),
+		"DefaultAllowedRemoteResources must cover the agents repo fallback URL shape")
 }
 
-func TestAgentsRepoFallback_LoadWithBase_NilAllowlist(t *testing.T) {
+func TestAgentsRepoFallback_LoadWithBase_DefaultAllowlist(t *testing.T) {
 	// Integration test for #3396: a URL-sourced harness (from agents-repo
 	// fallback) with pre_script/post_script must succeed when OrgAllowlist
-	// is populated via propagateDefaultAllowlist.
+	// carries the default allowlist (now always set via config loading or
+	// the nil-config fallback in runAgent).
 	preScript := []byte("#!/bin/bash\necho pre")
 	postScript := []byte("#!/bin/bash\necho post")
 	fakeSHA := "abcdef1234567890abcdef1234567890abcdef12"
@@ -3709,44 +3754,21 @@ post_script: scripts/post-triage.sh
 	workDir := t.TempDir()
 	sourceURL := srv.URL + "/" + fakeSHA + "/harness/triage.yaml"
 
-	// Write harness locally (simulating the cache write from tryAgentsRepoFallback).
 	harnessDir := filepath.Join(workDir, "harness")
 	require.NoError(t, os.MkdirAll(harnessDir, 0o755))
 	harnessPath := filepath.Join(harnessDir, "triage.yaml")
 	require.NoError(t, os.WriteFile(harnessPath, harnessContent, 0o644))
 
-	// Without the fix: OrgAllowlist nil + SourceURL set → fails.
-	_, _, err := harness.LoadWithBase(context.Background(), harnessPath, harness.ComposeOpts{
-		WorkspaceRoot: workDir,
-		FetchPolicy:   policy,
-		SourceURL:     sourceURL,
-		// OrgAllowlist nil — reproduces the bug.
-	})
-	require.Error(t, err, "should fail with nil allowlist")
-	assert.Contains(t, err.Error(), "not in allowed_remote_resources")
-
-	// With the fix: propagateDefaultAllowlist sets the default → succeeds.
+	// With the test server's URL in the allowlist, LoadWithBase succeeds.
 	opts := harness.ComposeOpts{
 		WorkspaceRoot: workDir,
 		FetchPolicy:   policy,
 		SourceURL:     sourceURL,
+		OrgAllowlist:  []string{srv.URL + "/"},
 	}
-	propagateDefaultAllowlist(&opts)
-	assert.Equal(t, config.DefaultAllowedRemoteResources(), opts.OrgAllowlist,
-		"propagateDefaultAllowlist should set the default list")
-
-	// Verify the real default list covers the fallback URL shape.
-	// A future edit to DefaultAllowedRemoteResources() that drops the
-	// agents repo prefix would regress #3396 silently without this.
-	sampleURL := defaultAgentsRepoURLPrefix + strings.Repeat("a", 40) + "/scripts/pre-triage.sh"
-	assert.NotEmpty(t, harness.MatchingAllowedPrefixInList(sampleURL, config.DefaultAllowedRemoteResources()),
-		"DefaultAllowedRemoteResources must cover the agents repo fallback URL shape")
-
-	// Override allowlist to match test server (default points at github.com).
-	opts.OrgAllowlist = []string{srv.URL + "/"}
 
 	h, _, err := harness.LoadWithBase(context.Background(), harnessPath, opts)
-	require.NoError(t, err, "should succeed with allowlist propagated")
+	require.NoError(t, err, "should succeed with allowlist set")
 	assert.True(t, filepath.IsAbs(h.PreScript), "pre_script should be resolved to cache path")
 	assert.True(t, filepath.IsAbs(h.PostScript), "post_script should be resolved to cache path")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -185,6 +185,34 @@ func DefaultAllowedRemoteResources() []string {
 	}
 }
 
+// EnsureDefaultAllowedRemoteResources returns a new slice with default
+// allowed-remote-resources prefixes merged into the provided list.
+// Nil input (field omitted from YAML) returns defaults alone.
+// An explicit empty slice (allowed_remote_resources: []) is returned
+// unchanged to preserve deny-all semantics. Non-empty input gets any
+// missing defaults appended (preserving the caller's original ordering).
+func EnsureDefaultAllowedRemoteResources(existing []string) []string {
+	if existing == nil {
+		return DefaultAllowedRemoteResources()
+	}
+	if len(existing) == 0 {
+		return existing
+	}
+	defaults := DefaultAllowedRemoteResources()
+	seen := make(map[string]bool, len(existing))
+	for _, e := range existing {
+		seen[e] = true
+	}
+	result := make([]string, len(existing))
+	copy(result, existing)
+	for _, d := range defaults {
+		if !seen[d] {
+			result = append(result, d)
+		}
+	}
+	return result
+}
+
 // DefaultAgentEntries computes default agent URL entries for the given
 // harness names at a specific commit SHA. Each entry is a pinned
 // raw.githubusercontent.com URL with an integrity hash.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1741,3 +1741,55 @@ func TestOrgConfigFromPerRepo(t *testing.T) {
 	assert.Nil(t, org.Repos)
 	assert.Empty(t, org.Dispatch.Platform)
 }
+
+func TestEnsureDefaultAllowedRemoteResources(t *testing.T) {
+	defaults := DefaultAllowedRemoteResources()
+
+	t.Run("nil input returns defaults", func(t *testing.T) {
+		result := EnsureDefaultAllowedRemoteResources(nil)
+		assert.Equal(t, defaults, result)
+	})
+
+	t.Run("explicit empty preserves deny-all", func(t *testing.T) {
+		result := EnsureDefaultAllowedRemoteResources([]string{})
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("custom entries preserved with defaults appended", func(t *testing.T) {
+		custom := []string{"https://example.com/foo/"}
+		result := EnsureDefaultAllowedRemoteResources(custom)
+		expected := []string{
+			"https://example.com/foo/",
+			"https://raw.githubusercontent.com/fullsend-ai/fullsend/",
+			"https://raw.githubusercontent.com/fullsend-ai/agents/",
+		}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("already has defaults produces no duplicates", func(t *testing.T) {
+		result := EnsureDefaultAllowedRemoteResources(defaults)
+		assert.Equal(t, defaults, result)
+	})
+
+	t.Run("partial overlap adds only missing default", func(t *testing.T) {
+		partial := []string{defaults[0], "https://example.com/bar/"}
+		result := EnsureDefaultAllowedRemoteResources(partial)
+		expected := []string{defaults[0], "https://example.com/bar/", defaults[1]}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		first := EnsureDefaultAllowedRemoteResources([]string{"https://example.com/"})
+		second := EnsureDefaultAllowedRemoteResources(first)
+		assert.Equal(t, first, second)
+	})
+
+	t.Run("does not mutate input", func(t *testing.T) {
+		input := []string{"https://example.com/"}
+		inputCopy := make([]string, len(input))
+		copy(inputCopy, input)
+		_ = EnsureDefaultAllowedRemoteResources(input)
+		assert.Equal(t, inputCopy, input)
+	})
+}


### PR DESCRIPTION
## Summary

- Add `MergeDefaultAllowedRemoteResources` to merge the two first-party URL prefixes (`fullsend-ai/fullsend` and `fullsend-ai/agents`) into every loaded config at the `orgconfig.go` loading layer
- When no config file exists, `run.go` and `lock.go` now initialize `orgAllowlist` to the defaults instead of nil
- Remove the narrow `propagateDefaultAllowlist` fix from PR #3425, which is superseded by this broader approach

## Context

Repos that omit `allowed_remote_resources` from their `config.yaml` (like `fullsend-playground/node-api`) hit `"URL not in allowed_remote_resources"` errors when the harness composition step tries to resolve relative resources (pre/post scripts) from URL-sourced harnesses. PR #3425 patched this narrowly on the agents-repo fallback path, but the root fix is to ensure the defaults are always present after config loading.

Failing run: https://github.com/fullsend-playground/node-api/actions/runs/28953629888/job/85906703438?pr=6
Related: #3396

## Test plan

- [x] `TestMergeDefaultAllowedRemoteResources` — 7 subtests covering nil, empty, custom, dedup, partial overlap, idempotency, no-mutation
- [x] Updated existing orgconfig loading tests to expect defaults merged in
- [x] `go test ./internal/config/... ./internal/cli/...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)