### PR TITLE
ci(dispatch): allow checkout@v7 fork PR checkout in all reusable workflows

### DIFF
--- a/.github/workflows/reusable-code.yml
+++ b/.github/workflows/reusable-code.yml
@@ -66,6 +66,13 @@ jobs:
     steps:
       - name: Checkout config repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # checkout@v7 blocks fork PR checkouts on pull_request_target by default.
+          # Safe here: only .fullsend/ config is read, no fork code is executed,
+          # and credentials are not persisted.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
       - name: Checkout upstream defaults
         # Keep in sync with --vendor marker paths (see internal/scaffold/vendorcontent.go VendoredMarkerPath).

--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -81,7 +81,13 @@ jobs:
       - name: Checkout caller repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # checkout@v7 blocks fork PR checkouts on pull_request_target by
+          # default. Safe here: only .fullsend/ config is read, no fork code
+          # is executed, and credentials are not persisted. Pin to base branch
+          # so kill-switch / role gating always reads trusted config.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
           sparse-checkout: .fullsend/config.yaml
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/reusable-fix.yml
+++ b/.github/workflows/reusable-fix.yml
@@ -83,6 +83,13 @@ jobs:
     steps:
       - name: Checkout config repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # checkout@v7 blocks fork PR checkouts on pull_request_target by default.
+          # Safe here: only .fullsend/ config is read, no fork code is executed,
+          # and credentials are not persisted.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
       - name: Checkout upstream defaults
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''

--- a/.github/workflows/reusable-prioritize.yml
+++ b/.github/workflows/reusable-prioritize.yml
@@ -68,6 +68,13 @@ jobs:
     steps:
       - name: Checkout config repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # checkout@v7 blocks fork PR checkouts on pull_request_target by default.
+          # Safe here: only .fullsend/ config is read, no fork code is executed,
+          # and credentials are not persisted.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
       - name: Checkout upstream defaults
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''

--- a/.github/workflows/reusable-retro.yml
+++ b/.github/workflows/reusable-retro.yml
@@ -64,6 +64,13 @@ jobs:
     steps:
       - name: Checkout config repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # checkout@v7 blocks fork PR checkouts on pull_request_target by default.
+          # Safe here: only .fullsend/ config is read, no fork code is executed,
+          # and credentials are not persisted.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
       - name: Checkout upstream defaults
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -65,6 +65,13 @@ jobs:
     steps:
       - name: Checkout config repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # checkout@v7 blocks fork PR checkouts on pull_request_target by default.
+          # Safe here: only .fullsend/ config is read, no fork code is executed,
+          # and credentials are not persisted.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
       - name: Checkout upstream defaults
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''

--- a/.github/workflows/reusable-triage.yml
+++ b/.github/workflows/reusable-triage.yml
@@ -65,6 +65,13 @@ jobs:
     steps:
       - name: Checkout config repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # checkout@v7 blocks fork PR checkouts on pull_request_target by default.
+          # Safe here: only .fullsend/ config is read, no fork code is executed,
+          # and credentials are not persisted.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
       - name: Checkout upstream defaults
         if: hashFiles('.defaults/action.yml', '.fullsend/.defaults/action.yml') == ''


### PR DESCRIPTION
## Summary
- `actions/checkout@v7` blocks fork PR head checkouts on `pull_request_target` unless `allow-unsafe-pr-checkout` is set
- The `github` context is inherited through `workflow_call` chains, so `github.event_name` is `pull_request_target` in every reusable workflow — not just the dispatch Route job where the failure was first observed
- The initial triage identified only `reusable-dispatch.yml`, but fixing just the dispatch would unblock routing only to have the stage workflow (review, triage, code, fix, retro, prioritize) fail at its own "Checkout config repository" step with the same error
- All 7 checkout steps are safe: they read only `.fullsend/` config files, no fork code is executed, and credentials are not persisted
- Follows the same pattern established in #2503 (e2e) and #2534 (functional-tests)

Fixes #3689

## Test plan
- [ ] Re-run fork PR dispatch on an enrolled repo (e.g. `openshift-pipelines/opc`); Route job and stage job both check out config successfully
- [ ] Verify non-fork PRs and push events are unaffected (`allow-unsafe-pr-checkout` expression evaluates to `false` outside `pull_request_target`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)