### PR TITLE
feat(code-agent): add gitsign for cryptographic commit signing

### DIFF
--- a/images/code/Containerfile
+++ b/images/code/Containerfile
@@ -49,6 +49,13 @@ RUN if command -v apt-get >/dev/null 2>&1; then \
 # env file overrides this with the OpenShell bundle if present.
 RUN git config --system http.sslCAInfo /etc/ssl/certs/ca-certificates.crt 2>/dev/null || true
 
+# Configure Git to use gitsign for commit signing (keyless signing via Sigstore).
+# This enables cryptographic verification of agent commits.
+RUN git config --system gpg.format x509 \
+    && git config --system gpg.x509.program gitsign \
+    && git config --system commit.gpgsign true \
+    && git config --system tag.gpgsign true
+
 # ---------------------------------------------------------------------------
 # Go toolchain — needed to compile and run tests in Go-based target repos.
 # Without this the agent falls back to manual code review (no `go build`,
@@ -93,6 +100,26 @@ RUN case "$TARGETARCH" in \
     && mv "/tmp/lychee-${LY_TRIPLE}/lychee" /usr/local/bin/lychee \
     && chmod +x /usr/local/bin/lychee \
     && rm -rf /tmp/lychee.tar.gz "/tmp/lychee-${LY_TRIPLE}"
+
+# ---------------------------------------------------------------------------
+# gitsign — keyless Git signing using Sigstore. Used to cryptographically
+# sign agent commits with verifiable provenance via OIDC.
+# To update: bump GITSIGN_VERSION and GITSIGN_SHA256_{AMD64,ARM64} from:
+#   https://github.com/sigstore/gitsign/releases
+ARG GITSIGN_VERSION=0.16.1
+ARG GITSIGN_SHA256_AMD64=4a29a1f4b9add1f0f6d9a3e9e6ba0cffa121b971be82d62bb1496d7d1d877b0a
+ARG GITSIGN_SHA256_ARM64=66eb0378608c8fbceb497eecb58a525345549f46e9588616daa0f157624f33b4
+RUN case "$TARGETARCH" in \
+      amd64) GS_SHA="$GITSIGN_SHA256_AMD64" ;; \
+      arm64) GS_SHA="$GITSIGN_SHA256_ARM64" ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL \
+      "https://github.com/sigstore/gitsign/releases/download/v${GITSIGN_VERSION}/gitsign_${GITSIGN_VERSION}_linux_${TARGETARCH}" \
+      -o /tmp/gitsign \
+    && echo "${GS_SHA}  /tmp/gitsign" | sha256sum -c - \
+    && mv /tmp/gitsign /usr/local/bin/gitsign \
+    && chmod +x /usr/local/bin/gitsign
 
 # ---------------------------------------------------------------------------
 # gitleaks is already installed in the base sandbox image.


### PR DESCRIPTION
## Summary
Add gitsign (Sigstore keyless signing) to the code agent sandbox image to enable cryptographic commit signing. This provides verifiable proof of commit provenance using GitHub Actions OIDC tokens, allowing agent commits to pass repository signature verification requirements.

## Related Issue
https://github.com/fullsend-ai/fullsend/issues/1685

## Changes
- Install gitsign v0.16.1 binary with SHA256 verification for both amd64 and arm64 architectures
- Configure Git system-wide to use gitsign with x509 format (`gpg.format=x509`, `gpg.x509.program=gitsign`)
- Enable commit and tag signing by default (`commit.gpgsign=true`, `tag.gpgsign=true`)

## Testing
- [x] `make lint` passes (stage changes first, then run)
- [ ] Tests added/updated for new or modified logic
- [ ] Manual testing: Build image locally and verify gitsign is installed and configured
- [ ] Integration testing: Test with https://github.com/ansible-automation-platform/at-at-fullsend-test (repo requiring signed commits)

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it

## Additional Notes
This PR only covers the gitsign installation and Git configuration in the container image. The corresponding OIDC environment variables (`GITSIGN_CONNECTOR_ID`, `GITSIGN_TOKEN_PROVIDER`, `GITSIGN_REKOR_MODE`) are configured in the companion PR to the agents repository.

**Testing plan:** After this PR is merged, the `sandbox-images.yml` workflow will build and push the image with the SHA tag. I can then reference this SHA-tagged image in the test repository to verify commits are properly signed before creating the companion PR for the agents repo.
