### PR TITLE
feat(repos)!: add repos diff and repos sync CLI commands

### DIFF
--- a/docs/ADRs/0057-repos-management.md
+++ b/docs/ADRs/0057-repos-management.md
@@ -133,6 +133,4 @@ Implemented subcommands:
 - `repos status` — PR #4079
 - `repos add`, `repos remove`, `repos uninstall` — PR #4081
 - `repos upgrade`, `repos upgrade-mint` — PR #4080
-
-Remaining subcommands (`repos sync`, `repos diff`) are tracked in the
-[repos management plan](../plans/repos-management.md).
+- `repos diff`, `repos sync` — PR #4079

--- a/docs/cli/repos.md
+++ b/docs/cli/repos.md
@@ -16,6 +16,8 @@ Manage per-repo installations across multiple orgs via a declarative `repos.yaml
 | `fullsend repos remove <repos...>` | Remove repo entries from a repos.yaml manifest |
 | `fullsend repos uninstall <repos...>` | Tear down fullsend from specific repos |
 | `fullsend repos status` | Compare manifest against actual repo state |
+| `fullsend repos diff` | Show configuration drift between manifest and actual state |
+| `fullsend repos sync` | Reconcile configuration drift for installed repos |
 | `fullsend repos upgrade [repos...]` | Upgrade scaffold shim ref across repos |
 | `fullsend repos upgrade-mint` | Verify the token mint deployment matches the manifest |
 
@@ -158,6 +160,85 @@ The command returns a non-zero exit code when any repo has drift, is not install
 ### Authentication
 
 Requires a GitHub token via `GH_TOKEN`, `GITHUB_TOKEN`, or `gh auth token`.
+
+## `repos diff`
+
+Show configuration drift between the `repos.yaml` manifest and actual forge state. Only examines repos that are already installed (guard variable is `"true"`).
+
+```bash
+fullsend repos diff
+fullsend repos diff -f path/to/repos.yaml
+fullsend repos diff --repo owner/repo1 --repo owner/repo2
+fullsend repos diff --json
+```
+
+### Flags
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--manifest` | `-f` | `repos.yaml` | Path or HTTPS URL to manifest file |
+| `--json` | | `false` | Emit JSON output instead of table |
+| `--repo` | | | Filter to specific repos (repeatable) |
+| `--concurrency` | | `8` | Max parallel API calls |
+
+### JSON output
+
+With `--json`, returns a `DiffResult` object:
+
+```json
+{
+  "changes": [
+    {"owner": "acme", "repo": "api", "field": "FULLSEND_MINT_URL", "type": "variable", "action": "update", "old_value": "...", "new_value": "..."}
+  ],
+  "warnings": ["acme/web: not installed (guard variable missing) — run `repos install`"]
+}
+```
+
+### Exit codes
+
+Returns a non-zero exit code when drift exists (variables differ from manifest or secrets are missing). This makes it suitable for CI drift checks.
+
+## `repos sync`
+
+Reconcile configuration drift for installed repos by writing variables and secrets to match the manifest's desired state. Variables are only written when drift is detected; secrets are always written for convergence since their values cannot be read back.
+
+```bash
+fullsend repos sync
+fullsend repos sync -f repos.yaml --dry-run
+fullsend repos sync --repo acme/api --repo acme/web
+fullsend repos sync --json
+```
+
+### Flags
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--manifest` | `-f` | `repos.yaml` | Path or HTTPS URL to manifest file |
+| `--dry-run` | | `false` | Preview changes without applying them |
+| `--json` | | `false` | Emit JSON output instead of table |
+| `--repo` | | | Filter to specific repos (repeatable) |
+| `--concurrency` | | `4` | Max parallel operations (1-32) |
+
+### JSON output
+
+With `--json`, the output schema depends on mode:
+
+- **`sync --dry-run --json`** — returns a `DiffResult` (same schema as `repos diff --json`)
+- **`sync --json`** — returns a `SyncResult`:
+
+```json
+{
+  "applied": [
+    {"owner": "acme", "repo": "api", "field": "FULLSEND_MINT_URL", "type": "variable", "action": "update", "old_value": "...", "new_value": "..."}
+  ],
+  "failed": 0,
+  "warnings": []
+}
+```
+
+### Scope
+
+Sync reconciles variables (`FULLSEND_MINT_URL`, `FULLSEND_GCP_REGION`) and secrets (`FULLSEND_GCP_PROJECT_ID`). It does **not** touch scaffold shim version (`@ref`) or harness files — use `repos upgrade` for those.
 
 ## `repos add`
 

--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -76,6 +76,17 @@ fullsend
 │   │   ├── --skip-wif-cleanup               #   Skip GCP WIF provider deletion
 │   │   └── --concurrency <int>              #   Max parallel operations (1-32, default: 4)
 │   ├── status                               # Compare manifest against actual repo state
+│   ├── diff                                 # Show configuration drift between manifest and actual state
+│   │   ├── -f, --manifest <path>            #   Path or URL to repos.yaml (default: repos.yaml)
+│   │   ├── --json                           #   Emit JSON output instead of table
+│   │   ├── --repo <owner/repo>              #   Filter to specific repos (repeatable)
+│   │   └── --concurrency <int>              #   Max parallel API calls (default: 8)
+│   ├── sync                                 # Reconcile configuration drift for installed repos
+│   │   ├── -f, --manifest <path>            #   Path or URL to repos.yaml (default: repos.yaml)
+│   │   ├── --dry-run                        #   Preview changes without applying them
+│   │   ├── --json                           #   Emit JSON output instead of table
+│   │   ├── --repo <owner/repo>              #   Filter to specific repos (repeatable)
+│   │   └── --concurrency <int>              #   Max parallel operations (1-32, default: 4)
 │   ├── upgrade        [repos...]            # Upgrade scaffold shim ref across repos
 │   │   ├── -f, --manifest <path>            #   Path or URL to repos.yaml (default: repos.yaml)
 │   │   ├── --ref <version>                  #   Override manifest fullsend_ref for all repos

--- a/docs/guides/getting-started/operations.md
+++ b/docs/guides/getting-started/operations.md
@@ -83,6 +83,8 @@ For organizations that separate GCP and GitHub responsibilities across teams, fu
 | Fleet Admin | `fullsend repos remove <repos...>` | Remove repo entries from `repos.yaml` manifest (with optional `--uninstall`) |
 | Platform Admin | `fullsend repos uninstall <repos...>` | Tear down fullsend from repos (workflow, variables, secrets, WIF) without modifying manifest |
 | Fleet Admin | `fullsend repos status` | Compare `repos.yaml` manifest against actual per-repo state (drift detection) |
+| Fleet Admin | `fullsend repos diff` | Show configuration drift between manifest and actual forge state |
+| Platform Admin | `fullsend repos sync` | Reconcile configuration drift for installed repos (variables and secrets) |
 | Platform Admin | `fullsend repos upgrade [repos...]` | Upgrade scaffold shim ref across manifest repos |
 | Platform Admin | `fullsend repos upgrade-mint` | Verify the token mint deployment matches the manifest |
 

--- a/docs/plans/repos-management.md
+++ b/docs/plans/repos-management.md
@@ -203,12 +203,12 @@ Reconciles configuration drift for installed repos.
 |----------|--------|
 | `FULLSEND_MINT_URL` variable | Upsert to match manifest `mint.url` |
 | `FULLSEND_GCP_REGION` variable | Upsert to match resolved `inference_region` |
-| `FULLSEND_PER_REPO_INSTALL` variable | Ensure set to `"true"` |
 | `FULLSEND_GCP_PROJECT_ID` secret | Upsert to match resolved `inference_project` |
 
-Sync does **not** touch scaffold shim version (managed by `upgrade`)
-or harness files (managed via ADR 0045's `base` composition). Warns
-about repos with `FULLSEND_PER_REPO_INSTALL=true` not in the manifest.
+Sync does **not** touch scaffold shim version (managed by `upgrade`),
+harness files (managed via ADR 0045's `base` composition), or the
+`FULLSEND_PER_REPO_INSTALL` guard variable (managed exclusively by
+`repos install` — sync skips repos where the guard is not `"true"`).
 
 #### `fullsend repos upgrade`
 
@@ -968,7 +968,7 @@ call ordering via recorded method calls.
 
 ---
 
-### PR 6: `fullsend repos sync` + `fullsend repos diff`
+### PR 6: `fullsend repos sync` + `fullsend repos diff` — PR #4079
 
 **Scope:** New CLI commands. Writes variables/secrets.
 

--- a/internal/cli/repos.go
+++ b/internal/cli/repos.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -35,6 +36,8 @@ managing fullsend across many repositories and organizations.`,
 	cmd.AddCommand(newReposInstallCmd())
 	cmd.AddCommand(newReposUninstallCmd())
 	cmd.AddCommand(newReposStatusCmd())
+	cmd.AddCommand(newReposDiffCmd())
+	cmd.AddCommand(newReposSyncCmd())
 	cmd.AddCommand(newReposUpgradeCmd())
 	cmd.AddCommand(newReposUpgradeMintCmd())
 	return cmd
@@ -853,6 +856,10 @@ func runReposUninstall(ctx context.Context, opts *reposUninstallConfig, repoArgs
 		client = newGitHubLiveClient(token)
 	}
 
+	if err := checkPerRepoScopes(ctx, client, printer); err != nil {
+		return err
+	}
+
 	provFactory := buildProvisionerFactory(opts.testProvisioner, opts.skipWIFCleanup)
 
 	cfg := repos.UninstallConfig{
@@ -1009,6 +1016,210 @@ func (s *splitProjectAdapter) DeletePerRepoWIF(ctx context.Context, repo string)
 
 func (s *splitProjectAdapter) DeleteWIFProvider(ctx context.Context, repo string) error {
 	return s.inference.DeleteWIFProvider(ctx, repo)
+}
+
+type reposDiffConfig struct {
+	manifest    string
+	repoFilter  []string
+	jsonOutput  bool
+	concurrency int
+
+	testClient forge.Client
+	out        io.Writer
+}
+
+func newReposDiffCmd() *cobra.Command {
+	opts := &reposDiffConfig{}
+
+	cmd := &cobra.Command{
+		Use:   "diff",
+		Short: "Show configuration drift between manifest and actual state",
+		Long:  "Compare the repos.yaml manifest against actual forge state and display the changes needed to reconcile. Exit code 1 signals drift exists.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReposDiff(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.manifest, "manifest", "f", "repos.yaml", "path or HTTPS URL to manifest file")
+	cmd.Flags().StringArrayVar(&opts.repoFilter, "repo", nil, "filter to specific repos (repeatable)")
+	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit JSON output instead of table")
+	cmd.Flags().IntVar(&opts.concurrency, "concurrency", 8, "max parallel API calls")
+
+	return cmd
+}
+
+func runReposDiff(ctx context.Context, opts *reposDiffConfig) error {
+	out := opts.out
+	if out == nil {
+		out = os.Stdout
+	}
+	printerOut := out
+	if opts.jsonOutput {
+		printerOut = io.Discard
+	}
+	printer := ui.New(printerOut)
+
+	var client forge.Client
+	if opts.testClient != nil {
+		client = opts.testClient
+	} else {
+		token, err := resolveToken()
+		if err != nil {
+			return err
+		}
+		client = newGitHubLiveClient(token)
+	}
+
+	if err := checkPerRepoScopes(ctx, client, printer); err != nil {
+		return err
+	}
+
+	m, err := repos.LoadManifest(ctx, opts.manifest)
+	if err != nil {
+		return err
+	}
+	if err := m.Validate(); err != nil {
+		return fmt.Errorf("manifest validation failed: %w", err)
+	}
+
+	result, err := repos.Diff(ctx, m, client, opts.concurrency, opts.repoFilter)
+	if err != nil {
+		return err
+	}
+
+	if opts.jsonOutput {
+		b, marshalErr := json.MarshalIndent(result, "", "  ")
+		if marshalErr != nil {
+			return fmt.Errorf("marshalling JSON: %w", marshalErr)
+		}
+		fmt.Fprintln(out, string(b))
+	} else {
+		fmt.Fprint(out, repos.FormatDiffTable(result))
+	}
+
+	if len(result.Changes) > 0 {
+		return fmt.Errorf("%d changes needed to reconcile manifest", len(result.Changes))
+	}
+	return nil
+}
+
+type reposSyncConfig struct {
+	manifest    string
+	repoFilter  []string
+	dryRun      bool
+	jsonOutput  bool
+	concurrency int
+
+	testClient forge.Client
+	out        io.Writer
+}
+
+func newReposSyncCmd() *cobra.Command {
+	opts := &reposSyncConfig{}
+
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Reconcile configuration drift for installed repos",
+		Long:  "Apply variable and secret changes to reconcile installed repos with the manifest. Use --dry-run to preview changes without applying them.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReposSync(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.manifest, "manifest", "f", "repos.yaml", "path or HTTPS URL to manifest file")
+	cmd.Flags().StringArrayVar(&opts.repoFilter, "repo", nil, "filter to specific repos (repeatable)")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "preview changes without applying them")
+	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit JSON output instead of table")
+	cmd.Flags().IntVar(&opts.concurrency, "concurrency", 4, "max parallel operations (1-32)")
+
+	return cmd
+}
+
+func runReposSync(ctx context.Context, opts *reposSyncConfig) error {
+	out := opts.out
+	if out == nil {
+		out = os.Stdout
+	}
+	printerOut := out
+	if opts.jsonOutput {
+		printerOut = io.Discard
+	}
+	printer := ui.New(printerOut)
+
+	var client forge.Client
+	if opts.testClient != nil {
+		client = opts.testClient
+	} else {
+		token, err := resolveToken()
+		if err != nil {
+			return err
+		}
+		client = newGitHubLiveClient(token)
+	}
+
+	if err := checkPerRepoScopes(ctx, client, printer); err != nil {
+		return err
+	}
+
+	m, err := repos.LoadManifest(ctx, opts.manifest)
+	if err != nil {
+		return err
+	}
+	if err := m.Validate(); err != nil {
+		return fmt.Errorf("manifest validation failed: %w", err)
+	}
+
+	if opts.dryRun {
+		result, diffErr := repos.Diff(ctx, m, client, opts.concurrency, opts.repoFilter)
+		if diffErr != nil {
+			return diffErr
+		}
+
+		if opts.jsonOutput {
+			b, marshalErr := json.MarshalIndent(result, "", "  ")
+			if marshalErr != nil {
+				return fmt.Errorf("marshalling JSON: %w", marshalErr)
+			}
+			fmt.Fprintln(out, string(b))
+		} else {
+			fmt.Fprint(out, repos.FormatDiffTable(result))
+		}
+		if len(result.Changes) > 0 {
+			return fmt.Errorf("%d changes needed to reconcile manifest", len(result.Changes))
+		}
+		return nil
+	}
+
+	var progressFn repos.ProgressFunc
+	if !opts.jsonOutput {
+		progressFn = func(repo, phase, message string) {
+			printer.StepInfo(fmt.Sprintf("[%s] %s: %s", phase, repo, message))
+		}
+	}
+
+	result, err := repos.Sync(ctx, m, client, opts.concurrency, opts.repoFilter, progressFn)
+	if err != nil && result == nil {
+		return err
+	}
+
+	if opts.jsonOutput {
+		b, marshalErr := json.MarshalIndent(result, "", "  ")
+		if marshalErr != nil {
+			return fmt.Errorf("marshalling JSON: %w", marshalErr)
+		}
+		fmt.Fprintln(out, string(b))
+	} else {
+		if result.Failed > 0 {
+			fmt.Fprintf(out, "Applied %d changes, %d repos failed.\n", len(result.Applied), result.Failed)
+		} else {
+			fmt.Fprintf(out, "Applied %d changes.\n", len(result.Applied))
+		}
+		for _, w := range result.Warnings {
+			fmt.Fprintf(out, "WARNING: %s\n", w)
+		}
+	}
+
+	return err
 }
 
 // reposUpgradeConfig holds flag values and testing overrides for repos upgrade.

--- a/internal/cli/repos_test.go
+++ b/internal/cli/repos_test.go
@@ -28,6 +28,8 @@ func TestReposCommand_HasSubcommands(t *testing.T) {
 	assert.True(t, names["install"], "expected install subcommand")
 	assert.True(t, names["uninstall"], "expected uninstall subcommand")
 	assert.True(t, names["status"], "expected status subcommand")
+	assert.True(t, names["diff"], "expected diff subcommand")
+	assert.True(t, names["sync"], "expected sync subcommand")
 	assert.True(t, names["upgrade"], "expected upgrade subcommand")
 	assert.True(t, names["upgrade-mint"], "expected upgrade-mint subcommand")
 }
@@ -1505,4 +1507,170 @@ func TestRunReposUpgradeMint_Success(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Contains(t, prov.calls, "DiscoverMint")
+}
+
+const diffSyncManifestYAML = `version: 1
+mint:
+  url: https://mint.example.com
+  project: mint-proj
+  region: us-central1
+defaults:
+  inference_project: inf-proj
+  inference_region: us-central1
+  fullsend_ref: v1.0.0
+repos:
+  - repo: acme/api
+  - repo: acme/web
+`
+
+func TestRunReposDiff_NoDrift(t *testing.T) {
+	yaml := `version: 1
+mint:
+  url: https://mint.example.com
+  project: mint-proj
+  region: us-central1
+defaults:
+  inference_region: us-central1
+  fullsend_ref: v1.0.0
+repos:
+  - repo: acme/api
+`
+	manifestPath := writeTestManifest(t, yaml)
+	fc := newInstalledFakeClientCLI("acme/api")
+
+	err := runReposDiff(context.Background(), &reposDiffConfig{
+		manifest:    manifestPath,
+		concurrency: 4,
+		testClient:  fc,
+	})
+	require.NoError(t, err)
+}
+
+func TestRunReposDiff_WithDrift(t *testing.T) {
+	manifestPath := writeTestManifest(t, diffSyncManifestYAML)
+	fc := newInstalledFakeClientCLI("acme/api", "acme/web")
+	fc.VariableValues["acme/api/FULLSEND_MINT_URL"] = "https://old-mint.example.com"
+
+	err := runReposDiff(context.Background(), &reposDiffConfig{
+		manifest:    manifestPath,
+		concurrency: 4,
+		testClient:  fc,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "changes needed to reconcile")
+}
+
+func TestRunReposDiff_InvalidManifest(t *testing.T) {
+	err := runReposDiff(context.Background(), &reposDiffConfig{
+		manifest:    "/nonexistent/repos.yaml",
+		concurrency: 4,
+		testClient:  forge.NewFakeClient(),
+	})
+	require.Error(t, err)
+}
+
+// --- repos sync ---
+
+func TestRunReposSync_Success(t *testing.T) {
+	manifestPath := writeTestManifest(t, diffSyncManifestYAML)
+	fc := newInstalledFakeClientCLI("acme/api", "acme/web")
+	fc.VariableValues["acme/api/FULLSEND_MINT_URL"] = "https://old-mint.example.com"
+
+	err := runReposSync(context.Background(), &reposSyncConfig{
+		manifest:    manifestPath,
+		concurrency: 4,
+		testClient:  fc,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://mint.example.com", fc.VariableValues["acme/api/FULLSEND_MINT_URL"])
+}
+
+func TestRunReposSync_DryRun(t *testing.T) {
+	manifestPath := writeTestManifest(t, diffSyncManifestYAML)
+	fc := newInstalledFakeClientCLI("acme/api")
+	fc.VariableValues["acme/api/FULLSEND_MINT_URL"] = "https://old-mint.example.com"
+
+	err := runReposSync(context.Background(), &reposSyncConfig{
+		manifest:    manifestPath,
+		concurrency: 4,
+		dryRun:      true,
+		testClient:  fc,
+	})
+	require.Error(t, err, "dry-run should return error when drift exists")
+	assert.Contains(t, err.Error(), "changes needed to reconcile")
+	assert.Equal(t, "https://old-mint.example.com", fc.VariableValues["acme/api/FULLSEND_MINT_URL"],
+		"dry-run should not modify variables")
+}
+
+func TestRunReposSync_InvalidManifest(t *testing.T) {
+	err := runReposSync(context.Background(), &reposSyncConfig{
+		manifest:    "/nonexistent/repos.yaml",
+		concurrency: 4,
+		testClient:  forge.NewFakeClient(),
+	})
+	require.Error(t, err)
+}
+
+func TestRunReposDiff_JSON(t *testing.T) {
+	manifestPath := writeTestManifest(t, diffSyncManifestYAML)
+	fc := newInstalledFakeClientCLI("acme/api", "acme/web")
+	fc.VariableValues["acme/api/FULLSEND_MINT_URL"] = "https://old-mint.example.com"
+
+	var buf bytes.Buffer
+	err := runReposDiff(context.Background(), &reposDiffConfig{
+		manifest:    manifestPath,
+		concurrency: 4,
+		jsonOutput:  true,
+		testClient:  fc,
+		out:         &buf,
+	})
+	require.Error(t, err)
+
+	output := buf.String()
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(output), "{"), "JSON output should start with {")
+	assert.Contains(t, output, `"changes"`)
+	assert.NotContains(t, output, "Checking token permissions", "preflight text should not appear in JSON output")
+}
+
+func TestRunReposSync_JSON(t *testing.T) {
+	manifestPath := writeTestManifest(t, diffSyncManifestYAML)
+	fc := newInstalledFakeClientCLI("acme/api", "acme/web")
+	fc.VariableValues["acme/api/FULLSEND_MINT_URL"] = "https://old-mint.example.com"
+
+	var buf bytes.Buffer
+	err := runReposSync(context.Background(), &reposSyncConfig{
+		manifest:    manifestPath,
+		concurrency: 4,
+		jsonOutput:  true,
+		testClient:  fc,
+		out:         &buf,
+	})
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(output), "{"), "JSON output should start with {")
+	assert.Contains(t, output, `"applied"`)
+	assert.NotContains(t, output, "Checking token permissions", "preflight text should not appear in JSON output")
+}
+
+func TestRunReposSync_DryRun_JSON(t *testing.T) {
+	manifestPath := writeTestManifest(t, diffSyncManifestYAML)
+	fc := newInstalledFakeClientCLI("acme/api")
+	fc.VariableValues["acme/api/FULLSEND_MINT_URL"] = "https://old-mint.example.com"
+
+	var buf bytes.Buffer
+	err := runReposSync(context.Background(), &reposSyncConfig{
+		manifest:    manifestPath,
+		concurrency: 4,
+		dryRun:      true,
+		jsonOutput:  true,
+		testClient:  fc,
+		out:         &buf,
+	})
+	require.Error(t, err)
+
+	output := buf.String()
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(output), "{"), "JSON output should start with {")
+	assert.Contains(t, output, `"changes"`)
+	assert.NotContains(t, output, "Checking token permissions")
 }

--- a/internal/repos/init.go
+++ b/internal/repos/init.go
@@ -329,6 +329,9 @@ func discoverRepo(ctx context.Context, client forge.Client,
 	if err != nil && !state.Installed {
 		return DiscoveredRepo{}, err
 	}
+	if err != nil {
+		progress(fullName, "discover", fmt.Sprintf("warning: %v", err))
+	}
 
 	if state.Installed {
 		progress(fullName, "discover", "per-repo installation detected")

--- a/internal/repos/sync.go
+++ b/internal/repos/sync.go
@@ -1,0 +1,394 @@
+package repos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
+)
+
+// Change describes a single field that needs to be updated to reconcile
+// a repo's actual state with the manifest's desired state.
+type Change struct {
+	Owner    string `json:"owner"`
+	Repo     string `json:"repo"`
+	Field    string `json:"field"`
+	Type     string `json:"type"`                // "variable" or "secret"
+	Action   string `json:"action"`              // "create" or "update"
+	OldValue string `json:"old_value,omitempty"` // empty for secrets (not readable)
+	NewValue string `json:"new_value,omitempty"` // empty for secrets
+}
+
+// DiffResult holds the output of a diff operation.
+type DiffResult struct {
+	Changes  []Change `json:"changes"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// SyncResult holds the output of a sync operation.
+type SyncResult struct {
+	Applied  []Change `json:"applied"`
+	Failed   int      `json:"failed,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// managedVariables lists the repo variables that sync reconciles.
+// Values are logged in cleartext via progress callbacks — only add
+// non-sensitive fields here. Use managedSecrets for sensitive data.
+// The guard variable (FULLSEND_PER_REPO_INSTALL) is NOT included here —
+// it is managed by `repos install`. diffRepo skips repos where the guard
+// is not "true" to avoid bricking future install runs.
+var managedVariables = []struct {
+	name      string
+	resolveFn func(cfg ResolvedConfig) string
+}{
+	{"FULLSEND_MINT_URL", func(cfg ResolvedConfig) string { return cfg.MintURL }},
+	{"FULLSEND_GCP_REGION", func(cfg ResolvedConfig) string { return cfg.InferenceRegion }},
+}
+
+// managedSecrets lists the repo secrets that sync reconciles.
+var managedSecrets = []struct {
+	name      string
+	resolveFn func(cfg ResolvedConfig) string
+}{
+	{"FULLSEND_GCP_PROJECT_ID", func(cfg ResolvedConfig) string { return cfg.InferenceProject }},
+}
+
+func validateConcurrency(n int) error {
+	if n < 1 || n > 32 {
+		return fmt.Errorf("concurrency must be between 1 and 32, got %d", n)
+	}
+	return nil
+}
+
+// Diff compares the manifest's desired state against the actual forge
+// state and returns a list of changes needed to reconcile. Only examines
+// repos that are already installed (guard variable is "true");
+// uninstalled repos are reported as warnings.
+//
+// For secrets, Diff only reports missing secrets (action "create")
+// because secret values cannot be read back for comparison.
+func Diff(ctx context.Context, manifest *Manifest, client forge.Client, maxConcurrency int, repoFilter []string) (*DiffResult, error) {
+	if err := validateConcurrency(maxConcurrency); err != nil {
+		return nil, err
+	}
+
+	resolved, err := manifest.ExpandGlobs(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("resolving repos: %w", err)
+	}
+
+	if len(repoFilter) > 0 {
+		resolved, err = filterRepos(resolved, repoFilter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	type repoResult struct {
+		changes  []Change
+		warnings []string
+	}
+
+	results := make([]repoResult, len(resolved))
+	sem := make(chan struct{}, maxConcurrency)
+	var wg sync.WaitGroup
+
+	for i, rr := range resolved {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			wg.Wait()
+			return nil, ctx.Err()
+		}
+		wg.Add(1)
+		go func(idx int, rr ResolvedRepo) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			cfg := manifest.ResolveConfigForEntry(rr.Owner, rr.Repo, rr.Entry)
+			changes, warnings, _ := diffRepo(ctx, client, rr.Owner, rr.Repo, cfg)
+			results[idx] = repoResult{changes: changes, warnings: warnings}
+		}(i, rr)
+	}
+	wg.Wait()
+
+	allChanges := make([]Change, 0)
+	allWarnings := make([]string, 0)
+	for _, r := range results {
+		allChanges = append(allChanges, r.changes...)
+		allWarnings = append(allWarnings, r.warnings...)
+	}
+
+	return &DiffResult{Changes: allChanges, Warnings: allWarnings}, nil
+}
+
+// diffRepo computes the changes needed for a single repo.
+// The returned bool is true when the repo was successfully examined;
+// false means a fatal condition (API error, guard missing) and callers
+// should not attempt further writes.
+func diffRepo(ctx context.Context, client forge.Client, owner, repo string, cfg ResolvedConfig) ([]Change, []string, bool) {
+	vars, err := client.ListRepoVariables(ctx, owner, repo)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("%s/%s: error listing variables: %v", owner, repo, err)}, false
+	}
+
+	guard := vars[forge.PerRepoGuardVar]
+	if guard != "true" {
+		return nil, []string{fmt.Sprintf("%s/%s: not installed (guard variable missing) — run `repos install`", owner, repo)}, false
+	}
+
+	var changes []Change
+	var warnings []string
+
+	for _, mv := range managedVariables {
+		desired := mv.resolveFn(cfg)
+		if desired == "" {
+			continue
+		}
+		actual, exists := vars[mv.name]
+		if !exists {
+			changes = append(changes, Change{
+				Owner:    owner,
+				Repo:     repo,
+				Field:    mv.name,
+				Type:     "variable",
+				Action:   "create",
+				NewValue: desired,
+			})
+		} else if actual != desired {
+			changes = append(changes, Change{
+				Owner:    owner,
+				Repo:     repo,
+				Field:    mv.name,
+				Type:     "variable",
+				Action:   "update",
+				OldValue: actual,
+				NewValue: desired,
+			})
+		}
+	}
+
+	for _, ms := range managedSecrets {
+		desired := ms.resolveFn(cfg)
+		if desired == "" {
+			continue
+		}
+		exists, secretErr := client.RepoSecretExists(ctx, owner, repo, ms.name)
+		if secretErr != nil {
+			warnings = append(warnings, fmt.Sprintf("%s/%s: error checking secret %s: %v", owner, repo, ms.name, secretErr))
+			continue
+		}
+		if !exists {
+			changes = append(changes, Change{
+				Owner:  owner,
+				Repo:   repo,
+				Field:  ms.name,
+				Type:   "secret",
+				Action: "create",
+			})
+		}
+	}
+
+	return changes, warnings, true
+}
+
+// Sync reconciles configuration drift for installed repos by applying
+// variable and secret changes to match the manifest's desired state.
+// Variables are only written when drift is detected; secrets are always
+// written for convergence since their values cannot be read back.
+//
+// Sync does NOT touch scaffold shim version (@ref) or harness files.
+// Version changes are managed by `repos upgrade`.
+func Sync(ctx context.Context, manifest *Manifest, client forge.Client, maxConcurrency int, repoFilter []string, progress ProgressFunc) (*SyncResult, error) {
+	if err := validateConcurrency(maxConcurrency); err != nil {
+		return nil, err
+	}
+
+	if progress == nil {
+		progress = func(_, _, _ string) {}
+	}
+
+	resolved, err := manifest.ExpandGlobs(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("resolving repos: %w", err)
+	}
+
+	if len(repoFilter) > 0 {
+		resolved, err = filterRepos(resolved, repoFilter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	type repoResult struct {
+		applied  []Change
+		warnings []string
+		failed   bool
+	}
+
+	results := make([]repoResult, len(resolved))
+	sem := make(chan struct{}, maxConcurrency)
+	var wg sync.WaitGroup
+
+	for i, rr := range resolved {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			wg.Wait()
+			return nil, ctx.Err()
+		}
+		wg.Add(1)
+		go func(idx int, rr ResolvedRepo) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			cfg := manifest.ResolveConfigForEntry(rr.Owner, rr.Repo, rr.Entry)
+			repoFullName := rr.Owner + "/" + rr.Repo
+
+			changes, diffWarnings, ok := diffRepo(ctx, client, rr.Owner, rr.Repo, cfg)
+			var res repoResult
+			res.warnings = append(res.warnings, diffWarnings...)
+
+			if !ok {
+				results[idx] = res
+				return
+			}
+
+			if len(changes) == 0 {
+				secretChanges, secretErr := ensureSecrets(ctx, client, rr.Owner, rr.Repo, cfg, progress)
+				res.applied = append(res.applied, secretChanges...)
+				if secretErr != nil {
+					res.warnings = append(res.warnings, secretErr.Error())
+					res.failed = true
+					progress(repoFullName, "error", secretErr.Error())
+				}
+				results[idx] = res
+				return
+			}
+
+			applied, applyErr := applyChanges(ctx, client, rr.Owner, rr.Repo, cfg, changes, progress)
+			res.applied = append(res.applied, applied...)
+			if applyErr != nil {
+				res.warnings = append(res.warnings, applyErr.Error())
+				res.failed = true
+				progress(repoFullName, "error", applyErr.Error())
+			} else {
+				progress(repoFullName, "done", fmt.Sprintf("applied %d changes", len(applied)))
+			}
+			results[idx] = res
+		}(i, rr)
+	}
+	wg.Wait()
+
+	allApplied := make([]Change, 0)
+	syncWarnings := make([]string, 0)
+	failedCount := 0
+	for _, r := range results {
+		allApplied = append(allApplied, r.applied...)
+		syncWarnings = append(syncWarnings, r.warnings...)
+		if r.failed {
+			failedCount++
+		}
+	}
+
+	result := &SyncResult{Applied: allApplied, Failed: failedCount, Warnings: syncWarnings}
+	if failedCount > 0 {
+		return result, fmt.Errorf("%d repos failed to sync", failedCount)
+	}
+	return result, nil
+}
+
+// ensureSecrets writes all managed secrets for convergence, since their
+// values cannot be read back for comparison.
+func ensureSecrets(ctx context.Context, client forge.Client, owner, repo string, cfg ResolvedConfig, progress ProgressFunc) ([]Change, error) {
+	repoFullName := owner + "/" + repo
+	var applied []Change
+
+	for _, ms := range managedSecrets {
+		value := ms.resolveFn(cfg)
+		if value == "" {
+			continue
+		}
+		progress(repoFullName, "sync", fmt.Sprintf("ensure secret %s", ms.name))
+		if err := client.CreateRepoSecret(ctx, owner, repo, ms.name, value); err != nil {
+			return applied, fmt.Errorf("%s/%s: setting secret %s: %w", owner, repo, ms.name, err)
+		}
+		applied = append(applied, Change{
+			Owner:  owner,
+			Repo:   repo,
+			Field:  ms.name,
+			Type:   "secret",
+			Action: "update",
+		})
+	}
+
+	return applied, nil
+}
+
+func applyChanges(ctx context.Context, client forge.Client, owner, repo string, cfg ResolvedConfig, changes []Change, progress ProgressFunc) ([]Change, error) {
+	repoFullName := owner + "/" + repo
+	var applied []Change
+
+	for _, c := range changes {
+		if c.Type != "variable" {
+			continue
+		}
+		progress(repoFullName, "sync", fmt.Sprintf("%s %s=%s", c.Action, c.Field, c.NewValue))
+		if err := client.CreateOrUpdateRepoVariable(ctx, owner, repo, c.Field, c.NewValue); err != nil {
+			return applied, fmt.Errorf("%s/%s: setting variable %s: %w", owner, repo, c.Field, err)
+		}
+		applied = append(applied, c)
+	}
+
+	secretChanges, secretErr := ensureSecrets(ctx, client, owner, repo, cfg, progress)
+	applied = append(applied, secretChanges...)
+
+	return applied, secretErr
+}
+
+// FormatDiffTable renders a DiffResult as a human-readable table.
+func FormatDiffTable(result *DiffResult) string {
+	if len(result.Changes) == 0 && len(result.Warnings) == 0 {
+		return "No changes needed — all repos match the manifest.\n"
+	}
+
+	var b strings.Builder
+
+	if len(result.Changes) > 0 {
+		maxRepo := len("REPO")
+		maxField := len("FIELD")
+		for _, c := range result.Changes {
+			name := c.Owner + "/" + c.Repo
+			if len(name) > maxRepo {
+				maxRepo = len(name)
+			}
+			if len(c.Field) > maxField {
+				maxField = len(c.Field)
+			}
+		}
+
+		fmt.Fprintf(&b, "%-*s  %-*s  %-20s  %s\n", maxRepo, "REPO", maxField, "FIELD", "CURRENT", "DESIRED")
+		for _, c := range result.Changes {
+			name := c.Owner + "/" + c.Repo
+			current := c.OldValue
+			desired := c.NewValue
+			if c.Type == "secret" {
+				current = "(missing)"
+				desired = "(secret value)"
+			}
+			if current == "" {
+				current = "(not set)"
+			}
+			fmt.Fprintf(&b, "%-*s  %-*s  %-20s  %s\n", maxRepo, name, maxField, c.Field, current, desired)
+		}
+	}
+
+	for _, w := range result.Warnings {
+		fmt.Fprintf(&b, "WARNING: %s\n", w)
+	}
+
+	return b.String()
+}

--- a/internal/repos/sync_test.go
+++ b/internal/repos/sync_test.go
@@ -1,0 +1,1004 @@
+package repos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
+)
+
+func TestDiff_NoDrift(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://mint.example.com", "us-central1")
+	populateInstalledRepo(fc, "acme-corp", "web-frontend", "v2.3.0",
+		"https://mint.example.com", "us-central1")
+
+	fc.Secrets["acme-corp/api-server/FULLSEND_GCP_PROJECT_ID"] = true
+	fc.Secrets["acme-corp/web-frontend/FULLSEND_GCP_PROJECT_ID"] = true
+
+	result, err := Diff(context.Background(), m, fc, 4, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Changes) != 0 {
+		t.Errorf("expected 0 changes for no-drift repos, got %d: %+v", len(result.Changes), result.Changes)
+	}
+}
+
+func TestDiff_VariableDrift_MintURL(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://old-mint.example.com", "us-central1")
+
+	result, err := Diff(context.Background(), m, fc, 4, []string{"acme-corp/api-server"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, c := range result.Changes {
+		if c.Field == "FULLSEND_MINT_URL" && c.Type == "variable" {
+			found = true
+			if c.Action != "update" {
+				t.Errorf("action = %q, want update", c.Action)
+			}
+			if c.OldValue != "https://old-mint.example.com" {
+				t.Errorf("old value = %q", c.OldValue)
+			}
+			if c.NewValue != "https://mint.example.com" {
+				t.Errorf("new value = %q", c.NewValue)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected FULLSEND_MINT_URL change")
+	}
+}
+
+func TestDiff_VariableDrift_Region(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://mint.example.com", "us-west1")
+
+	result, err := Diff(context.Background(), m, fc, 4, []string{"acme-corp/api-server"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, c := range result.Changes {
+		if c.Field == "FULLSEND_GCP_REGION" && c.Action == "update" {
+			found = true
+			if c.OldValue != "us-west1" {
+				t.Errorf("old = %q, want us-west1", c.OldValue)
+			}
+			if c.NewValue != "us-central1" {
+				t.Errorf("new = %q, want us-central1", c.NewValue)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected FULLSEND_GCP_REGION change")
+	}
+}
+
+func TestDiff_MissingGuardVariable(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	fc.VariableValues["acme-corp/api-server/FULLSEND_MINT_URL"] = "https://mint.example.com"
+	fc.VariableValues["acme-corp/api-server/FULLSEND_GCP_REGION"] = "us-central1"
+
+	result, err := Diff(context.Background(), m, fc, 4, []string{"acme-corp/api-server"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Changes) != 0 {
+		t.Errorf("expected no changes for uninstalled repo, got %d", len(result.Changes))
+	}
+
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "not installed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected warning about uninstalled repo")
+	}
+}
+
+func TestDiff_SecretMissing(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+	m.Defaults.InferenceProject = "my-project"
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://mint.example.com", "us-central1")
+
+	result, err := Diff(context.Background(), m, fc, 4, []string{"acme-corp/api-server"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, c := range result.Changes {
+		if c.Field == "FULLSEND_GCP_PROJECT_ID" && c.Type == "secret" {
+			found = true
+			if c.Action != "create" {
+				t.Errorf("action = %q, want create", c.Action)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected secret create change")
+	}
+}
+
+func TestDiff_SecretExists_NoChange(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+	m.Defaults.InferenceProject = "my-project"
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://mint.example.com", "us-central1")
+	fc.Secrets["acme-corp/api-server/FULLSEND_GCP_PROJECT_ID"] = true
+
+	result, err := Diff(context.Background(), m, fc, 4, []string{"acme-corp/api-server"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, c := range result.Changes {
+		if c.Field == "FULLSEND_GCP_PROJECT_ID" && c.Type == "secret" {
+			t.Error("should not report change for existing secret (values cannot be compared)")
+		}
+	}
+}
+
+func TestDiff_RepoNotInstalled_Warning(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	result, err := Diff(context.Background(), m, fc, 4, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Changes) != 0 {
+		t.Errorf("expected no changes for uninstalled repos, got %d", len(result.Changes))
+	}
+
+	installWarnings := 0
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "not installed") {
+			installWarnings++
+		}
+	}
+	if installWarnings != 2 {
+		t.Errorf("expected 2 not-installed warnings, got %d", installWarnings)
+	}
+}
+
+func TestDiff_APIError_Warning(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := &Manifest{
+		Version: 1,
+		Mint: MintConfig{
+			URL:     "https://mint.example.com",
+			Project: "proj",
+			Region:  "us-central1",
+		},
+		Repos: []RepoEntry{{Repo: "org/repo"}},
+	}
+
+	fc.Errors["ListRepoVariables"] = fmt.Errorf("rate limit exceeded")
+
+	result, err := Diff(context.Background(), m, fc, 4, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Warnings) == 0 {
+		t.Error("expected warning from API error")
+	}
+	if !strings.Contains(result.Warnings[0], "rate limit") {
+		t.Errorf("warning = %q, want to contain 'rate limit'", result.Warnings[0])
+	}
+}
+
+func TestDiff_MultipleRepos(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://old-mint.example.com", "us-central1")
+	populateInstalledRepo(fc, "acme-corp", "web-frontend", "v2.3.0",
+		"https://mint.example.com", "us-west1")
+
+	result, err := Diff(context.Background(), m, fc, 4, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	repoChanges := map[string]int{}
+	for _, c := range result.Changes {
+		if c.Type == "variable" {
+			repoChanges[c.Owner+"/"+c.Repo]++
+		}
+	}
+	if repoChanges["acme-corp/api-server"] < 1 {
+		t.Error("expected at least 1 variable change for api-server")
+	}
+	if repoChanges["acme-corp/web-frontend"] < 1 {
+		t.Error("expected at least 1 variable change for web-frontend")
+	}
+}
+
+func TestDiff_RepoFilter(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://old-mint.example.com", "us-central1")
+	populateInstalledRepo(fc, "acme-corp", "web-frontend", "v2.3.0",
+		"https://old-mint.example.com", "us-central1")
+
+	result, err := Diff(context.Background(), m, fc, 4, []string{"acme-corp/api-server"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, c := range result.Changes {
+		if c.Repo == "web-frontend" {
+			t.Error("web-frontend should be filtered out")
+		}
+	}
+}
+
+func TestDiff_GlobExpansion(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.OrgRepos = map[string][]forge.Repository{
+		"acme-corp": {
+			{Name: "api-server", FullName: "acme-corp/api-server"},
+			{Name: "web-app", FullName: "acme-corp/web-app"},
+		},
+	}
+
+	m := &Manifest{
+		Version: 1,
+		Mint: MintConfig{
+			URL:     "https://mint.example.com",
+			Project: "proj",
+			Region:  "us-central1",
+		},
+		Defaults: DefaultsConfig{
+			InferenceRegion: "us-central1",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/*"}},
+	}
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://old.example.com", "us-central1")
+
+	result, err := Diff(context.Background(), m, fc, 4, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, c := range result.Changes {
+		if c.Repo == "api-server" && c.Field == "FULLSEND_MINT_URL" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected mint URL change for glob-expanded api-server")
+	}
+}
+
+func TestDiff_EmptyManifest(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := &Manifest{
+		Version: 1,
+		Mint: MintConfig{
+			URL:     "https://mint.example.com",
+			Project: "proj",
+			Region:  "us-central1",
+		},
+	}
+
+	result, err := Diff(context.Background(), m, fc, 4, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Changes) != 0 {
+		t.Errorf("expected 0 changes, got %d", len(result.Changes))
+	}
+}
+
+func TestDiff_EmptyDesiredValue_Skips(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := &Manifest{
+		Version: 1,
+		Mint: MintConfig{
+			URL:     "",
+			Project: "proj",
+			Region:  "us-central1",
+		},
+		Defaults: DefaultsConfig{
+			InferenceRegion: "",
+		},
+		Repos: []RepoEntry{{Repo: "org/repo"}},
+	}
+
+	populateInstalledRepo(fc, "org", "repo", "v2.3.0",
+		"https://some-mint.example.com", "us-west1")
+
+	result, err := Diff(context.Background(), m, fc, 4, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, c := range result.Changes {
+		if c.Type == "variable" && (c.Field == "FULLSEND_MINT_URL" || c.Field == "FULLSEND_GCP_REGION") {
+			t.Errorf("should not report change when desired is empty: %+v", c)
+		}
+	}
+}
+
+func TestDiff_ConcurrencyValidation(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	tests := []struct {
+		name        string
+		concurrency int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+		{"too_high", 33},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Diff(context.Background(), m, fc, tt.concurrency, nil)
+			if err == nil {
+				t.Error("expected error for invalid concurrency")
+			}
+			if !strings.Contains(err.Error(), "concurrency must be between 1 and 32") {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDiff_SecretCheckError_Warning(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := &Manifest{
+		Version: 1,
+		Mint: MintConfig{
+			URL:     "https://mint.example.com",
+			Project: "proj",
+			Region:  "us-central1",
+		},
+		Defaults: DefaultsConfig{
+			InferenceProject: "my-project",
+			InferenceRegion:  "us-central1",
+		},
+		Repos: []RepoEntry{{Repo: "org/repo"}},
+	}
+
+	populateInstalledRepo(fc, "org", "repo", "v2.3.0",
+		"https://mint.example.com", "us-central1")
+	fc.Errors["RepoSecretExists"] = fmt.Errorf("secret API error")
+
+	result, err := Diff(context.Background(), m, fc, 4, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Warnings) == 0 {
+		t.Error("expected warning from secret check error")
+	}
+
+	for _, c := range result.Changes {
+		if c.Type == "secret" {
+			t.Error("should not report secret change when check failed")
+		}
+	}
+}
+
+func TestSync_NoDrift_NoVariableWrites(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+	m.Defaults.InferenceProject = ""
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://mint.example.com", "us-central1")
+	populateInstalledRepo(fc, "acme-corp", "web-frontend", "v2.3.0",
+		"https://mint.example.com", "us-central1")
+
+	result, err := Sync(context.Background(), m, fc, 4, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fc.Variables) != 0 {
+		t.Errorf("expected no variable writes, got %d", len(fc.Variables))
+	}
+	if result.Failed != 0 {
+		t.Errorf("expected 0 failures, got %d", result.Failed)
+	}
+}
+
+func TestSync_AppliesVariableChanges(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://old-mint.example.com", "us-central1")
+
+	var progressCalls []string
+	progress := func(repo, phase, msg string) {
+		progressCalls = append(progressCalls, fmt.Sprintf("%s/%s/%s", repo, phase, msg))
+	}
+
+	result, err := Sync(context.Background(), m, fc, 4, []string{"acme-corp/api-server"}, progress)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundMintWrite := false
+	for _, v := range fc.Variables {
+		if v.Name == "FULLSEND_MINT_URL" && v.Value == "https://mint.example.com" {
+			foundMintWrite = true
+		}
+	}
+	if !foundMintWrite {
+		t.Error("expected FULLSEND_MINT_URL to be written")
+	}
+
+	if len(result.Applied) == 0 {
+		t.Error("expected applied changes")
+	}
+
+	if len(progressCalls) == 0 {
+		t.Error("expected progress callbacks")
+	}
+}
+
+func TestSync_AppliesSecretChanges(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+	m.Defaults.InferenceProject = "my-project"
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://mint.example.com", "us-central1")
+
+	result, err := Sync(context.Background(), m, fc, 4, []string{"acme-corp/api-server"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundSecret := false
+	for _, s := range fc.CreatedSecrets {
+		if s.Name == "FULLSEND_GCP_PROJECT_ID" && s.Value == "my-project" {
+			foundSecret = true
+		}
+	}
+	if !foundSecret {
+		t.Error("expected FULLSEND_GCP_PROJECT_ID secret to be created")
+	}
+
+	foundApplied := false
+	for _, c := range result.Applied {
+		if c.Field == "FULLSEND_GCP_PROJECT_ID" && c.Type == "secret" {
+			foundApplied = true
+		}
+	}
+	if !foundApplied {
+		t.Error("expected secret change in applied list")
+	}
+}
+
+func TestSync_VariableWriteError(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://old-mint.example.com", "us-central1")
+
+	fc.Errors["CreateOrUpdateRepoVariable"] = fmt.Errorf("write error")
+
+	result, err := Sync(context.Background(), m, fc, 4, []string{"acme-corp/api-server"}, nil)
+	if err == nil {
+		t.Fatal("expected error from variable write failure")
+	}
+	if result.Failed != 1 {
+		t.Errorf("expected 1 failure, got %d", result.Failed)
+	}
+}
+
+func TestSync_SecretWriteError(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+	m.Defaults.InferenceProject = "my-project"
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://mint.example.com", "us-central1")
+
+	fc.Errors["CreateRepoSecret"] = fmt.Errorf("secret write error")
+
+	_, err := Sync(context.Background(), m, fc, 4, []string{"acme-corp/api-server"}, nil)
+	if err == nil {
+		t.Fatal("expected error from secret write failure")
+	}
+}
+
+func TestSync_NilProgress(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://old-mint.example.com", "us-central1")
+
+	_, err := Sync(context.Background(), m, fc, 4, []string{"acme-corp/api-server"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error with nil progress: %v", err)
+	}
+}
+
+func TestSync_DiffAPIError_SkipsReconciliation(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+	m.Defaults.InferenceProject = "my-project"
+
+	fc.Errors["ListRepoVariables"] = fmt.Errorf("API rate limit exceeded")
+
+	result, err := Sync(context.Background(), m, fc, 4, nil, nil)
+	if err != nil {
+		t.Fatalf("expected no error (warnings only), got: %v", err)
+	}
+
+	if len(result.Applied) != 0 {
+		t.Errorf("expected no applied changes, got %d", len(result.Applied))
+	}
+	if len(result.Warnings) == 0 {
+		t.Error("expected warnings from API error")
+	}
+	if result.Failed != 0 {
+		t.Errorf("expected 0 failures (warnings only), got %d", result.Failed)
+	}
+}
+
+func TestSync_MultipleRepos(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://old.example.com", "us-central1")
+	populateInstalledRepo(fc, "acme-corp", "web-frontend", "v2.3.0",
+		"https://old.example.com", "us-central1")
+
+	result, err := Sync(context.Background(), m, fc, 4, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	repos := map[string]bool{}
+	for _, c := range result.Applied {
+		repos[c.Owner+"/"+c.Repo] = true
+	}
+	if !repos["acme-corp/api-server"] {
+		t.Error("expected changes applied to api-server")
+	}
+	if !repos["acme-corp/web-frontend"] {
+		t.Error("expected changes applied to web-frontend")
+	}
+}
+
+func TestSync_ConcurrencyValidation(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	_, err := Sync(context.Background(), m, fc, 0, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid concurrency")
+	}
+	if !strings.Contains(err.Error(), "concurrency must be between 1 and 32") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSync_GlobWithPerEntryOverride(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.OrgRepos = map[string][]forge.Repository{
+		"acme": {{Name: "api", FullName: "acme/api"}},
+	}
+
+	m := &Manifest{
+		Version: 1,
+		Mint: MintConfig{
+			URL:     "https://mint.example.com",
+			Project: "proj",
+			Region:  "us-central1",
+		},
+		Defaults: DefaultsConfig{
+			InferenceProject: "default-project",
+			InferenceRegion:  "us-central1",
+		},
+		Repos: []RepoEntry{{
+			Repo:             "acme/*",
+			InferenceProject: NullableString{Value: "override-project", Set: true},
+		}},
+	}
+
+	populateInstalledRepo(fc, "acme", "api", "v2.3.0",
+		"https://mint.example.com", "us-central1")
+
+	result, err := Sync(context.Background(), m, fc, 4, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundOverride := false
+	for _, s := range fc.CreatedSecrets {
+		if s.Name == "FULLSEND_GCP_PROJECT_ID" {
+			foundOverride = true
+			if s.Value != "override-project" {
+				t.Errorf("expected override-project, got %q", s.Value)
+			}
+		}
+	}
+	if !foundOverride {
+		t.Errorf("expected FULLSEND_GCP_PROJECT_ID to be written; applied=%+v", result.Applied)
+	}
+}
+
+func TestFormatDiffTable_NoChanges(t *testing.T) {
+	result := &DiffResult{}
+	output := FormatDiffTable(result)
+	if !strings.Contains(output, "No changes needed") {
+		t.Errorf("expected 'No changes needed', got %q", output)
+	}
+}
+
+func TestFormatDiffTable_VariableChanges(t *testing.T) {
+	result := &DiffResult{
+		Changes: []Change{
+			{
+				Owner:    "org",
+				Repo:     "repo",
+				Field:    "FULLSEND_MINT_URL",
+				Type:     "variable",
+				Action:   "update",
+				OldValue: "https://old",
+				NewValue: "https://new",
+			},
+		},
+	}
+	output := FormatDiffTable(result)
+	if !strings.Contains(output, "FULLSEND_MINT_URL") {
+		t.Error("expected field name in output")
+	}
+	if !strings.Contains(output, "https://old") {
+		t.Error("expected old value in output")
+	}
+	if !strings.Contains(output, "https://new") {
+		t.Error("expected new value in output")
+	}
+}
+
+func TestFormatDiffTable_SecretCreate(t *testing.T) {
+	result := &DiffResult{
+		Changes: []Change{
+			{
+				Owner:  "org",
+				Repo:   "repo",
+				Field:  "FULLSEND_GCP_PROJECT_ID",
+				Type:   "secret",
+				Action: "create",
+			},
+		},
+	}
+	output := FormatDiffTable(result)
+	if !strings.Contains(output, "(missing)") {
+		t.Error("expected '(missing)' for create secret")
+	}
+	if !strings.Contains(output, "(secret value)") {
+		t.Error("expected '(secret value)' for desired secret")
+	}
+}
+
+func TestFormatDiffTable_VariableCreate(t *testing.T) {
+	result := &DiffResult{
+		Changes: []Change{
+			{
+				Owner:    "org",
+				Repo:     "repo",
+				Field:    "FULLSEND_MINT_URL",
+				Type:     "variable",
+				Action:   "create",
+				NewValue: "https://mint.example.com",
+			},
+		},
+	}
+	output := FormatDiffTable(result)
+	if !strings.Contains(output, "(not set)") {
+		t.Error("expected '(not set)' for create variable with empty old value")
+	}
+}
+
+func TestFormatDiffTable_WithWarnings(t *testing.T) {
+	result := &DiffResult{
+		Warnings: []string{"org/repo: error listing variables: rate limit"},
+	}
+	output := FormatDiffTable(result)
+	if !strings.Contains(output, "WARNING:") {
+		t.Error("expected WARNING prefix in output")
+	}
+	if !strings.Contains(output, "rate limit") {
+		t.Error("expected warning text in output")
+	}
+	if strings.Contains(output, "No changes needed") {
+		t.Error("should not say 'No changes needed' when there are warnings")
+	}
+}
+
+func TestFormatDiffTable_ColumnHeaders(t *testing.T) {
+	result := &DiffResult{
+		Changes: []Change{
+			{Owner: "o", Repo: "r", Field: "F", Type: "variable", Action: "update", OldValue: "a", NewValue: "b"},
+		},
+	}
+	output := FormatDiffTable(result)
+	if !strings.Contains(output, "REPO") || !strings.Contains(output, "FIELD") ||
+		!strings.Contains(output, "CURRENT") || !strings.Contains(output, "DESIRED") {
+		t.Errorf("missing column headers in output: %q", output)
+	}
+}
+
+func TestDiff_GlobExpandError(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.Errors["ListOrgRepos"] = fmt.Errorf("org not found")
+
+	m := &Manifest{
+		Version: 1,
+		Mint: MintConfig{
+			URL:     "https://mint.example.com",
+			Project: "proj",
+			Region:  "us-central1",
+		},
+		Repos: []RepoEntry{{Repo: "bad-org/*"}},
+	}
+
+	_, err := Diff(context.Background(), m, fc, 4, nil)
+	if err == nil {
+		t.Fatal("expected error from glob expansion")
+	}
+}
+
+func TestDiff_PerRepoOverride(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := &Manifest{
+		Version: 1,
+		Mint: MintConfig{
+			URL:     "https://mint.example.com",
+			Project: "proj",
+			Region:  "us-central1",
+		},
+		Defaults: DefaultsConfig{
+			InferenceRegion: "us-central1",
+		},
+		Repos: []RepoEntry{
+			{
+				Repo:            "org/repo",
+				InferenceRegion: NullableString{Value: "eu-west1", Set: true},
+			},
+		},
+	}
+
+	populateInstalledRepo(fc, "org", "repo", "v2.3.0",
+		"https://mint.example.com", "eu-west1")
+
+	result, err := Diff(context.Background(), m, fc, 4, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, c := range result.Changes {
+		if c.Field == "FULLSEND_GCP_REGION" && c.Type == "variable" {
+			t.Error("should not report region drift when per-repo override matches actual")
+		}
+	}
+}
+
+func TestSync_RepoFilter(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://old.example.com", "us-central1")
+	populateInstalledRepo(fc, "acme-corp", "web-frontend", "v2.3.0",
+		"https://old.example.com", "us-central1")
+
+	result, err := Sync(context.Background(), m, fc, 4, []string{"acme-corp/api-server"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, c := range result.Applied {
+		if c.Repo == "web-frontend" {
+			t.Error("web-frontend should be filtered out")
+		}
+	}
+}
+
+func TestDiff_GuardVarFalse_Warning(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := &Manifest{
+		Version: 1,
+		Mint: MintConfig{
+			URL:     "https://mint.example.com",
+			Project: "proj",
+			Region:  "us-central1",
+		},
+		Repos: []RepoEntry{{Repo: "org/repo"}},
+	}
+
+	fc.VariableValues["org/repo/FULLSEND_PER_REPO_INSTALL"] = "false"
+
+	result, err := Diff(context.Background(), m, fc, 4, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Changes) != 0 {
+		t.Errorf("expected no changes when guard is false, got %d", len(result.Changes))
+	}
+
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "not installed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected not-installed warning")
+	}
+}
+
+func TestSync_GlobExpansion(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.OrgRepos = map[string][]forge.Repository{
+		"acme": {{Name: "api", FullName: "acme/api"}},
+	}
+
+	m := &Manifest{
+		Version: 1,
+		Mint: MintConfig{
+			URL:     "https://mint.example.com",
+			Project: "proj",
+			Region:  "us-central1",
+		},
+		Defaults: DefaultsConfig{
+			InferenceRegion: "us-central1",
+		},
+		Repos: []RepoEntry{{Repo: "acme/*"}},
+	}
+
+	populateInstalledRepo(fc, "acme", "api", "v2.3.0",
+		"https://old.example.com", "us-central1")
+
+	result, err := Sync(context.Background(), m, fc, 4, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundWrite := false
+	for _, c := range result.Applied {
+		if c.Repo == "api" && c.Field == "FULLSEND_MINT_URL" {
+			foundWrite = true
+		}
+	}
+	if !foundWrite {
+		t.Error("expected mint URL sync for glob-expanded repo")
+	}
+}
+
+func TestDiff_MultiOrg(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := &Manifest{
+		Version: 1,
+		Mint: MintConfig{
+			URL:     "https://mint.example.com",
+			Project: "proj",
+			Region:  "us-central1",
+		},
+		Defaults: DefaultsConfig{
+			InferenceRegion: "us-central1",
+		},
+		Repos: []RepoEntry{
+			{Repo: "org-a/repo1"},
+			{Repo: "org-b/repo2"},
+		},
+	}
+
+	populateInstalledRepo(fc, "org-a", "repo1", "v2.3.0", "https://old.example.com", "us-central1")
+	populateInstalledRepo(fc, "org-b", "repo2", "v2.3.0", "https://old.example.com", "us-central1")
+
+	result, err := Diff(context.Background(), m, fc, 4, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	orgs := map[string]bool{}
+	for _, c := range result.Changes {
+		orgs[c.Owner] = true
+	}
+	if !orgs["org-a"] || !orgs["org-b"] {
+		t.Error("expected changes from both orgs")
+	}
+}
+
+func TestValidateConcurrency(t *testing.T) {
+	if err := validateConcurrency(1); err != nil {
+		t.Errorf("expected 1 to be valid: %v", err)
+	}
+	if err := validateConcurrency(32); err != nil {
+		t.Errorf("expected 32 to be valid: %v", err)
+	}
+	if err := validateConcurrency(0); err == nil {
+		t.Error("expected 0 to be invalid")
+	}
+	if err := validateConcurrency(33); err == nil {
+		t.Error("expected 33 to be invalid")
+	}
+}
+
+func TestSync_EnsuresSecretsOnNoDrift(t *testing.T) {
+	fc := forge.NewFakeClient()
+	m := newTestManifest()
+	m.Defaults.InferenceProject = "my-project"
+
+	populateInstalledRepo(fc, "acme-corp", "api-server", "v2.3.0",
+		"https://mint.example.com", "us-central1")
+	fc.Secrets["acme-corp/api-server/FULLSEND_GCP_PROJECT_ID"] = true
+
+	result, err := Sync(context.Background(), m, fc, 4, []string{"acme-corp/api-server"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundSecret := false
+	for _, s := range fc.CreatedSecrets {
+		if s.Name == "FULLSEND_GCP_PROJECT_ID" && s.Value == "my-project" {
+			foundSecret = true
+		}
+	}
+	if !foundSecret {
+		t.Error("expected secret to be written for convergence even when no drift detected")
+	}
+
+	foundApplied := false
+	for _, c := range result.Applied {
+		if c.Field == "FULLSEND_GCP_PROJECT_ID" && c.Type == "secret" {
+			foundApplied = true
+		}
+	}
+	if !foundApplied {
+		t.Error("expected secret in applied list")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `fullsend repos diff` command — read-only preview of configuration drift between the `repos.yaml` manifest and actual forge state
- Add `fullsend repos sync` command — writes variables and secrets to reconcile repos with the manifest
- Sync reconciles 3 variables (`FULLSEND_PER_REPO_INSTALL`, `FULLSEND_MINT_URL`, `FULLSEND_GCP_REGION`) and 1 secret (`FULLSEND_GCP_PROJECT_ID`); does **not** touch scaffold shim version or harness files (managed by `repos upgrade`)
- Guard variable (`FULLSEND_PER_REPO_INSTALL`) is reconciled per the plan spec — repos with a missing or incorrect guard will report drift and be healed by sync
- `checkPerRepoScopes` preflight runs for both `diff` and `sync`, with `--json`-safe output (printer writes to `io.Discard` in JSON mode)
- CLI wiring follows the config-struct + `run*()` pattern from #4081 with `testClient` DI for integration testing

Implements PR 6 from the [repos management plan](docs/plans/repos-management.md).

## Files changed

| File | Description |
|------|-------------|
| `internal/repos/sync.go` | Core `Diff()`, `Sync()`, `FormatDiffTable()` with semaphore-bounded concurrency |
| `internal/repos/sync_test.go` | 38 tests — 89-100% coverage across all sync.go functions |
| `internal/cli/repos.go` | `reposDiffConfig`/`reposSyncConfig` structs, `runReposDiff()`/`runReposSync()` functions, cobra command wiring |
| `internal/cli/repos_test.go` | Flag tests + 6 integration tests calling `run*()` directly with fake clients |

## Test plan

- [x] `go test ./internal/repos/` — all 38 sync tests pass
- [x] `go test ./internal/cli/` — all repos CLI tests pass (flag tests + integration tests)
- [x] `go build ./...` — clean build
- [x] Coverage for sync.go: `Diff` 93.3%, `diffRepo` 100%, `Sync` 89.7%, `ensureSecrets`/`applyChanges`/`validateConcurrency`/`FormatDiffTable` 100%
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)