### PR TITLE
feat(repos): add upgrade and upgrade-mint subcommands

### DIFF
--- a/docs/ADRs/0057-repos-management.md
+++ b/docs/ADRs/0057-repos-management.md
@@ -74,7 +74,7 @@ to Terraform vs cloud provider CLIs.
 | `repos install` | Provision fullsend on uninstalled manifest repos |
 | `repos sync` / `repos diff` | Reconcile configuration drift |
 | `repos upgrade` | Upgrade scaffold shim ref across repos |
-| `repos upgrade-mint` | Upgrade token mint Cloud Function |
+| `repos upgrade-mint` | Verify token mint deployment against manifest |
 | `repos remove` | Remove fullsend from specific repos |
 
 **Manifest:** a YAML file declaring desired state — mint config, default
@@ -132,7 +132,7 @@ Implemented subcommands:
 - `repos install` — PR #3033
 - `repos status` — PR #4079
 - `repos add`, `repos remove`, `repos uninstall` — PR #4081
+- `repos upgrade`, `repos upgrade-mint` — PR #4080
 
-Remaining subcommands (`repos sync`, `repos diff`, `repos upgrade`,
-`repos upgrade-mint`) are tracked in the
+Remaining subcommands (`repos sync`, `repos diff`) are tracked in the
 [repos management plan](../plans/repos-management.md).

--- a/docs/cli/repos.md
+++ b/docs/cli/repos.md
@@ -16,6 +16,8 @@ Manage per-repo installations across multiple orgs via a declarative `repos.yaml
 | `fullsend repos remove <repos...>` | Remove repo entries from a repos.yaml manifest |
 | `fullsend repos uninstall <repos...>` | Tear down fullsend from specific repos |
 | `fullsend repos status` | Compare manifest against actual repo state |
+| `fullsend repos upgrade [repos...]` | Upgrade scaffold shim ref across repos |
+| `fullsend repos upgrade-mint` | Verify the token mint deployment matches the manifest |
 
 ## `repos init`
 
@@ -235,6 +237,54 @@ fullsend repos uninstall acme/old-api --dry-run
 | `--yes` | `false` | Skip confirmation prompt when multiple repos are targeted |
 | `--skip-wif-cleanup` | `false` | Skip GCP WIF provider deletion |
 | `--concurrency` | `4` | Max parallel operations (1-32) |
+
+## `repos upgrade`
+
+Upgrades the fullsend scaffold workflow ref for repos defined in a `repos.yaml` manifest. Reads each repo's current workflow file, compares against the manifest's `fullsend_ref` (or `--ref` override), and commits the updated workflow.
+
+Floating refs (`latest`, `main`, `v0`) are skipped. Downgrades are blocked unless `--force` is set.
+
+```bash
+fullsend repos upgrade -f repos.yaml
+fullsend repos upgrade --dry-run
+fullsend repos upgrade acme/api acme/web
+fullsend repos upgrade --ref v2.4.0
+```
+
+### Flags
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--manifest` | `-f` | `repos.yaml` | Path or HTTPS URL to manifest file |
+| `--ref` | | | Override manifest `fullsend_ref` for all repos |
+| `--dry-run` | | `false` | Preview what would be upgraded without making changes |
+| `--force` | | `false` | Upgrade even if current ref is newer than target |
+| `--concurrency` | | `4` | Max parallel operations (1-32) |
+| `--direct` | | `false` | Push scaffold directly to default branch (skip PR) |
+
+### Positional arguments
+
+When repos are specified as positional arguments, only those repos are upgraded. Supports exact `owner/repo` names and glob patterns (e.g. `acme/*`), matched via `filepath.Match` against manifest entries. When no repos are specified, all manifest repos are upgraded.
+
+### Limitations
+
+**Tag-only pinning.** `repos upgrade` writes the manifest's `fullsend_ref` tag directly into `uses:` lines. If a repo currently uses SHA pinning (e.g. `@abc123 # v1.9.0`), the upgrade replaces the SHA with the tag, losing the pin. To restore SHA pinning after upgrade, re-run a per-repo install or manually resolve the tag to a SHA. A future enhancement will resolve tags to SHAs via the forge API.
+
+## `repos upgrade-mint`
+
+Verifies the token mint Cloud Function matches the manifest configuration. Discovers the current mint deployment and checks that its URL matches the manifest's `mint.url`.
+
+Run this before `repos upgrade` to ensure mint compatibility.
+
+```bash
+fullsend repos upgrade-mint -f repos.yaml
+```
+
+### Flags
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--manifest` | `-f` | `repos.yaml` | Path or HTTPS URL to manifest file |
 
 ## See also
 

--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -75,7 +75,16 @@ fullsend
 │   │   ├── --yes                            #   Skip confirmation for glob patterns
 │   │   ├── --skip-wif-cleanup               #   Skip GCP WIF provider deletion
 │   │   └── --concurrency <int>              #   Max parallel operations (1-32, default: 4)
-│   └── status                               # Compare manifest against actual repo state
+│   ├── status                               # Compare manifest against actual repo state
+│   ├── upgrade        [repos...]            # Upgrade scaffold shim ref across repos
+│   │   ├── -f, --manifest <path>            #   Path or URL to repos.yaml (default: repos.yaml)
+│   │   ├── --ref <version>                  #   Override manifest fullsend_ref for all repos
+│   │   ├── --dry-run                        #   Preview without making changes
+│   │   ├── --force                          #   Upgrade even if current ref is newer
+│   │   ├── --direct                         #   Push directly to default branch (skip PR)
+│   │   └── --concurrency <int>              #   Max parallel operations (1-32, default: 4)
+│   └── upgrade-mint                         # Verify token mint deployment matches manifest
+│       └── -f, --manifest <path>            #   Path or URL to repos.yaml (default: repos.yaml)
 ├── agent                                    # Manage agent registrations in config
 │   ├── add          <url-or-path>            # Register an agent (URL auto-pinned)
 │   ├── list                                  # List registered agents

--- a/docs/guides/getting-started/operations.md
+++ b/docs/guides/getting-started/operations.md
@@ -26,12 +26,18 @@ fullsend github set "$OWNER/$REPO" FULLSEND_GCP_REGION global
 
 ## Syncing workflow templates
 
-After upgrading the fullsend CLI, re-run `github setup` to update the workflow file:
+After upgrading the fullsend CLI, re-run `github setup` to update the workflow file for a single repo:
 
 ```bash
 fullsend github setup "$OWNER/$REPO" \
   --inference-project "<GCP_PROJECT>" \
   --inference-wif-provider "<WIF_PROVIDER>"
+```
+
+For manifest-managed installations, use `repos upgrade` to update workflow refs across all repos:
+
+```bash
+fullsend repos upgrade -f repos.yaml
 ```
 
 This is idempotent — it updates the workflow file in place without changing other configuration.
@@ -77,6 +83,8 @@ For organizations that separate GCP and GitHub responsibilities across teams, fu
 | Fleet Admin | `fullsend repos remove <repos...>` | Remove repo entries from `repos.yaml` manifest (with optional `--uninstall`) |
 | Platform Admin | `fullsend repos uninstall <repos...>` | Tear down fullsend from repos (workflow, variables, secrets, WIF) without modifying manifest |
 | Fleet Admin | `fullsend repos status` | Compare `repos.yaml` manifest against actual per-repo state (drift detection) |
+| Platform Admin | `fullsend repos upgrade [repos...]` | Upgrade scaffold shim ref across manifest repos |
+| Platform Admin | `fullsend repos upgrade-mint` | Verify the token mint deployment matches the manifest |
 
 | Developer | `fullsend agent add <url-or-path>` | Register an agent in config (URL auto-pinned to commit SHA) |
 | Developer | `fullsend agent list` | List registered agents and their sources |

--- a/docs/plans/repos-management.md
+++ b/docs/plans/repos-management.md
@@ -212,37 +212,35 @@ about repos with `FULLSEND_PER_REPO_INSTALL=true` not in the manifest.
 
 #### `fullsend repos upgrade`
 
-Upgrades scaffold shim ref. Uses
-[ADR 0048](../ADRs/0048-automatic-updates.md)'s `--upstream-ref` —
-regenerates the shim with the new `__FULLSEND_REF__` value.
+Upgrades scaffold shim ref across repos by replacing `@ref` in all
+`fullsend-ai/fullsend` `uses:` lines within workflow files.
 
 ```
 $ fullsend repos upgrade
-
-Checking mint compatibility...
-  Mint at https://fullsend-mint-abc123-uc.a.run.app: v2.3.0 ✓
 
 Upgrading repos:
   acme-corp/api-server       v2.1.0 → v2.3.0  ✓
   acme-corp/web-frontend     v2.1.0 → v2.3.0  ✓
   acme-corp/legacy-service   v2.1.0            (pinned, already current)
-  acme-corp/bleeding-edge    latest            (non-semver, skipped)
+  acme-corp/bleeding-edge    latest            (floating tag, skipped)
 
 2 upgraded, 1 current, 1 skipped
 ```
 
-Version safety: checks mint compatibility before upgrading, blocks
-downgrades by default (`--force` to override), respects per-repo
-pinned versions. The `--ref` flag overrides the manifest for one-off
-upgrades.
+Version safety: blocks downgrades by default (`--force` to override),
+skips floating refs (branch names, partial versions like `v0`, `v1.2`),
+respects per-repo pinned versions. The `--ref` flag overrides the
+manifest for one-off upgrades.
+
+**Known limitation:** writes tags directly into `uses:` lines — repos
+using SHA pinning lose their pin on upgrade.
 
 #### `fullsend repos upgrade-mint`
 
-Upgrades the token mint Cloud Function. Uses existing provisioner
-deploy logic. Must run before `repos upgrade` if the mint version
-is behind the target fullsend ref. The `/health` endpoint must be
-extended to include a `version` field (currently only returns
-`{"status":"ok"}`).
+Verifies the token mint deployment matches the manifest configuration.
+Discovers the current mint via `DiscoverMint` and checks that its URL
+matches `mint.url`. Run before `repos upgrade` to confirm the mint
+is reachable and correctly configured.
 
 #### `fullsend repos add`
 
@@ -950,7 +948,7 @@ collected in `BatchInstallResult.Failed`.
 `ProvisionerFactory` creates a provisioner scoped to a specific repo:
 
 ```go
-type ProvisionerFactory func(cfg InstallConfig) WIFProvisioner
+type ProvisionerFactory func(cfg ResolvedConfig) WIFProvisioner
 ```
 
 #### `internal/repos/batch_install_test.go` (new)
@@ -1051,10 +1049,12 @@ Unit tests with `forge.FakeClient`.
 
 ---
 
-### PR 7: `fullsend repos upgrade` + `fullsend repos upgrade-mint`
+### PR 7: `fullsend repos upgrade` + `fullsend repos upgrade-mint` ✓
 
-**Scope:** New CLI commands. Writes workflow files, deploys Cloud
-Function.
+**Status:** Implemented in [#4080](https://github.com/fullsend-ai/fullsend/pull/4080).
+
+**Scope:** New CLI commands. Writes workflow files, verifies mint
+deployment.
 
 **Depends on:** PR 4 (reuses `extractWorkflowRef()` for reading
 current refs from workflow files).
@@ -1067,10 +1067,11 @@ Add `newReposUpgradeCmd()` and `newReposUpgradeMintCmd()`.
 
 - `--manifest` / `-f`.
 - `--ref` (string): override manifest `fullsend_ref`.
-- `--repo` (repeatable).
+- Positional args `[repos...]`: filter to specific repos (supports globs via `filepath.Match`).
 - `--dry-run`.
 - `--force`: upgrade even if current ref is newer.
 - `--concurrency` (int, default 4).
+- `--direct`: push scaffold directly to default branch (skip PR).
 
 `upgrade-mint` flags:
 
@@ -1114,49 +1115,43 @@ Upgrade logic per repo:
    `extractWorkflowRef()`.
 2. Determine target ref: `--ref` flag > per-repo `fullsend_ref` >
    `defaults.fullsend_ref`.
-3. Skip if target is a non-semver ref (e.g., `latest`, branch names).
-   Floating tags are not upgraded — they already track the newest
-   release. Log as "floating tag, skipped".
-4. Skip if current == target.
+3. Skip if target is a floating ref (`latest`, `main`, `master`,
+   or partial version tags like `v0`, `v1.2`).
+4. Skip if current ref is floating (same criteria as step 3).
 5. If both current and target are valid semver: skip if current >
    target unless `--force` is set (prevents accidental downgrade).
    If current is not valid semver (e.g., a branch name or SHA),
    proceed with the upgrade — the current ref cannot be compared.
-6. Regenerate scaffold shim with new ref using
-   `scaffold.PerRepoShimTemplate()`.
-7. Commit via `CommitFiles` (or `CommitFilesToBranch` + PR if branch
-   protection).
+6. Replace `@ref` in all `fullsend-ai/fullsend` `uses:` lines via
+   `replaceShimRef()` regex. Skip if no lines matched.
+7. Commit via `ScaffoldCommitFunc` (injected; the CLI layer wires it
+   to `CommitFilesToBranch` or direct push depending on `--direct`).
 
 Ref replacement in scaffold:
 
 ```go
-func replaceShimRef(content []byte, newRef string) ([]byte, error)
+func replaceShimRef(content []byte, newRef, newTag string) ([]byte, bool)
 ```
 
-Replaces all `@<oldRef>` occurrences in `uses:` lines referencing
-`fullsend-ai/fullsend`, and updates `fullsend_actions_ref` and
-`fullsend_cli_ref` input values — matching the `__FULLSEND_REF__`
-template from ADR 0048.
+Replaces all `@<oldRef>` occurrences (and optional trailing `# tag`
+comments) in `uses:` lines referencing `fullsend-ai/fullsend`. The
+regex uses `[ \t]*` (not `\s*`) for the comment group to avoid
+matching across newlines.
 
 In-place replacement is chosen over full scaffold regeneration to
-preserve any user customizations in the shim workflow. The tradeoff
-is fragility if ADR 0048's final field names differ from the regex
-targets — the implementation must align with ADR 0048's shipped
-template. If that dependency proves unstable, fall back to full
-regeneration via `scaffold.PerRepoShimTemplate()`.
+preserve any user customizations in the shim workflow.
 
-Mint compatibility check:
+**Limitation — tag-only pinning:** `replaceShimRef` writes the
+manifest tag directly into `uses:` lines. SHA-pinned repos
+(e.g., `@abc123 # v1.9.0`) lose their pin. A future enhancement
+will resolve tags to SHAs via the forge API.
 
-- Query mint `/health` endpoint for version.
-- Compare against target fullsend ref (semver).
-- Refuse if mint version < minimum required for target ref.
-- Direct operator to `repos upgrade-mint` first.
-
-`UpgradeMint`:
+`UpgradeMint` (verification only — full redeploy deferred until
+`/health` version endpoint is available):
 
 - Create provisioner from manifest's mint config.
-- Call provisioner deploy with force mode to redeploy the function.
-- Wait for health check to pass.
+- Discover the current mint deployment via `DiscoverMint`.
+- Verify discovered mint URL matches the manifest's `mint.url`.
 
 #### `internal/repos/upgrade_test.go` (new)
 
@@ -1165,16 +1160,18 @@ Mint compatibility check:
 - Mixed: some current, some behind, some ahead.
 - `--force` overrides "ahead" skip.
 - `--ref` overrides manifest ref.
-- `--repo` filter.
+- Positional args filter.
 - Dry-run → no writes.
-- Semver comparison: table-driven tests.
-- Branch protection → PR creation fallback.
-- Mint too old → error with upgrade-mint message.
+- Semver comparison: table-driven tests (including prerelease §11).
+- Floating ref detection (partial versions, branch names).
+- Standalone comment preservation across newlines.
+- `--direct` flag passed through to commit function.
+- Mint URL verification (match, mismatch, discover error, empty URL).
 
 #### Test strategy
 
-Unit tests with `forge.FakeClient`. Semver comparison as table-driven
-tests. Mint compatibility tested with a fake HTTP server.
+Unit tests with `forge.FakeClient` and fake `WIFProvisioner`.
+Semver comparison as table-driven tests.
 
 ---
 

--- a/internal/cli/repos.go
+++ b/internal/cli/repos.go
@@ -35,6 +35,8 @@ managing fullsend across many repositories and organizations.`,
 	cmd.AddCommand(newReposInstallCmd())
 	cmd.AddCommand(newReposUninstallCmd())
 	cmd.AddCommand(newReposStatusCmd())
+	cmd.AddCommand(newReposUpgradeCmd())
+	cmd.AddCommand(newReposUpgradeMintCmd())
 	return cmd
 }
 
@@ -1007,4 +1009,222 @@ func (s *splitProjectAdapter) DeletePerRepoWIF(ctx context.Context, repo string)
 
 func (s *splitProjectAdapter) DeleteWIFProvider(ctx context.Context, repo string) error {
 	return s.inference.DeleteWIFProvider(ctx, repo)
+}
+
+// reposUpgradeConfig holds flag values and testing overrides for repos upgrade.
+type reposUpgradeConfig struct {
+	manifest    string
+	refOverride string
+	dryRun      bool
+	force       bool
+	concurrency int
+	direct      bool
+
+	// Testing overrides — when non-nil, used instead of resolving from
+	// the environment. Not set by CLI flag parsing.
+	testClient forge.Client
+}
+
+func newReposUpgradeCmd() *cobra.Command {
+	opts := &reposUpgradeConfig{}
+
+	cmd := &cobra.Command{
+		Use:   "upgrade [repos...]",
+		Short: "Upgrade scaffold shim ref across repos",
+		Long: `Upgrades the fullsend scaffold workflow ref for repos defined in a repos.yaml manifest.
+
+When repos are specified as positional arguments (owner/repo format), only those
+repos are upgraded. When no repos are specified, all manifest repos are upgraded.
+
+Reads each repo's current workflow file, compares against the manifest's
+fullsend_ref (or --ref override), and commits the updated workflow.
+
+Floating refs (latest, main, v0) are skipped. Downgrades are blocked
+unless --force is set.`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReposUpgrade(cmd.Context(), opts, args)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.manifest, "manifest", "f", "repos.yaml", "path or HTTPS URL to manifest file")
+	cmd.Flags().StringVar(&opts.refOverride, "ref", "", "override manifest fullsend_ref for all repos")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "preview what would be upgraded without making changes")
+	cmd.Flags().BoolVar(&opts.force, "force", false, "upgrade even if current ref is newer than target")
+	cmd.Flags().IntVar(&opts.concurrency, "concurrency", 4, "max parallel operations")
+	cmd.Flags().BoolVar(&opts.direct, "direct", false, "push scaffold directly to default branch (skip PR)")
+
+	return cmd
+}
+
+func runReposUpgrade(ctx context.Context, opts *reposUpgradeConfig, repoFilter []string) error {
+	printer := ui.New(os.Stdout)
+
+	if opts.concurrency < 1 || opts.concurrency > 32 {
+		return fmt.Errorf("--concurrency must be between 1 and 32, got %d", opts.concurrency)
+	}
+
+	if opts.refOverride != "" && !repos.IsValidRef(opts.refOverride) {
+		return fmt.Errorf("--ref value %q contains invalid characters; only alphanumeric, dot, underscore, and hyphen are allowed", opts.refOverride)
+	}
+
+	printer.StepStart("Loading manifest")
+	m, err := repos.LoadManifest(ctx, opts.manifest)
+	if err != nil {
+		return fmt.Errorf("loading manifest: %w", err)
+	}
+	if err := m.Validate(); err != nil {
+		return fmt.Errorf("manifest validation failed: %w", err)
+	}
+	printer.StepDone(fmt.Sprintf("Loaded manifest with %d repo entries", len(m.Repos)))
+
+	var client forge.Client
+	if opts.testClient != nil {
+		client = opts.testClient
+	} else {
+		token, tokenErr := resolveToken()
+		if tokenErr != nil {
+			return tokenErr
+		}
+		client = newGitHubLiveClient(token)
+	}
+
+	if err := checkPerRepoScopes(ctx, client, printer); err != nil {
+		return err
+	}
+
+	commitFn := func(ctx context.Context, owner, repo string, files []forge.TreeFile, isDirect bool) error {
+		targetRepo, repoErr := client.GetRepo(ctx, owner, repo)
+		if repoErr != nil {
+			return fmt.Errorf("getting repo info: %w", repoErr)
+		}
+		commitMsg := "chore: upgrade fullsend scaffold ref"
+		prTitle := "chore: upgrade fullsend scaffold ref"
+		prBody := "This PR upgrades the fullsend scaffold workflow ref.\n\n" +
+			"Merge this PR to activate the updated workflows."
+		_, commitErr := layers.CommitScaffoldFiles(ctx, client, printer, owner, repo,
+			targetRepo.DefaultBranch, commitMsg, prTitle, prBody, files, isDirect, nil)
+		return commitErr
+	}
+
+	cfg := repos.UpgradeConfig{
+		Manifest:       m,
+		RefOverride:    opts.refOverride,
+		RepoFilter:     repoFilter,
+		DryRun:         opts.dryRun,
+		Force:          opts.force,
+		Direct:         opts.direct,
+		MaxConcurrency: opts.concurrency,
+	}
+
+	progressFn := func(repo, phase, msg string) {
+		switch phase {
+		case "done":
+			printer.StepDone(fmt.Sprintf("[%s] %s", repo, msg))
+		default:
+			printer.StepInfo(fmt.Sprintf("[%s] %s", repo, msg))
+		}
+	}
+
+	printer.Blank()
+	if opts.dryRun {
+		printer.StepStart("Dry-run: previewing upgrades")
+	} else {
+		printer.StepStart("Upgrading repos")
+	}
+
+	results, err := repos.Upgrade(ctx, cfg, client, commitFn, progressFn)
+	if err != nil {
+		return err
+	}
+
+	var upgraded, skipped, failed int
+	for _, r := range results {
+		switch {
+		case r.Error != nil:
+			failed++
+			printer.StepInfo(fmt.Sprintf("  FAILED: %s/%s — %v", r.Owner, r.Repo, r.Error))
+		case r.Upgraded:
+			upgraded++
+		case r.Skipped:
+			skipped++
+		}
+	}
+
+	printer.Blank()
+	printer.StepDone(fmt.Sprintf("Upgrade complete: %d upgraded, %d skipped, %d failed",
+		upgraded, skipped, failed))
+
+	if failed > 0 {
+		return fmt.Errorf("%d repos failed to upgrade", failed)
+	}
+	return nil
+}
+
+// reposUpgradeMintConfig holds flag values and testing overrides for repos upgrade-mint.
+type reposUpgradeMintConfig struct {
+	manifest string
+
+	// Testing overrides — when non-nil, used instead of resolving from
+	// the environment. Not set by CLI flag parsing.
+	testProvisioner repos.WIFProvisioner
+}
+
+func newReposUpgradeMintCmd() *cobra.Command {
+	opts := &reposUpgradeMintConfig{}
+
+	cmd := &cobra.Command{
+		Use:   "upgrade-mint",
+		Short: "Verify the token mint deployment",
+		Long: `Verifies the token mint Cloud Function matches the manifest configuration.
+
+Discovers the current mint deployment and checks that its URL matches
+the manifest's mint.url. Run this before 'repos upgrade' to ensure
+mint compatibility.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReposUpgradeMint(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.manifest, "manifest", "f", "repos.yaml", "path or HTTPS URL to manifest file")
+
+	return cmd
+}
+
+func runReposUpgradeMint(ctx context.Context, opts *reposUpgradeMintConfig) error {
+	printer := ui.New(os.Stdout)
+
+	printer.StepStart("Loading manifest")
+	m, err := repos.LoadManifest(ctx, opts.manifest)
+	if err != nil {
+		return fmt.Errorf("loading manifest: %w", err)
+	}
+	if err := m.Validate(); err != nil {
+		return fmt.Errorf("manifest validation failed: %w", err)
+	}
+	printer.StepDone("Loaded manifest")
+
+	var provisioner repos.WIFProvisioner
+	if opts.testProvisioner != nil {
+		provisioner = opts.testProvisioner
+	} else {
+		provisioner = &gcfProvisionerAdapter{
+			provisioner: gcf.NewProvisioner(gcf.Config{
+				ProjectID: m.Mint.Project,
+				Region:    m.Mint.Region,
+				MintURL:   m.Mint.URL,
+			}, gcf.NewLiveGCFClient(m.Mint.Project)),
+		}
+	}
+
+	progressFn := func(repo, phase, msg string) {
+		printer.StepInfo(fmt.Sprintf("[%s] %s", repo, msg))
+	}
+
+	if err := repos.UpgradeMint(ctx, m, provisioner, progressFn); err != nil {
+		return err
+	}
+
+	printer.StepDone("Mint verified successfully")
+	return nil
 }

--- a/internal/cli/repos_test.go
+++ b/internal/cli/repos_test.go
@@ -28,6 +28,8 @@ func TestReposCommand_HasSubcommands(t *testing.T) {
 	assert.True(t, names["install"], "expected install subcommand")
 	assert.True(t, names["uninstall"], "expected uninstall subcommand")
 	assert.True(t, names["status"], "expected status subcommand")
+	assert.True(t, names["upgrade"], "expected upgrade subcommand")
+	assert.True(t, names["upgrade-mint"], "expected upgrade-mint subcommand")
 }
 
 func TestReposCommand_RegisteredInRoot(t *testing.T) {
@@ -1236,4 +1238,271 @@ func TestBuildProvisionerFactory_WithTestProv(t *testing.T) {
 		InferenceRegion:  "us-central1",
 	})
 	assert.Equal(t, prov, result)
+}
+
+// --- repos upgrade ---
+
+func TestReposUpgradeCmd_Flags(t *testing.T) {
+	cmd := newReposUpgradeCmd()
+
+	manifestFlag := cmd.Flags().Lookup("manifest")
+	require.NotNil(t, manifestFlag, "expected --manifest flag")
+	assert.Equal(t, "repos.yaml", manifestFlag.DefValue)
+
+	refFlag := cmd.Flags().Lookup("ref")
+	require.NotNil(t, refFlag, "expected --ref flag")
+	assert.Equal(t, "", refFlag.DefValue)
+
+	dryRunFlag := cmd.Flags().Lookup("dry-run")
+	require.NotNil(t, dryRunFlag, "expected --dry-run flag")
+	assert.Equal(t, "false", dryRunFlag.DefValue)
+
+	forceFlag := cmd.Flags().Lookup("force")
+	require.NotNil(t, forceFlag, "expected --force flag")
+	assert.Equal(t, "false", forceFlag.DefValue)
+
+	concurrencyFlag := cmd.Flags().Lookup("concurrency")
+	require.NotNil(t, concurrencyFlag, "expected --concurrency flag")
+	assert.Equal(t, "4", concurrencyFlag.DefValue)
+
+	directFlag := cmd.Flags().Lookup("direct")
+	require.NotNil(t, directFlag, "expected --direct flag")
+	assert.Equal(t, "false", directFlag.DefValue)
+
+	repoFlag := cmd.Flags().Lookup("repo")
+	assert.Nil(t, repoFlag, "--repo flag should not exist, use positional args")
+}
+
+func TestReposUpgradeCmd_ManifestShortFlag(t *testing.T) {
+	cmd := newReposUpgradeCmd()
+	shorthand := cmd.Flags().ShorthandLookup("f")
+	require.NotNil(t, shorthand, "expected -f shorthand for --manifest")
+}
+
+func TestRunReposUpgrade_DryRun(t *testing.T) {
+	yaml := `version: 1
+mint:
+  url: https://mint.example.com
+  project: mint-proj
+  region: us-central1
+defaults:
+  inference_project: inf-proj
+  inference_region: us-central1
+  fullsend_ref: v2.0.0
+repos:
+  - repo: acme/api
+`
+	manifestPath := writeTestManifest(t, yaml)
+	fc := newInstallFakeClient("acme/api")
+	fc.FileContents["acme/api/.github/workflows/fullsend.yml"] = []byte(
+		"uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v1.0.0\n",
+	)
+
+	err := runReposUpgrade(context.Background(), &reposUpgradeConfig{
+		manifest:    manifestPath,
+		dryRun:      true,
+		concurrency: 4,
+		testClient:  fc,
+	}, nil)
+	require.NoError(t, err)
+}
+
+func TestRunReposUpgrade_InvalidManifest(t *testing.T) {
+	fc := newInstallFakeClient()
+
+	err := runReposUpgrade(context.Background(), &reposUpgradeConfig{
+		manifest:    "/nonexistent/repos.yaml",
+		concurrency: 4,
+		testClient:  fc,
+	}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "loading manifest")
+}
+
+func TestRunReposUpgrade_ConcurrencyValidation(t *testing.T) {
+	manifestPath := writeTestManifest(t, testManifestYAML)
+
+	err := runReposUpgrade(context.Background(), &reposUpgradeConfig{
+		manifest:    manifestPath,
+		concurrency: 0,
+		testClient:  newInstallFakeClient(),
+	}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--concurrency must be between 1 and 32")
+}
+
+func TestRunReposUpgrade_WithFilter(t *testing.T) {
+	yaml := `version: 1
+mint:
+  url: https://mint.example.com
+  project: mint-proj
+  region: us-central1
+defaults:
+  inference_project: inf-proj
+  inference_region: us-central1
+  fullsend_ref: v2.0.0
+repos:
+  - repo: acme/api
+  - repo: acme/web
+`
+	manifestPath := writeTestManifest(t, yaml)
+	fc := newInstallFakeClient("acme/api", "acme/web")
+	fc.FileContents["acme/api/.github/workflows/fullsend.yml"] = []byte(
+		"uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v1.0.0\n",
+	)
+	fc.FileContents["acme/web/.github/workflows/fullsend.yml"] = []byte(
+		"uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v1.0.0\n",
+	)
+
+	err := runReposUpgrade(context.Background(), &reposUpgradeConfig{
+		manifest:    manifestPath,
+		dryRun:      true,
+		concurrency: 4,
+		testClient:  fc,
+	}, []string{"acme/api"})
+	require.NoError(t, err)
+}
+
+func TestRunReposUpgrade_InvalidRefFormat(t *testing.T) {
+	manifestPath := writeTestManifest(t, testManifestYAML)
+
+	err := runReposUpgrade(context.Background(), &reposUpgradeConfig{
+		manifest:    manifestPath,
+		refOverride: "v1.0.0$bad",
+		concurrency: 4,
+		testClient:  newInstallFakeClient(),
+	}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid characters")
+}
+
+func TestRunReposUpgrade_HighConcurrency(t *testing.T) {
+	manifestPath := writeTestManifest(t, testManifestYAML)
+
+	err := runReposUpgrade(context.Background(), &reposUpgradeConfig{
+		manifest:    manifestPath,
+		concurrency: 33,
+		testClient:  newInstallFakeClient(),
+	}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--concurrency must be between 1 and 32")
+}
+
+func TestRunReposUpgrade_FullUpgrade(t *testing.T) {
+	yaml := `version: 1
+mint:
+  url: https://mint.example.com
+  project: mint-proj
+  region: us-central1
+defaults:
+  inference_project: inf-proj
+  inference_region: us-central1
+  fullsend_ref: v2.0.0
+repos:
+  - repo: acme/api
+`
+	manifestPath := writeTestManifest(t, yaml)
+	fc := newInstallFakeClient("acme/api")
+	fc.FileContents["acme/api/.github/workflows/fullsend.yml"] = []byte(
+		"uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v1.0.0\n",
+	)
+
+	err := runReposUpgrade(context.Background(), &reposUpgradeConfig{
+		manifest:    manifestPath,
+		concurrency: 4,
+		direct:      true,
+		testClient:  fc,
+	}, nil)
+	require.NoError(t, err)
+}
+
+func TestRunReposUpgrade_WithRefOverride(t *testing.T) {
+	manifestPath := writeTestManifest(t, testManifestYAML)
+	fc := newInstallFakeClient("acme/api")
+	fc.FileContents["acme/api/.github/workflows/fullsend.yml"] = []byte(
+		"uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v0.9.0\n",
+	)
+
+	err := runReposUpgrade(context.Background(), &reposUpgradeConfig{
+		manifest:    manifestPath,
+		refOverride: "v2.0.0",
+		dryRun:      true,
+		concurrency: 4,
+		testClient:  fc,
+	}, nil)
+	require.NoError(t, err)
+}
+
+func TestRunReposUpgrade_ManifestValidationFailure(t *testing.T) {
+	badManifest := `version: 99
+mint:
+  url: https://mint.example.com
+  project: mint-proj
+  region: us-central1
+repos:
+  - repo: acme/api
+`
+	manifestPath := writeTestManifest(t, badManifest)
+
+	err := runReposUpgrade(context.Background(), &reposUpgradeConfig{
+		manifest:    manifestPath,
+		concurrency: 4,
+		testClient:  newInstallFakeClient(),
+	}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "manifest validation failed")
+}
+
+// --- repos upgrade-mint ---
+
+func TestReposUpgradeMintCmd_Flags(t *testing.T) {
+	cmd := newReposUpgradeMintCmd()
+
+	manifestFlag := cmd.Flags().Lookup("manifest")
+	require.NotNil(t, manifestFlag, "expected --manifest flag")
+	assert.Equal(t, "repos.yaml", manifestFlag.DefValue)
+}
+
+func TestReposUpgradeMintCmd_ManifestShortFlag(t *testing.T) {
+	cmd := newReposUpgradeMintCmd()
+	shorthand := cmd.Flags().ShorthandLookup("f")
+	require.NotNil(t, shorthand, "expected -f shorthand for --manifest")
+}
+
+func TestRunReposUpgradeMint_InvalidManifest(t *testing.T) {
+	err := runReposUpgradeMint(context.Background(), &reposUpgradeMintConfig{
+		manifest: "/nonexistent/repos.yaml",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "loading manifest")
+}
+
+func TestRunReposUpgradeMint_ManifestValidationFailure(t *testing.T) {
+	badManifest := `version: 99
+mint:
+  url: https://mint.example.com
+  project: mint-proj
+  region: us-central1
+repos:
+  - repo: acme/api
+`
+	manifestPath := writeTestManifest(t, badManifest)
+
+	err := runReposUpgradeMint(context.Background(), &reposUpgradeMintConfig{
+		manifest: manifestPath,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "manifest validation failed")
+}
+
+func TestRunReposUpgradeMint_Success(t *testing.T) {
+	manifestPath := writeTestManifest(t, testManifestYAML)
+	prov := &trackingProvisioner{label: "https://mint.example.com"}
+
+	err := runReposUpgradeMint(context.Background(), &reposUpgradeMintConfig{
+		manifest:        manifestPath,
+		testProvisioner: prov,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, prov.calls, "DiscoverMint")
 }

--- a/internal/repos/manifest.go
+++ b/internal/repos/manifest.go
@@ -350,6 +350,10 @@ func (m *Manifest) Validate() error {
 		return fmt.Errorf("mint.region is required")
 	}
 
+	if m.Defaults.FullsendRef != "" && !IsValidRef(m.Defaults.FullsendRef) {
+		return fmt.Errorf("defaults.fullsend_ref %q contains invalid characters; only alphanumeric, dot, underscore, and hyphen are allowed", m.Defaults.FullsendRef)
+	}
+
 	// Validate repo entries.
 	seen := make(map[string]bool, len(m.Repos))
 	for i, entry := range m.Repos {
@@ -372,6 +376,10 @@ func (m *Manifest) Validate() error {
 			if _, err := filepath.Match(parts[1], "test"); err != nil {
 				return fmt.Errorf("repos[%d]: invalid glob pattern %q: %w", i, entry.Repo, err)
 			}
+		}
+
+		if entry.FullsendRef.Set && !entry.FullsendRef.Null && entry.FullsendRef.Value != "" && !IsValidRef(entry.FullsendRef.Value) {
+			return fmt.Errorf("repos[%d]: fullsend_ref %q contains invalid characters; only alphanumeric, dot, underscore, and hyphen are allowed", i, entry.FullsendRef.Value)
 		}
 
 		// Check for duplicates.

--- a/internal/repos/manifest_test.go
+++ b/internal/repos/manifest_test.go
@@ -460,6 +460,32 @@ repos:
 	assert.NoError(t, m.Validate())
 }
 
+func TestValidate_InvalidDefaultFullsendRef(t *testing.T) {
+	m := Manifest{
+		Version:  1,
+		Mint:     MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{FullsendRef: "v1.0.0; rm -rf /"},
+		Repos:    []RepoEntry{{Repo: "acme/repo"}},
+	}
+	err := m.Validate()
+	assert.ErrorContains(t, err, "defaults.fullsend_ref")
+	assert.ErrorContains(t, err, "invalid characters")
+}
+
+func TestValidate_InvalidPerRepoFullsendRef(t *testing.T) {
+	m := Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Repos: []RepoEntry{{
+			Repo:        "acme/repo",
+			FullsendRef: NullableString{Value: "v1.0.0$(evil)", Set: true},
+		}},
+	}
+	err := m.Validate()
+	assert.ErrorContains(t, err, "fullsend_ref")
+	assert.ErrorContains(t, err, "invalid characters")
+}
+
 func TestValidate_OwnerWildcard(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/repos/upgrade.go
+++ b/internal/repos/upgrade.go
@@ -1,0 +1,409 @@
+package repos
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
+)
+
+// UpgradeConfig holds configuration for a batch upgrade operation.
+type UpgradeConfig struct {
+	Manifest       *Manifest
+	RefOverride    string
+	RepoFilter     []string
+	DryRun         bool
+	Force          bool
+	Direct         bool
+	MaxConcurrency int
+}
+
+// UpgradeResult holds the outcome of upgrading a single repo.
+type UpgradeResult struct {
+	Owner      string
+	Repo       string
+	OldRef     string
+	NewRef     string
+	Upgraded   bool
+	Skipped    bool
+	SkipReason string
+	Error      error
+}
+
+// safeRefPattern validates that a ref contains only characters safe for
+// GitHub Actions uses: lines.
+var safeRefPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// IsValidRef reports whether ref contains only characters safe for use in
+// GitHub Actions workflow uses: lines.
+func IsValidRef(ref string) bool {
+	return ref != "" && safeRefPattern.MatchString(ref)
+}
+
+// shimRefPattern matches all @ref occurrences in fullsend-ai/fullsend workflow uses: lines.
+// The trailing comment group uses [ \t]* (not \s*) to avoid matching across newlines.
+var shimRefPattern = regexp.MustCompile(
+	`(uses:\s+fullsend-ai/fullsend/[^@]+@)\S+([ \t]*#.*)?`,
+)
+
+// replaceShimRef replaces the @ref (and optional trailing # tag comment) in all
+// fullsend-ai/fullsend uses: lines within a workflow file. The newRef and
+// newTag are formatted as "newRef # newTag" when newTag is non-empty and
+// differs from newRef.
+func replaceShimRef(content []byte, newRef, newTag string) ([]byte, bool) {
+	suffix := newRef
+	if newTag != "" && newTag != newRef {
+		suffix = newRef + " # " + newTag
+	}
+
+	safe := strings.ReplaceAll(suffix, "$", "$$")
+	replaced := shimRefPattern.ReplaceAllString(string(content), "${1}"+safe)
+	changed := replaced != string(content)
+	return []byte(replaced), changed
+}
+
+// Upgrade upgrades the scaffold shim ref across repos in the manifest.
+// It reads each repo's current workflow file, determines whether an upgrade
+// is needed, and commits the updated workflow with the new ref.
+func Upgrade(ctx context.Context, cfg UpgradeConfig,
+	client forge.Client,
+	commitFn ScaffoldCommitFunc,
+	progress ProgressFunc) ([]UpgradeResult, error) {
+
+	if progress == nil {
+		progress = func(_, _, _ string) {}
+	}
+
+	resolved, err := cfg.Manifest.ExpandGlobs(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("resolving repos: %w", err)
+	}
+
+	if len(cfg.RepoFilter) > 0 {
+		resolved, err = filterRepos(resolved, cfg.RepoFilter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if cfg.MaxConcurrency <= 0 || cfg.MaxConcurrency > 32 {
+		return nil, fmt.Errorf("concurrency must be between 1 and 32, got %d", cfg.MaxConcurrency)
+	}
+
+	results := make([]UpgradeResult, len(resolved))
+	sem := make(chan struct{}, cfg.MaxConcurrency)
+	var wg sync.WaitGroup
+
+	for i, rr := range resolved {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			wg.Wait()
+			return nil, ctx.Err()
+		}
+		wg.Add(1)
+		go func(idx int, rr ResolvedRepo) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			resolvedCfg := cfg.Manifest.ResolveConfigForEntry(rr.Owner, rr.Repo, rr.Entry)
+			result := upgradeRepo(ctx, client, commitFn, rr.Owner, rr.Repo, resolvedCfg, cfg, progress)
+			results[idx] = result
+		}(i, rr)
+	}
+	wg.Wait()
+
+	return results, nil
+}
+
+func upgradeRepo(ctx context.Context, client forge.Client,
+	commitFn ScaffoldCommitFunc,
+	owner, repo string,
+	resolvedCfg ResolvedConfig,
+	cfg UpgradeConfig,
+	progress ProgressFunc) UpgradeResult {
+
+	repoFullName := owner + "/" + repo
+	result := UpgradeResult{Owner: owner, Repo: repo}
+
+	targetRef := cfg.RefOverride
+	if targetRef == "" {
+		targetRef = resolvedCfg.FullsendRef
+	}
+	if targetRef == "" {
+		result.Skipped = true
+		result.SkipReason = "no target ref configured"
+		return result
+	}
+	if !IsValidRef(targetRef) {
+		result.Error = fmt.Errorf("ref %q contains invalid characters; only alphanumeric, dot, underscore, and hyphen are allowed", targetRef)
+		return result
+	}
+	result.NewRef = targetRef
+
+	if isFloatingRef(targetRef) {
+		result.Skipped = true
+		result.SkipReason = "floating tag, skipped"
+		return result
+	}
+
+	progress(repoFullName, "read", "Reading workflow file")
+
+	content, workflowPath, err := readWorkflowContent(ctx, client, owner, repo)
+	if err != nil {
+		result.Error = fmt.Errorf("reading workflow: %w", err)
+		return result
+	}
+	if content == nil {
+		result.Skipped = true
+		result.SkipReason = "workflow file not found"
+		return result
+	}
+
+	currentRef := extractWorkflowRef(content)
+	result.OldRef = currentRef
+
+	if isFloatingRef(currentRef) {
+		result.Skipped = true
+		result.SkipReason = "floating tag, skipped"
+		return result
+	}
+
+	if !cfg.Force && isSemver(currentRef) && isSemver(targetRef) {
+		if compareSemver(currentRef, targetRef) > 0 {
+			result.Skipped = true
+			result.SkipReason = fmt.Sprintf("current %s is newer than target %s (use --force to override)", currentRef, targetRef)
+			return result
+		}
+	}
+
+	// The target ref for the uses: line is expected to be a SHA when ADR 0048's
+	// --upstream-ref is used, but the manifest's fullsend_ref is a version tag.
+	// We use the tag as both the ref and the comment since we don't have the SHA.
+	newContent, changed := replaceShimRef(content, targetRef, "")
+	if !changed {
+		result.Skipped = true
+		result.SkipReason = "no uses: lines matched for replacement"
+		return result
+	}
+
+	if cfg.DryRun {
+		result.Upgraded = true
+		progress(repoFullName, "dry-run", fmt.Sprintf("Would upgrade %s → %s", currentRef, targetRef))
+		return result
+	}
+
+	progress(repoFullName, "upgrade", fmt.Sprintf("Upgrading %s → %s", currentRef, targetRef))
+
+	files := []forge.TreeFile{{
+		Path:    workflowPath,
+		Content: newContent,
+		Mode:    "100644",
+	}}
+
+	if err := commitFn(ctx, owner, repo, files, cfg.Direct); err != nil {
+		result.Error = fmt.Errorf("committing upgrade: %w", err)
+		return result
+	}
+
+	result.Upgraded = true
+	progress(repoFullName, "done", fmt.Sprintf("Upgraded %s → %s", currentRef, targetRef))
+	return result
+}
+
+// readWorkflowContent tries each known shim workflow path and returns
+// the content and path of the first one found, or (nil, "", nil) if none.
+func readWorkflowContent(ctx context.Context, client forge.Client, owner, repo string) ([]byte, string, error) {
+	for _, path := range workflowPaths {
+		content, err := client.GetFileContent(ctx, owner, repo, path)
+		if err != nil {
+			if forge.IsNotFound(err) {
+				continue
+			}
+			return nil, "", err
+		}
+		return content, path, nil
+	}
+	return nil, "", nil
+}
+
+// isFloatingRef returns true for refs that are not pinned versions —
+// branch names, "latest", or non-semver floating tags like "v0".
+func isFloatingRef(ref string) bool {
+	if ref == "" {
+		return false
+	}
+	lower := strings.ToLower(ref)
+	if lower == "latest" || lower == "main" || lower == "master" {
+		return true
+	}
+	// A partial semver ref (e.g., "v0", "v1", "v1.2") is floating because it
+	// does not pin to a specific patch version and cannot be reliably compared.
+	if isPartialVersionTag(ref) {
+		return true
+	}
+	return false
+}
+
+// partialVersionPattern matches version tags that are missing the patch
+// component: "v0", "v1", "v1.2", etc. Full semver (vX.Y.Z) is NOT matched.
+var partialVersionPattern = regexp.MustCompile(`^v\d+(\.\d+)?$`)
+
+func isPartialVersionTag(ref string) bool {
+	return partialVersionPattern.MatchString(ref)
+}
+
+// isSemver returns true if the ref looks like a semver version tag (vX.Y.Z with optional pre-release).
+var semverPattern = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)`)
+
+func isSemver(ref string) bool {
+	return semverPattern.MatchString(ref)
+}
+
+// semverFullPattern captures major, minor, patch, and optional prerelease suffix.
+// Build metadata (+...) is excluded per semver 2.0.0 §10.
+var semverFullPattern = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)(?:-([^+]+))?`)
+
+// compareSemver compares two semver refs (vX.Y.Z or vX.Y.Z-pre format).
+// Returns -1 if a < b, 0 if a == b, 1 if a > b.
+// Prerelease versions are less than their release counterparts
+// (e.g., v2.3.0-rc1 < v2.3.0). Prerelease identifiers are compared
+// per semver 2.0.0 §11: split by ".", numeric segments compared as
+// integers, string segments compared lexically, numeric < string,
+// and fewer fields is less when all preceding fields are equal.
+func compareSemver(a, b string) int {
+	am := semverFullPattern.FindStringSubmatch(a)
+	bm := semverFullPattern.FindStringSubmatch(b)
+	if am == nil || bm == nil {
+		return 0
+	}
+	for i := 1; i <= 3; i++ {
+		av := parseUint(am[i])
+		bv := parseUint(bm[i])
+		if av < bv {
+			return -1
+		}
+		if av > bv {
+			return 1
+		}
+	}
+	aPre := am[4]
+	bPre := bm[4]
+	if aPre == "" && bPre == "" {
+		return 0
+	}
+	if aPre == "" {
+		return 1
+	}
+	if bPre == "" {
+		return -1
+	}
+	return comparePrerelease(aPre, bPre)
+}
+
+// comparePrerelease compares dot-separated prerelease identifiers per
+// semver 2.0.0 §11.
+func comparePrerelease(a, b string) int {
+	as := strings.Split(a, ".")
+	bs := strings.Split(b, ".")
+	n := len(as)
+	if len(bs) < n {
+		n = len(bs)
+	}
+	for i := 0; i < n; i++ {
+		if c := comparePreID(as[i], bs[i]); c != 0 {
+			return c
+		}
+	}
+	if len(as) < len(bs) {
+		return -1
+	}
+	if len(as) > len(bs) {
+		return 1
+	}
+	return 0
+}
+
+func comparePreID(a, b string) int {
+	aNum, aIsNum := tryParseUint(a)
+	bNum, bIsNum := tryParseUint(b)
+	switch {
+	case aIsNum && bIsNum:
+		if aNum < bNum {
+			return -1
+		}
+		if aNum > bNum {
+			return 1
+		}
+		return 0
+	case aIsNum:
+		return -1
+	case bIsNum:
+		return 1
+	default:
+		if a < b {
+			return -1
+		}
+		if a > b {
+			return 1
+		}
+		return 0
+	}
+}
+
+func tryParseUint(s string) (uint64, bool) {
+	if s == "" {
+		return 0, false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+	}
+	return parseUint(s), true
+}
+
+func parseUint(s string) uint64 {
+	const maxSafe = ^uint64(0)/10 - 1
+	var n uint64
+	for _, c := range s {
+		if n > maxSafe {
+			return ^uint64(0)
+		}
+		n = n*10 + uint64(c-'0')
+	}
+	return n
+}
+
+// UpgradeMint verifies the token mint deployment matches the manifest configuration.
+func UpgradeMint(ctx context.Context, manifest *Manifest,
+	provisioner WIFProvisioner,
+	progress ProgressFunc) error {
+
+	if progress == nil {
+		progress = func(_, _, _ string) {}
+	}
+
+	progress("mint", "discover", "Checking current mint deployment")
+
+	discovery, err := provisioner.DiscoverMint(ctx)
+	if err != nil {
+		return fmt.Errorf("discovering mint: %w", err)
+	}
+
+	if discovery.URL == "" {
+		return fmt.Errorf("mint discovery returned empty URL")
+	}
+
+	progress("mint", "discover", fmt.Sprintf("Found mint at %s", discovery.URL))
+
+	if discovery.URL != manifest.Mint.URL {
+		return fmt.Errorf("discovered mint URL %q does not match manifest mint URL %q", discovery.URL, manifest.Mint.URL)
+	}
+
+	progress("mint", "done", "Mint verified successfully")
+	return nil
+}

--- a/internal/repos/upgrade_test.go
+++ b/internal/repos/upgrade_test.go
@@ -1,0 +1,1324 @@
+package repos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/fullsend-ai/fullsend/internal/forge"
+)
+
+func newUpgradeManifest(defaultRef string) *Manifest {
+	return &Manifest{
+		Version: 1,
+		Mint: MintConfig{
+			URL:     "https://mint.example.com",
+			Project: "example-project",
+			Region:  "us-central1",
+		},
+		Defaults: DefaultsConfig{
+			InferenceProject: "example-inference",
+			InferenceRegion:  "us-central1",
+			FullsendRef:      defaultRef,
+		},
+		Repos: []RepoEntry{
+			{Repo: "acme-corp/api-server"},
+			{Repo: "acme-corp/web-frontend"},
+		},
+	}
+}
+
+func makeWorkflow(ref string) []byte {
+	return []byte(fmt.Sprintf(`name: fullsend
+on:
+  workflow_dispatch:
+jobs:
+  dispatch:
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@%s
+    with:
+      install_mode: per-repo
+`, ref))
+}
+
+func noopCommitFn(_ context.Context, _, _ string, _ []forge.TreeFile, _ bool) error {
+	return nil
+}
+
+func TestUpgrade_AllBehindTarget(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+	fc.FileContents["acme-corp/web-frontend/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+
+	m := newUpgradeManifest("v2.3.0")
+	cfg := UpgradeConfig{
+		Manifest:       m,
+		MaxConcurrency: 2,
+	}
+
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+
+	for _, r := range results {
+		if !r.Upgraded {
+			t.Errorf("%s/%s: expected Upgraded=true, got false (skip=%q, err=%v)",
+				r.Owner, r.Repo, r.SkipReason, r.Error)
+		}
+		if r.OldRef != "v2.1.0" {
+			t.Errorf("%s/%s: OldRef = %q, want v2.1.0", r.Owner, r.Repo, r.OldRef)
+		}
+		if r.NewRef != "v2.3.0" {
+			t.Errorf("%s/%s: NewRef = %q, want v2.3.0", r.Owner, r.Repo, r.NewRef)
+		}
+	}
+}
+
+func TestUpgrade_AllAtTarget(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.3.0")
+	fc.FileContents["acme-corp/web-frontend/.github/workflows/fullsend.yml"] = makeWorkflow("v2.3.0")
+
+	m := newUpgradeManifest("v2.3.0")
+	cfg := UpgradeConfig{
+		Manifest:       m,
+		MaxConcurrency: 2,
+	}
+
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, r := range results {
+		if !r.Skipped {
+			t.Errorf("%s/%s: expected Skipped=true", r.Owner, r.Repo)
+		}
+		if r.SkipReason != "no uses: lines matched for replacement" {
+			t.Errorf("%s/%s: SkipReason = %q, want 'no uses: lines matched for replacement'", r.Owner, r.Repo, r.SkipReason)
+		}
+	}
+}
+
+func TestUpgrade_MixedStates(t *testing.T) {
+	m := &Manifest{
+		Version: 1,
+		Mint: MintConfig{
+			URL:     "https://mint.example.com",
+			Project: "example-project",
+			Region:  "us-central1",
+		},
+		Defaults: DefaultsConfig{
+			FullsendRef: "v2.3.0",
+		},
+		Repos: []RepoEntry{
+			{Repo: "acme-corp/current"},
+			{Repo: "acme-corp/behind"},
+			{Repo: "acme-corp/ahead"},
+		},
+	}
+
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/current/.github/workflows/fullsend.yml"] = makeWorkflow("v2.3.0")
+	fc.FileContents["acme-corp/behind/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+	fc.FileContents["acme-corp/ahead/.github/workflows/fullsend.yml"] = makeWorkflow("v2.5.0")
+
+	cfg := UpgradeConfig{
+		Manifest:       m,
+		MaxConcurrency: 4,
+	}
+
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	byRepo := make(map[string]UpgradeResult)
+	for _, r := range results {
+		byRepo[r.Owner+"/"+r.Repo] = r
+	}
+
+	if r := byRepo["acme-corp/current"]; !r.Skipped || r.SkipReason != "no uses: lines matched for replacement" {
+		t.Errorf("current: expected skipped (already at target), got Skipped=%v, reason=%q", r.Skipped, r.SkipReason)
+	}
+	if r := byRepo["acme-corp/behind"]; !r.Upgraded {
+		t.Errorf("behind: expected Upgraded=true, got %v (reason=%q, err=%v)", r.Upgraded, r.SkipReason, r.Error)
+	}
+	if r := byRepo["acme-corp/ahead"]; !r.Skipped || r.SkipReason == "" {
+		t.Errorf("ahead: expected skipped (newer), got Skipped=%v, reason=%q", r.Skipped, r.SkipReason)
+	}
+}
+
+func TestUpgrade_ForceOverridesNewerCheck(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.5.0")
+	fc.FileContents["acme-corp/web-frontend/.github/workflows/fullsend.yml"] = makeWorkflow("v2.5.0")
+
+	m := newUpgradeManifest("v2.3.0")
+	cfg := UpgradeConfig{
+		Manifest:       m,
+		Force:          true,
+		MaxConcurrency: 2,
+	}
+
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, r := range results {
+		if !r.Upgraded {
+			t.Errorf("%s/%s: expected Upgraded=true with --force, got Skipped=%v reason=%q",
+				r.Owner, r.Repo, r.Skipped, r.SkipReason)
+		}
+	}
+}
+
+func TestUpgrade_RefOverride(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+	fc.FileContents["acme-corp/web-frontend/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+
+	m := newUpgradeManifest("v2.3.0")
+	cfg := UpgradeConfig{
+		Manifest:       m,
+		RefOverride:    "v2.5.0",
+		MaxConcurrency: 2,
+	}
+
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, r := range results {
+		if r.NewRef != "v2.5.0" {
+			t.Errorf("%s/%s: NewRef = %q, want v2.5.0", r.Owner, r.Repo, r.NewRef)
+		}
+		if !r.Upgraded {
+			t.Errorf("%s/%s: expected Upgraded=true", r.Owner, r.Repo)
+		}
+	}
+}
+
+func TestUpgrade_RepoFilter(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+	fc.FileContents["acme-corp/web-frontend/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+
+	m := newUpgradeManifest("v2.3.0")
+	cfg := UpgradeConfig{
+		Manifest:       m,
+		RepoFilter:     []string{"acme-corp/api-server"},
+		MaxConcurrency: 2,
+	}
+
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1 (filtered)", len(results))
+	}
+	if results[0].Owner+"/"+results[0].Repo != "acme-corp/api-server" {
+		t.Errorf("filtered to wrong repo: %s/%s", results[0].Owner, results[0].Repo)
+	}
+}
+
+func TestUpgrade_DryRun(t *testing.T) {
+	commitCalled := false
+	dryRunCommitFn := func(_ context.Context, _, _ string, _ []forge.TreeFile, _ bool) error {
+		commitCalled = true
+		return nil
+	}
+
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+	fc.FileContents["acme-corp/web-frontend/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+
+	m := newUpgradeManifest("v2.3.0")
+	cfg := UpgradeConfig{
+		Manifest:       m,
+		DryRun:         true,
+		MaxConcurrency: 2,
+	}
+
+	results, err := Upgrade(context.Background(), cfg, fc, dryRunCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if commitCalled {
+		t.Error("commit function should not be called during dry-run")
+	}
+
+	for _, r := range results {
+		if !r.Upgraded {
+			t.Errorf("%s/%s: expected Upgraded=true in dry-run", r.Owner, r.Repo)
+		}
+	}
+}
+
+func TestUpgrade_FloatingTargetRefSkipped(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{
+			FullsendRef: "latest",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !results[0].Skipped || results[0].SkipReason != "floating tag, skipped" {
+		t.Errorf("expected floating tag skip, got Skipped=%v, reason=%q", results[0].Skipped, results[0].SkipReason)
+	}
+}
+
+func TestUpgrade_FloatingCurrentRefSkipped(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v0")
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{
+			FullsendRef: "v2.3.0",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !results[0].Skipped || results[0].SkipReason != "floating tag, skipped" {
+		t.Errorf("expected floating current ref skip, got Skipped=%v, reason=%q", results[0].Skipped, results[0].SkipReason)
+	}
+}
+
+func TestUpgrade_PartialVersionTargetSkipped(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{
+			FullsendRef: "v2.3",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !results[0].Skipped || results[0].SkipReason != "floating tag, skipped" {
+		t.Errorf("expected floating tag skip for partial version, got Skipped=%v, reason=%q", results[0].Skipped, results[0].SkipReason)
+	}
+}
+
+func TestUpgrade_PartialVersionCurrentRefSkipped(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v1.2")
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{
+			FullsendRef: "v2.3.0",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !results[0].Skipped || results[0].SkipReason != "floating tag, skipped" {
+		t.Errorf("expected floating tag skip for partial version current ref, got Skipped=%v, reason=%q", results[0].Skipped, results[0].SkipReason)
+	}
+}
+
+func TestUpgrade_WorkflowNotFound(t *testing.T) {
+	fc := forge.NewFakeClient()
+	// No workflow file set — FakeClient returns not-found.
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{
+			FullsendRef: "v2.3.0",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !results[0].Skipped || results[0].SkipReason != "workflow file not found" {
+		t.Errorf("expected 'workflow file not found', got Skipped=%v, reason=%q", results[0].Skipped, results[0].SkipReason)
+	}
+}
+
+func TestUpgrade_CommitError(t *testing.T) {
+	errCommitFn := func(_ context.Context, _, _ string, _ []forge.TreeFile, _ bool) error {
+		return fmt.Errorf("permission denied")
+	}
+
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{
+			FullsendRef: "v2.3.0",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+	results, err := Upgrade(context.Background(), cfg, fc, errCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if results[0].Error == nil {
+		t.Error("expected error on commit failure")
+	}
+	if results[0].Upgraded {
+		t.Error("should not be marked upgraded when commit fails")
+	}
+}
+
+func TestUpgrade_VerifiesWorkflowContent(t *testing.T) {
+	var committedFiles []forge.TreeFile
+	recordingCommitFn := func(_ context.Context, _, _ string, files []forge.TreeFile, _ bool) error {
+		committedFiles = files
+		return nil
+	}
+
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{
+			FullsendRef: "v2.3.0",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+	results, err := Upgrade(context.Background(), cfg, fc, recordingCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !results[0].Upgraded {
+		t.Fatal("expected Upgraded=true")
+	}
+
+	if len(committedFiles) != 1 {
+		t.Fatalf("expected 1 committed file, got %d", len(committedFiles))
+	}
+
+	content := string(committedFiles[0].Content)
+	if !containsRef(content, "v2.3.0") {
+		t.Errorf("committed content should contain @v2.3.0, got:\n%s", content)
+	}
+	if containsRef(content, "v2.1.0") {
+		t.Errorf("committed content should not contain @v2.1.0, got:\n%s", content)
+	}
+
+	if committedFiles[0].Path != ".github/workflows/fullsend.yml" {
+		t.Errorf("committed path = %q, want .github/workflows/fullsend.yml", committedFiles[0].Path)
+	}
+}
+
+func containsRef(content, ref string) bool {
+	return findRefInContent(content, ref)
+}
+
+func findRefInContent(content, ref string) bool {
+	target := "@" + ref
+	for _, line := range splitLines(content) {
+		if len(line) > 0 && indexOf(line, target) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			lines = append(lines, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestUpgrade_NoTargetRef(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+
+	m := &Manifest{
+		Version:  1,
+		Mint:     MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{},
+		Repos:    []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !results[0].Skipped || results[0].SkipReason != "no target ref configured" {
+		t.Errorf("expected skip due to no target ref, got Skipped=%v, reason=%q",
+			results[0].Skipped, results[0].SkipReason)
+	}
+}
+
+func TestUpgrade_NonSemverCurrentRef(t *testing.T) {
+	fc := forge.NewFakeClient()
+	// SHA ref that isn't semver — should proceed with upgrade (can't compare).
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("abc123def")
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{
+			FullsendRef: "v2.3.0",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !results[0].Upgraded {
+		t.Errorf("expected upgrade for non-semver current ref, got Skipped=%v, reason=%q",
+			results[0].Skipped, results[0].SkipReason)
+	}
+}
+
+func TestUpgrade_PerRepoOverrideRef(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+	fc.FileContents["acme-corp/web-frontend/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{
+			FullsendRef: "v2.3.0",
+		},
+		Repos: []RepoEntry{
+			{Repo: "acme-corp/api-server"},
+			{Repo: "acme-corp/web-frontend", FullsendRef: NullableString{Set: true, Value: "v2.1.0"}},
+		},
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 2}
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	byRepo := make(map[string]UpgradeResult)
+	for _, r := range results {
+		byRepo[r.Owner+"/"+r.Repo] = r
+	}
+
+	if r := byRepo["acme-corp/api-server"]; !r.Upgraded {
+		t.Errorf("api-server: expected Upgraded=true")
+	}
+
+	if r := byRepo["acme-corp/web-frontend"]; !r.Skipped {
+		t.Errorf("web-frontend: expected Skipped=true (pinned to same version), got Upgraded=%v, reason=%q",
+			r.Upgraded, r.SkipReason)
+	}
+}
+
+func TestUpgrade_YAMLExtension(t *testing.T) {
+	fc := forge.NewFakeClient()
+	// Use .yaml extension instead of .yml
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yaml"] = makeWorkflow("v2.1.0")
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{
+			FullsendRef: "v2.3.0",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+
+	var committedPath string
+	commitFn := func(_ context.Context, _, _ string, files []forge.TreeFile, _ bool) error {
+		if len(files) > 0 {
+			committedPath = files[0].Path
+		}
+		return nil
+	}
+
+	results, err := Upgrade(context.Background(), cfg, fc, commitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !results[0].Upgraded {
+		t.Fatalf("expected Upgraded=true")
+	}
+	if committedPath != ".github/workflows/fullsend.yaml" {
+		t.Errorf("committed path = %q, want .github/workflows/fullsend.yaml", committedPath)
+	}
+}
+
+func TestUpgrade_ProgressCallback(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{
+			FullsendRef: "v2.3.0",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	var phases []string
+	progressFn := func(repo, phase, msg string) {
+		phases = append(phases, phase)
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+	_, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, progressFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(phases) == 0 {
+		t.Error("expected progress callbacks, got none")
+	}
+
+	hasDone := false
+	for _, p := range phases {
+		if p == "done" {
+			hasDone = true
+		}
+	}
+	if !hasDone {
+		t.Error("expected 'done' phase in progress callbacks")
+	}
+}
+
+func TestReplaceShimRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		newRef   string
+		newTag   string
+		wantRef  string
+		wantDiff bool
+	}{
+		{
+			name:     "simple ref replacement",
+			input:    "    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v2.1.0\n",
+			newRef:   "v2.3.0",
+			wantRef:  "@v2.3.0",
+			wantDiff: true,
+		},
+		{
+			name:     "ref with tag comment",
+			input:    "    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@abc123 # v2.1.0\n",
+			newRef:   "v2.3.0",
+			wantRef:  "@v2.3.0",
+			wantDiff: true,
+		},
+		{
+			name:     "new ref with tag",
+			input:    "    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v2.1.0\n",
+			newRef:   "def456",
+			newTag:   "v2.3.0",
+			wantRef:  "@def456 # v2.3.0",
+			wantDiff: true,
+		},
+		{
+			name:     "same ref no change",
+			input:    "    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v2.3.0\n",
+			newRef:   "v2.3.0",
+			wantRef:  "@v2.3.0",
+			wantDiff: false,
+		},
+		{
+			name:     "no matching uses line",
+			input:    "    uses: actions/checkout@v4\n",
+			newRef:   "v2.3.0",
+			wantDiff: false,
+		},
+		{
+			name: "multiple uses lines",
+			input: `    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v2.1.0
+    uses: fullsend-ai/fullsend/.github/actions/mint-token@v2.1.0
+`,
+			newRef:   "v2.3.0",
+			wantRef:  "@v2.3.0",
+			wantDiff: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, changed := replaceShimRef([]byte(tt.input), tt.newRef, tt.newTag)
+			if changed != tt.wantDiff {
+				t.Errorf("changed = %v, want %v", changed, tt.wantDiff)
+			}
+			if tt.wantRef != "" && changed {
+				content := string(result)
+				if indexOf(content, tt.wantRef) < 0 {
+					t.Errorf("result should contain %q, got:\n%s", tt.wantRef, content)
+				}
+			}
+		})
+	}
+}
+
+func TestCompareSemver(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"v2.1.0", "v2.3.0", -1},
+		{"v2.3.0", "v2.1.0", 1},
+		{"v2.3.0", "v2.3.0", 0},
+		{"v1.0.0", "v2.0.0", -1},
+		{"v2.0.0", "v1.0.0", 1},
+		{"v2.3.1", "v2.3.0", 1},
+		{"v2.3.0", "v2.3.1", -1},
+		{"v10.0.0", "v2.0.0", 1},
+		{"v0.1.0", "v0.2.0", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s_vs_%s", tt.a, tt.b), func(t *testing.T) {
+			got := compareSemver(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("compareSemver(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSemver(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"v2.3.0", true},
+		{"v0.1.0", true},
+		{"v10.20.30", true},
+		{"v2.3.0-rc1", true},
+		{"latest", false},
+		{"main", false},
+		{"abc123", false},
+		{"v0", false},
+		{"v1", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			got := isSemver(tt.ref)
+			if got != tt.want {
+				t.Errorf("isSemver(%q) = %v, want %v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsFloatingRef(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"latest", true},
+		{"main", true},
+		{"master", true},
+		{"v0", true},
+		{"v1", true},
+		{"v2", true},
+		{"v2.3.0", false},
+		{"abc123", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			got := isFloatingRef(tt.ref)
+			if got != tt.want {
+				t.Errorf("isFloatingRef(%q) = %v, want %v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpgradeMint_Success(t *testing.T) {
+	prov := &fakeProvisioner{
+		discoverResult: &MintDiscovery{
+			URL: "https://mint.example.com",
+		},
+	}
+
+	m := newUpgradeManifest("v2.3.0")
+
+	err := UpgradeMint(context.Background(), m, prov, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpgradeMint_URLMismatch(t *testing.T) {
+	prov := &fakeProvisioner{
+		discoverResult: &MintDiscovery{
+			URL: "https://other-mint.example.com",
+		},
+	}
+
+	m := newUpgradeManifest("v2.3.0")
+
+	err := UpgradeMint(context.Background(), m, prov, nil)
+	if err == nil {
+		t.Fatal("expected error for URL mismatch")
+	}
+	if indexOf(err.Error(), "does not match") < 0 {
+		t.Errorf("error should mention mismatch, got: %v", err)
+	}
+}
+
+func TestUpgradeMint_DiscoverError(t *testing.T) {
+	prov := &fakeProvisioner{
+		discoverErr: fmt.Errorf("network error"),
+	}
+
+	m := newUpgradeManifest("v2.3.0")
+
+	err := UpgradeMint(context.Background(), m, prov, nil)
+	if err == nil {
+		t.Fatal("expected error for discover failure")
+	}
+}
+
+func TestUpgradeMint_EmptyURL(t *testing.T) {
+	prov := &fakeProvisioner{
+		discoverResult: &MintDiscovery{
+			URL: "",
+		},
+	}
+
+	m := newUpgradeManifest("v2.3.0")
+
+	err := UpgradeMint(context.Background(), m, prov, nil)
+	if err == nil {
+		t.Fatal("expected error for empty URL")
+	}
+}
+
+type fakeProvisioner struct {
+	discoverResult *MintDiscovery
+	discoverErr    error
+	provisionWIF   string
+	provisionErr   error
+}
+
+func (f *fakeProvisioner) DiscoverMint(_ context.Context) (*MintDiscovery, error) {
+	return f.discoverResult, f.discoverErr
+}
+
+func (f *fakeProvisioner) ProvisionWIF(_ context.Context) (string, error) {
+	return f.provisionWIF, f.provisionErr
+}
+
+func (f *fakeProvisioner) RegisterPerRepoWIF(_ context.Context, _ string) error {
+	return nil
+}
+
+func (f *fakeProvisioner) EnsureOrgInMint(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (f *fakeProvisioner) DeletePerRepoWIF(_ context.Context, _ string) error {
+	return nil
+}
+
+func (f *fakeProvisioner) DeleteWIFProvider(_ context.Context, _ string) error {
+	return nil
+}
+
+func TestUpgrade_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fc := forge.NewFakeClient()
+	m := newUpgradeManifest("v2.3.0")
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+
+	_, err := Upgrade(ctx, cfg, fc, noopCommitFn, nil)
+	if err == nil {
+		t.Error("expected context cancellation error")
+	}
+}
+
+func TestUpgrade_PartialVersionTag(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"v0", true},
+		{"v1", true},
+		{"v99", true},
+		{"v1.0", true},
+		{"v1.2", true},
+		{"v10.20", true},
+		{"v1.0.0", false},
+		{"v1.2.3", false},
+		{"main", false},
+		{"latest", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			got := isPartialVersionTag(tt.ref)
+			if got != tt.want {
+				t.Errorf("isPartialVersionTag(%q) = %v, want %v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReplaceShimRef_TagMatchesRef(t *testing.T) {
+	input := "    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v2.1.0\n"
+	result, changed := replaceShimRef([]byte(input), "v2.3.0", "v2.3.0")
+	if !changed {
+		t.Error("expected change")
+	}
+	content := string(result)
+	if indexOf(content, "# v2.3.0") >= 0 {
+		t.Error("should not add comment when tag == ref")
+	}
+}
+
+func TestReplaceShimRef_EmptyTag(t *testing.T) {
+	input := "    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v2.1.0\n"
+	result, changed := replaceShimRef([]byte(input), "v2.3.0", "")
+	if !changed {
+		t.Error("expected change")
+	}
+	content := string(result)
+	if indexOf(content, "#") >= 0 {
+		t.Error("should not add comment when tag is empty")
+	}
+}
+
+func TestReplaceShimRef_MultiWordComment(t *testing.T) {
+	input := "    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v2.1.0 # version 2.1.0\n"
+	result, changed := replaceShimRef([]byte(input), "v2.3.0", "")
+	if !changed {
+		t.Fatal("expected content to change")
+	}
+	want := "    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v2.3.0\n"
+	if string(result) != want {
+		t.Errorf("got %q, want %q", string(result), want)
+	}
+}
+
+func TestCompareSemver_BuildMetadataIgnored(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"v1.0.0-rc1+build123", "v1.0.0-rc1+build456", 0},
+		{"v1.0.0+build1", "v1.0.0+build2", 0},
+		{"v1.0.0-rc1+build", "v1.0.0-rc2", -1},
+	}
+	for _, tt := range tests {
+		got := compareSemver(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("compareSemver(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestCompareSemver_NonSemver(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{"a non-semver", "abc123", "v2.3.0", 0},
+		{"b non-semver", "v2.3.0", "abc123", 0},
+		{"both non-semver", "abc", "def", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareSemver(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("compareSemver(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsFloatingRef_Empty(t *testing.T) {
+	if isFloatingRef("") {
+		t.Error("empty string should not be floating")
+	}
+}
+
+func TestUpgrade_APIErrorOnWorkflowRead(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.Errors["GetFileContent"] = fmt.Errorf("API rate limit exceeded")
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{
+			FullsendRef: "v2.3.0",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if results[0].Error == nil {
+		t.Error("expected error for API failure")
+	}
+}
+
+func TestUpgradeMint_ProgressCallback(t *testing.T) {
+	prov := &fakeProvisioner{
+		discoverResult: &MintDiscovery{
+			URL: "https://mint.example.com",
+		},
+	}
+
+	var phases []string
+	progressFn := func(_, phase, _ string) {
+		phases = append(phases, phase)
+	}
+
+	m := newUpgradeManifest("v2.3.0")
+	err := UpgradeMint(context.Background(), m, prov, progressFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(phases) == 0 {
+		t.Error("expected progress callbacks")
+	}
+}
+
+func TestUpgrade_DirectFlagPassedToCommitFn(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+
+	var receivedDirect bool
+	trackingCommitFn := func(_ context.Context, _, _ string, _ []forge.TreeFile, direct bool) error {
+		receivedDirect = direct
+		return nil
+	}
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "us-central1"},
+		Defaults: DefaultsConfig{
+			InferenceProject: "inf",
+			InferenceRegion:  "us-central1",
+			FullsendRef:      "v2.3.0",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{
+		Manifest:       m,
+		Direct:         false,
+		MaxConcurrency: 1,
+	}
+
+	results, err := Upgrade(context.Background(), cfg, fc, trackingCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 || !results[0].Upgraded {
+		t.Fatal("expected one upgraded result")
+	}
+	if receivedDirect {
+		t.Error("commitFn received direct=true, want false")
+	}
+
+	receivedDirect = false
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+	cfg.Direct = true
+
+	results, err = Upgrade(context.Background(), cfg, fc, trackingCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 || !results[0].Upgraded {
+		t.Fatal("expected one upgraded result")
+	}
+	if !receivedDirect {
+		t.Error("commitFn received direct=false, want true")
+	}
+}
+
+func TestUpgrade_MixedRefsWorkflowAtTargetActionStale(t *testing.T) {
+	mixedContent := []byte(`name: fullsend
+on:
+  workflow_dispatch:
+jobs:
+  dispatch:
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v2.3.0
+    with:
+      install_mode: per-repo
+  mint:
+    steps:
+      - uses: fullsend-ai/fullsend/.github/actions/mint-token@v2.1.0
+`)
+
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = mixedContent
+
+	m := &Manifest{
+		Version:  1,
+		Mint:     MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{FullsendRef: "v2.3.0"},
+		Repos:    []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	var committed []byte
+	commitFn := func(_ context.Context, _, _ string, files []forge.TreeFile, _ bool) error {
+		committed = files[0].Content
+		return nil
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1, Direct: true}
+	results, err := Upgrade(context.Background(), cfg, fc, commitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 1 || !results[0].Upgraded {
+		t.Fatal("expected upgrade when action ref is stale even though workflow ref matches target")
+	}
+	if !strings.Contains(string(committed), "mint-token@v2.3.0") {
+		t.Errorf("expected action ref updated to v2.3.0, got: %s", committed)
+	}
+}
+
+func TestCompareSemver_PrereleaseHandling(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"v2.3.0", "v2.3.0-rc1", 1},
+		{"v2.3.0-rc1", "v2.3.0", -1},
+		{"v2.3.0-rc1", "v2.3.0-rc2", -1},
+		{"v2.3.0-rc2", "v2.3.0-rc1", 1},
+		{"v2.3.0-alpha", "v2.3.0-beta", -1},
+		{"v2.3.0-rc1", "v2.3.0-rc1", 0},
+		{"v1.0.0", "v2.0.0-rc1", -1},
+		{"v2.0.0-rc1", "v1.0.0", 1},
+		// semver 2.0.0 §11: numeric identifiers compared as integers
+		{"v1.0.0-2", "v1.0.0-10", -1},
+		{"v1.0.0-10", "v1.0.0-2", 1},
+		// numeric < string
+		{"v1.0.0-1", "v1.0.0-alpha", -1},
+		{"v1.0.0-alpha", "v1.0.0-1", 1},
+		// dot-separated: more fields is greater when prefix matches
+		{"v1.0.0-alpha", "v1.0.0-alpha.1", -1},
+		{"v1.0.0-alpha.1", "v1.0.0-alpha", 1},
+		// dot-separated numeric comparison
+		{"v1.0.0-1.2", "v1.0.0-1.10", -1},
+		{"v1.0.0-1.10", "v1.0.0-1.2", 1},
+		// mixed dot-separated: alpha.1 < alpha.beta (1 is numeric < string)
+		{"v1.0.0-alpha.1", "v1.0.0-alpha.beta", -1},
+	}
+	for _, tt := range tests {
+		got := compareSemver(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("compareSemver(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestUpgrade_PrereleaseDowngradeBlocked(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.3.0")
+
+	m := &Manifest{
+		Version: 1,
+		Mint:    MintConfig{URL: "https://mint.example.com", Project: "p", Region: "us-central1"},
+		Defaults: DefaultsConfig{
+			InferenceProject: "inf",
+			InferenceRegion:  "us-central1",
+			FullsendRef:      "v2.3.0-rc1",
+		},
+		Repos: []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{
+		Manifest:       m,
+		MaxConcurrency: 1,
+	}
+
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	r := results[0]
+	if !r.Skipped {
+		t.Error("expected Skipped=true for prerelease downgrade")
+	}
+	if r.SkipReason == "" {
+		t.Error("expected non-empty SkipReason")
+	}
+}
+
+func TestIsValidRef(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"v1.0.0", true},
+		{"v2.3.0-rc1", true},
+		{"main", true},
+		{"abc123def", true},
+		{"v1.0.0_beta", true},
+		{"", false},
+		{"v1.0.0$bad", false},
+		{"ref with spaces", false},
+		{"ref@sha", false},
+		{"ref#comment", false},
+		{"ref\nnewline", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			if got := IsValidRef(tt.ref); got != tt.want {
+				t.Errorf("IsValidRef(%q) = %v, want %v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpgrade_InvalidManifestRef(t *testing.T) {
+	fc := forge.NewFakeClient()
+	fc.FileContents["acme-corp/api-server/.github/workflows/fullsend.yml"] = makeWorkflow("v2.1.0")
+
+	m := &Manifest{
+		Version:  1,
+		Mint:     MintConfig{URL: "https://mint.example.com", Project: "p", Region: "r"},
+		Defaults: DefaultsConfig{FullsendRef: "v3.0.0; rm -rf /"},
+		Repos:    []RepoEntry{{Repo: "acme-corp/api-server"}},
+	}
+
+	cfg := UpgradeConfig{Manifest: m, MaxConcurrency: 1}
+	results, err := Upgrade(context.Background(), cfg, fc, noopCommitFn, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if results[0].Error == nil {
+		t.Fatal("expected error for invalid manifest ref, got nil")
+	}
+	if !strings.Contains(results[0].Error.Error(), "invalid characters") {
+		t.Errorf("expected invalid characters error, got: %v", results[0].Error)
+	}
+}
+
+func TestReplaceShimRef_StandaloneCommentPreserved(t *testing.T) {
+	input := `    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v2.1.0
+    # This is a standalone comment on the next line
+    with:
+`
+	result, changed := replaceShimRef([]byte(input), "v2.3.0", "")
+	if !changed {
+		t.Fatal("expected content to change")
+	}
+	content := string(result)
+	if !strings.Contains(content, "# This is a standalone comment") {
+		t.Errorf("standalone comment on the next line was deleted; got:\n%s", content)
+	}
+	if !strings.Contains(content, "@v2.3.0") {
+		t.Errorf("ref should be updated to v2.3.0; got:\n%s", content)
+	}
+}
+
+func TestReplaceShimRef_DollarSignInRef(t *testing.T) {
+	content := []byte("    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v1.0.0\n")
+	result, changed := replaceShimRef(content, "v2.0.0$test", "")
+	if !changed {
+		t.Fatal("expected content to change")
+	}
+	want := "    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v2.0.0$test\n"
+	if string(result) != want {
+		t.Errorf("got %q, want %q", string(result), want)
+	}
+}


### PR DESCRIPTION
## Summary

- Implement `fullsend repos upgrade` to upgrade scaffold shim refs across repos in a manifest, with semver comparison, floating ref detection, `--force`/`--dry-run`/`--ref` flags, positional args for repo filtering, and bounded concurrency.
- Implement `fullsend repos upgrade-mint` to verify the mint deployment matches the manifest configuration.
- PR 7 of the [ADR 0057 repos-management implementation plan](docs/plans/repos-management.md).

> **Note:** This PR adds entirely new subcommands (`upgrade`, `upgrade-mint`) that have never been released. No `!` breaking-change suffix is needed — there is no existing behavior to break.

## Changes

| File | Action |
|------|--------|
| `internal/repos/upgrade.go` | Create — `Upgrade()`, `UpgradeMint()`, `replaceShimRef()`, semver helpers |
| `internal/repos/upgrade_test.go` | Create — 45 tests covering upgrade logic, ref replacement, semver comparison, floating ref detection |
| `internal/cli/repos.go` | Modify — wire `repos upgrade` and `repos upgrade-mint` commands |
| `internal/cli/repos_test.go` | Modify — 16 tests for flag registration, shorthands, subcommand wiring, and integration |
| `internal/repos/manifest.go` | Modify — add `IsValidRef` validation in `Validate()` for `defaults.fullsend_ref` and per-repo `fullsend_ref` |
| `internal/repos/manifest_test.go` | Modify — add validation tests for invalid refs |
| `docs/ADRs/0057-repos-management.md` | Modify — update Implementation Status, fix `upgrade-mint` description |
| `docs/plans/repos-management.md` | Modify — mark PR 7 complete, update upgrade/upgrade-mint descriptions to match implementation, fix `ProvisionerFactory` type signature |
| `docs/cli/repos.md` | Modify — add `upgrade` and `upgrade-mint` command documentation |
| `docs/guides/dev/cli-internals.md` | Modify — add upgrade/upgrade-mint to CLI tree |
| `docs/guides/getting-started/operations.md` | Modify — add upgrade/upgrade-mint to operations table |

## ADR edits

ADR 0057 (Accepted) is modified to:
- Update Implementation Status: marks `repos upgrade` and `repos upgrade-mint` as implemented in PR #4080
- Fix `upgrade-mint` subcommand description from "Upgrade token mint Cloud Function" to "Verify token mint deployment against manifest" (matches actual implementation)

## CLI pattern alignment (PR #4081)

Follows the patterns established by PR #4081 (`repos add`, `repos remove`, `repos uninstall`):
- `reposUpgradeConfig` / `reposUpgradeMintConfig` structs with `testClient` / `testProvisioner` fields for test injection
- Positional args for repo filtering (`upgrade [repos...]`) instead of `--repo` flag
- Run functions take config struct pointers: `runReposUpgrade(ctx, opts, repoFilter)`
- CLI-level tests for flags, shorthands, subcommand wiring, and integration via test hooks

## Test plan

- [x] 45 upgrade-related tests pass (`go test ./internal/repos/`)
- [x] 16 CLI upgrade tests pass (`go test ./internal/cli/ -run TestReposUpgrade`)
- [x] Full repos and CLI package test suites pass
- [x] `go build ./...` compiles cleanly
- [x] `go vet` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)