### PR TITLE
ci(e2e): add local GitHub emulator driver for scm.Driver tests

### DIFF
--- a/.github/workflows/scm-emulate.yml
+++ b/.github/workflows/scm-emulate.yml
@@ -1,0 +1,52 @@
+name: SCM Emulate Driver
+
+# This job needs zero secrets — it spawns a local vercel-labs/emulate
+# subprocess (no live GitHub org, no GCP WIF, no mint). Unlike e2e.yml's
+# pull_request_target-based jobs, it uses plain pull_request so fork PRs
+# check out and run directly with the default read-only GITHUB_TOKEN, no
+# gate/authorization step needed. See docs/guides/dev/behaviour-drivers.md
+# for what this package does and does not cover.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'e2e/behaviour/drivers/scm/emulate/**'
+      - 'e2e/behaviour/drivers/scm/driver.go'
+      - 'e2e/behaviour/drivers/scm/github/**'
+      - 'internal/forge/github/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/scm-emulate.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'e2e/behaviour/drivers/scm/emulate/**'
+      - 'e2e/behaviour/drivers/scm/driver.go'
+      - 'e2e/behaviour/drivers/scm/github/**'
+      - 'internal/forge/github/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/scm-emulate.yml'
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Run scm/emulate driver tests
+        run: go test -tags behaviour -race -count=1 -v ./e2e/behaviour/drivers/scm/emulate/...

--- a/docs/guides/dev/behaviour-drivers.md
+++ b/docs/guides/dev/behaviour-drivers.md
@@ -44,6 +44,28 @@ Teardown removes shim workflows, stale branches, and open fullsend PRs on `test-
 
 Use `forge.Client` for operations it already exposes; add REST helpers inside the driver package only when necessary (e.g. `GetIssue` with labels).
 
+## Local emulator (`scm/emulate`)
+
+`e2e/behaviour/drivers/scm/emulate/` implements `scm.Driver` against a locally spawned
+[vercel-labs/emulate](https://github.com/vercel-labs/emulate) GitHub instance instead of live
+GitHub — no pool org, no mint, no secrets, sub-second per test. It reuses `scm/github`'s driver
+unmodified: `emulate.Start` just points `forge/github.LiveClient` at the emulator's localhost
+URL via `WithBaseURL` and wraps it with `github.New`.
+
+This package deliberately does **not** follow the "Adding an SCM driver" checklist above — it
+is not registered as a `BEHAVIOUR_SCM` value and is not wired into `suite_test.go`. emulate's
+Actions endpoints are REST record-level only (list/get/dispatch/cancel/logs as data); it does
+not execute real workflow YAML. So it can never satisfy `ci.Driver` for scenarios like
+`triage.feature` that assert on real agent execution — pairing it with `BEHAVIOUR_CI=githubactions`
+would silently produce a suite that can never observe what it's supposed to test. Import it
+directly in Go test code that only needs SCM-level state (issues, labels, comments) and no
+live Actions run — e.g. a future dispatch-routing test, or `eval/`-layer fixture setup.
+
+There is no reset endpoint: `reset()` in emulate is reachable only through its programmatic
+`createEmulator()` API, not the CLI-spawned server this package shells out to. Start one
+`Instance` per test binary (see `emulate_test.go`'s `TestMain`) and let each test create its
+own issue — `CreateIssue` returns a fresh, unique number every call, so tests don't collide.
+
 ## Adding a CI driver
 
 1. Implement `ci.Driver` — `WaitForWorkflow`, `AssertNoWorkflow`, `GetRunLogs`, `DownloadArtifacts`.
@@ -58,7 +80,7 @@ Steps use `world.Install` for config repo paths (`ConfigOwner`, `ConfigRepo`, `C
 
 ## Testing drivers
 
-Prefer unit tests with `httptest` for REST helpers. Optional smoke scenarios against live backends mirror admin e2e credentials (`GITHUB_TOKEN`, halfsend org pool).
+Prefer unit tests with `httptest` for REST helpers. Optional smoke scenarios against live backends mirror admin e2e credentials (`GITHUB_TOKEN`, halfsend org pool). For scenarios that only need SCM-level state and no live Actions run, prefer `scm/emulate` (above) over `httptest` or live credentials — real multi-endpoint behavior (create → label → read-back) without hand-stubbing each response.
 
 ## Future backends checklist
 

--- a/e2e/behaviour/drivers/scm/emulate/emulate.go
+++ b/e2e/behaviour/drivers/scm/emulate/emulate.go
@@ -1,0 +1,206 @@
+//go:build behaviour
+
+// Package emulate spawns a local vercel-labs/emulate GitHub instance and
+// wires it to the existing scm/github driver via LiveClient.WithBaseURL. It
+// does not implement scm.Driver itself — it composes the real one, so
+// CreateIssue/AddIssueLabels/AddComment/GetIssue/CommitFile/CloseIssue are
+// the same code paths exercised against live GitHub.
+//
+// This package is standalone: it is not registered as a BEHAVIOUR_SCM
+// option and is not wired into suite_test.go. emulate's Actions endpoints
+// are REST record-level only (list/get/dispatch/cancel/logs as data) — it
+// does not execute real workflow YAML, so it can never satisfy ci.Driver
+// for scenarios that assert on real agent execution. See
+// docs/guides/dev/behaviour-drivers.md for the intended use (direct import
+// by Go test code that only needs SCM-level state, not a live Actions run).
+//
+// There is no HTTP reset endpoint: reset() in vercel-labs/emulate is an
+// in-process JS method reachable only through the programmatic
+// createEmulator() API, not exposed by the CLI-spawned server. Callers get
+// isolation by starting one Instance per test binary (see emulate_test.go's
+// TestMain) and letting each test create its own issue — CreateIssue
+// returns a fresh, unique number every call, so tests don't collide.
+package emulate
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"github.com/fullsend-ai/fullsend/e2e/behaviour/drivers/scm"
+	"github.com/fullsend-ai/fullsend/e2e/behaviour/drivers/scm/github"
+	forgegithub "github.com/fullsend-ai/fullsend/internal/forge/github"
+)
+
+const (
+	// emulatePackage pins the exact npm version so a CI run today and one
+	// next month spawn identical route behavior. Bump deliberately.
+	//
+	// This is a version pin, not an integrity/hash pin — npx resolves
+	// whatever npm currently serves for this version string, so a
+	// compromised republish under this exact version could still run on
+	// the CI runner. Accepted risk: the workflow that invokes this grants
+	// no secrets and uses the default read-only GITHUB_TOKEN on plain
+	// pull_request (not pull_request_target), so there is nothing for a
+	// compromised package to exfiltrate. If that trigger or permission
+	// scope ever changes, revisit this (e.g. install from a committed
+	// package-lock.json via `npm ci` instead of `npx --yes`).
+	emulatePackage = "emulate@0.8.0"
+
+	startTimeout       = 15 * time.Second
+	healthPoll         = 200 * time.Millisecond
+	healthCheckTimeout = 2 * time.Second
+)
+
+// healthCheckClient bounds each individual health-check request. Using
+// http.DefaultClient (no timeout) would let a stalled request block
+// indefinitely if the caller's ctx has no deadline, defeating
+// waitHealthy's startTimeout loop.
+var healthCheckClient = &http.Client{Timeout: healthCheckTimeout}
+
+// Instance owns a running `emulate` subprocess and a scm.Driver wired to
+// it. It satisfies scm.Driver by embedding the real github driver.
+type Instance struct {
+	scm.Driver
+
+	cmd      *exec.Cmd
+	baseURL  string
+	client   *forgegithub.LiveClient
+	seedPath string
+}
+
+// Start launches `npx emulate --service github` with a generated seed file,
+// waits for it to become healthy, and returns an Instance ready to use as a
+// scm.Driver. Call Close to shut the subprocess down. logf receives the
+// subprocess's stderr, one line per call.
+func Start(ctx context.Context, opts SeedOptions, logf func(string, ...any)) (*Instance, error) {
+	port, err := freePort()
+	if err != nil {
+		return nil, fmt.Errorf("emulate: reserving port: %w", err)
+	}
+
+	seedPath, token, err := writeSeedFile(opts)
+	if err != nil {
+		return nil, fmt.Errorf("emulate: writing seed config: %w", err)
+	}
+
+	// exec.Command, not CommandContext: the subprocess must outlive Start.
+	// ctx here only bounds the startup health-check below — it may carry a
+	// short deadline that has nothing to do with how long the caller wants
+	// the emulator to keep running. The process's actual lifetime is
+	// controlled by Close.
+	cmd := exec.Command("npx", "--yes", emulatePackage,
+		"--service", "github",
+		"--port", strconv.Itoa(port),
+		"--seed", seedPath,
+	)
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		_ = os.Remove(seedPath)
+		return nil, fmt.Errorf("emulate: attaching stderr: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		_ = os.Remove(seedPath)
+		return nil, fmt.Errorf("emulate: starting subprocess (is Node/npx installed?): %w", err)
+	}
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	go streamLog(stderr, logf)
+
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	if err := waitHealthy(ctx, baseURL); err != nil {
+		killAndReap(cmd)
+		_ = os.Remove(seedPath)
+		return nil, fmt.Errorf("emulate: did not become healthy: %w", err)
+	}
+
+	client := forgegithub.New(token).WithBaseURL(baseURL)
+
+	return &Instance{
+		Driver:   github.New(client),
+		cmd:      cmd,
+		baseURL:  baseURL,
+		client:   client,
+		seedPath: seedPath,
+	}, nil
+}
+
+// BaseURL returns the emulator's HTTP address, for pointing other
+// components under test (e.g. a dispatch webhook receiver) at it.
+func (i *Instance) BaseURL() string { return i.baseURL }
+
+// Client exposes the underlying forge client for callers that need
+// operations beyond scm.Driver's minimal surface.
+func (i *Instance) Client() *forgegithub.LiveClient { return i.client }
+
+// Close terminates the emulate subprocess and removes the seed file.
+func (i *Instance) Close() error {
+	defer os.Remove(i.seedPath)
+	killAndReap(i.cmd)
+	return nil
+}
+
+// killAndReap kills cmd and waits for it to exit. Wait's error is
+// discarded: on the expected path it's "signal: killed" from our own
+// Kill call, not a genuine failure. Skipping Wait entirely would leak
+// the process's stderr pipe fd and leave it unreaped, so it must still
+// be called — just not surfaced as a failure.
+func killAndReap(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+}
+
+func waitHealthy(ctx context.Context, baseURL string) error {
+	deadline := time.Now().Add(startTimeout)
+	for time.Now().Before(deadline) {
+		if healthCheck(ctx, baseURL) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(healthPoll):
+		}
+	}
+	return fmt.Errorf("timed out after %s", startTimeout)
+}
+
+func healthCheck(ctx context.Context, baseURL string) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/rate_limit", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := healthCheckClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+func streamLog(r io.Reader, logf func(string, ...any)) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		logf("[emulate] %s", scanner.Text())
+	}
+}

--- a/e2e/behaviour/drivers/scm/emulate/emulate_test.go
+++ b/e2e/behaviour/drivers/scm/emulate/emulate_test.go
@@ -1,0 +1,132 @@
+//go:build behaviour
+
+package emulate_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fullsend-ai/fullsend/e2e/behaviour/drivers/scm"
+	"github.com/fullsend-ai/fullsend/e2e/behaviour/drivers/scm/emulate"
+)
+
+// Compile-time check: Instance satisfies scm.Driver.
+var _ scm.Driver = (*emulate.Instance)(nil)
+
+const (
+	testOrg  = "emu-org"
+	testRepo = "emu-repo"
+)
+
+var inst *emulate.Instance
+
+// TestMain starts one shared Instance for the whole package — spawning
+// `npx emulate` per test function would pay Node startup cost for no
+// isolation benefit, since CreateIssue returns a fresh, unique number on
+// every call and tests only ever touch the issue they created.
+func TestMain(m *testing.M) {
+	if _, err := exec.LookPath("npx"); err != nil {
+		if inCI() {
+			// scm-emulate.yml runs actions/setup-node before this suite, so
+			// a missing npx in CI means Node setup broke, not that Node is
+			// unavailable by design. Failing loud here prevents a silently
+			// green job that ran zero tests.
+			println("emulate: npx not found on PATH in CI (broken Node setup?):", err.Error())
+			os.Exit(1)
+		}
+		// No Node/npx on PATH locally — skip the whole binary rather than
+		// fail, since Node isn't a universal prerequisite for this repo.
+		os.Exit(0)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	started, err := emulate.Start(ctx, emulate.SeedOptions{Org: testOrg, Repo: testRepo}, func(format string, args ...any) {
+		// Discard subprocess log lines in the test run; keep them for
+		// manual debugging by swapping this for t.Logf-style output.
+	})
+	if err != nil {
+		println("emulate: failed to start:", err.Error())
+		os.Exit(1)
+	}
+	inst = started
+
+	code := m.Run()
+	_ = inst.Close()
+	os.Exit(code)
+}
+
+// inCI reports whether the test binary is running in GitHub Actions (or
+// any CI system that sets the conventional CI env var).
+func inCI() bool {
+	return os.Getenv("CI") == "true" || os.Getenv("GITHUB_ACTIONS") == "true"
+}
+
+func TestCreateAndLabelIssue(t *testing.T) {
+	ctx := context.Background()
+
+	issue, err := inst.CreateIssue(ctx, testOrg, testRepo, "Login fails", "steps to reproduce")
+	require.NoError(t, err)
+	require.NotZero(t, issue.Number)
+	assert.Equal(t, "Login fails", issue.Title)
+	assert.Equal(t, "steps to reproduce", issue.Body)
+
+	require.NoError(t, inst.AddIssueLabels(ctx, testOrg, testRepo, issue.Number, "ready-for-triage"))
+
+	got, err := inst.GetIssue(ctx, testOrg, testRepo, issue.Number)
+	require.NoError(t, err)
+	assert.Contains(t, got.Labels, "ready-for-triage")
+}
+
+func TestCommentAndClose(t *testing.T) {
+	ctx := context.Background()
+
+	issue, err := inst.CreateIssue(ctx, testOrg, testRepo, "Flaky test", "intermittent failure")
+	require.NoError(t, err)
+
+	comment, err := inst.AddComment(ctx, testOrg, testRepo, issue.Number, "investigating")
+	require.NoError(t, err)
+	assert.Equal(t, "investigating", comment.Body)
+	assert.NotZero(t, comment.ID)
+
+	// forge.Issue has no State field, so CloseIssue's effect isn't
+	// re-verifiable through GetIssue with the current driver — this only
+	// asserts the state-transition PATCH itself succeeds against the
+	// emulator.
+	require.NoError(t, inst.CloseIssue(ctx, testOrg, testRepo, issue.Number))
+}
+
+func TestCommitFile(t *testing.T) {
+	// Skipped: emulate@0.8.0's GET /repos/:owner/:repo/git/commits/:sha
+	// route reuses the REST commits-API formatter (nested commit.tree.sha,
+	// GitHub-user author/committer) instead of the git-data API's
+	// documented shape (top-level tree.sha, git-author name/email/date) —
+	// confirmed by reading packages/@emulators/github/src/routes/branches.ts
+	// (formatCommitJson, used by both routes). forge/github.LiveClient's
+	// CommitFiles correctly expects the real, documented git-data shape,
+	// so it fails to find commitObj.Tree.SHA against this emulator. This is
+	// an emulate bug, not a fullsend one — CommitFile is already covered
+	// against live GitHub via steps/dummy_agent.go and steps/cleanup.go in
+	// the existing behaviour suite. Reported upstream:
+	// https://github.com/vercel-labs/emulate/issues/190 — un-skip once
+	// fixed and the pinned version is bumped past it.
+	t.Skip("emulate git/commits response shape bug — see comment, vercel-labs/emulate#190")
+
+	ctx := context.Background()
+
+	path := "committed/hello.txt"
+	content := []byte("hello from emulate driver test\n")
+
+	require.NoError(t, inst.CommitFile(ctx, testOrg, testRepo, path, "test: add hello.txt", content))
+
+	got, err := inst.Client().GetFileContent(ctx, testOrg, testRepo, path)
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}

--- a/e2e/behaviour/drivers/scm/emulate/seed.go
+++ b/e2e/behaviour/drivers/scm/emulate/seed.go
@@ -1,0 +1,91 @@
+//go:build behaviour
+
+package emulate
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	defaultToken = "e2e-emulate-token" //nolint:gosec // local-only emulator credential, not a real secret
+	defaultOrg   = "emu-org"
+	defaultRepo  = "emu-repo"
+	botLogin     = "e2e-bot"
+)
+
+// SeedOptions describes the minimal fixture an emulate instance needs for
+// scm.Driver scenarios. Extend with an "apps" block when a test needs
+// GitHub App JWT / installation-token flows (e.g. token-mint regression
+// cases) — emulate supports it, this struct just doesn't expose it yet.
+type SeedOptions struct {
+	Org   string
+	Repo  string
+	Token string
+}
+
+func (o SeedOptions) withDefaults() SeedOptions {
+	if o.Org == "" {
+		o.Org = defaultOrg
+	}
+	if o.Repo == "" {
+		o.Repo = defaultRepo
+	}
+	if o.Token == "" {
+		o.Token = defaultToken
+	}
+	return o
+}
+
+// writeSeedFile renders opts into an emulate seed YAML file in a temp
+// location and returns its path and the token to authenticate with.
+func writeSeedFile(opts SeedOptions) (path, token string, err error) {
+	opts = opts.withDefaults()
+
+	cfg := map[string]any{
+		"tokens": map[string]any{
+			opts.Token: map[string]any{
+				"login":  botLogin,
+				"scopes": []string{"repo"},
+			},
+		},
+		"github": map[string]any{
+			// A token's login must resolve to a real seeded user: the
+			// emulator's assertAuthenticatedUser looks up the actor by
+			// login in the users store separately from the token map, so
+			// an unseeded login 401s with the same "Requires
+			// authentication" message as a missing token entirely.
+			"users": []map[string]any{
+				{"login": botLogin, "name": "E2E Bot", "email": botLogin + "@example.com"},
+			},
+			"orgs": []map[string]any{
+				{"login": opts.Org, "name": opts.Org},
+			},
+			"repos": []map[string]any{
+				{"owner": opts.Org, "name": opts.Repo, "auto_init": true},
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return "", "", err
+	}
+
+	f, err := os.CreateTemp("", "emulate-seed-*.yaml")
+	if err != nil {
+		return "", "", err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", "", err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", "", err
+	}
+	return filepath.Clean(f.Name()), opts.Token, nil
+}


### PR DESCRIPTION
## Summary
Adds a `scm.Driver` implementation backed by a locally spawned `vercel-labs/emulate` GitHub instance, for tests that only need SCM-level state (issues, labels, comments) — no live GitHub org, no mint, no secrets. Standalone by design: not registered as a `BEHAVIOUR_SCM` value, since emulate's Actions endpoints are record-level only and can never back a real `ci.Driver`.

## Related Issue
None filed — follow-up on the Layer-2 (mocked-external-dependency) testing gap named in ADR 0052 and loosely tracked under #73.

## Changes
- `e2e/behaviour/drivers/scm/emulate/`: `Instance`/`Start`/`Close` spawn a version-pinned `npx emulate@0.8.0` subprocess, health-check it via `/rate_limit`, and wire `forge/github.LiveClient` at its base URL via `WithBaseURL` — reuses the existing `scm/github` driver unmodified.
- `.github/workflows/scm-emulate.yml`: new secret-free CI job on plain `pull_request` (no `gate` dependency, safe for fork PRs), runs `go test -tags behaviour` scoped to this package only.
- `docs/guides/dev/behaviour-drivers.md`: documents the package and explains why it deliberately does not follow the "Adding an SCM driver" checklist (CI-driver mismatch).

## Testing
- [x] `make lint` passes — verified go-fmt, go-vet, pinact (SHA-pin check), and actionlint individually against the changed files (no golangci-lint step in this repo's CI)
- [x] Tests added — `emulate_test.go` exercises create issue → add label → read back → add comment → close, against a real spawned emulator instance; passes locally in under a second

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it