### PR TITLE
test: disable commit signing in ephemeral test repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,9 @@ go-build:
 	go build -ldflags "-X github.com/fullsend-ai/fullsend/internal/cli.version=$(VERSION)" -o bin/fullsend ./cmd/fullsend/
 
 go-test:
-	GH_TOKEN= GITHUB_TOKEN= go test -race -cover ./...
+	GH_TOKEN= GITHUB_TOKEN= \
+	GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false \
+	go test -race -cover ./...
 
 go-lint:
 	golangci-lint run ./...

--- a/eval/scripts/setup-fixture.sh
+++ b/eval/scripts/setup-fixture.sh
@@ -65,6 +65,7 @@ GH_CRED_HELPER='!f(){ echo "password=${GH_TOKEN}"; };f'
 git -c "credential.helper=${GH_CRED_HELPER}" \
   clone "https://x-access-token@github.com/${EPHEMERAL_REPO}.git" "$TARGET_DIR"
 git -C "$TARGET_DIR" config credential.helper "${GH_CRED_HELPER}"
+git -C "$TARGET_DIR" config commit.gpgsign false
 
 if [[ -d "${CASE_SOURCE_DIR}/repo" ]]; then
   cp -a "${CASE_SOURCE_DIR}/repo/." "$TARGET_DIR/"

--- a/internal/gitfetch/gitfetch_test.go
+++ b/internal/gitfetch/gitfetch_test.go
@@ -16,6 +16,20 @@ import (
 	"time"
 )
 
+// testGitEnv returns environment variables for ephemeral test repos,
+// including signing disable so global gitsign/gpgsign config is not invoked.
+func testGitEnv() []string {
+	return []string{
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=commit.gpgsign",
+		"GIT_CONFIG_VALUE_0=false",
+	}
+}
+
 // createTestRepo creates a git repo in a temp dir with the given files,
 // commits them, and returns the file:// URL and commit SHA.
 func createTestRepo(t *testing.T, files map[string]string) (repoURL, commitSHA string) {
@@ -29,12 +43,7 @@ func createTestRepo(t *testing.T, files map[string]string) (repoURL, commitSHA s
 		t.Helper()
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=test",
-			"GIT_AUTHOR_EMAIL=test@test.com",
-			"GIT_COMMITTER_NAME=test",
-			"GIT_COMMITTER_EMAIL=test@test.com",
-		)
+		cmd.Env = append(os.Environ(), testGitEnv()...)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
@@ -43,6 +52,7 @@ func createTestRepo(t *testing.T, files map[string]string) (repoURL, commitSHA s
 	}
 
 	run("init", "-b", "main")
+	run("config", "commit.gpgsign", "false")
 
 	for path, content := range files {
 		full := filepath.Join(dir, filepath.FromSlash(path))
@@ -153,12 +163,7 @@ func TestFetchTree_TagRef(t *testing.T) {
 		t.Helper()
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=test",
-			"GIT_AUTHOR_EMAIL=test@test.com",
-			"GIT_COMMITTER_NAME=test",
-			"GIT_COMMITTER_EMAIL=test@test.com",
-		)
+		cmd.Env = append(os.Environ(), testGitEnv()...)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
 		}
@@ -428,18 +433,14 @@ func TestFetchTree_SymlinkRejected(t *testing.T) {
 		t.Helper()
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=test",
-			"GIT_AUTHOR_EMAIL=test@test.com",
-			"GIT_COMMITTER_NAME=test",
-			"GIT_COMMITTER_EMAIL=test@test.com",
-		)
+		cmd.Env = append(os.Environ(), testGitEnv()...)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
 		}
 	}
 
 	run("init", "-b", "main")
+	run("config", "commit.gpgsign", "false")
 
 	skillDir := filepath.Join(dir, "skills", "evil")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
@@ -612,12 +613,7 @@ func TestFetchTree_AuthFallbackHTTP(t *testing.T) {
 		t.Helper()
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=test",
-			"GIT_AUTHOR_EMAIL=test@test.com",
-			"GIT_COMMITTER_NAME=test",
-			"GIT_COMMITTER_EMAIL=test@test.com",
-		)
+		cmd.Env = append(os.Environ(), testGitEnv()...)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
 		}
@@ -631,6 +627,7 @@ func TestFetchTree_AuthFallbackHTTP(t *testing.T) {
 	workDir := t.TempDir()
 	gitCmd(workDir, "clone", bareDir, "work")
 	work := filepath.Join(workDir, "work")
+	gitCmd(work, "config", "commit.gpgsign", "false")
 	skillDir := filepath.Join(work, "skills", "review")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- Disable commit signing in ephemeral git repos created by unit tests and eval fixtures
- Add a Makefile `go-test` env safety net so future test git subprocesses skip gitsign
- Leaves global/worktree signing unchanged for real developer commits

## Related Issue
N/A — local developer ergonomics (gitsign rate limits during `make go-test`)

## Changes
- Add `testGitEnv()` in `internal/gitfetch/gitfetch_test.go` with `commit.gpgsign=false` via `GIT_CONFIG_*` and local repo config after init
- Export signing-disable `GIT_CONFIG` vars in `Makefile` `go-test` target
- Set `commit.gpgsign false` on eval fixture repos in `eval/scripts/setup-fixture.sh`

## Testing
- [x] `make go-test` passes (via `mise exec`)
- [x] Verified temp test repos have `commit.gpgsign=false` while worktree still inherits global `true`

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it

Made with [Cursor](https://cursor.com)