### PR TITLE
fix(dispatch): route pull_request_target.labeled to review stage

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -272,6 +272,11 @@ jobs:
                     STAGE="review"
                   fi
                   ;;
+                labeled)
+                  if [[ "${TRIGGERING_LABEL}" == "ready-for-review" ]]; then
+                    STAGE="review"
+                  fi
+                  ;;
                 closed)
                   STAGE="retro"
                   ;;

--- a/internal/harnessdispatch/auth_test.go
+++ b/internal/harnessdispatch/auth_test.go
@@ -99,6 +99,22 @@ func TestIsAuthorized_LabelRemovedRequiresWriteRole(t *testing.T) {
 	assert.False(t, IsAuthorized(ev))
 }
 
+func TestIsAuthorized_BotOpenedPRFallsThrough(t *testing.T) {
+	// Bot-opened PR events have no special bypass in the pre-CEL gate.
+	// Trusted-bot handling lives in bash dispatch (is_trusted_bot) and
+	// CEL trigger expressions, not here.
+	ev := &normevent.Event{
+		Transition: normevent.Transition{Kind: normevent.TransitionOpened},
+		Source:     normevent.Source{System: normevent.SystemGitHub},
+		Actor: normevent.Actor{
+			ID:   "myapp-coder[bot]",
+			Kind: normevent.ActorBot,
+			Role: normevent.RoleNone,
+		},
+	}
+	assert.False(t, IsAuthorized(ev))
+}
+
 func TestIsAuthorized_OpenedRequiresWriteRole(t *testing.T) {
 	ev := &normevent.Event{
 		Transition: normevent.Transition{Kind: normevent.TransitionOpened},

--- a/internal/harnessdispatch/input/ghaevent_test.go
+++ b/internal/harnessdispatch/input/ghaevent_test.go
@@ -81,6 +81,41 @@ func TestLoadGHAEvent_PROpened(t *testing.T) {
 	assert.NotNil(t, ev.State.ChangeProposal)
 }
 
+func TestLoadGHAEvent_PROpenedByBot(t *testing.T) {
+	raw := map[string]any{
+		"action": "opened",
+		"pull_request": map[string]any{
+			"number":   float64(101),
+			"html_url": "https://github.com/o/r/pull/101",
+			"user":     map[string]any{"login": "myapp-coder[bot]"},
+			"labels":   []any{},
+			"head": map[string]any{
+				"ref":  "agent/fix-thing",
+				"sha":  "cccccccccccccccccccccccccccccccccccccccc",
+				"repo": map[string]any{"full_name": "o/r"},
+			},
+			"base": map[string]any{
+				"ref":  "main",
+				"repo": map[string]any{"full_name": "o/r"},
+			},
+		},
+		"sender": map[string]any{"login": "myapp-coder[bot]", "type": "Bot"},
+	}
+	path := writeEventFile(t, raw)
+
+	client := forge.NewFakeClient()
+
+	ev, err := input.LoadGHAEvent(context.Background(), input.GHAEventOptions{
+		EventPath:  path,
+		EventName:  "pull_request_target",
+		Repository: "o/r",
+		Forge:      client,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, normevent.ActorBot, ev.Actor.Kind)
+	assert.Equal(t, normevent.RoleNone, ev.Actor.Role)
+}
+
 func TestLoadGHAEvent_PRLabeled(t *testing.T) {
 	raw := map[string]any{
 		"action": "labeled",

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -204,6 +204,11 @@ jobs:
                     STAGE="review"
                   fi
                   ;;
+                labeled)
+                  if [[ "${TRIGGERING_LABEL}" == "ready-for-review" ]]; then
+                    STAGE="review"
+                  fi
+                  ;;
                 closed)
                   STAGE="retro"
                   ;;


### PR DESCRIPTION
Closes #2674

## Summary

- Add `labeled)` case under `pull_request_target)` in both dispatch files so `ready-for-review` triggers review dispatch
- Add Go test for bot-opened PR detection (`ActorBot` + `RoleNone`)
- Add Go test documenting that the pre-CEL auth gate does not bypass write checks for bot-opened events

## Problem

Bot-authored PRs (e.g. `fullsend-ai-coder[bot]`) never get automated review. The `is_event_actor_authorized` check on `pull_request_target.opened` calls `has_write_permission`, which queries the GitHub collaborator permission API. GitHub App bot accounts authenticate via installation tokens, not the collaborator model, so the API returns a non-write role and dispatch silently skips.

PR #2679 tried to fix this by having `post-code.sh` apply a `ready-for-review` label to use the ungated label dispatch path. But the shim subscribes to `pull_request_target: [opened, synchronize, ready_for_review, closed]` without `labeled`, and `issues.labeled` does not fire for PRs. The label was applied but never triggered dispatch.

## Fix

The shim template already includes `labeled` in `pull_request_target.types` (it just hasn't been reconciled to all repos yet). This PR adds the missing routing: a `labeled)` case under `pull_request_target)` that dispatches to `review` when `ready-for-review` is applied. No explicit auth gate is needed because label application itself requires write access.

## Test plan

- [ ] `go test ./internal/harnessdispatch/...` passes
- [ ] After merge + reconcile, next bot-authored PR gets a review agent comment
- [ ] Dispatch logs show `STAGE=review` for `pull_request_target.labeled` events with `ready-for-review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)