### PR TITLE
chore(#5056): track wranglerVersion pins with Renovate custom manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,16 @@
       "depNameTemplate": "NVIDIA/OpenShell",
       "datasourceTemplate": "github-tags",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Track wranglerVersion pins in site-deploy.yml so they bump with the cloudflare-workers group",
+      "managerFilePatterns": ["/^\\.github/workflows/site-deploy\\.yml$/"],
+      "matchStrings": [
+        "wranglerVersion: \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "depNameTemplate": "wrangler",
+      "datasourceTemplate": "npm"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds a Renovate `customManagers` regex entry so the two `wranglerVersion: "<version>"` pins in `.github/workflows/site-deploy.yml` are tracked against the `wrangler` npm package and bump together with the `cloudflare-workers` group, instead of silently drifting behind `package.json`/`package-lock.json`.

## Related Issue
Fixes #5056

## Changes
- `renovate.json`: new regex custom manager scoped to `.github/workflows/site-deploy.yml`, matching `wranglerVersion: "<semver>"`, `depName: wrangler`, `datasource: npm`. The existing `cloudflare-workers` packageRule matches on package name with no manager restriction, so the workflow pins join the same grouped PR automatically — no changes to the group rule needed.

Once this lands, Renovate should open a grouped PR bumping the workflow pins from 4.110.0 to 4.111.0, closing the drift introduced by #5052.

## Testing
- [x] `make lint` passes (staged changes first)
- [x] `renovate-config-validator` (renovate 43.264.2): "Config validated successfully"
- [x] Regex verified against `.github/workflows/site-deploy.yml` — matches exactly the two `wranglerVersion: "4.110.0"` pins
- [ ] Tests added/updated for new or modified logic — not applicable, Renovate config only

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it