### PR TITLE
ci(e2e): wire CF mint secrets into behaviour job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -255,6 +255,15 @@ jobs:
           BEHAVIOUR_ARTIFACT_DIR: ${{ runner.temp }}/behaviour-artifacts
           E2E_GCP_PROJECT_ID: ${{ secrets.E2E_GCP_PROJECT_ID }}
           E2E_GCP_WIF_PROVIDER: ${{ secrets.E2E_GCP_WIF_PROVIDER }}
+          # CF mint BT path: temp Worker deploy needs role PEMs + Cloudflare creds
+          TEST_FULLSEND_PEM: ${{ secrets.TEST_FULLSEND_PEM }}
+          TEST_TRIAGE_PEM: ${{ secrets.TEST_TRIAGE_PEM }}
+          TEST_CODER_PEM: ${{ secrets.TEST_CODER_PEM }}
+          TEST_REVIEW_PEM: ${{ secrets.TEST_REVIEW_PEM }}
+          TEST_RETRO_PEM: ${{ secrets.TEST_RETRO_PEM }}
+          TEST_PRIORITIZE_PEM: ${{ secrets.TEST_PRIORITIZE_PEM }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Upload behaviour debug artifacts
         if: failure() && steps.changes.outputs.relevant != 'false'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -262,8 +262,10 @@ jobs:
           TEST_REVIEW_PEM: ${{ secrets.TEST_REVIEW_PEM }}
           TEST_RETRO_PEM: ${{ secrets.TEST_RETRO_PEM }}
           TEST_PRIORITIZE_PEM: ${{ secrets.TEST_PRIORITIZE_PEM }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # Env names match Wrangler/mint deploy; values come from TEST_*-prefixed
+          # repo secrets (not the prod site-deploy CLOUDFLARE_* secrets).
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
 
       - name: Upload behaviour debug artifacts
         if: failure() && steps.changes.outputs.relevant != 'false'


### PR DESCRIPTION
## Summary
Wire the existing repo secrets for CF mint BT (`TEST_*_PEM` and Cloudflare credentials) into the `behaviour` job so `make behaviour-test` can deploy a temporary Worker mint in CI. This is workflow wiring only (prerequisite for #5109).

## Related Issue
Fixes #5167

## Changes
- Add `TEST_FULLSEND_PEM`, `TEST_TRIAGE_PEM`, `TEST_CODER_PEM`, `TEST_REVIEW_PEM`, `TEST_RETRO_PEM`, `TEST_PRIORITIZE_PEM`, `CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_API_TOKEN` to the "Run behaviour tests" step env in `.github/workflows/e2e.yml`
- Authorization is unchanged (`pull_request_target` + gate job)

## Testing
- [x] `make lint` passes (stage changes first, then run)
- [ ] Tests added/updated for new or modified logic — N/A (workflow env wiring only; end-to-end verification lands with #5109)

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it


Made with [Cursor](https://cursor.com)