### PR TITLE
feat(#5183): publish runner image with fullsend CLI and host-side run dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Build context trim for images/runner/Containerfile (context = repo root).
+# Only the Go source, go.mod/go.sum, and .github/scripts/openshell-version.sh
+# are consumed by the build.
+.git
+bin/
+node_modules/
+**/node_modules/
+images/
+website/
+web/
+cloudflare_site/
+e2e/
+eval/
+experiments/
+docs/
+# Keep local credential artifacts out of the build context. They never
+# reach the final image (only /out/fullsend is copied forward), but they
+# should not enter intermediate build-stage layers either.
+.env*
+**/.env*
+*.pem
+**/*.pem
+**/*credentials*.json
+**/*serviceaccount*.json

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -1,0 +1,143 @@
+name: Runner Image
+
+on:
+  push:
+    tags:
+      # Same pattern as release.yml — the runner image is a release
+      # artifact, so it must publish for exactly the tags that cut a
+      # release (sandbox-images.yml uses a looser two-component pattern).
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+    branches:
+      - main
+    paths:
+      - "images/runner/**"
+      - ".dockerignore"
+      - ".github/workflows/runner-image.yml"
+      - ".github/scripts/openshell-version.sh"
+  pull_request:
+    paths:
+      - "images/runner/**"
+      - ".dockerignore"
+      - ".github/workflows/runner-image.yml"
+      - ".github/scripts/openshell-version.sh"
+  workflow_dispatch:
+
+# NOTE: GitHub Actions ignores `paths` filters on tag pushes, so every
+# semver tag triggers a build. This is intentional — the runner image
+# bundles the fullsend CLI built from the tagged source, so it must be
+# published alongside every release (#5183). Branch pushes and PRs still
+# respect the paths filter.
+
+jobs:
+  build-runner:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    env:
+      RUNNER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/fullsend-runner
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      # Mirror GoReleaser's version format: the tag without the leading v on
+      # tag pushes, a dev pseudo-version everywhere else. Injected into the
+      # binary via the same ldflags as .goreleaser.yml.
+      - name: Compute fullsend version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "value=${GITHUB_REF_NAME#v}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "value=dev-${GITHUB_SHA::7}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ${{ env.RUNNER_IMAGE_NAME }}
+          # No raw `latest` on main pushes (unlike the sandbox images):
+          # main builds carry a dev pseudo-version binary. The default
+          # `latest=auto` flavor still tags `latest` on non-prerelease
+          # semver tag pushes. `dev` is scoped to main-branch pushes so
+          # release builds never move it onto a release image.
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
+
+      # Build a single-platform image locally and smoke-test the dependency
+      # surface BEFORE anything is pushed — a broken tool must never reach
+      # the registry under a release tag or `latest`. Multi-arch builds
+      # cannot --load, so this is a separate linux/amd64 build; it seeds
+      # the GHA cache that the push build below reuses. The smoke test only
+      # exercises linux/amd64 — arm64 correctness is enforced by the
+      # per-arch checksum verification during the multi-arch build, which
+      # fails the workflow (before push) on a wrong-arch download.
+      - name: Build runner image for smoke test
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: images/runner/Containerfile
+          platforms: linux/amd64
+          load: true
+          tags: fullsend-runner:ci-smoke
+          build-args: |
+            FULLSEND_VERSION=${{ steps.version.outputs.value }}
+            FULLSEND_COMMIT=${{ github.sha }}
+          cache-from: type=gha,scope=runner
+          cache-to: type=gha,mode=max,scope=runner
+
+      - name: Validate host-side dependency surface
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          docker run --rm --entrypoint '' -e EXPECTED_VERSION fullsend-runner:ci-smoke bash -c '
+            set -euo pipefail
+            fail() { echo "FAIL: $1"; exit 1; }
+            fullsend --version | grep -F "${EXPECTED_VERSION}" \
+              || fail "fullsend --version does not report ${EXPECTED_VERSION}"
+            openshell --version   || fail "openshell missing"
+            gh --version          || fail "gh missing"
+            gitleaks version      || fail "gitleaks missing"
+            pre-commit --version  || fail "pre-commit missing"
+            gitlint --version     || fail "gitlint missing"
+            python3 -c "import jsonschema" || fail "python3 jsonschema missing"
+            go version            || fail "go missing"
+            gcloud --version      || fail "gcloud missing"
+            git --version         || fail "git missing"
+            jq --version          || fail "jq missing"
+            tar --version >/dev/null || fail "tar missing"
+          '
+
+      # Multi-arch build and push, gated on the smoke test above. The
+      # amd64 leg replays from the GHA cache seeded by the smoke-test
+      # build; only the arm64 leg builds fresh here.
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: images/runner/Containerfile
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            FULLSEND_VERSION=${{ steps.version.outputs.value }}
+            FULLSEND_COMMIT=${{ github.sha }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=runner
+          cache-to: type=gha,mode=max,scope=runner

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -11,7 +11,7 @@ Linux are supported with Podman as the container runtime.
 | Requirement | macOS | Linux |
 |-------------|-------|-------|
 | Container runtime | Podman Desktop with a running machine | Podman |
-| [OpenShell](https://github.com/NVIDIA/OpenShell) | 0.0.83 | 0.0.83 |
+| [OpenShell](https://github.com/NVIDIA/OpenShell) | [Pinned per release](https://github.com/fullsend-ai/fullsend/blob/main/.github/scripts/openshell-version.sh) | Same |
 | GCP project | [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled with [Claude models](https://console.cloud.google.com/vertex-ai/model-garden) enabled | Same |
 | GCP credentials | Service account key (see section below) | Same |
 | GitHub PAT | Classic PAT with `repo` scope (see section below) | Same |
@@ -48,11 +48,15 @@ fullsend --version
 
 [OpenShell](https://github.com/NVIDIA/OpenShell) provides the sandbox runtime. There are multiple ways
 to install it, here we use one similar to how we download it on Fullsend. Use the version
-fullsend is pinned to — the source of truth is `.github/scripts/openshell-version.sh`
+fullsend is pinned to — the source of truth is
+[`.github/scripts/openshell-version.sh`](https://github.com/fullsend-ai/fullsend/blob/main/.github/scripts/openshell-version.sh)
 in the fullsend repo at your release tag (also printed on Fullsend workflow runs).
+This pin is bumped automatically by Renovate when new OpenShell releases are
+tagged, so the version below is an example — always check the pin file for
+the current value.
 
 ```bash
-export OPENSHELL_VERSION=0.0.83
+export OPENSHELL_VERSION=0.0.83  # check the pin file for the current version
 curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/v${OPENSHELL_VERSION}/install.sh | OPENSHELL_VERSION=v${OPENSHELL_VERSION} sh
 openshell --version
 ```

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -51,122 +51,12 @@ to install it, here we use one similar to how we download it on Fullsend. Use th
 fullsend is pinned to — the source of truth is
 [`.github/scripts/openshell-version.sh`](https://github.com/fullsend-ai/fullsend/blob/main/.github/scripts/openshell-version.sh)
 in the fullsend repo at your release tag (also printed on Fullsend workflow runs).
-This pin is bumped automatically by Renovate when new OpenShell releases are
-tagged, so the version below is an example — always check the pin file for
-the current value.
 
 ```bash
 export OPENSHELL_VERSION=0.0.83  # check the pin file for the current version
 curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/v${OPENSHELL_VERSION}/install.sh | OPENSHELL_VERSION=v${OPENSHELL_VERSION} sh
 openshell --version
 ```
-
-## Alternative: run the CLI from the container image
-
-Instead of downloading the fullsend binary and assembling its host-side
-dependencies yourself (gh, python3 + jsonschema, gitleaks, pre-commit, Go —
-tools the CI runners ship but your machine may not), you can run the CLI
-from the released runner image. It bundles the fullsend CLI and every
-host-side run dependency at the versions the release was tested with,
-including the pinned OpenShell CLI:
-
-```bash
-podman pull ghcr.io/fullsend-ai/fullsend-runner:latest
-```
-
-The image is published alongside each release starting with the first
-release cut after this feature landed. The example below reuses the env
-files and `/tmp` clones prepared in the sections that follow — read those
-first if you are setting up from scratch. The containerized path has been
-validated for the image build and its full tool surface; treat it as the
-newer alternative to the native binary, which remains the most-exercised
-setup.
-
-You still need on the host: Podman, the `openshell-gateway` service (see
-[Install OpenShell](#install-openshell) — the gateway and sandboxes stay on
-the host; only the CLI moves into the container), GCP credentials, and a
-GitHub token.
-
-Mount your OpenShell client config and the same paths you would pass to a
-native `fullsend run`, keeping identical paths inside the container so the
-flag values are unchanged. On Linux, `--network=host` lets the containerized
-CLI reach the gateway on `127.0.0.1` exactly like the native binary:
-
-```bash
-podman run --rm -it --network=host \
-  -v "$HOME/.config/openshell:/root/.config/openshell" \
-  -v /tmp/fullsend:/tmp/fullsend \
-  -v /tmp/fullsend-ai_fullsend:/tmp/fullsend-ai_fullsend \
-  -v /tmp/target-repo:/tmp/target-repo \
-  -v "$PWD:/work" \
-  ghcr.io/fullsend-ai/fullsend-runner:latest \
-  run triage \
-    --fullsend-dir /tmp/fullsend-ai_fullsend/internal/scaffold/fullsend-repo/ \
-    --target-repo /tmp/target-repo/ \
-    --env-file fullsend-gcp.env \
-    --env-file fullsend-triage.env
-```
-
-The `/tmp/fullsend` mount matters: without `--output-dir`, the CLI writes
-run artifacts (telemetry, `output.jsonl`, per-iteration transcripts,
-collected logs) under `/tmp/fullsend/` — unmounted, they vanish with the
-`--rm` container. Mount it (or pass `--output-dir` pointing at a mounted
-path) to keep them on the host.
-
-The image's working directory is `/work`, so relative paths in `--env-file`
-(and relative `GOOGLE_APPLICATION_CREDENTIALS` inside env files) resolve
-against the mounted current directory. Pin a version with
-`ghcr.io/fullsend-ai/fullsend-runner:{version}` — image tags match release
-versions.
-
-On SELinux-enforcing hosts (Fedora/RHEL), bind mounts may need the `:z`
-suffix (see the [Linux platform notes](#platform-notes) below). Prefer
-adding `:z` only to the `/tmp` and `$PWD` mounts — relabeling
-`~/.config/openshell` touches files the host gateway also reads.
-
-One diagnostic difference from the native binary: when a sandbox fails to
-become ready, the containerized CLI cannot collect container logs (podman
-stays on the host), so run `podman logs <sandbox-container>` on the host
-instead.
-
-The image also includes the `gcloud` CLI (pinned per release), which is useful
-for the [GCP credential setup](#get-google-cloud-platform-credentials) below.
-The agent run itself does not need `gcloud` auth — it only reads the generated
-service-account key file via `GOOGLE_APPLICATION_CREDENTIALS`.
-
-The simpler path is to run `gcloud` on the host (see below) and then mount the
-resulting key file into the container. If you need to run `gcloud` from inside
-the container, note:
-
-- **Auth persistence**: mount `~/.config/gcloud` so credentials survive the
-  `--rm` container:
-
-  ```bash
-  podman run --rm -it \
-    -v "$HOME/.config/gcloud:/root/.config/gcloud" \
-    -v "$PWD:/work" \
-    --entrypoint bash \
-    ghcr.io/fullsend-ai/fullsend-runner:latest
-  ```
-
-- **Browserless auth**: `gcloud auth login` inside the container starts the
-  **remote-bootstrap flow** — it prints a command of the form
-  `gcloud auth login --remote-bootstrap="..."` that you run on a host machine
-  that has a browser and gcloud ≥ 372.0.0 installed, then paste the output
-  back into the container. This is a two-machine flow, not a URL + code
-  exchange.
-
-  The easier alternative is to create the service account key on the host
-  (where gcloud has browser access) and copy the JSON key file into the
-  mounted working directory.
-
-**macOS**: the containerized path on macOS is untested. With a Podman machine,
-`--network=host` reaches the VM's loopback, not the macOS host where the
-gateway runs. Podman machines expose `host.containers.internal` as a host alias
-(via gvproxy), which may work if the gateway is bound to all interfaces; see
-also `OPENSHELL_BIND_ADDRESS` in the OpenShell docs. Until this is verified,
-use the native darwin binary for macOS. If you try this and it works, please
-open an issue or PR to document the approach.
 
 ## Get Google Cloud Platform credentials
 
@@ -201,6 +91,12 @@ CLOUD_ML_REGION=global
 GOOGLE_APPLICATION_CREDENTIALS=fullsend-local-credentials.json
 ```
 
+**Tip**: if you plan to run the CLI from the
+[container image](#alternative-run-the-cli-from-the-container-image) instead
+of the native binary, keep the key file and env file in your working
+directory — the container mounts it as `/work` and resolves
+`GOOGLE_APPLICATION_CREDENTIALS` relative to it.
+
 ## Get a GitHub token
 
 Create a [fine grained token](https://github.com/settings/personal-access-tokens) at GitHub. The
@@ -231,6 +127,11 @@ Check the variables they need in their environment files, referenced in their ha
 
 **Tip**: use `--no-post-script` in the `fullsend run` calls to avoid side-effects. You
 can also use `--keep-sandbox` to debug failures (but remember to remove them).
+
+**Tip**: `fullsend run` uses multiple tools on your system. Instead of
+installing them all, you can use a container image fullsend publishes — see
+[Alternative: run the CLI from the container image](#alternative-run-the-cli-from-the-container-image)
+below.
 
 **Note**: to run custom agents set `--fullsend-dir` to the directory where your
 custom agent definitions exist.
@@ -370,6 +271,54 @@ fullsend run triage \
 Status comment behavior is configured via `status_notifications` in
 `config.yaml`. See the [operations guide](../getting-started/operations.md#status-notifications).
 
+## Alternative: run the CLI from the container image
+
+Instead of downloading the fullsend binary and installing its host-side
+dependencies, you can run the CLI from the released runner image:
+
+```bash
+podman pull ghcr.io/fullsend-ai/fullsend-runner:latest
+```
+
+You still need on the host: Podman, OpenShell (the gateway and sandboxes
+stay on the host; only the CLI moves into the container), GCP credentials,
+and a GitHub token.
+
+**macOS**: this path is untested — see the [macOS platform notes](#macos)
+before trying it.
+
+Mount your OpenShell client config and the same paths you would pass to a
+native `fullsend run`. On Linux, `--network=host` lets the containerized
+CLI reach the gateway on `127.0.0.1`:
+
+```bash
+podman run --rm -it --network=host \
+  -v "$HOME/.config/openshell:/root/.config/openshell" \
+  -v /tmp/fullsend:/tmp/fullsend \
+  -v /tmp/fullsend-ai_fullsend:/tmp/fullsend-ai_fullsend \
+  -v /tmp/target-repo:/tmp/target-repo \
+  -v "$PWD:/work" \
+  ghcr.io/fullsend-ai/fullsend-runner:latest \
+  run triage \
+    --fullsend-dir /tmp/fullsend-ai_fullsend/internal/scaffold/fullsend-repo/ \
+    --target-repo /tmp/target-repo/ \
+    --env-file fullsend-gcp.env \
+    --env-file fullsend-triage.env
+```
+
+The image's working directory is `/work`, so relative paths in `--env-file`
+resolve against the mounted current directory. Run artifacts are written to
+`/tmp/fullsend/` — mount it (or pass `--output-dir` pointing at a mounted
+path) to keep them on the host.
+
+When using `--keep-sandbox` the CLI within the container is not able to
+gather podman logs, because the `podman` binary is not installed within.
+Run `podman logs <sandbox-container>` manually on your machine.
+
+On SELinux-enforcing hosts (Fedora/RHEL), bind mounts may need the `:z`
+suffix. Prefer adding `:z` only to the `/tmp` and `$PWD` mounts —
+relabeling `~/.config/openshell` touches files the host gateway also reads.
+
 ## Simulating Fullsend's real customization layers
 
 Fullsend automatically aggregates different layers of information before running `fullsend run`.
@@ -413,6 +362,7 @@ When you execute `fullsend run`, pass `--fullsend-dir` as `/tmp/agents/`.
 - **Podman machine**: ensure the Podman machine is running (`podman machine start`) before invoking fullsend. The CLI does not start it automatically.
 - **Podman host-gateway**: if sandbox creation fails with `unable to replace "host-gateway"`, set `host_containers_internal_ip = "192.168.127.254"` under `[containers]` in `~/.config/containers/containers.conf` and restart the Podman machine.
 - **Architecture mismatch**: if your sandbox image uses a different CPU architecture than the host (e.g. amd64 image on an arm64 Mac via QEMU emulation), set `FULLSEND_SANDBOX_ARCH=amd64` so the CLI downloads the correct binary. This is not needed in the typical setup where the Podman VM matches the host arch.
+- **Container image**: the containerized CLI path is untested on macOS. `--network=host` reaches the Podman VM's loopback, not the macOS host where the gateway runs. Use the native darwin binary until this is verified — if you try the container path and it works, please open an issue or PR.
 
 ### Linux
 

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -92,9 +92,9 @@ GOOGLE_APPLICATION_CREDENTIALS=fullsend-local-credentials.json
 ```
 
 **Tip**: if you plan to run the CLI from the
-[container image](#alternative-run-the-cli-from-the-container-image) instead
-of the native binary, keep the key file and env file in your working
-directory — the container mounts it as `/work` and resolves
+[container image](#alternative-run-the-cli-from-the-container-image-linux-only)
+(Linux only) instead of the native binary, keep the key file and env file in
+your working directory — the container mounts it as `/work` and resolves
 `GOOGLE_APPLICATION_CREDENTIALS` relative to it.
 
 ## Get a GitHub token
@@ -128,10 +128,10 @@ Check the variables they need in their environment files, referenced in their ha
 **Tip**: use `--no-post-script` in the `fullsend run` calls to avoid side-effects. You
 can also use `--keep-sandbox` to debug failures (but remember to remove them).
 
-**Tip**: `fullsend run` uses multiple tools on your system. Instead of
-installing them all, you can use a container image fullsend publishes — see
-[Alternative: run the CLI from the container image](#alternative-run-the-cli-from-the-container-image)
-below.
+**Tip**: `fullsend run` uses multiple tools on your system. On Linux, instead
+of installing them all, you can use a container image fullsend publishes —
+see [Alternative: run the CLI from the container image](#alternative-run-the-cli-from-the-container-image-linux-only)
+below. This does not currently work on macOS.
 
 **Note**: to run custom agents set `--fullsend-dir` to the directory where your
 custom agent definitions exist.
@@ -271,7 +271,11 @@ fullsend run triage \
 Status comment behavior is configured via `status_notifications` in
 `config.yaml`. See the [operations guide](../getting-started/operations.md#status-notifications).
 
-## Alternative: run the CLI from the container image
+## Alternative: run the CLI from the container image (Linux only)
+
+**macOS**: skip this section — the containerized CLI cannot reach the host
+gateway from a Podman machine. See the [macOS platform notes](#macos) for
+why, and use the native darwin binary instead.
 
 Instead of downloading the fullsend binary and installing its host-side
 dependencies, you can run the CLI from the released runner image:
@@ -284,12 +288,9 @@ You still need on the host: Podman, OpenShell (the gateway and sandboxes
 stay on the host; only the CLI moves into the container), GCP credentials,
 and a GitHub token.
 
-**macOS**: this path does not work — see the [macOS platform notes](#macos)
-for why.
-
 Mount your OpenShell client config and the same paths you would pass to a
-native `fullsend run`. On Linux, `--network=host` lets the containerized
-CLI reach the gateway on `127.0.0.1`:
+native `fullsend run`. `--network=host` lets the containerized CLI reach
+the gateway on `127.0.0.1`:
 
 ```bash
 podman run --rm -it --network=host \

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -92,7 +92,7 @@ GOOGLE_APPLICATION_CREDENTIALS=fullsend-local-credentials.json
 ```
 
 **Tip**: if you plan to run the CLI from the
-[container image](#alternative-run-the-cli-from-the-container-image-linux-only)
+[container image](#run-from-a-container-linux)
 (Linux only) instead of the native binary, keep the key file and env file in
 your working directory — the container mounts it as `/work` and resolves
 `GOOGLE_APPLICATION_CREDENTIALS` relative to it.
@@ -130,7 +130,7 @@ can also use `--keep-sandbox` to debug failures (but remember to remove them).
 
 **Tip**: `fullsend run` uses multiple tools on your system. On Linux, instead
 of installing them all, you can use a container image fullsend publishes —
-see [Alternative: run the CLI from the container image](#alternative-run-the-cli-from-the-container-image-linux-only)
+see [Alternative: run the CLI from the container image](#run-from-a-container-linux)
 below. This does not currently work on macOS.
 
 **Note**: to run custom agents set `--fullsend-dir` to the directory where your
@@ -271,7 +271,7 @@ fullsend run triage \
 Status comment behavior is configured via `status_notifications` in
 `config.yaml`. See the [operations guide](../getting-started/operations.md#status-notifications).
 
-## Alternative: run the CLI from the container image (Linux only)
+## Run from a container (Linux)
 
 **macOS**: skip this section — the containerized CLI cannot reach the host
 gateway from a Podman machine. See the [macOS platform notes](#macos) for

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -284,8 +284,8 @@ You still need on the host: Podman, OpenShell (the gateway and sandboxes
 stay on the host; only the CLI moves into the container), GCP credentials,
 and a GitHub token.
 
-**macOS**: this path is untested — see the [macOS platform notes](#macos)
-before trying it.
+**macOS**: this path does not work — see the [macOS platform notes](#macos)
+for why.
 
 Mount your OpenShell client config and the same paths you would pass to a
 native `fullsend run`. On Linux, `--network=host` lets the containerized
@@ -362,7 +362,8 @@ When you execute `fullsend run`, pass `--fullsend-dir` as `/tmp/agents/`.
 - **Podman machine**: ensure the Podman machine is running (`podman machine start`) before invoking fullsend. The CLI does not start it automatically.
 - **Podman host-gateway**: if sandbox creation fails with `unable to replace "host-gateway"`, set `host_containers_internal_ip = "192.168.127.254"` under `[containers]` in `~/.config/containers/containers.conf` and restart the Podman machine.
 - **Architecture mismatch**: if your sandbox image uses a different CPU architecture than the host (e.g. amd64 image on an arm64 Mac via QEMU emulation), set `FULLSEND_SANDBOX_ARCH=amd64` so the CLI downloads the correct binary. This is not needed in the typical setup where the Podman VM matches the host arch.
-- **Container image**: the containerized CLI path is untested on macOS. `--network=host` reaches the Podman VM's loopback, not the macOS host where the gateway runs. Use the native darwin binary until this is verified — if you try the container path and it works, please open an issue or PR.
+- **Container image**: confirmed non-functional on macOS — sandbox creation fails with a connection-refused error. `--network=host` reaches the Podman VM's loopback, not the macOS host where the gateway runs, and `host.containers.internal` does not help either since the gateway binds to `127.0.0.1` only, not all interfaces. Use the native darwin binary.
+- **Container image mounts**: separately, bind-mounting `/tmp/...` paths (as shown in the container examples) fails with `statfs: no such file or directory` on macOS — Podman Desktop's VM shares `/Users`, `/private`, and `/var/folders` via virtiofs, but not the literal `/tmp` path, and Podman does not resolve the `/tmp` → `/private/tmp` symlink before mounting. Use `/private/tmp/...` (and `$(pwd -P)` instead of `$PWD`) if experimenting further.
 
 ### Linux
 

--- a/docs/guides/user/running-agents-locally.md
+++ b/docs/guides/user/running-agents-locally.md
@@ -11,7 +11,7 @@ Linux are supported with Podman as the container runtime.
 | Requirement | macOS | Linux |
 |-------------|-------|-------|
 | Container runtime | Podman Desktop with a running machine | Podman |
-| [OpenShell](https://github.com/NVIDIA/OpenShell) | 0.0.72 | 0.0.72 |
+| [OpenShell](https://github.com/NVIDIA/OpenShell) | 0.0.83 | 0.0.83 |
 | GCP project | [Agent Platform API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled with [Claude models](https://console.cloud.google.com/vertex-ai/model-garden) enabled | Same |
 | GCP credentials | Service account key (see section below) | Same |
 | GitHub PAT | Classic PAT with `repo` scope (see section below) | Same |
@@ -47,14 +47,122 @@ fullsend --version
 ## Install OpenShell
 
 [OpenShell](https://github.com/NVIDIA/OpenShell) provides the sandbox runtime. There are multiple ways
-to install it, here we use one similar to how we download it on Fullsend. Use the same version
-printed on your Fullsend workflow for better reproducibility.
+to install it, here we use one similar to how we download it on Fullsend. Use the version
+fullsend is pinned to — the source of truth is `.github/scripts/openshell-version.sh`
+in the fullsend repo at your release tag (also printed on Fullsend workflow runs).
 
 ```bash
-export OPENSHELL_VERSION=0.0.72
+export OPENSHELL_VERSION=0.0.83
 curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/v${OPENSHELL_VERSION}/install.sh | OPENSHELL_VERSION=v${OPENSHELL_VERSION} sh
 openshell --version
 ```
+
+## Alternative: run the CLI from the container image
+
+Instead of downloading the fullsend binary and assembling its host-side
+dependencies yourself (gh, python3 + jsonschema, gitleaks, pre-commit, Go —
+tools the CI runners ship but your machine may not), you can run the CLI
+from the released runner image. It bundles the fullsend CLI and every
+host-side run dependency at the versions the release was tested with,
+including the pinned OpenShell CLI:
+
+```bash
+podman pull ghcr.io/fullsend-ai/fullsend-runner:latest
+```
+
+The image is published alongside each release starting with the first
+release cut after this feature landed. The example below reuses the env
+files and `/tmp` clones prepared in the sections that follow — read those
+first if you are setting up from scratch. The containerized path has been
+validated for the image build and its full tool surface; treat it as the
+newer alternative to the native binary, which remains the most-exercised
+setup.
+
+You still need on the host: Podman, the `openshell-gateway` service (see
+[Install OpenShell](#install-openshell) — the gateway and sandboxes stay on
+the host; only the CLI moves into the container), GCP credentials, and a
+GitHub token.
+
+Mount your OpenShell client config and the same paths you would pass to a
+native `fullsend run`, keeping identical paths inside the container so the
+flag values are unchanged. On Linux, `--network=host` lets the containerized
+CLI reach the gateway on `127.0.0.1` exactly like the native binary:
+
+```bash
+podman run --rm -it --network=host \
+  -v "$HOME/.config/openshell:/root/.config/openshell" \
+  -v /tmp/fullsend:/tmp/fullsend \
+  -v /tmp/fullsend-ai_fullsend:/tmp/fullsend-ai_fullsend \
+  -v /tmp/target-repo:/tmp/target-repo \
+  -v "$PWD:/work" \
+  ghcr.io/fullsend-ai/fullsend-runner:latest \
+  run triage \
+    --fullsend-dir /tmp/fullsend-ai_fullsend/internal/scaffold/fullsend-repo/ \
+    --target-repo /tmp/target-repo/ \
+    --env-file fullsend-gcp.env \
+    --env-file fullsend-triage.env
+```
+
+The `/tmp/fullsend` mount matters: without `--output-dir`, the CLI writes
+run artifacts (telemetry, `output.jsonl`, per-iteration transcripts,
+collected logs) under `/tmp/fullsend/` — unmounted, they vanish with the
+`--rm` container. Mount it (or pass `--output-dir` pointing at a mounted
+path) to keep them on the host.
+
+The image's working directory is `/work`, so relative paths in `--env-file`
+(and relative `GOOGLE_APPLICATION_CREDENTIALS` inside env files) resolve
+against the mounted current directory. Pin a version with
+`ghcr.io/fullsend-ai/fullsend-runner:{version}` — image tags match release
+versions.
+
+On SELinux-enforcing hosts (Fedora/RHEL), bind mounts may need the `:z`
+suffix (see the [Linux platform notes](#platform-notes) below). Prefer
+adding `:z` only to the `/tmp` and `$PWD` mounts — relabeling
+`~/.config/openshell` touches files the host gateway also reads.
+
+One diagnostic difference from the native binary: when a sandbox fails to
+become ready, the containerized CLI cannot collect container logs (podman
+stays on the host), so run `podman logs <sandbox-container>` on the host
+instead.
+
+The image also includes the `gcloud` CLI (pinned per release), which is useful
+for the [GCP credential setup](#get-google-cloud-platform-credentials) below.
+The agent run itself does not need `gcloud` auth — it only reads the generated
+service-account key file via `GOOGLE_APPLICATION_CREDENTIALS`.
+
+The simpler path is to run `gcloud` on the host (see below) and then mount the
+resulting key file into the container. If you need to run `gcloud` from inside
+the container, note:
+
+- **Auth persistence**: mount `~/.config/gcloud` so credentials survive the
+  `--rm` container:
+
+  ```bash
+  podman run --rm -it \
+    -v "$HOME/.config/gcloud:/root/.config/gcloud" \
+    -v "$PWD:/work" \
+    --entrypoint bash \
+    ghcr.io/fullsend-ai/fullsend-runner:latest
+  ```
+
+- **Browserless auth**: `gcloud auth login` inside the container starts the
+  **remote-bootstrap flow** — it prints a command of the form
+  `gcloud auth login --remote-bootstrap="..."` that you run on a host machine
+  that has a browser and gcloud ≥ 372.0.0 installed, then paste the output
+  back into the container. This is a two-machine flow, not a URL + code
+  exchange.
+
+  The easier alternative is to create the service account key on the host
+  (where gcloud has browser access) and copy the JSON key file into the
+  mounted working directory.
+
+**macOS**: the containerized path on macOS is untested. With a Podman machine,
+`--network=host` reaches the VM's loopback, not the macOS host where the
+gateway runs. Podman machines expose `host.containers.internal` as a host alias
+(via gvproxy), which may work if the gateway is bound to all interfaces; see
+also `OPENSHELL_BIND_ADDRESS` in the OpenShell docs. Until this is verified,
+use the native darwin binary for macOS. If you try this and it works, please
+open an issue or PR to document the approach.
 
 ## Get Google Cloud Platform credentials
 

--- a/images/README.md
+++ b/images/README.md
@@ -1,8 +1,10 @@
-# Sandbox Images
+# Images
 
 Fullsend agents run inside sandboxed container images managed by
 [OpenShell](https://github.com/nvidia/openshell-community).  This directory
-contains the Containerfiles and supporting scripts for those images.
+contains the Containerfiles and supporting scripts for those images, plus
+the **runner image** — a host-side image bundling the fullsend CLI and its
+run dependencies (see [Runner image](#runner-image) below).
 
 ## Image hierarchy
 
@@ -18,6 +20,31 @@ ghcr.io/nvidia/openshell-community/sandboxes/base  (upstream, multi-arch)
 | `fullsend-code` | [`images/code/`](code/) | Extends `fullsend-sandbox` with Go toolchain and scan-secrets wrapper. Used by the code-implementation agent. |
 
 Both images are built for **linux/amd64** and **linux/arm64**.
+
+## Runner image
+
+`ghcr.io/fullsend-ai/fullsend-runner` ([`images/runner/`](runner/)) is **not
+a sandbox image** — agents never run inside it. It packages the host side of
+`fullsend run`: the fullsend CLI built from the tagged source, the pinned
+OpenShell CLI, and every binary the CLI's pre-scripts, validation loop, and
+post-scripts invoke on the machine running fullsend (`gh`, `gitleaks`,
+`pre-commit`, `gitlint`, `python3` + `jsonschema`, Go, `git`, `jq`, `tar`).
+It reproduces the environment the composite action assembles in CI so local
+runs behave identically (#5183). It also carries the `gcloud` CLI — not a
+fullsend dependency, but needed for the GCP credential bootstrap in the
+local-run guide.
+
+Podman, the `openshell-gateway` service, and the sandbox supervisor image
+stay on the host — the containerized CLI talks to the host gateway over the
+network, and sandboxes still spawn on the host. See
+[Running agents locally](../docs/guides/user/running-agents-locally.md) for
+usage.
+
+The runner image is built by `.github/workflows/runner-image.yml` on every
+version tag (published alongside the release tarballs, tagged with the same
+semver) and on changes to `images/runner/`. Unlike the sandbox images,
+pushes to `main` do not move a `latest` tag — `latest` always points at the
+newest release.
 
 ## Tags and versioning
 
@@ -109,6 +136,10 @@ Every binary downloaded during the build is **version-pinned** and
 | Claude Code | Official installer script | HTTPS only (no checksum, version floats) |
 | acli | `ACLI_VERSION` + `ACLI_SHA256_{AMD64,ARM64}` | `sha256sum -c` |
 | pre-commit, gitlint | pip version pins | pip integrity check |
+| UBI 10 base + go-toolset builder (runner) | Manifest list digest (`@sha256:...`) | Immutable OCI content hash (anonymous pull, no subscription) |
+| OpenShell CLI (runner) | `.github/scripts/openshell-version.sh` | `sha256sum -c` against release checksums file (integrity only — the checksums file is downloaded from the same release; baked-SHA verification possible in future if added to `openshell-version.sh`) |
+| gh CLI (runner) | `GH_VERSION` + `GH_SHA256_{AMD64,ARM64}` | `sha256sum -c` |
+| gcloud CLI (runner) | `GCLOUD_VERSION` + `GCLOUD_SHA256_{AMD64,ARM64}` | `sha256sum -c` |
 
 GitHub Actions are pinned to full commit SHAs (not floating tags).
 
@@ -133,6 +164,14 @@ podman build -t fullsend-sandbox:local \
 podman build -t fullsend-code:local \
   --build-arg BASE_IMAGE=fullsend-sandbox:local \
   -f images/code/Containerfile images/code/
+```
+
+The runner image builds from the repo root (it compiles the fullsend
+binary from source):
+
+```bash
+podman build -t fullsend-runner:local \
+  -f images/runner/Containerfile .
 ```
 
 Build for a specific platform (requires QEMU registration):

--- a/images/runner/Containerfile
+++ b/images/runner/Containerfile
@@ -1,0 +1,256 @@
+# Containerfile — runner image with the fullsend CLI and every host-side
+# run dependency pre-installed (#5183).
+#
+# Unlike images/sandbox/ and images/code/ (which agents run INSIDE, managed
+# by OpenShell), this image is the HOST side of `fullsend run`: the CLI plus
+# the binaries its pre-scripts, validation loop, and post-scripts invoke on
+# the machine running fullsend. It covers the same host-side dependency
+# surface the composite action assembles in CI, at the same pinned
+# versions, so local runs stop failing on missing or mismatched tools.
+#
+#   - fullsend        (built from this repo's source at the same ref)
+#   - openshell CLI   (pinned via .github/scripts/openshell-version.sh)
+#   - gh              (scaffold pre/post scripts: GitHub API, PR/issue ops)
+#   - gitleaks        (post-code/post-fix secret-scan gate)
+#   - pre-commit + gitlint (post-script hook runs on target repos)
+#   - python3 + jsonschema (validate-output-schema.sh, ADR 0022)
+#   - Go toolchain    (sandbox binary cross-compile fallback + Go pre-commit hooks)
+#   - gcloud          (not invoked by fullsend — included for the GCP
+#                      credential bootstrap in running-agents-locally.md)
+#   - git, jq, tar, curl
+#
+# NOT included (stays on the host): Podman, the openshell-gateway service,
+# and the sandbox supervisor image. The containerized CLI talks to the host
+# gateway over the network — sandboxes still spawn on the host.
+#
+# Built by .github/workflows/runner-image.yml on version tags and on
+# changes to images/runner/. Build context is the REPO ROOT (the fullsend
+# binary is compiled from source):
+#
+#   podman build -t fullsend-runner:local \
+#     -f images/runner/Containerfile .
+#
+# Published to: ghcr.io/fullsend-ai/fullsend-runner
+
+# ---------------------------------------------------------------------------
+# Build stage — compile the fullsend binary. Runs on the build platform and
+# cross-compiles for TARGETARCH so multi-arch builds avoid QEMU-emulated
+# Go compilation. UBI images pull anonymously from
+# registry.access.redhat.com — no Red Hat subscription required.
+# registry.access.redhat.com/ubi10/go-toolset:latest
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset@sha256:40eb0e19d90700b02aa1055810a637f307af48c2d1cb376905bc53e3e583af6f AS build
+
+USER 0
+WORKDIR /src
+COPY go.mod go.sum ./
+# go.mod replaces the mintcore module with a local path; its go.mod must be
+# present for go mod download to resolve the module graph.
+COPY internal/mintcore/go.mod internal/mintcore/go.sum* ./internal/mintcore/
+RUN go mod download
+COPY . .
+
+ARG TARGETARCH
+# Version metadata injected by CI; mirrors the ldflags in .goreleaser.yml so
+# `fullsend --version` inside the image reports the release version.
+ARG FULLSEND_VERSION=dev
+ARG FULLSEND_COMMIT=unknown
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
+    go build -trimpath \
+      -ldflags "-s -w -X github.com/fullsend-ai/fullsend/internal/cli.version=${FULLSEND_VERSION} -X github.com/fullsend-ai/fullsend/internal/cli.commitSHA=${FULLSEND_COMMIT}" \
+      -o /out/fullsend ./cmd/fullsend/
+
+# ---------------------------------------------------------------------------
+# Runtime stage — UBI 10 (anonymous pull from registry.access.redhat.com,
+# no subscription). Deliberately NOT ubi10/go-toolset: that is a builder
+# image carrying gcc and build deps (~1 GB); plain UBI plus the pinned Go
+# tarball below is far smaller. All tool versions are pinned explicitly
+# (pip transitive dependencies resolve at build time), so the tools match
+# the composite action's runs on GitHub-hosted runners regardless of the
+# distro underneath.
+#
+# No USER directive — the image deliberately runs as root. It is a local
+# convenience wrapper, not a sandbox (agents never run inside it), and
+# under rootless podman container root maps to the invoking host user, so
+# bind-mounted configs and repos keep sane ownership without UID mapping.
+# registry.access.redhat.com/ubi10/ubi:latest
+FROM registry.access.redhat.com/ubi10/ubi@sha256:802583cce6369422f62434fccd9bf310655c065cc9f4f60a007faf095e57afc7
+
+# NOTE: no SHELL directive — podman's default OCI image format ignores it,
+# so all RUN steps below stay POSIX-sh compatible for docker AND podman.
+
+# BuildKit automatic platform ARG — set by --platform during multi-arch builds.
+ARG TARGETARCH
+
+# ---------------------------------------------------------------------------
+# Base packages. python3 + pip back the validation loop
+# (validate-output-schema.sh); git/jq/curl are used throughout the CLI and
+# scaffold scripts; openssh-clients covers ssh git remotes; gzip and
+# findutils back the tar.gz extraction steps below. --allowerasing lets
+# full curl replace the base image's curl-minimal.
+RUN dnf install -y --allowerasing --setopt=install_weak_deps=False \
+      ca-certificates \
+      curl \
+      findutils \
+      git \
+      gzip \
+      jq \
+      openssh-clients \
+      python3 \
+      python3-pip \
+      tar \
+    && dnf clean all
+
+# ---------------------------------------------------------------------------
+# gcloud CLI — fullsend never invokes it, but the local-run guide's GCP
+# credential bootstrap (service account + ADC key creation) does. Google's
+# apt/yum repos only ship el8/el9 builds, so install the versioned release
+# tarball. gcloud runs on the system python3 (CLOUDSDK_PYTHON below); the
+# tarball's bundled Python runtime and anthoscli are removed to keep the
+# image small.
+# To update: bump GCLOUD_VERSION and refresh GCLOUD_SHA256_{AMD64,ARM64}
+# from the checksums at https://cloud.google.com/sdk/docs/install
+ENV CLOUDSDK_PYTHON=/usr/bin/python3
+ARG GCLOUD_VERSION=576.0.0
+ARG GCLOUD_SHA256_AMD64=7094a08e8fc3772cdbfb1a8a1920300f52fec5e370c9f9c803c2a3c8824a32c2
+ARG GCLOUD_SHA256_ARM64=be6077ade7b08312a250b49b5838473253c52e25358c63cfb2cfb4095503b5f2
+RUN case "$TARGETARCH" in \
+      amd64) GC_ARCH="x86_64"; GC_SHA="$GCLOUD_SHA256_AMD64" ;; \
+      arm64) GC_ARCH="arm";    GC_SHA="$GCLOUD_SHA256_ARM64" ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL \
+      "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_VERSION}-linux-${GC_ARCH}.tar.gz" \
+      -o /tmp/gcloud.tar.gz \
+    && echo "${GC_SHA}  /tmp/gcloud.tar.gz" | sha256sum -c - \
+    && tar xzf /tmp/gcloud.tar.gz -C /opt \
+    && rm -rf /opt/google-cloud-sdk/platform/bundledpythonunix \
+      /opt/google-cloud-sdk/bin/anthoscli \
+      /opt/google-cloud-sdk/platform/anthoscli_licenses \
+    && ln -s /opt/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud \
+    && ln -s /opt/google-cloud-sdk/bin/gsutil /usr/local/bin/gsutil \
+    && rm /tmp/gcloud.tar.gz \
+    && gcloud --version
+
+# ---------------------------------------------------------------------------
+# OpenShell CLI — client only; the gateway and supervisor stay on the host.
+# The version pin is sourced from the same file the composite action and
+# Renovate use, so the image can never drift from the tested version.
+# The release ships a static musl binary, verified against the release
+# checksums file.
+# The pin file is a bash script; extract the value instead of sourcing it
+# so this step runs under plain sh.
+COPY .github/scripts/openshell-version.sh /tmp/openshell-version.sh
+RUN OPENSHELL_VERSION="$(sed -n 's/^OPENSHELL_VERSION=//p' /tmp/openshell-version.sh)" \
+    && test -n "$OPENSHELL_VERSION" \
+    && case "$TARGETARCH" in \
+         amd64) OS_TRIPLE="x86_64-unknown-linux-musl" ;; \
+         arm64) OS_TRIPLE="aarch64-unknown-linux-musl" ;; \
+         *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+       esac \
+    && curl -fsSL \
+      "https://github.com/NVIDIA/OpenShell/releases/download/v${OPENSHELL_VERSION}/openshell-${OS_TRIPLE}.tar.gz" \
+      -o /tmp/openshell.tar.gz \
+    && curl -fsSL \
+      "https://github.com/NVIDIA/OpenShell/releases/download/v${OPENSHELL_VERSION}/openshell-checksums-sha256.txt" \
+      -o /tmp/openshell-checksums.txt \
+    && grep " openshell-${OS_TRIPLE}.tar.gz\$" /tmp/openshell-checksums.txt \
+      | sed "s| openshell-${OS_TRIPLE}.tar.gz\$| /tmp/openshell.tar.gz|" \
+      | sha256sum -c - \
+    && mkdir -p /tmp/openshell \
+    && tar xzf /tmp/openshell.tar.gz -C /tmp/openshell \
+    && install -m 0755 "$(find /tmp/openshell -type f -name openshell | head -1)" /usr/local/bin/openshell \
+    && rm -rf /tmp/openshell /tmp/openshell.tar.gz /tmp/openshell-checksums.txt /tmp/openshell-version.sh \
+    && openshell --version
+
+# ---------------------------------------------------------------------------
+# gh — GitHub CLI used by the scaffold pre/post scripts. GitHub-hosted
+# runners ship it preinstalled; local machines do not.
+# To update: bump GH_VERSION and GH_SHA256_{AMD64,ARM64} from
+#   https://github.com/cli/cli/releases (gh_<version>_checksums.txt)
+ARG GH_VERSION=2.96.0
+ARG GH_SHA256_AMD64=83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60
+ARG GH_SHA256_ARM64=06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909
+RUN case "$TARGETARCH" in \
+      amd64) GH_SHA="$GH_SHA256_AMD64" ;; \
+      arm64) GH_SHA="$GH_SHA256_ARM64" ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL \
+      "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${TARGETARCH}.tar.gz" \
+      -o /tmp/gh.tar.gz \
+    && echo "${GH_SHA}  /tmp/gh.tar.gz" | sha256sum -c - \
+    && tar xzf /tmp/gh.tar.gz -C /tmp \
+    && install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh" /usr/local/bin/gh \
+    && rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_${TARGETARCH}"
+
+# ---------------------------------------------------------------------------
+# gitleaks — post-code.sh / post-fix.sh secret-scan gate. Baked in so the
+# scripts' self-install fallback (linux x64 only) never fires.
+# Version and checksums match images/sandbox/Containerfile.
+# To update: bump GITLEAKS_VERSION and GITLEAKS_SHA256_{AMD64,ARM64} from:
+#   https://github.com/gitleaks/gitleaks/releases
+ARG GITLEAKS_VERSION=8.30.1
+ARG GITLEAKS_SHA256_AMD64=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+ARG GITLEAKS_SHA256_ARM64=e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080
+RUN case "$TARGETARCH" in \
+      amd64) GL_ARCH="x64";   GL_SHA="$GITLEAKS_SHA256_AMD64" ;; \
+      arm64) GL_ARCH="arm64"; GL_SHA="$GITLEAKS_SHA256_ARM64" ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL \
+      "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_${GL_ARCH}.tar.gz" \
+      -o /tmp/gitleaks.tar.gz \
+    && echo "${GL_SHA}  /tmp/gitleaks.tar.gz" | sha256sum -c - \
+    && tar xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks \
+    && rm /tmp/gitleaks.tar.gz
+
+# ---------------------------------------------------------------------------
+# Go toolchain — sandbox binary cross-compile fallback (internal/binary/
+# crosscompile.go) and pre-commit hooks in Go target repos. The composite
+# action installs Go pinned to the target repo's go.mod (go-version-file);
+# the image bakes a fixed toolchain instead. GOTOOLCHAIN=auto (set below)
+# lets target repos requiring a newer Go version download it automatically
+# at runtime without failing hard. Version and checksums match images/code/Containerfile.
+# To update: get the latest linux-{amd64,arm64} archive + sha256 from
+#   https://go.dev/dl/?mode=json
+ARG GO_VERSION=1.26.0
+ARG GO_SHA256_AMD64=aac1b08a0fb0c4e0a7c1555beb7b59180b05dfc5a3d62e40e9de90cd42f88235
+ARG GO_SHA256_ARM64=bd03b743eb6eb4193ea3c3fd3956546bf0e3ca5b7076c8226334afe6b75704cd
+RUN case "$TARGETARCH" in \
+      amd64) GO_SHA="$GO_SHA256_AMD64" ;; \
+      arm64) GO_SHA="$GO_SHA256_ARM64" ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
+      -o /tmp/go.tar.gz \
+    && echo "${GO_SHA}  /tmp/go.tar.gz" | sha256sum -c - \
+    && tar -C /usr/local -xzf /tmp/go.tar.gz \
+    && rm /tmp/go.tar.gz
+
+# ---------------------------------------------------------------------------
+# pre-commit + gitlint (post-script hook runs) and jsonschema (validation
+# loop, ADR 0022). Versions match images/sandbox/Containerfile. The
+# composite action installs jsonschema as a range (>=4.18.0); the image
+# pins the exact version the sandbox image was tested with, since a
+# release image must be reproducible.
+ARG PRECOMMIT_VERSION=4.5.1
+ARG GITLINT_VERSION=0.19.1
+ARG JSONSCHEMA_VERSION=4.23.0
+RUN pip install --no-cache-dir --break-system-packages \
+      "pre-commit==${PRECOMMIT_VERSION}" \
+      "gitlint-core==${GITLINT_VERSION}" \
+      "jsonschema==${JSONSCHEMA_VERSION}"
+
+# ---------------------------------------------------------------------------
+# fullsend CLI, built in the build stage from this repo's source.
+COPY --from=build /out/fullsend /usr/local/bin/fullsend
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+# Allow target repos with a newer go.mod toolchain directive to auto-download
+# the required toolchain at runtime rather than failing with "GOTOOLCHAIN=local".
+ENV GOTOOLCHAIN=auto
+
+WORKDIR /work
+
+ENTRYPOINT ["/usr/local/bin/fullsend"]
+CMD ["--help"]

--- a/renovate.json
+++ b/renovate.json
@@ -53,6 +53,17 @@
     },
     {
       "customType": "regex",
+      "description": "Track the gcloud CLI version pin in the runner image. GCLOUD_SHA256_{AMD64,ARM64} must be refreshed manually from https://cloud.google.com/sdk/docs/install — the runner-image PR build fails on checksum mismatch until they are.",
+      "managerFilePatterns": ["/^images/runner/Containerfile$/"],
+      "matchStrings": [
+        "ARG GCLOUD_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "gcr.io/google.com/cloudsdktool/google-cloud-cli",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
       "description": "Track wranglerVersion pins in site-deploy.yml so they bump with the cloudflare-workers group",
       "managerFilePatterns": ["/^\\.github/workflows/site-deploy\\.yml$/"],
       "matchStrings": [


### PR DESCRIPTION
## Summary

Publish `ghcr.io/fullsend-ai/fullsend-runner` on every version tag: a UBI 10-based image bundling the fullsend CLI (compiled from the tagged source) and every host-side dependency that `fullsend run`'s pre-scripts, validation loop, and post-scripts invoke — so local runs get the same environment the composite action assembles in CI instead of failing on missing dependencies. Podman, the openshell-gateway, and the supervisor image stay on the host; the containerized CLI reaches the gateway over the network and sandboxes still spawn on the host.

## Related Issue

Closes #5183

## Changes

- `images/runner/Containerfile` — multi-stage build:
  - Build stage on `ubi10/go-toolset` (anonymous pull from registry.access.redhat.com) cross-compiles fullsend with the same ldflags as GoReleaser, so `fullsend --version` reports the release version.
  - Runtime stage on plain `ubi10/ubi` (deliberately not go-toolset, which carries gcc/build deps and adds ~600 MB) with: OpenShell CLI pinned via `.github/scripts/openshell-version.sh` (extracted at build time, so Renovate's existing pin bumps flow through automatically), gh, gitleaks, pre-commit + gitlint, python3 + jsonschema, Go, git, jq, tar.
  - gcloud CLI included for the local-run guide's GCP credential bootstrap (fullsend itself never invokes it); runs on the system python3 with the bundled Python runtime and anthoscli stripped. Final size ~1.1 GB.
  - All third-party downloads version-pinned and SHA256-verified, matching the pins in `images/sandbox` and `images/code` where shared; base images digest-pinned.
- `.github/workflows/runner-image.yml` — builds and pushes linux/amd64 + linux/arm64 on version tags and on `images/runner/` changes; smoke-tests the full dependency surface on a loaded single-platform build. No `latest` from main pushes — `latest` always points at the newest release.
- `renovate.json` — custom manager tracking `GCLOUD_VERSION` against `gcr.io/google.com/cloudsdktool/google-cloud-cli` tags. The SHA256 args are refreshed manually; a stale-hash bump PR fails the runner-image PR build's checksum verification, which blocks automerge.
- `docs/guides/user/running-agents-locally.md` — new section on running the CLI from the container: mounts, `--network=host` gateway access on Linux, macOS limitation, and the gcloud auth flow in a browserless container (`gcloud auth login --no-launch-browser`, persisting `~/.config/gcloud` via mount).
- `images/README.md` — runner image section (explicitly not a sandbox image) and supply-chain table rows.
- `.dockerignore` — trims the repo-root build context.

## Testing

- [x] `make lint` passes (stage changes first, then run)
- [x] Local `podman build` of the image plus the same smoke test the workflow runs: all checks pass — fullsend reports the injected version, openshell 0.0.83 (matching the pin), gh 2.96.0, gitleaks 8.30.1, pre-commit 4.5.1, gitlint 0.19.1, jsonschema import, Go 1.26.0, Google Cloud SDK 576.0.0, git/jq/tar present
- [ ] Tests added/updated for new or modified logic — no Go/script logic changed; the workflow's smoke-test step is the test surface for the image

## Checklist

- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it