### PR TITLE
fix(dispatch): log why comment-triggered dispatches are skipped

### DIFF
--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -107,6 +107,21 @@ jobs:
             return 1
           }
 
+          comment_from_user() {
+            if [[ "${COMMENT_USER_TYPE}" == "Bot" ]]; then
+              echo "::notice::Skipping dispatch for bot comment"
+              return 1
+            fi
+            return 0
+          }
+          comment_from_authorized_user() {
+            if ! is_authorized; then
+              echo "::notice::Skipping dispatch for unauthorized comment from ${COMMENT_USER_LOGIN}"
+              return 1
+            fi
+            return comment_from_user
+          }
+
           # Extract the first word of the comment as the command
           COMMAND=""
           if [[ -n "${COMMENT_BODY:-}" ]]; then
@@ -117,34 +132,34 @@ jobs:
             issue_comment)
               case "${COMMAND}" in
                 /fs-triage)
-                  if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
+                  if comment_from_authorized_user; then
                     STAGE="triage"
                   fi
                   ;;
                 /fs-code)
                   if [[ "${ISSUE_HAS_PR}" == "false" ]]; then
-                    if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
+                    if comment_from_authorized_user; then
                       STAGE="code"
                     fi
                   fi
                   ;;
                 /fs-review)
                   if [[ "${ISSUE_HAS_PR}" == "true" ]]; then
-                    if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
+                    if comment_from_authorized_user; then
                       STAGE="review"
                     fi
                   fi
                   ;;
                 /fs-fix)
                   if [[ "${ISSUE_HAS_PR}" == "true" ]]; then
-                    if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
+                    if comment_from_authorized_user; then
                       STAGE="fix"
                       TRIGGER_SOURCE="${COMMENT_USER_LOGIN}"
                     fi
                   fi
                   ;;
                 /fs-retro|/fullsend)
-                  if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
+                  if comment_from_authorized_user; then
                     if [[ "${COMMAND}" == "/fullsend" ]]; then
                       SECOND_WORD="$(printf '%s\n' "${COMMENT_BODY}" | head -1 | tr -d '\r' | awk '{print $2}')"
                       if [[ "${SECOND_WORD}" == "retro" ]]; then
@@ -156,7 +171,7 @@ jobs:
                   fi
                   ;;
                 /fs-prioritize)
-                  if [[ "${COMMENT_USER_TYPE}" != "Bot" ]] && is_authorized; then
+                  if comment_from_authorized_user; then
                     STAGE="prioritize"
                   fi
                   ;;
@@ -165,7 +180,7 @@ jobs:
                   # re-trigger triage by providing clarification on needs-info
                   # issues. Full write-permission check is not required here.
                   if has_label "needs-info" && ! has_label "feature"; then
-                    if [[ "${COMMENT_USER_TYPE}" != "Bot" ]]; then
+                    if comment_from_user; then
                       if [[ "${COMMENT_AUTHOR_ASSOC}" != "NONE" ]] || is_issue_author; then
                         STAGE="triage"
                       fi

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -224,9 +224,13 @@ func TestDispatchWorkflowContent(t *testing.T) {
 	assert.Contains(t, s, `COMMENT_AUTHOR_ASSOC`)
 	// Auto-triage requires assoc != NONE or issue author
 	assert.Contains(t, s, "is_issue_author")
-	// Bot filtering
+	// Bot filtering and skip notices via shared helpers
 	assert.Contains(t, s, `COMMENT_USER_TYPE`)
-	assert.Contains(t, s, `!= "Bot"`)
+	assert.Contains(t, s, `comment_from_user`)
+	assert.Contains(t, s, `comment_from_authorized_user`)
+	assert.Contains(t, s, `== "Bot"`)
+	assert.Contains(t, s, `Skipping dispatch for bot comment`)
+	assert.Contains(t, s, `Skipping dispatch for unauthorized comment`)
 	// No-fix label check (uses PR_LABELS for pull_request_review events)
 	assert.Contains(t, s, "fullsend-no-fix")
 	assert.Contains(t, s, "PR_LABELS")


### PR DESCRIPTION
Emit notice annotations when bot or unauthorized comments are ignored,
and centralize those checks in shared helpers.
    
Signed-off-by: Romain Arnaud <rarnaud@redhat.com>
Co-authored-by: Cursor <cursoragent@cursor.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Summary
When a comment does not trigger a stage, the reason is logged to the output.

## Related Issue
N/A

## Changes
- Shell script for `Determine stage` in `fullsend-ai_fullsend/internal/scaffold/fullsend-repo/.github/workflows` has been updated to output why a comment may not trigger a given stage.

## Testing
- [ ] `make lint` passes (stage changes first, then run): not working in my env
- [x] Tests added/updated for new or modified logic

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it
