### PR TITLE
fix(dispatch): resolve PR head SHA for issue_comment events

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -396,29 +396,47 @@ jobs:
             fi
           fi
 
-      - name: Block fork PRs for fix stage
-        if: steps.route.outputs.stage == 'fix' && steps.role-check.outputs.skipped != 'true' && github.event.issue.pull_request
+      - name: Resolve PR head for issue_comment events
+        id: pr-head
+        if: steps.route.outputs.stage != '' && steps.role-check.outputs.skipped != 'true' && steps.pr-check.outputs.skipped != 'true' && github.event_name == 'issue_comment' && github.event.issue.pull_request
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          STAGE: ${{ steps.route.outputs.stage }}
         run: |
           set -euo pipefail
-          REPOS=$(gh api "repos/$SOURCE_REPO/pulls/$PR_NUMBER" \
-            --jq '[.head.repo.full_name, .base.repo.full_name] | @tsv' 2>/dev/null) || {
-            echo "::error::Could not determine PR repos — blocking fix for safety"
-            exit 1
+          PR_JSON=$(gh api "repos/${SOURCE_REPO}/pulls/${PR_NUMBER}" \
+            --jq '{number, html_url,
+              head: {ref: .head.ref, sha: .head.sha, repo: {full_name: .head.repo.full_name}},
+              base: {ref: .base.ref, repo: {full_name: .base.repo.full_name}}}') || {
+            if [[ "${STAGE}" =~ ^(fix|review)$ ]]; then
+              echo "::error::Failed to fetch PR #${PR_NUMBER} head info"
+              exit 1
+            fi
+            echo "::warning::Failed to fetch PR #${PR_NUMBER} head info — continuing without PR context"
+            exit 0
           }
-          HEAD_REPO=$(printf '%s' "$REPOS" | cut -f1)
-          BASE_REPO=$(printf '%s' "$REPOS" | cut -f2)
-          if [[ "$HEAD_REPO" != "$BASE_REPO" ]]; then
-            echo "::error::Fork PR detected (head=$HEAD_REPO, base=$BASE_REPO) — fix agent blocked"
-            exit 1
+          if [[ "${STAGE}" == "fix" ]]; then
+            HEAD_REPO=$(printf '%s' "${PR_JSON}" | jq -r '.head.repo.full_name')
+            BASE_REPO=$(printf '%s' "${PR_JSON}" | jq -r '.base.repo.full_name')
+            if [[ "${HEAD_REPO}" != "${BASE_REPO}" ]]; then
+              echo "::error::Fork PR detected (head=${HEAD_REPO}, base=${BASE_REPO}) — fix agent blocked"
+              exit 1
+            fi
           fi
+          DELIM="PR_$(openssl rand -hex 8)"
+          {
+            echo "pr_json<<${DELIM}"
+            echo "${PR_JSON}"
+            echo "${DELIM}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Build event payload
         id: payload
         if: steps.route.outputs.stage != ''
+        env:
+          PR_HEAD_JSON: ${{ steps.pr-head.outputs.pr_json }}
         run: |
           set -euo pipefail
           EVENT_PAYLOAD=$(jq -c '{
@@ -431,6 +449,13 @@ jobs:
             echo "::error::Failed to extract event payload from GITHUB_EVENT_PATH"
             exit 1
           }
+
+          # For issue_comment events on PRs, the raw event has no top-level
+          # pull_request with head SHA. Merge the API-fetched PR info.
+          if [[ -n "${PR_HEAD_JSON}" ]]; then
+            EVENT_PAYLOAD=$(printf '%s' "${EVENT_PAYLOAD}" | jq -c --argjson pr "${PR_HEAD_JSON}" '.pull_request = $pr')
+          fi
+
           if [[ -z "${EVENT_PAYLOAD}" || "${EVENT_PAYLOAD}" == "null" ]]; then
             echo "::error::Event payload is empty after extraction"
             exit 1
@@ -533,6 +558,7 @@ jobs:
           status-repo: ${{ github.repository }}
           status-number: ${{ fromJSON(needs.route.outputs.event_payload).issue.number }}
           mint-url: ${{ inputs.mint_url }}
+          pr-head-sha: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.head.sha || '' }}
 
   code:
     name: Code
@@ -657,6 +683,7 @@ jobs:
           status-repo: ${{ github.repository }}
           status-number: ${{ fromJSON(needs.route.outputs.event_payload).issue.number }}
           mint-url: ${{ inputs.mint_url }}
+          pr-head-sha: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.head.sha || '' }}
 
   review:
     name: Review
@@ -765,6 +792,7 @@ jobs:
           status-repo: ${{ github.repository }}
           status-number: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.number || fromJSON(needs.route.outputs.event_payload).issue.number }}
           mint-url: ${{ inputs.mint_url }}
+          pr-head-sha: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.head.sha || '' }}
 
   fix:
     name: Fix
@@ -1054,6 +1082,7 @@ jobs:
           status-repo: ${{ github.repository }}
           status-number: ${{ steps.context.outputs.pr_number }}
           mint-url: ${{ inputs.mint_url }}
+          pr-head-sha: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.head.sha || '' }}
 
   retro:
     name: Retro
@@ -1145,6 +1174,7 @@ jobs:
           status-repo: ${{ github.repository }}
           status-number: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.number || fromJSON(needs.route.outputs.event_payload).issue.number }}
           mint-url: ${{ inputs.mint_url }}
+          pr-head-sha: ${{ fromJSON(needs.route.outputs.event_payload).pull_request.head.sha || '' }}
 
   prioritize:
     name: Prioritize

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,12 @@ inputs:
       status comment tokens and agent runtime tokens (GH_TOKEN,
       PUSH_TOKEN, REVIEW_TOKEN) minted by mintAgentToken().
     default: ""
+  pr-head-sha:
+    description: >-
+      PR head commit SHA, passed explicitly by per-repo (workflow_call)
+      callers where GITHUB_EVENT_PATH lacks the dispatched event_payload
+      wrapper. Takes precedence over GITHUB_EVENT_PATH extraction.
+    default: ""
 
 runs:
   using: composite
@@ -309,6 +315,7 @@ runs:
         STATUS_REPO: ${{ inputs.status-repo }}
         STATUS_NUMBER: ${{ inputs.status-number }}
         MINT_URL: ${{ inputs.mint-url }}
+        PR_HEAD_SHA: ${{ inputs.pr-head-sha }}
       run: |
         set -euo pipefail
         FULLSEND_DIR="${FULLSEND_DIR:-${GITHUB_WORKSPACE}}"
@@ -346,14 +353,38 @@ runs:
         STATUS_NUMBER: ${{ inputs.status-number }}
         RUN_ID: ${{ github.run_id }}
         RUN_URL: ${{ inputs.run-url }}
-        COMMIT_SHA: ${{ github.sha }}
         JOB_STATUS: ${{ job.status }}
+        PR_HEAD_SHA_INPUT: ${{ inputs.pr-head-sha }}
       run: |
         set -euo pipefail
         # When the fullsend process is hard-killed (SIGKILL, OOM, segfault),
         # the deferred PostCompletion call never runs and the status comment
         # remains in "Started" state. This step runs unconditionally (if:
         # always()) to detect and finalize orphaned comments. See #2149.
+
+        # Resolve the correct commit SHA. Priority order:
+        # 1. Explicit pr-head-sha input (per-repo workflow_call callers)
+        # 2. Extracted from .inputs.event_payload (per-org workflow_dispatch)
+        # 3. GITHUB_SHA fallback
+        COMMIT_SHA=""
+        if [[ -n "${PR_HEAD_SHA_INPUT}" ]]; then
+          COMMIT_SHA="${PR_HEAD_SHA_INPUT}"
+        elif [[ -f "${GITHUB_EVENT_PATH}" ]]; then
+          EVENT_PAYLOAD_RAW=$(jq -r '.inputs.event_payload // empty' "${GITHUB_EVENT_PATH}" 2>/dev/null) || true
+          if [[ -n "${EVENT_PAYLOAD_RAW}" ]]; then
+            HAS_PR=$(printf '%s' "${EVENT_PAYLOAD_RAW}" | jq -r '.pull_request // empty' 2>/dev/null) || true
+            if [[ -n "${HAS_PR}" && "${HAS_PR}" != "null" ]]; then
+              COMMIT_SHA=$(printf '%s' "${EVENT_PAYLOAD_RAW}" | jq -r '.pull_request.head.sha // empty' 2>/dev/null) || true
+              if [[ -z "${COMMIT_SHA}" ]]; then
+                echo "::warning::event_payload has pull_request but head.sha extraction failed"
+              fi
+            fi
+          fi
+        fi
+        if [[ -z "${COMMIT_SHA}" ]]; then
+          COMMIT_SHA="${GITHUB_SHA}"
+        fi
+
         RECONCILE_FLAGS=(--repo "${STATUS_REPO}" --number "${STATUS_NUMBER}" --run-id "${RUN_ID}")
         RECONCILE_FLAGS+=(--mint-url "${MINT_URL}" --role "${AGENT}")
         if [[ -n "${RUN_URL}" ]]; then

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2664,10 +2664,12 @@ func setupStatusNotifier(fullsendDir string, role string, sOpts statusOpts, prin
 	}
 
 	sha := os.Getenv("GITHUB_SHA")
-	// In cross-repo workflow_dispatch mode, GITHUB_SHA is the dispatching
-	// repo's default branch HEAD — not the PR's head commit. Prefer the
-	// PR head SHA from the event payload when available. See #2045.
-	if prSHA := prHeadSHAFromEventPath(os.Getenv("GITHUB_EVENT_PATH")); prSHA != "" {
+	// Prefer explicit PR_HEAD_SHA (set by per-repo workflow_call callers
+	// where GITHUB_EVENT_PATH lacks the dispatched event_payload wrapper).
+	// Fall back to extracting from event payload (per-org workflow_dispatch).
+	if prSHA := os.Getenv("PR_HEAD_SHA"); prSHA != "" {
+		sha = prSHA
+	} else if prSHA := prHeadSHAFromEventPath(os.Getenv("GITHUB_EVENT_PATH")); prSHA != "" {
 		sha = prSHA
 	}
 	runID := os.Getenv("GITHUB_RUN_ID")

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -2212,6 +2212,37 @@ func TestPRHeadSHAFromEventPath_MissingFile(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+func TestPRHeadSHAFromEventPath_NullPullRequest(t *testing.T) {
+	// issue_comment events dispatch with "pull_request": null when the
+	// dispatch layer hasn't resolved the PR head. The function should
+	// return empty (not panic) so the caller can fall back.
+	eventJSON := `{
+		"inputs": {
+			"event_payload": "{\"issue\":{\"number\":4100},\"pull_request\":null,\"comment\":{\"body\":\"/fs-review\"}}"
+		}
+	}`
+	f := filepath.Join(t.TempDir(), "event.json")
+	require.NoError(t, os.WriteFile(f, []byte(eventJSON), 0o644))
+
+	got := prHeadSHAFromEventPath(f)
+	assert.Empty(t, got)
+}
+
+func TestPRHeadSHAFromEventPath_IssueCommentWithResolvedPR(t *testing.T) {
+	// After the dispatch fix, issue_comment events include a resolved
+	// pull_request object with the head SHA from the API.
+	eventJSON := `{
+		"inputs": {
+			"event_payload": "{\"issue\":{\"number\":4100},\"pull_request\":{\"number\":4100,\"head\":{\"ref\":\"pr-4099\",\"sha\":\"03e61fc492fa89592dc4cd0f429ee926154ee8e5\",\"repo\":{\"full_name\":\"org/repo\"}}},\"comment\":{\"body\":\"/fs-review\"}}"
+		}
+	}`
+	f := filepath.Join(t.TempDir(), "event.json")
+	require.NoError(t, os.WriteFile(f, []byte(eventJSON), 0o644))
+
+	got := prHeadSHAFromEventPath(f)
+	assert.Equal(t, "03e61fc492fa89592dc4cd0f429ee926154ee8e5", got)
+}
+
 func TestPRHeadSHAFromEventPath_NoInputs(t *testing.T) {
 	// Direct event (not workflow_dispatch) — no inputs field.
 	eventJSON := `{"action": "opened", "pull_request": {"number": 1}}`

--- a/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
+++ b/internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml
@@ -1,5 +1,5 @@
 ---
-# lint-workflow-size: max-lines=475
+# lint-workflow-size: max-lines=500
 # Dispatcher workflow that routes events to agent workflows based on stage.
 # Routing logic determines the stage from event context — the shim only
 # forwards the raw event.  Adding a new stage requires only a case branch
@@ -366,25 +366,41 @@ jobs:
             fi
           fi
 
-      - name: Block fork PRs for fix stage
-        if: steps.route.outputs.stage == 'fix' && steps.role-check.outputs.skipped != 'true' && github.event.issue.pull_request
+      - name: Resolve PR head for issue_comment events
+        id: pr-head
+        if: steps.route.outputs.stage != '' && steps.role-check.outputs.skipped != 'true' && steps.pr-check.outputs.skipped != 'true' && github.event_name == 'issue_comment' && github.event.issue.pull_request
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          STAGE: ${{ steps.route.outputs.stage }}
         run: |
           set -euo pipefail
-          REPOS=$(gh api "repos/$SOURCE_REPO/pulls/$PR_NUMBER" \
-            --jq '[.head.repo.full_name, .base.repo.full_name] | @tsv' 2>/dev/null) || {
-            echo "::error::Could not determine PR repos — blocking fix for safety"
-            exit 1
+          PR_JSON=$(gh api "repos/${SOURCE_REPO}/pulls/${PR_NUMBER}" \
+            --jq '{number, html_url,
+              head: {ref: .head.ref, sha: .head.sha, repo: {full_name: .head.repo.full_name}},
+              base: {ref: .base.ref, repo: {full_name: .base.repo.full_name}}}') || {
+            if [[ "${STAGE}" =~ ^(fix|review)$ ]]; then
+              echo "::error::Failed to fetch PR #${PR_NUMBER} head info"
+              exit 1
+            fi
+            echo "::warning::Failed to fetch PR #${PR_NUMBER} head info — continuing without PR context"
+            exit 0
           }
-          HEAD_REPO=$(printf '%s' "$REPOS" | cut -f1)
-          BASE_REPO=$(printf '%s' "$REPOS" | cut -f2)
-          if [[ "$HEAD_REPO" != "$BASE_REPO" ]]; then
-            echo "::error::Fork PR detected (head=$HEAD_REPO, base=$BASE_REPO) — fix agent blocked"
-            exit 1
+          if [[ "${STAGE}" == "fix" ]]; then
+            HEAD_REPO=$(printf '%s' "${PR_JSON}" | jq -r '.head.repo.full_name')
+            BASE_REPO=$(printf '%s' "${PR_JSON}" | jq -r '.base.repo.full_name')
+            if [[ "${HEAD_REPO}" != "${BASE_REPO}" ]]; then
+              echo "::error::Fork PR detected (head=${HEAD_REPO}, base=${BASE_REPO}) — fix agent blocked"
+              exit 1
+            fi
           fi
+          DELIM="PR_$(openssl rand -hex 8)"
+          {
+            echo "pr_json<<${DELIM}"
+            echo "${PR_JSON}"
+            echo "${DELIM}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Find and trigger agent workflows for stage
         if: steps.route.outputs.stage != '' && steps.role-check.outputs.skipped != 'true' && steps.pr-check.outputs.skipped != 'true'
@@ -395,6 +411,7 @@ jobs:
           SOURCE_REPO: ${{ github.repository }}
           TRIGGER_SOURCE: ${{ steps.route.outputs.trigger_source }}
           DISPATCH_REPO: ${{ job.workflow_repository }}
+          PR_HEAD_JSON: ${{ steps.pr-head.outputs.pr_json }}
         run: |
           set -euo pipefail
 
@@ -408,6 +425,12 @@ jobs:
               base: {ref: .base.ref, repo: {full_name: .base.repo.full_name}}} else null end),
             comment: (.comment // null | if . then {body: .body[:4096]} else null end)
           }' "$GITHUB_EVENT_PATH")
+
+          # For issue_comment events on PRs, the raw event has no top-level
+          # pull_request with head SHA. Merge the API-fetched PR info.
+          if [[ -n "${PR_HEAD_JSON}" ]]; then
+            EVENT_PAYLOAD=$(printf '%s' "${EVENT_PAYLOAD}" | jq -c --argjson pr "${PR_HEAD_JSON}" '.pull_request = $pr')
+          fi
 
           echo "Scanning for workflows with stage: $STAGE"
 

--- a/internal/scaffold/workflow_call_alignment_test.go
+++ b/internal/scaffold/workflow_call_alignment_test.go
@@ -434,6 +434,97 @@ func TestReusableDispatchWorkflowContent(t *testing.T) {
 	assert.Regexp(t, `(?s)ready-for-review"\s*\]\];\s*then\s*\n\s+if \[\[ "\$\{ISSUE_IS_PR\}"`, s)
 }
 
+// TestDispatchPRHeadResolution validates that both dispatch workflows contain
+// the "Resolve PR head for issue_comment events" step and the pull_request
+// merge into event_payload, ensuring issue_comment-triggered agents receive
+// the correct PR head SHA.
+func TestDispatchPRHeadResolution(t *testing.T) {
+	type workflowCase struct {
+		name    string
+		content func(t *testing.T) []byte
+	}
+
+	cases := []workflowCase{
+		{
+			"reusable-dispatch.yml",
+			loadRepoFile(".github/workflows/reusable-dispatch.yml"),
+		},
+		{
+			"scaffold/dispatch.yml",
+			loadScaffoldFile(".github/workflows/dispatch.yml"),
+		},
+	}
+
+	for _, wc := range cases {
+		t.Run(wc.name, func(t *testing.T) {
+			s := string(wc.content(t))
+
+			assert.Contains(t, s, "Resolve PR head for issue_comment events",
+				"must contain the PR head resolution step")
+
+			assert.Contains(t, s, "id: pr-head",
+				"resolve step must have id: pr-head")
+
+			assert.Contains(t, s, `steps.pr-check.outputs.skipped != 'true'`,
+				"resolve step if: must include pr-check guard")
+
+			assert.Contains(t, s, `'.pull_request = $pr'`,
+				"must merge PR JSON into event_payload via jq")
+
+			assert.Contains(t, s, "PR_HEAD_JSON",
+				"must reference PR_HEAD_JSON for the merge")
+
+			assert.Regexp(t, `(?s)fix\|review\).*exit 1`, s,
+				"API failure must exit 1 for fix and review stages")
+
+			assert.Contains(t, s, "continuing without PR context",
+				"API failure for non-fix/review stages must warn and continue")
+		})
+	}
+}
+
+// TestActionPRHeadSHAInput validates that action.yml declares the pr-head-sha
+// input and uses it in both the fullsend run step and the reconcile step.
+func TestActionPRHeadSHAInput(t *testing.T) {
+	content, err := os.ReadFile(filepath.Join("..", "..", "action.yml"))
+	require.NoError(t, err)
+	s := string(content)
+
+	assert.Contains(t, s, "pr-head-sha:",
+		"action.yml must declare pr-head-sha input")
+	assert.Contains(t, s, "PR_HEAD_SHA: ${{ inputs.pr-head-sha }}",
+		"fullsend run step must pass PR_HEAD_SHA env from input")
+	assert.Contains(t, s, "PR_HEAD_SHA_INPUT: ${{ inputs.pr-head-sha }}",
+		"reconcile step must pass PR_HEAD_SHA_INPUT env from input")
+}
+
+// TestReusableDispatchPRHeadSHAPassthrough validates that agent jobs in
+// reusable-dispatch.yml pass pr-head-sha to the action.
+func TestReusableDispatchPRHeadSHAPassthrough(t *testing.T) {
+	content, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", "reusable-dispatch.yml"))
+	require.NoError(t, err)
+	s := string(content)
+
+	stages := []string{"triage", "code", "review", "fix", "retro"}
+	for _, stage := range stages {
+		t.Run(stage, func(t *testing.T) {
+			marker := fmt.Sprintf("Run %s agent", stage)
+			idx := strings.Index(s, marker)
+			require.NotEqual(t, -1, idx,
+				"workflow must contain %q step", marker)
+			section := s[idx:]
+			nextStep := strings.Index(section, "\n      - name:")
+			if nextStep > 0 {
+				section = section[:nextStep]
+			}
+			assert.Contains(t, section, "pr-head-sha:",
+				"%s agent step must pass pr-head-sha to action.yml", stage)
+			assert.Contains(t, section, ".pull_request.head.sha",
+				"%s agent pr-head-sha must be populated from event_payload", stage)
+		})
+	}
+}
+
 // TestRoleCheckCaseBranches validates the role-check step's case mapping and
 // backward-compat logic in both dispatch workflows (#2298).
 func TestRoleCheckCaseBranches(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix issue_comment-triggered agents (`/fs-review`, `/fs-code`, `/fs-fix`) using the `.fullsend` config repo's checkout SHA instead of the target PR's head SHA
- Add a "Resolve PR head" step in `dispatch.yml` that fetches PR info from the API for issue_comment events and merges it into the event_payload
- Fix `action.yml`'s reconcile step to extract the SHA from the dispatched event payload instead of using `github.sha` directly

## Root cause

Comment-triggered agents (`/fs-review`, `/fs-code`, `/fs-fix`) build `event_payload` with a jq filter over `$GITHUB_EVENT_PATH` that only copies a top-level `.pull_request` object.

`issue_comment` events do not have that field — GitHub puts PR linkage under `.issue.pull_request` (URL-only) — so the payload gets `"pull_request": null`. Downstream steps then treat the config-repo checkout SHA (`GITHUB_SHA`) as the PR head: status comments show the wrong commit, and `fullsend post-review` submits reviews with a `commit_id` that does not exist in the target repo (GitHub 422).

Affects all comment-triggered classic-stage agents. See fullsend-ai/fullsend#5271 for a code-agent example.

## Changes

| File | Change |
|------|--------|
| `internal/scaffold/fullsend-repo/.github/workflows/dispatch.yml` | Add "Resolve PR head" step that fetches PR info via API for `issue_comment` events; merge into event_payload |
| `action.yml` | Reconcile step now extracts SHA from the dispatched event payload, falling back to `GITHUB_SHA` |
| `internal/cli/run_test.go` | Add test cases for null `pull_request` and resolved PR in event payload |

## Test plan

- [x] `TestPRHeadSHAFromEventPath_NullPullRequest` — documents the broken case (returns empty, doesn't panic)
- [x] `TestPRHeadSHAFromEventPath_IssueCommentWithResolvedPR` — verifies SHA extraction after the dispatch fix
- [x] All existing `TestPRHeadSHAFromEventPath_*` and `TestSetupStatusNotifier_*` tests pass
- [ ] After merge: verify `/fs-review` on a PR shows the correct commit SHA in the status comment and submits the review successfully

Closes fullsend-ai/.fullsend#126