### PR TITLE
feat: forward SSH_SIGNING_KEY secret to code agent sandbox

### DIFF
--- a/.github/workflows/reusable-dispatch.yml
+++ b/.github/workflows/reusable-dispatch.yml
@@ -71,6 +71,12 @@ on:
           secret). Optional — unset leaves export disabled unless the
           endpoint variable alone suffices.
         required: false
+      SSH_SIGNING_KEY:
+        description: >-
+          SSH private key for commit signing. Repos that opt into SSH
+          signing set this as a repo secret; the code agent's
+          gpg.ssh.program wrapper writes it to a temp file at sign time.
+        required: false
 
 jobs:
   route:
@@ -662,6 +668,7 @@ jobs:
           AGENT_PREFIX: CODE_
           CODE_TARGET_REPO_DIR: target-repo
           CODE_ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
+          CODE_SSH_SIGNING_KEY: ${{ secrets.SSH_SIGNING_KEY }}
           CODE_CLOUD_ML_REGION: ${{ inputs.gcp_region }}
           CODE_ISSUE_NUMBER: ${{ fromJSON(needs.route.outputs.event_payload).issue.number }}
         run: bash .github/scripts/setup-agent-env.sh


### PR DESCRIPTION
## Summary
Enables repos to opt into SSH commit signing by setting an SSH_SIGNING_KEY repo secret. 
The setup-agent-env script strips the CODE_ prefix and exports it for fullsend run to expand into env.sandbox.

## Related Issue
related to: https://github.com/fullsend-ai/fullsend/issues/1685

## Changes
  - Declared `SSH_SIGNING_KEY` as an optional secret input in `on.workflow_call.secrets`
  - Added `CODE_SSH_SIGNING_KEY` to the code agent's "Setup agent environment" step, following the same pattern as `CODE_ANTHROPIC_VERTEX_PROJECT_ID`

## Testing
- [x] `make lint` passes (stage changes first, then run)
- [ ] Tests added/updated for new or modified logic

## Checklist
- [ ] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [ ] Commits are signed off (DCO) — human and human-directed agent sessions only
- [ ] I wrote this contribution myself and can explain all changes in it
