### PR TITLE
ci(renovate): add custom manager to auto-bump tirith CLI version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,11 @@
       "description": "Group Cloudflare Worker packages to prevent broken lockfile-only PRs from peer dependency conflicts",
       "matchPackageNames": ["/^@cloudflare\\//", "wrangler", "miniflare"],
       "groupName": "cloudflare-workers"
+    },
+    {
+      "description": "Disable automerge for tirith — Renovate bumps the version but SHA256 checksums need manual refresh, so the PR always needs human intervention",
+      "matchPackageNames": ["sheeki03/tirith"],
+      "automerge": false
     }
   ],
   "postUpdateOptions": ["gomodTidy"],
@@ -81,6 +86,17 @@
       ],
       "depNameTemplate": "@anthropic-ai/claude-code",
       "datasourceTemplate": "npm"
+    },
+    {
+      "customType": "regex",
+      "description": "Track tirith CLI version pin in the sandbox image. TIRITH_SHA256_{AMD64,ARM64} must be refreshed manually from the release checksums.txt at https://github.com/sheeki03/tirith/releases — the image build fails on checksum mismatch until they are.",
+      "managerFilePatterns": ["/^images/sandbox/Containerfile$/"],
+      "matchStrings": [
+        "ARG TIRITH_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "sheeki03/tirith",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add a Renovate custom regex manager to track the `ARG TIRITH_VERSION=` pin in `images/sandbox/Containerfile` against `sheeki03/tirith` GitHub releases
- Renovate will open a PR when a new tirith release is tagged, bumping the version number automatically
- SHA256 checksums (`TIRITH_SHA256_{AMD64,ARM64}`) must still be refreshed manually from the release's `checksums.txt` — the image build fails on checksum mismatch until they are

## Test plan

- [ ] Verify `renovate.json` is valid JSON
- [ ] Confirm Renovate detects the new custom manager on the next dependency dashboard refresh
- [ ] Validate that the regex matches the existing `ARG TIRITH_VERSION=0.3.1` line in the Containerfile