### PR TITLE
docs(cli): update --fullsend-dir help text from stale layout phrasing

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -31,7 +31,7 @@ fullsend agent add harness/custom-review.yaml --name my-review --fullsend-dir .f
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--fullsend-dir` | | Base directory containing the `.fullsend` layout (required) |
+| `--fullsend-dir` | | Path to the `.fullsend` configuration directory (required) |
 | `--name` | derived from filename | Explicit agent name |
 
 GitHub blob URLs are resolved to pinned `raw.githubusercontent.com` URLs. Non-GitHub URLs must already contain a commit SHA in the path. Local paths must be relative, must not contain path traversal (`..`), and the file must exist. If an agent with the same name already exists, the command fails.
@@ -48,7 +48,7 @@ fullsend agent list --fullsend-dir .fullsend
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--fullsend-dir` | | Base directory containing the `.fullsend` layout (required) |
+| `--fullsend-dir` | | Path to the `.fullsend` configuration directory (required) |
 
 Read-only. Displays a table with `NAME` and `SOURCE` columns. For URL agents, the `#sha256=...` integrity hash suffix is stripped from the displayed source for readability. Disabled agents (`enabled: false`) are included in the listing.
 
@@ -72,7 +72,7 @@ fullsend agent update triage a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2 --fullsend
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--fullsend-dir` | | Base directory containing the `.fullsend` layout (required) |
+| `--fullsend-dir` | | Path to the `.fullsend` configuration directory (required) |
 
 Only URL agents can be updated — local path agents have nothing to pin. Non-GitHub URL agents require an explicit SHA argument. The integrity hash is recomputed by fetching the content at the new SHA.
 
@@ -88,7 +88,7 @@ fullsend agent remove triage --fullsend-dir .fullsend
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--fullsend-dir` | | Base directory containing the `.fullsend` layout (required) |
+| `--fullsend-dir` | | Path to the `.fullsend` configuration directory (required) |
 
 ## `agent migrate-customizations`
 
@@ -103,7 +103,7 @@ fullsend agent migrate-customizations --fullsend-dir .fullsend --repo owner/repo
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--fullsend-dir` | | Base directory containing the `.fullsend` layout (required) |
+| `--fullsend-dir` | | Path to the `.fullsend` configuration directory (required) |
 | `--repo` | | Target repository (`owner/repo`) for the migration PR (required unless `--dry-run`) |
 | `--dry-run` | `false` | Show what would change without creating a PR |
 

--- a/docs/guides/dev/cli-internals.md
+++ b/docs/guides/dev/cli-internals.md
@@ -102,19 +102,19 @@ fullsend
 │   ├── update       <name> [sha]             # Re-pin URL agent to new commit SHA
 │   ├── remove       <name>                   # Unregister agent from config
 │   └── migrate-customizations               # Migrate customized/ → config agents
-│       ├── --fullsend-dir <dir>             #   Base directory with .fullsend layout
+│       ├── --fullsend-dir <dir>             #   .fullsend configuration directory
 │       ├── --repo <owner/repo>              #   Target repo for migration PR
 │       └── --dry-run                        #   Preview changes without PR
 ├── lock             [agent-name]              # Pin remote deps to lock.yaml
 │   ├── --all                                #   Lock all harnesses in the harness directory
-│   ├── --fullsend-dir <path>                #   Base directory with .fullsend layout
+│   ├── --fullsend-dir <path>                #   .fullsend configuration directory
 │   ├── --forge <platform>                   #   Lock only this forge variant; omit for all
 │   ├── --update                             #   Force re-resolve even if current
 │   ├── --offline                            #   Reject network fetches
 │   ├── --max-depth <int>                    #   Max transitive dependency depth
 │   └── --max-resources <int>                #   Max total remote resources
 ├── run                                      # Execute an agent in a sandbox
-│   ├── --fullsend-dir <path>                #   Base directory with .fullsend layout
+│   ├── --fullsend-dir <path>                #   .fullsend configuration directory
 │   ├── --target-repo <path>                 #   Path to the target repository
 │   ├── --output-dir <path>                  #   Base directory for run output
 │   ├── --env-file <path>                    #   Load env vars from dotenv file (repeatable)

--- a/docs/testing/functional-tests.md
+++ b/docs/testing/functional-tests.md
@@ -63,7 +63,7 @@ one. Results are printed to stdout with pass/fail per judge and threshold.
 | `ANTHROPIC_VERTEX_PROJECT_ID` | Yes | GCP project with Vertex AI access |
 | `GOOGLE_CLOUD_PROJECT` | Yes | GCP project ID |
 | `CLOUD_ML_REGION` | Yes | GCP region for Vertex AI (e.g. `us-central1`) |
-| `FULLSEND_DIR` | No | Path to fullsend scaffold directory (default: `internal/scaffold/fullsend-repo`) |
+| `FULLSEND_DIR` | No | Path to the .fullsend configuration directory (default: `internal/scaffold/fullsend-repo`) |
 | `EVALS_HOST_CREDENTIALS` | No | Path to host GCP credentials for scoring (CI only — overrides sandbox-rewritten creds) |
 
 ## Directory layout

--- a/eval/scripts/run-fullsend.sh
+++ b/eval/scripts/run-fullsend.sh
@@ -11,7 +11,7 @@
 #   $3 — output directory
 #
 # Required env (injected by harness from hook outputs + execution.env):
-#   FULLSEND_DIR    — path to the fullsend scaffold directory
+#   FULLSEND_DIR    — path to the .fullsend configuration directory
 #   GH_TOKEN        — GitHub token
 #   FIXTURE_URL     — URL of the fixture (issue or PR)
 #   FIXTURE_TYPE    — "issue" or "pull_request"

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -69,7 +69,7 @@ Examples:
 			return runAgentAdd(cmd.Context(), args[0], name, fullsendDir, forgeClient, printer)
 		},
 	}
-	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "base directory containing the .fullsend layout")
+	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "path to the .fullsend configuration directory")
 	cmd.Flags().StringVar(&name, "name", "", "explicit agent name (default: derived from filename)")
 	_ = cmd.MarkFlagRequired("fullsend-dir")
 	return cmd
@@ -87,7 +87,7 @@ func newAgentListCmd() *cobra.Command {
 			return runAgentList(fullsendDir, printer)
 		},
 	}
-	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "base directory containing the .fullsend layout")
+	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "path to the .fullsend configuration directory")
 	_ = cmd.MarkFlagRequired("fullsend-dir")
 	return cmd
 }
@@ -120,7 +120,7 @@ Only URL agents can be updated — local path agents have nothing to pin.`,
 			return runAgentUpdate(cmd.Context(), args[0], sha, fullsendDir, forgeClient, printer)
 		},
 	}
-	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "base directory containing the .fullsend layout")
+	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "path to the .fullsend configuration directory")
 	_ = cmd.MarkFlagRequired("fullsend-dir")
 	return cmd
 }
@@ -137,7 +137,7 @@ func newAgentRemoveCmd() *cobra.Command {
 			return runAgentRemove(fullsendDir, args[0], printer)
 		},
 	}
-	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "base directory containing the .fullsend layout")
+	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "path to the .fullsend configuration directory")
 	_ = cmd.MarkFlagRequired("fullsend-dir")
 	return cmd
 }

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -66,7 +66,7 @@ use the same pinned dependencies.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "base directory containing the .fullsend layout")
+	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "path to the .fullsend configuration directory")
 	cmd.Flags().BoolVar(&update, "update", false, "force re-resolve even if lock entry is current")
 	cmd.Flags().BoolVar(&lockAll, "all", false, "lock all harness files in the .fullsend/harness/ directory")
 	cmd.Flags().StringVar(&forgeFlag, "forge", "", `forge platform to lock (e.g. "github"); omit to lock all forge variants`)

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -63,7 +63,7 @@ Use --dry-run to preview changes without creating a PR.`,
 			return runMigrateCustomizations(cmd.Context(), fullsendDir, repoFlag, dryRun, forgeClient, printer)
 		},
 	}
-	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "base directory containing the .fullsend layout")
+	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "path to the .fullsend configuration directory")
 	cmd.Flags().StringVar(&repoFlag, "repo", "", "target repository (owner/repo) for the migration PR")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would change without creating a PR")
 	_ = cmd.MarkFlagRequired("fullsend-dir")

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -239,7 +239,7 @@ func newRunCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "base directory containing the .fullsend layout")
+	cmd.Flags().StringVar(&fullsendDir, "fullsend-dir", "", "path to the .fullsend configuration directory")
 	cmd.Flags().StringVar(&outputBase, "output-dir", "", "base directory for run output (default: /tmp/fullsend)")
 	cmd.Flags().StringVar(&targetRepo, "target-repo", "", "path to the target repository")
 	cmd.Flags().StringVar(&fullsendBinary, "fullsend-binary", "", "path to a Linux fullsend binary to copy into the sandbox (default: current executable)")


### PR DESCRIPTION
## Summary

- Update `--fullsend-dir` help text across all 7 CLI commands from `"base directory containing the .fullsend layout"` to `"path to the .fullsend configuration directory"`
- Update eval script comment from "fullsend scaffold directory" to match
- Update CLI reference docs (`docs/cli/agent.md`, `docs/guides/dev/cli-internals.md`, `docs/testing/functional-tests.md`)

## Context

Issue #5288 flagged the stale `.fullsend layout` phrasing in the `--fullsend-dir` help text. After investigation, the flag name itself is correct — the directory IS the `.fullsend/` project configuration root (config, harness, lock, profiles, providers). The "layout" phrasing was a holdover from the pre-agent-extraction era when the directory mirrored the `internal/scaffold/` structure.

This PR keeps the `--fullsend-dir` flag name and only updates the description to reflect what the directory actually contains. Supersedes #5291 which attempted a full flag rename.

Refs: #5288

## Testing

- [x] `go vet ./internal/cli/...` passes
- [x] `gofmt` clean
- [x] No functional changes — help text only