### PR TITLE
ci(#5455): stop non-ok-to-test labels cancelling e2e runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,9 +54,12 @@ concurrency:
     ${{ github.event_name == 'pull_request_target'
         && format('e2e-{0}', github.event.pull_request.number)
         || format('{0}-{1}', github.workflow, github.ref) }}
+  # Explicit outer parens: (A && B) || (C && D). Relies on && binding tighter
+  # than ||; keep the grouping obvious so a future || clause cannot silently
+  # disable cancel for non-pull_request_target triggers.
   cancel-in-progress: >-
-    ${{ github.event_name == 'pull_request_target'
-        && (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test')
+    ${{ (github.event_name == 'pull_request_target'
+        && (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test'))
         || (github.event_name != 'pull_request_target' && github.ref != 'refs/heads/main') }}
 
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,6 +46,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+# Non-ok-to-test labeled events still start a workflow run (GitHub cannot filter
+# by label name at on:), but must not cancel an in-progress opened/synchronize
+# run — same actionable filter as the gate job if: below.
 concurrency:
   group: >-
     ${{ github.event_name == 'pull_request_target'
@@ -53,7 +56,8 @@ concurrency:
         || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: >-
     ${{ github.event_name == 'pull_request_target'
-        || github.ref != 'refs/heads/main' }}
+        && (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test')
+        || (github.event_name != 'pull_request_target' && github.ref != 'refs/heads/main') }}
 
 jobs:
   gate:

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -29,9 +29,12 @@ concurrency:
     ${{ github.event_name == 'pull_request_target'
         && format('functional-{0}', github.event.pull_request.number)
         || format('{0}-{1}', github.workflow, github.ref) }}
+  # Explicit outer parens: (A && B) || (C && D). Relies on && binding tighter
+  # than ||; keep the grouping obvious so a future || clause cannot silently
+  # disable cancel for non-pull_request_target triggers. Keep in sync with e2e.yml.
   cancel-in-progress: >-
-    ${{ github.event_name == 'pull_request_target'
-        && (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test')
+    ${{ (github.event_name == 'pull_request_target'
+        && (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test'))
         || (github.event_name != 'pull_request_target' && github.ref != 'refs/heads/main') }}
 
 jobs:

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -21,6 +21,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+# Non-ok-to-test labeled events still start a workflow run (GitHub cannot filter
+# by label name at on:), but must not cancel an in-progress opened/synchronize
+# run — same actionable filter as the gate job if: below.
 concurrency:
   group: >-
     ${{ github.event_name == 'pull_request_target'
@@ -28,7 +31,8 @@ concurrency:
         || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: >-
     ${{ github.event_name == 'pull_request_target'
-        || github.ref != 'refs/heads/main' }}
+        && (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test')
+        || (github.event_name != 'pull_request_target' && github.ref != 'refs/heads/main') }}
 
 jobs:
   gate:

--- a/docs/guides/dev/e2e-testing.md
+++ b/docs/guides/dev/e2e-testing.md
@@ -161,13 +161,17 @@ Other labels (for example `ready-for-review`, `requires-manual-review`, or
 `component/*`) do **not** authorize e2e and do **not** cancel an in-progress
 e2e or functional-test run for that PR. Only `opened` / `synchronize` /
 `reopened`, and `labeled` when the label is `ok-to-test`, cancel in-progress
-work in the per-PR concurrency group.
+work in the per-PR concurrency group. GitHub still starts a workflow run for
+every `labeled` event (labels cannot be filtered at `on:`); for non-actionable
+labels the gate job is skipped entirely, so the run finishes quickly as skipped
+and no sticky `<!-- e2e-gate -->` comment is posted.
 
 ### Blocked runs
 
-When e2e does not run, a sticky PR comment (marker `<!-- e2e-gate -->`) explains
-why and what to do. Re-run the workflow or add/re-apply `ok-to-test` as
-appropriate.
+When the gate **runs** and denies authorization, a sticky PR comment (marker
+`<!-- e2e-gate -->`) explains why and what to do. That is distinct from a
+non-actionable label event, where the gate never runs and no comment appears.
+Re-run the workflow or add/re-apply `ok-to-test` as appropriate.
 
 ## CI architecture
 

--- a/docs/guides/dev/e2e-testing.md
+++ b/docs/guides/dev/e2e-testing.md
@@ -157,6 +157,12 @@ the frozen PR `updated_at` from the workflow event (`PR_UPDATED_AT`); the live
 API fallback may over-reject when non-push activity bumped `updated_at`.
 Applying the label triggers immediate authorization on `labeled` events.
 
+Other labels (for example `ready-for-review`, `requires-manual-review`, or
+`component/*`) do **not** authorize e2e and do **not** cancel an in-progress
+e2e or functional-test run for that PR. Only `opened` / `synchronize` /
+`reopened`, and `labeled` when the label is `ok-to-test`, cancel in-progress
+work in the per-PR concurrency group.
+
 ### Blocked runs
 
 When e2e does not run, a sticky PR comment (marker `<!-- e2e-gate -->`) explains

--- a/docs/guides/dev/e2e-testing.md
+++ b/docs/guides/dev/e2e-testing.md
@@ -162,9 +162,13 @@ Other labels (for example `ready-for-review`, `requires-manual-review`, or
 e2e or functional-test run for that PR. Only `opened` / `synchronize` /
 `reopened`, and `labeled` when the label is `ok-to-test`, cancel in-progress
 work in the per-PR concurrency group. GitHub still starts a workflow run for
-every `labeled` event (labels cannot be filtered at `on:`); for non-actionable
-labels the gate job is skipped entirely, so the run finishes quickly as skipped
-and no sticky `<!-- e2e-gate -->` comment is posted.
+every `labeled` event (labels cannot be filtered at `on:`). For non-actionable
+labels the gate job is skipped entirely and no sticky `<!-- e2e-gate -->`
+comment is posted. If an actionable run is already in progress, that new run
+sits **pending** until the active run finishes (it does not skip immediately).
+If several non-actionable labels land in a burst, GitHub cancels earlier
+pending runs in the concurrency group; only the last dequeued run executes and
+skips. Either way the original in-progress run is left alone.
 
 ### Blocked runs
 


### PR DESCRIPTION
## Summary

- Align `cancel-in-progress` in E2E and Functional Tests workflows with the existing gate filter so non-`ok-to-test` `labeled` events (e.g. `ready-for-review`) no longer cancel an in-progress `opened`/`synchronize` run.
- Document the concurrency behavior in the e2e testing guide.

## Related Issue

Closes #5455

## Changes

- `.github/workflows/e2e.yml` — only cancel for actionable PR events
- `.github/workflows/functional-tests.yml` — same change
- `docs/guides/dev/e2e-testing.md` — note that other labels neither authorize nor cancel

## Testing

- [x] `make lint` (pre-commit) passed on staged files
- [ ] Manual verification: bot PR open + immediate `ready-for-review` should leave the initial e2e run running

## Checklist

- [x] Gate `if:` and `cancel-in-progress` use the same actionable filter
- [x] Both e2e and functional-tests workflows updated
- [x] Docs updated


Made with [Cursor](https://cursor.com)