### PR TITLE
ci(#5481): add mint-cf-worker-test workflow and stub Make target

### DIFF
--- a/.github/workflows/mint-cf-worker-test.yml
+++ b/.github/workflows/mint-cf-worker-test.yml
@@ -10,17 +10,20 @@ name: Mint CF Worker Test
 on:
   push:
     branches: [main]
+    # SYNC-WITH: grep in "Check for mint-cf-worker-relevant changes" step
     paths:
       - "internal/dispatch/cf/**"
       - "cmd/mint-wasm/**"
       - "Makefile"
       - ".github/workflows/mint-cf-worker-test.yml"
   pull_request:
+    # SYNC-WITH: grep in "Check for mint-cf-worker-relevant changes" step
     paths:
       - "internal/dispatch/cf/**"
       - "cmd/mint-wasm/**"
       - "Makefile"
       - ".github/workflows/mint-cf-worker-test.yml"
+  merge_group:
   workflow_dispatch:
 
 permissions:
@@ -34,7 +37,38 @@ jobs:
   mint-cf-worker-test:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # merge_group cannot use on.paths; skip early when unrelated files changed.
+      - name: Check for mint-cf-worker-relevant changes
+        id: changes
+        if: github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          MERGE_GROUP_BASE: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD: ${{ github.event.merge_group.head_sha }}
+        # SYNC-WITH: push.paths / pull_request.paths filters above
+        run: |
+          FILES=$(gh api "repos/${REPO}/compare/${MERGE_GROUP_BASE}...${MERGE_GROUP_HEAD}" --jq '.files[].filename') || {
+            echo "::warning::Failed to fetch merge group files — running mint-cf-worker-test as a precaution"
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          FILE_COUNT=$(echo "$FILES" | wc -l)
+          if [ "$FILE_COUNT" -ge 300 ]; then
+            echo "::warning::Compare API returned $FILE_COUNT files (possible truncation at 300) — running mint-cf-worker-test as a precaution"
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if echo "$FILES" | grep -qE '^internal/dispatch/cf/|^cmd/mint-wasm/|^Makefile$|^\.github/workflows/mint-cf-worker-test\.yml$'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No mint-cf-worker-relevant files changed — skipping"
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.changes.outputs.relevant != 'false'
 
       - name: Run CF mint Worker bridge smoke tests
+        if: steps.changes.outputs.relevant != 'false'
         run: make mint-cf-worker-test

--- a/.github/workflows/mint-cf-worker-test.yml
+++ b/.github/workflows/mint-cf-worker-test.yml
@@ -30,12 +30,14 @@ permissions:
   contents: read
 
 concurrency:
-  group: mint-cf-worker-test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   mint-cf-worker-test:
     runs-on: ubuntu-24.04
+    # Stub is near-instant; headroom for the real wasm-stage + npm smoke (#5427).
+    timeout-minutes: 15
     steps:
       # merge_group cannot use on.paths; skip early when unrelated files changed.
       - name: Check for mint-cf-worker-relevant changes

--- a/.github/workflows/mint-cf-worker-test.yml
+++ b/.github/workflows/mint-cf-worker-test.yml
@@ -1,0 +1,40 @@
+name: Mint CF Worker Test
+
+# Path-filtered CI entry point for the CF mint Worker JS↔WASM bridge smoke
+# tests. Calls `make mint-cf-worker-test` (qualified name — not bare
+# `worker-test`) so other Workers in this repo do not collide.
+#
+# The Make target starts as a stub (#5481); #5427 / follow-up fills it with
+# wasm-stage + workersrc install/test without renaming the CI contract.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "internal/dispatch/cf/**"
+      - "cmd/mint-wasm/**"
+      - "Makefile"
+      - ".github/workflows/mint-cf-worker-test.yml"
+  pull_request:
+    paths:
+      - "internal/dispatch/cf/**"
+      - "cmd/mint-wasm/**"
+      - "Makefile"
+      - ".github/workflows/mint-cf-worker-test.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mint-cf-worker-test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mint-cf-worker-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Run CF mint Worker bridge smoke tests
+        run: make mint-cf-worker-test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
        mindmap go-build go-test go-lint go-fmt go-vet go-tidy \
        lint-md-links script-test test \
        e2e-test behaviour-test lint-eval-cases functional-tests \
-       wasm-build
+       wasm-build mint-cf-worker-test
 
 # Let Go automatically download the toolchain version required by go.mod.
 # This ensures local builds use the right version without manual intervention.
@@ -33,6 +33,7 @@ help:
 	@echo "  lint-eval-cases      - Lint eval case definitions (annotations.yaml completeness)"
 	@echo "  functional-tests     - Run functional agent tests (requires EVAL_ORG, FULLSEND_DIR, GH_TOKEN, GCP creds)"
 	@echo "  wasm-build           - Build mintcore WASM binary and report gzip size vs Workers limits"
+	@echo "  mint-cf-worker-test  - Run CF mint Worker bridge smoke tests (stub until workersrc lands)"
 
 # Install all development tools needed for linting, formatting, and pre-commit hooks.
 # Prerequisites: uv (https://docs.astral.sh/uv/) and go (https://go.dev/)
@@ -139,6 +140,13 @@ wasm-build:
 		exit 1; \
 	fi
 	@echo "==> WASM build OK"
+
+# Stub CI contract for CF mint Worker bridge smoke tests (#5481).
+# Populated by #5427 / follow-up with wasm-stage + workersrc npm test.
+# Do not rename: .github/workflows/mint-cf-worker-test.yml calls this target.
+mint-cf-worker-test:
+	@echo "==> mint-cf-worker-test: stub (no CF Worker bridge tests yet)"
+	@echo "    Replace this stub when internal/dispatch/cf/workersrc lands (#5427)."
 
 lint-md-links:
 	lychee --offline --no-progress --include-fragments --exclude-path node_modules --exclude-path experiments '**/*.md'


### PR DESCRIPTION
## Summary

Add a path-filtered GitHub Actions workflow and a stub `mint-cf-worker-test` Make target so CF mint Worker bridge smoke tests have a stable CI contract. PR #5427 can fill in the real `wasm-stage` + workersrc sequence without renaming the target or landing workflow changes from agents.

## Related Issue

Closes #5481

## Changes

- Add `.github/workflows/mint-cf-worker-test.yml` calling `make mint-cf-worker-test`, path-filtered for `internal/dispatch/cf/**`, `cmd/mint-wasm/**`, `Makefile`, and the workflow itself
- Add stub `mint-cf-worker-test` Make target (qualified name — not bare `worker-test`) documented in `make help`

## Testing

- [x] `make mint-cf-worker-test` runs the stub successfully
- [x] `make help` lists `mint-cf-worker-test`
- [x] `make lint` passes (staged changes)

## Checklist

- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it


Made with [Cursor](https://cursor.com)