### PR TITLE
fix(#5377): retry agent token minting with exponential backoff

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2802,17 +2802,9 @@ func mintAgentToken(ctx context.Context, role, mintURL string, printer *ui.Print
 	}
 	printer.StepStart("Minting agent token (role: " + role + ")")
 
-	result, err := statusMintToken(ctx, mintclient.MintRequest{
-		MintURL: mintURL,
-		Role:    role,
-		Repos:   repos,
-	})
+	result, err := mintAgentTokenWithRetry(ctx, role, mintURL, repos, printer)
 	if err != nil {
-		return false, nil, fmt.Errorf("minting agent token for role %s: %w", role, err)
-	}
-
-	if !mintTokenPattern.MatchString(result.Token) {
-		return false, nil, fmt.Errorf("minted agent token contains unexpected characters for role %s", role)
+		return false, nil, err
 	}
 
 	// TODO(ADR-0045 R22): use forge platform context instead of raw env check.
@@ -2860,6 +2852,73 @@ func mintAgentToken(ctx context.Context, role, mintURL string, printer *ui.Print
 	}, result.ExpiresAt)
 	printer.StepDone("Agent token minted (expires " + expiresAt + ")")
 	return true, cleanup, nil
+}
+
+// mintTokenMaxAttempts is the total number of minting attempts — the initial
+// attempt plus mintTokenMaxAttempts-1 retries — before mintAgentTokenWithRetry
+// gives up.
+const mintTokenMaxAttempts = 4
+
+// mintTokenMaxBackoff caps the delay mintTokenBackoff can return, guarding
+// against overflow or runaway waits if mintTokenMaxAttempts ever grows.
+const mintTokenMaxBackoff = 8 * time.Second
+
+// mintTokenBackoff computes the delay before the retry that follows the
+// given failed attempt (1-indexed), doubling each time: 2s, 4s, 8s for the
+// default mintTokenMaxAttempts of 4. It is a package variable so tests can
+// shorten it and avoid real sleeps.
+var mintTokenBackoff = func(attempt int) time.Duration {
+	shift := attempt - 1
+	if shift > 10 {
+		shift = 10
+	}
+	backoff := 2 * time.Second * time.Duration(uint64(1)<<uint(shift))
+	if backoff > mintTokenMaxBackoff {
+		backoff = mintTokenMaxBackoff
+	}
+	return backoff
+}
+
+// mintAgentTokenWithRetry retries only the token-shape validation performed
+// on top of statusMintToken's response — a malformed token on an otherwise
+// successful mint call, the exact failure reported in issue #5377 ("minted
+// agent token contains unexpected characters"). Issue #5377 suspects, but
+// never confirms, that this is a transient response glitch; retrying it
+// tests that suspicion without re-litigating it. statusMintToken
+// (mintclient.MintToken) already retries transient request failures (5xx,
+// network errors) internally and fails fast on permanent ones (4xx), so its
+// errors are returned as-is rather than retried a second time here — doing
+// so would retry permanent failures pointlessly and compound latency on
+// persistent transient ones.
+func mintAgentTokenWithRetry(ctx context.Context, role, mintURL string, repos []string, printer *ui.Printer) (*mintclient.MintResult, error) {
+	var lastErr error
+	for attempt := 1; attempt <= mintTokenMaxAttempts; attempt++ {
+		result, err := statusMintToken(ctx, mintclient.MintRequest{
+			MintURL: mintURL,
+			Role:    role,
+			Repos:   repos,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("minting agent token for role %s: %w", role, err)
+		}
+		if mintTokenPattern.MatchString(result.Token) {
+			return result, nil
+		}
+		lastErr = fmt.Errorf("minted agent token contains unexpected characters")
+
+		if attempt < mintTokenMaxAttempts {
+			backoff := mintTokenBackoff(attempt)
+			printer.StepWarn(fmt.Sprintf("Minting agent token failed (attempt %d/%d): %v — retrying in %s", attempt, mintTokenMaxAttempts, lastErr, backoff))
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
+		}
+	}
+	return nil, fmt.Errorf("minting agent token for role %s failed after %d attempts: %w", role, mintTokenMaxAttempts, lastErr)
 }
 
 // resolveMintRepos determines which repos to request token access for.

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3174,6 +3174,15 @@ func TestWriteMetricsJSON(t *testing.T) {
 
 // --- mintAgentToken tests ---
 
+// useZeroMintTokenBackoff overrides mintTokenBackoff to skip real sleeps so
+// tests exercising mint retries run fast, restoring the original on cleanup.
+func useZeroMintTokenBackoff(t *testing.T) {
+	t.Helper()
+	orig := mintTokenBackoff
+	mintTokenBackoff = func(int) time.Duration { return 0 }
+	t.Cleanup(func() { mintTokenBackoff = orig })
+}
+
 func TestMintAgentToken_SkipsWhenNoMintURL(t *testing.T) {
 	printer := ui.New(io.Discard)
 	minted, _, err := mintAgentToken(context.Background(), "coder", "", printer)
@@ -3325,7 +3334,9 @@ func TestMintAgentToken_MintError(t *testing.T) {
 	origMint := statusMintToken
 	defer func() { statusMintToken = origMint }()
 
+	var calls int
 	statusMintToken = func(_ context.Context, _ mintclient.MintRequest) (*mintclient.MintResult, error) {
+		calls++
 		return nil, fmt.Errorf("OIDC exchange failed")
 	}
 
@@ -3335,6 +3346,7 @@ func TestMintAgentToken_MintError(t *testing.T) {
 	_, _, err := mintAgentToken(context.Background(), "coder", "https://mint.example.com", printer)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "minting agent token for role coder")
+	assert.Equal(t, 1, calls, "a request error should fail immediately — statusMintToken already retries transient failures and fails fast on permanent ones internally")
 }
 
 func TestMintAgentToken_RepoResolutionError(t *testing.T) {
@@ -3353,6 +3365,7 @@ func TestMintAgentToken_RepoResolutionError(t *testing.T) {
 func TestMintAgentToken_RejectsMalformedToken(t *testing.T) {
 	origMint := statusMintToken
 	defer func() { statusMintToken = origMint }()
+	useZeroMintTokenBackoff(t)
 
 	statusMintToken = func(_ context.Context, _ mintclient.MintRequest) (*mintclient.MintResult, error) {
 		return &mintclient.MintResult{Token: "bad token with spaces!", ExpiresAt: "2026-06-15T12:00:00Z"}, nil
@@ -3364,6 +3377,96 @@ func TestMintAgentToken_RejectsMalformedToken(t *testing.T) {
 	_, _, err := mintAgentToken(context.Background(), "coder", "https://mint.example.com", printer)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected characters")
+}
+
+func TestMintAgentToken_RetriesMalformedTokenThenSucceeds(t *testing.T) {
+	origMint := statusMintToken
+	defer func() { statusMintToken = origMint }()
+	useZeroMintTokenBackoff(t)
+
+	var calls int
+	statusMintToken = func(_ context.Context, _ mintclient.MintRequest) (*mintclient.MintResult, error) {
+		calls++
+		if calls == 1 {
+			return &mintclient.MintResult{Token: "bad token with spaces!", ExpiresAt: "2026-06-15T12:00:00Z"}, nil
+		}
+		return &mintclient.MintResult{Token: "test-recovered-token", ExpiresAt: "2026-06-15T12:00:00Z"}, nil
+	}
+
+	t.Setenv("REPO_FULL_NAME", "org/my-repo")
+	t.Setenv("GH_TOKEN", "")
+
+	var buf bytes.Buffer
+	printer := ui.New(&buf)
+	minted, cleanup, err := mintAgentToken(context.Background(), "coder", "https://mint.example.com", printer)
+	require.NoError(t, err)
+	defer cleanup()
+	assert.True(t, minted)
+	assert.Equal(t, 2, calls, "a malformed token should be retried, not treated as fatal")
+	assert.Equal(t, "test-recovered-token", os.Getenv("GH_TOKEN"))
+
+	output := buf.String()
+	assert.Contains(t, output, "attempt 1/4")
+	assert.Contains(t, output, "retrying in")
+}
+
+func TestMintAgentToken_ExhaustsAllRetriesBeforeFailing(t *testing.T) {
+	origMint := statusMintToken
+	defer func() { statusMintToken = origMint }()
+	useZeroMintTokenBackoff(t)
+
+	var calls int
+	statusMintToken = func(_ context.Context, _ mintclient.MintRequest) (*mintclient.MintResult, error) {
+		calls++
+		return &mintclient.MintResult{Token: "still bad!", ExpiresAt: "2026-06-15T12:00:00Z"}, nil
+	}
+
+	t.Setenv("REPO_FULL_NAME", "org/my-repo")
+
+	printer := ui.New(io.Discard)
+	_, _, err := mintAgentToken(context.Background(), "coder", "https://mint.example.com", printer)
+	require.Error(t, err)
+	assert.Equal(t, mintTokenMaxAttempts, calls, "should attempt exactly mintTokenMaxAttempts times before giving up")
+	assert.Contains(t, err.Error(), fmt.Sprintf("failed after %d attempts", mintTokenMaxAttempts), "final error should surface the total attempt count")
+}
+
+func TestMintAgentToken_RetryAbortsOnContextCancellation(t *testing.T) {
+	origMint := statusMintToken
+	defer func() { statusMintToken = origMint }()
+
+	// Deliberately not using useZeroMintTokenBackoff: cancel() fires from
+	// inside the mock before mintAgentTokenWithRetry reaches its select, so
+	// ctx.Done() always wins over the real backoff timer regardless of its
+	// duration — this stays fast without needing the zero-backoff seam.
+	var calls int
+	ctx, cancel := context.WithCancel(context.Background())
+	statusMintToken = func(_ context.Context, _ mintclient.MintRequest) (*mintclient.MintResult, error) {
+		calls++
+		cancel()
+		return &mintclient.MintResult{Token: "still bad!", ExpiresAt: "2026-06-15T12:00:00Z"}, nil
+	}
+
+	t.Setenv("REPO_FULL_NAME", "org/my-repo")
+
+	printer := ui.New(io.Discard)
+	_, _, err := mintAgentToken(ctx, "coder", "https://mint.example.com", printer)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, calls, "should stop retrying once the context is cancelled during backoff")
+}
+
+func TestMintTokenBackoff_Doubles(t *testing.T) {
+	assert.Equal(t, 2*time.Second, mintTokenBackoff(1))
+	assert.Equal(t, 4*time.Second, mintTokenBackoff(2))
+	assert.Equal(t, 8*time.Second, mintTokenBackoff(3))
+}
+
+func TestMintTokenBackoff_CapsAtMax(t *testing.T) {
+	// attempt 4 exercises the value clamp alone (shift=3 needs no shift-guard,
+	// but 2s*2^3=16s exceeds mintTokenMaxBackoff); attempt 20 additionally
+	// exercises the shift guard (shift would otherwise be 19).
+	assert.Equal(t, mintTokenMaxBackoff, mintTokenBackoff(4))
+	assert.Equal(t, mintTokenMaxBackoff, mintTokenBackoff(20))
 }
 
 func TestMintAgentToken_MasksTokenInGitHubActions(t *testing.T) {


### PR DESCRIPTION
## Summary
Retries the agent token minting step's malformed-token failure (issue #5377's exact reported symptom — "minted agent token contains unexpected characters" on an otherwise-successful mint call) up to 4 attempts with 2s/4s/8s backoff, instead of aborting the harness run on the first occurrence.

## Related Issue
Fixes #5377

## Design notes
An earlier revision of this PR retried every `statusMintToken` error uniformly. Review found this contradicted issue #5377's own triage analysis, which asks to distinguish retryable (5xx/timeouts) from non-retryable (4xx auth) failures — and that `internal/mintclient`'s `MintToken` already does exactly that internally (see `TestMintToken_RetriesOn500` / `TestMintToken_DoesNotRetryOn4xx`), so a second retry layer on top would either retry permanent failures pointlessly or compound latency on persistent transient ones. The final design only retries the token-pattern-validation failure, which `mintclient` structurally can't see (that HTTP call already returned 200 OK) — every other error surfaces immediately, unretried, exactly as before this PR.

## Changes
- `mintAgentTokenWithRetry` retries only the `mintTokenPattern` validation failure, up to `mintTokenMaxAttempts` (4) attempts with 2s/4s/8s backoff (capped, with an overflow guard).
- `statusMintToken` errors (network/HTTP failures) are returned immediately, unretried — `mintclient.MintToken` already retries transient failures and fails fast on permanent ones internally.
- Logs a `StepWarn` with the attempt number and error on each retry; the final error after exhausting all attempts states the total attempt count.
- Backoff uses `time.NewTimer` and respects context cancellation via `select` on `ctx.Done()`.
- Test seam `mintTokenBackoff` (package var) lets tests skip real sleeps.

## Out of scope
Three other call sites share a similar single-shot "mint, then reject on pattern mismatch" pattern (the status-notifier's client factory, `fullsend token`, `fullsend reconcile-status`). Issue #5377 explicitly scopes to only the step that logs "Minting agent token (role: )" (`mintAgentToken`), so those are left untouched here — a candidate for a follow-up issue if the same transient-failure mode shows up there in practice.

## Testing
- [x] `make lint` passes (stage changes first, then run)
- [x] Tests added/updated for new or modified logic
- [x] `go test -race ./internal/cli/...` passes (one pre-existing, unrelated flake — `TestRunAgent_PerRepoConfig` — fails identically on `main`)

## Checklist
- [x] PR title follows [Conventional Commits](COMMITS.md) (correct type, `!` for breaking changes)
- [x] Commits are signed off (DCO) — human and human-directed agent sessions only
- [x] I wrote this contribution myself and can explain all changes in it
